### PR TITLE
fix(docker): update GraalVM native-image tag from ol9-java25 to 25-ol9

### DIFF
--- a/kelta-ai/Dockerfile
+++ b/kelta-ai/Dockerfile
@@ -2,7 +2,7 @@
 # Builder: GraalVM CE 25 + Maven  |  Runtime: debian:12-slim (no JRE needed)
 
 ARG MAVEN_VERSION=3.9.9
-ARG GRAALVM_IMAGE=ghcr.io/graalvm/native-image-community:ol9-java25
+ARG GRAALVM_IMAGE=ghcr.io/graalvm/native-image-community:25-ol9
 
 # =============================================================================
 # Stage 1: Build runtime-platform dependencies

--- a/kelta-gateway/Dockerfile
+++ b/kelta-gateway/Dockerfile
@@ -2,7 +2,7 @@
 # Builder: GraalVM CE 25 + Maven  |  Runtime: debian:12-slim (no JRE needed)
 
 ARG MAVEN_VERSION=3.9.9
-ARG GRAALVM_IMAGE=ghcr.io/graalvm/native-image-community:ol9-java25
+ARG GRAALVM_IMAGE=ghcr.io/graalvm/native-image-community:25-ol9
 
 # =============================================================================
 # Stage 1: Build runtime-platform dependencies

--- a/kelta-worker/Dockerfile
+++ b/kelta-worker/Dockerfile
@@ -2,7 +2,7 @@
 # Builder: GraalVM CE 25 + Maven  |  Runtime: debian:12-slim (no JRE needed)
 
 ARG MAVEN_VERSION=3.9.9
-ARG GRAALVM_IMAGE=ghcr.io/graalvm/native-image-community:ol9-java25
+ARG GRAALVM_IMAGE=ghcr.io/graalvm/native-image-community:25-ol9
 
 # =============================================================================
 # Stage 1: Build runtime-platform dependencies


### PR DESCRIPTION
## Summary
- Update GraalVM native-image base image tag in all three service Dockerfiles (gateway, worker, ai)
- `ghcr.io/graalvm/native-image-community:ol9-java25` → `ghcr.io/graalvm/native-image-community:25-ol9`

GraalVM changed their container tag naming convention. The old `ol9-java25` tag was removed; the equivalent image is published as `25-ol9`.

## Test plan
- [ ] CI passes (no native build in CI, but Dockerfiles parse correctly)
- [ ] AOT container build succeeds with the new tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)