### PR TITLE
chore(dev): IntelliJ run configs + README local dev guide

### DIFF
--- a/.run/kelta-ai.run.xml
+++ b/.run/kelta-ai.run.xml
@@ -1,0 +1,24 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="kelta-ai" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot">
+    <option name="SPRING_BOOT_MAIN_CLASS" value="io.kelta.ai.AiApplication" />
+    <module name="kelta-ai" />
+    <envs>
+      <!-- Database -->
+      <env name="SPRING_DATASOURCE_URL" value="jdbc:postgresql://localhost:5432/kelta_control_plane" />
+      <env name="SPRING_DATASOURCE_USERNAME" value="kelta" />
+      <env name="SPRING_DATASOURCE_PASSWORD" value="kelta" />
+      <!-- Redis -->
+      <env name="SPRING_DATA_REDIS_HOST" value="localhost" />
+      <env name="SPRING_DATA_REDIS_PORT" value="6379" />
+      <!-- Worker (on host port) -->
+      <env name="WORKER_SERVICE_URL" value="http://localhost:8083" />
+      <!-- Secrets — copy from your .env file, or set in IDE Environment Variables dialog -->
+      <env name="ANTHROPIC_API_KEY" value="$ANTHROPIC_API_KEY$" />
+      <!-- Logging -->
+      <env name="LOG_LEVEL" value="INFO" />
+    </envs>
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.run/kelta-auth.run.xml
+++ b/.run/kelta-auth.run.xml
@@ -1,0 +1,38 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="kelta-auth" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot">
+    <option name="SPRING_BOOT_MAIN_CLASS" value="io.kelta.auth.AuthApplication" />
+    <module name="kelta-auth" />
+    <envs>
+      <!-- Database — shared with kelta-worker -->
+      <env name="DB_URL" value="jdbc:postgresql://localhost:5432/kelta_control_plane" />
+      <env name="DB_USERNAME" value="kelta" />
+      <env name="DB_PASSWORD" value="kelta" />
+      <!-- Redis -->
+      <env name="SPRING_DATA_REDIS_HOST" value="localhost" />
+      <env name="SPRING_DATA_REDIS_PORT" value="6379" />
+      <!--
+        CRITICAL: kelta-auth must issue tokens with the same issuer URI that kelta-gateway
+        validates against. When running in the IDE alongside a compose stack, both must use
+        http://kelta-auth:8080. Add to /etc/hosts (one-time):
+            127.0.0.1  kelta-auth
+      -->
+      <env name="KELTA_AUTH_ISSUER_URI" value="http://kelta-auth:8080" />
+      <env name="WORKER_SERVICE_URL" value="http://localhost:8083" />
+      <!-- Session / CORS -->
+      <env name="COOKIE_DOMAIN" value="localhost" />
+      <env name="UI_BASE_URL" value="http://localhost:5173" />
+      <env name="CORS_ALLOWED_ORIGINS" value="http://localhost:5173" />
+      <env name="DIRECT_LOGIN_ENABLED" value="true" />
+      <!-- Secrets — copy from your .env file, or set in IDE Environment Variables dialog -->
+      <env name="KELTA_ENCRYPTION_KEY" value="$KELTA_ENCRYPTION_KEY$" />
+      <env name="JWK_SET" value="$JWK_SET$" />
+      <env name="KELTA_INTERNAL_TOKEN" value="dev-internal-token" />
+      <!-- Logging -->
+      <env name="LOG_LEVEL" value="INFO" />
+      <env name="SECURITY_LOG_LEVEL" value="WARN" />
+    </envs>
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.run/kelta-gateway.run.xml
+++ b/.run/kelta-gateway.run.xml
@@ -1,0 +1,31 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="kelta-gateway" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot">
+    <option name="SPRING_BOOT_MAIN_CLASS" value="io.kelta.gateway.GatewayApplication" />
+    <module name="kelta-gateway" />
+    <envs>
+      <!-- Redis -->
+      <env name="REDIS_HOST" value="localhost" />
+      <env name="REDIS_PORT" value="6379" />
+      <!-- NATS -->
+      <env name="NATS_URL" value="nats://localhost:4222" />
+      <!--
+        CRITICAL: must exactly match KELTA_AUTH_ISSUER_URI in kelta-auth.
+        With SINGLE_ISSUER=true the gateway validates all JWTs against this URI.
+        See /etc/hosts note in kelta-auth.run.xml.
+      -->
+      <env name="KELTA_AUTH_ISSUER_URI" value="http://kelta-auth:8080" />
+      <!-- Route to worker and AI on host ports -->
+      <env name="WORKER_SERVICE_URL" value="http://localhost:8083" />
+      <env name="AI_SERVICE_URL" value="http://localhost:8084" />
+      <!-- Cerbos (from compose stack) -->
+      <env name="CERBOS_HOST" value="localhost" />
+      <env name="CERBOS_GRPC_PORT" value="3593" />
+      <env name="SINGLE_ISSUER" value="true" />
+      <!-- Logging -->
+      <env name="LOG_LEVEL" value="INFO" />
+    </envs>
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.run/kelta-worker.run.xml
+++ b/.run/kelta-worker.run.xml
@@ -1,0 +1,41 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="kelta-worker" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot">
+    <option name="SPRING_BOOT_MAIN_CLASS" value="io.kelta.worker.WorkerApplication" />
+    <module name="kelta-worker" />
+    <envs>
+      <!-- Database -->
+      <env name="SPRING_DATASOURCE_URL" value="jdbc:postgresql://localhost:5432/kelta_control_plane" />
+      <env name="SPRING_DATASOURCE_USERNAME" value="kelta" />
+      <env name="SPRING_DATASOURCE_PASSWORD" value="kelta" />
+      <!-- Redis -->
+      <env name="SPRING_DATA_REDIS_HOST" value="localhost" />
+      <env name="SPRING_DATA_REDIS_PORT" value="6379" />
+      <!-- NATS -->
+      <env name="NATS_URL" value="nats://localhost:4222" />
+      <!--
+        See /etc/hosts note in kelta-auth.run.xml — both gateway and worker resolve
+        kelta-auth tokens against this issuer URI.
+      -->
+      <env name="KELTA_AUTH_ISSUER_URI" value="http://kelta-auth:8080" />
+      <env name="EXTERNAL_BASE_URL" value="http://localhost:8080" />
+      <!-- Cerbos (from compose stack) -->
+      <env name="CERBOS_HOST" value="localhost" />
+      <env name="CERBOS_GRPC_PORT" value="3593" />
+      <!-- Email — disabled for local dev (enable mailpit profile for SMTP UI) -->
+      <env name="EMAIL_ENABLED" value="false" />
+      <env name="SMTP_HOST" value="localhost" />
+      <env name="SMTP_PORT" value="1025" />
+      <env name="SMTP_AUTH" value="false" />
+      <env name="SMTP_STARTTLS" value="false" />
+      <env name="SCHEDULER_ENABLED" value="true" />
+      <!-- Secrets — copy from your .env file, or set in IDE Environment Variables dialog -->
+      <env name="KELTA_ENCRYPTION_KEY" value="$KELTA_ENCRYPTION_KEY$" />
+      <env name="KELTA_INTERNAL_TOKEN" value="dev-internal-token" />
+      <!-- Logging -->
+      <env name="LOG_LEVEL" value="INFO" />
+    </envs>
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/README.md
+++ b/README.md
@@ -14,11 +14,10 @@ Kelta is a platform for building dynamic, runtime-configurable enterprise applic
                     │    Redis     │      │  PostgreSQL  │
                     │   (Cache)    │      │     (DB)     │
                     └──────────────┘      └──────────────┘
-                           │
-                    ┌──────┴───────┐
-                    │    Kafka     │
-                    │  (Events)    │
-                    └──────────────┘
+       ┌──────────────┐     ┌──────────────┐     ┌──────────────┐
+       │  kelta-auth  │     │    Cerbos    │     │     NATS     │
+       │   (OIDC)     │     │   (Authz)    │     │  (JetStream) │
+       └──────────────┘     └──────────────┘     └──────────────┘
 ```
 
 ## Project Structure
@@ -48,51 +47,89 @@ Kelta is a platform for building dynamic, runtime-configurable enterprise applic
 
 ## Prerequisites
 
-- Java 21 (Temurin recommended)
+- Java 25 (Temurin recommended)
 - Maven 3.9+
-- Node.js 18+
+- Node.js 20+
 - Docker & Docker Compose
 
-## Getting Started
+## Local Development
 
-### 1. Start Infrastructure
-
-```bash
-cp .env.example .env
-docker-compose up -d
-```
-
-This starts PostgreSQL, Redis, Kafka, and Keycloak. Optional debugging tools (Kafka UI, Redis Commander, pgAdmin) are available via the `tools` profile:
+### One-command start
 
 ```bash
-docker-compose --profile tools up -d
+make setup   # first time only: copies .env, generates RSA JWK + AES key
+make up      # starts postgres, redis, nats, cerbos, auth, worker, gateway, ui
+make seed    # waits for healthy stack, then prints credentials
 ```
 
-### 2. Build Runtime Libraries
+Default credentials (seeded by Flyway migrations):
 
-The runtime modules must be built first as they are dependencies for the gateway and worker.
+| Field | Value |
+|-------|-------|
+| URL | http://localhost:5173 |
+| Email | `admin@kelta.local` |
+| Password | `password` (force-change on first login) |
+| Tenant slug | `default` |
+
+### Service ports
+
+| Service | Host port | Notes |
+|---------|-----------|-------|
+| kelta-ui | :5173 | React admin UI |
+| kelta-gateway | :8080 | Main API entry point |
+| kelta-auth | :8081 | Internal OIDC provider |
+| kelta-worker | :8083 | Business logic + Flyway |
+| kelta-ai | :8084 | AI service (`--profile ai`) |
+| Cerbos | :3592 (HTTP) / :3593 (gRPC) | Authorization engine |
+| PostgreSQL | :5432 | |
+| Redis | :6379 | |
+| NATS | :4222 | |
+| pgAdmin | :8092 | `--profile tools` |
+| Redis Commander | :8091 | `--profile tools` |
+| Mailpit (SMTP UI) | :8025 | `--profile tools` |
+
+### Useful Makefile targets
+
+```bash
+make up-ai           # default stack + kelta-ai (needs ANTHROPIC_API_KEY in .env)
+make up-full         # default + ai + tools
+make rebuild SVC=kelta-worker   # rebuild + restart one service
+make logs SVC=kelta-gateway     # tail logs
+make down            # stop all containers
+make reset           # wipe volumes and restart clean
+```
+
+### Debugging a service in the IDE (hybrid mode)
+
+Stop the container for the service you want to debug, then launch it from IntelliJ using the checked-in run config in `.run/`:
+
+```bash
+make debug SVC=kelta-worker
+# IntelliJ → Run → kelta-worker  (or use .run/kelta-worker.run.xml)
+```
+
+**One-time `/etc/hosts` entry required** (issuer URI consistency):
+
+```
+127.0.0.1  kelta-auth
+```
+
+This is necessary because `KELTA_AUTH_ISSUER_URI=http://kelta-auth:8080` is used
+everywhere — inside Docker via container DNS and from the IDE via this hosts entry.
+Without it, gateway's `single-issuer` validation will reject tokens issued by
+kelta-auth running in the IDE.
+
+**Secrets in run configs** — the `.run/*.run.xml` files use `$VAR_NAME$` for
+secrets (`KELTA_ENCRYPTION_KEY`, `JWK_SET`, `ANTHROPIC_API_KEY`). Set them in
+the IntelliJ _Run/Debug Configurations → Environment variables_ dialog by
+copying the values from your `.env` file.
+
+### Build runtime libraries (required before first IDE run)
 
 ```bash
 mvn clean install -DskipTests -f kelta-platform/pom.xml \
   -pl runtime/runtime-core,runtime/runtime-events,runtime/runtime-jsonapi,runtime/runtime-module-core,runtime/runtime-module-integration,runtime/runtime-module-schema \
   -am -B
-```
-
-### 3. Run Backend Services
-
-```bash
-# Gateway (port 8080)
-mvn spring-boot:run -f kelta-gateway/pom.xml
-
-# Worker (port 8083)
-mvn spring-boot:run -f kelta-worker/pom.xml
-```
-
-### 4. Run Frontend
-
-```bash
-cd kelta-web && npm install
-cd kelta-ui/app && npm install && npm run dev
 ```
 
 ## Running Tests
@@ -122,29 +159,16 @@ npm run format:check
 npm run test:coverage
 ```
 
-## Local Services
-
-| Service | URL | Notes |
-|---------|-----|-------|
-| Gateway API | http://localhost:8080 | Main API entry point |
-| Worker | http://localhost:8083 | Worker service |
-| Keycloak | http://localhost:8180 | OIDC provider (admin/admin) |
-| Kafka UI | http://localhost:8090 | Requires `tools` profile |
-| Redis Commander | http://localhost:8091 | Requires `tools` profile |
-| pgAdmin | http://localhost:8092 | Requires `tools` profile |
-
 ## Environment Variables
 
-See [`.env.example`](.env.example) for the full list. Key variables:
+See [`.env.example`](.env.example). The only required secrets are generated by `make gen-keys`:
 
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `DB_HOST` | `localhost` | PostgreSQL host |
-| `DB_PORT` | `5432` | PostgreSQL port |
-| `KAFKA_BOOTSTRAP_SERVERS` | `localhost:9094` | Kafka broker address |
-| `OIDC_ISSUER_URI` | `http://localhost:8180/realms/kelta` | Keycloak OIDC issuer |
-| `SECURITY_ENABLED` | `true` | Enable/disable authentication |
-| `KAFKA_EVENTS_ENABLED` | `true` | Enable/disable Kafka event publishing |
+| Variable | Description |
+|----------|-------------|
+| `JWK_SET` | RSA-2048 JWK Set for JWT signing (generated by `make gen-keys`) |
+| `KELTA_ENCRYPTION_KEY` | AES-256 key for envelope encryption (generated by `make gen-keys`) |
+| `KELTA_INTERNAL_TOKEN` | Shared secret for internal service calls (default: `dev-internal-token`) |
+| `ANTHROPIC_API_KEY` | Required only when running kelta-ai (`--profile ai`) |
 
 ## CI/CD
 


### PR DESCRIPTION
## Summary

- Adds `.run/kelta-{auth,worker,gateway,ai}.run.xml` — IntelliJ Spring Boot run configs pre-loaded with env vars for running one service in the IDE while everything else stays in Docker compose
- Updates `README.md`: replaces stale Keycloak/Kafka references with current architecture diagram, service port table, and hybrid debug instructions

## How to use

```bash
# Stop the service you want to debug (keeps rest of stack running)
make debug SVC=kelta-worker

# Then in IntelliJ: Run → kelta-worker (or open .run/kelta-worker.run.xml)
```

**One-time /etc/hosts setup** (documented in README):
```
127.0.0.1  kelta-auth
```

Required because `KELTA_AUTH_ISSUER_URI=http://kelta-auth:8080` is used everywhere for issuer URI consistency with `single-issuer=true` in the gateway.

**Secrets** (`JWK_SET`, `KELTA_ENCRYPTION_KEY`, `ANTHROPIC_API_KEY`) are stored as `$VAR$` macros in the XML — copy values from `.env` into the IntelliJ Run Configuration dialog.

## Test plan

- [ ] Open project in IntelliJ — all four `.run/` configs appear in the Run menu
- [ ] `make debug SVC=kelta-worker` stops the container
- [ ] Launch kelta-worker run config, set a breakpoint in a controller
- [ ] UI request hits the breakpoint
- [ ] Swap back: `docker compose up -d kelta-worker` restores container

🤖 Generated with [Claude Code](https://claude.com/claude-code)