### PR TITLE
fix(worker,gateway): revert V102 migration and add gRPC native-image reflection

### DIFF
--- a/kelta-ai/Dockerfile
+++ b/kelta-ai/Dockerfile
@@ -2,7 +2,7 @@
 # Builder: GraalVM CE 25 + Maven  |  Runtime: debian:12-slim (no JRE needed)
 
 ARG MAVEN_VERSION=3.9.9
-ARG GRAALVM_IMAGE=ghcr.io/graalvm/native-image-community:ol9-java25
+ARG GRAALVM_IMAGE=ghcr.io/graalvm/native-image-community:25-ol9
 
 # =============================================================================
 # Stage 1: Build runtime-platform dependencies

--- a/kelta-gateway/Dockerfile
+++ b/kelta-gateway/Dockerfile
@@ -2,7 +2,7 @@
 # Builder: GraalVM CE 25 + Maven  |  Runtime: debian:12-slim (no JRE needed)
 
 ARG MAVEN_VERSION=3.9.9
-ARG GRAALVM_IMAGE=ghcr.io/graalvm/native-image-community:ol9-java25
+ARG GRAALVM_IMAGE=ghcr.io/graalvm/native-image-community:25-ol9
 
 # =============================================================================
 # Stage 1: Build runtime-platform dependencies

--- a/kelta-gateway/src/main/resources/META-INF/native-image/io.kelta/kelta-gateway/reflect-config.json
+++ b/kelta-gateway/src/main/resources/META-INF/native-image/io.kelta/kelta-gateway/reflect-config.json
@@ -1,0 +1,8 @@
+[
+  {
+    "name": "io.grpc.netty.shaded.io.netty.channel.socket.nio.NioSocketChannel",
+    "methods": [
+      { "name": "<init>", "parameterTypes": [] }
+    ]
+  }
+]

--- a/kelta-worker/Dockerfile
+++ b/kelta-worker/Dockerfile
@@ -2,7 +2,7 @@
 # Builder: GraalVM CE 25 + Maven  |  Runtime: debian:12-slim (no JRE needed)
 
 ARG MAVEN_VERSION=3.9.9
-ARG GRAALVM_IMAGE=ghcr.io/graalvm/native-image-community:ol9-java25
+ARG GRAALVM_IMAGE=ghcr.io/graalvm/native-image-community:25-ol9
 
 # =============================================================================
 # Stage 1: Build runtime-platform dependencies

--- a/kelta-worker/src/main/resources/META-INF/native-image/io.kelta/kelta-worker/reflect-config.json
+++ b/kelta-worker/src/main/resources/META-INF/native-image/io.kelta/kelta-worker/reflect-config.json
@@ -1,0 +1,8 @@
+[
+  {
+    "name": "io.grpc.netty.shaded.io.netty.channel.socket.nio.NioSocketChannel",
+    "methods": [
+      { "name": "<init>", "parameterTypes": [] }
+    ]
+  }
+]

--- a/kelta-worker/src/main/resources/db/migration/V102__seed_default_admin_users.sql
+++ b/kelta-worker/src/main/resources/db/migration/V102__seed_default_admin_users.sql
@@ -7,7 +7,7 @@
 --
 -- Username: admin
 -- Email:    admin@kelta.local
--- Password: password (BCrypt-hashed, force_change_on_login = FALSE)
+-- Password: password (BCrypt-hashed, force_change_on_login = TRUE)
 
 DO $$
 DECLARE
@@ -43,10 +43,9 @@ BEGIN
         INSERT INTO platform_user (id, tenant_id, email, username, first_name, last_name, status, profile_id, created_at, updated_at)
         VALUES (new_user_id, t.id, 'admin@kelta.local', 'admin', 'System', 'Administrator', 'ACTIVE', admin_profile_id, NOW(), NOW());
 
-        -- Create user_credential with BCrypt hash of 'password'; no forced change so automated
-        -- tools (e.g. test harness, local dev) can authenticate immediately.
+        -- Create user_credential with BCrypt hash of 'password' and force change on first login
         INSERT INTO user_credential (id, user_id, password_hash, force_change_on_login, created_at)
-        VALUES (gen_random_uuid()::text, new_user_id, '$2a$10$zAQaSHX1XSR1bwUL3pz9EOzecplsxInVizZc9HwLf7xPluSiE1EP6', FALSE, NOW());
+        VALUES (gen_random_uuid()::text, new_user_id, '$2a$10$zAQaSHX1XSR1bwUL3pz9EOzecplsxInVizZc9HwLf7xPluSiE1EP6', TRUE, NOW());
 
         RAISE NOTICE 'Created default admin user for tenant % (%)', t.slug, t.id;
     END LOOP;

--- a/kelta-worker/src/main/resources/db/migration/V125__disable_forced_password_change_for_admin.sql
+++ b/kelta-worker/src/main/resources/db/migration/V125__disable_forced_password_change_for_admin.sql
@@ -1,0 +1,10 @@
+-- Disable forced password change for the default admin user so automated
+-- tools (e.g. test harness, local dev) can authenticate immediately
+-- without an interactive password-change flow.
+UPDATE user_credential
+SET    force_change_on_login = FALSE
+WHERE  user_id IN (
+    SELECT pu.id
+    FROM   platform_user pu
+    WHERE  pu.email = 'admin@kelta.local'
+);


### PR DESCRIPTION
## Summary
- Revert V102 migration to original (fixes Flyway checksum mismatch on worker)
- Add V125 migration to apply the `force_change_on_login = FALSE` change properly
- Add `reflect-config.json` for gateway and worker to register `NioSocketChannel` no-arg constructor for GraalVM native image

## Why

**Worker CrashLoopBackOff**: PR #725 modified the already-applied V102 migration, causing a Flyway checksum mismatch (`-1022025530` vs `275234460`). Flyway refuses to run until the migration matches.

**Gateway CrashLoopBackOff**: The Cerbos gRPC SDK uses shaded Netty (`io.grpc.netty.shaded.io.netty.channel.socket.nio.NioSocketChannel`) which requires reflective access to its no-arg constructor. GraalVM native image strips this by default, causing `NoSuchMethodException` at runtime.

## Test plan
- [ ] CI passes
- [ ] Worker starts without Flyway errors
- [ ] Gateway starts without gRPC/Netty reflection errors
- [ ] AOT container build succeeds with reflect-config

🤖 Generated with [Claude Code](https://claude.com/claude-code)