### PR TITLE
fix(worker): replace @Lazy with ObjectProvider for native image AOT

### DIFF
--- a/kelta-worker/src/main/java/io/kelta/worker/config/WorkerMetricsConfig.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/config/WorkerMetricsConfig.java
@@ -3,8 +3,8 @@ package io.kelta.worker.config;
 import io.kelta.worker.service.CollectionLifecycleManager;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Lazy;
 
 import java.lang.management.ManagementFactory;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -27,8 +27,13 @@ public class WorkerMetricsConfig {
 
     private final AtomicInteger initializingCount = new AtomicInteger(0);
 
+    // ObjectProvider instead of @Lazy to break the circular dependency with
+    // CollectionLifecycleManager. @Lazy creates a CGLIB proxy at runtime which
+    // is not supported in GraalVM native images. ObjectProvider defers resolution
+    // and is fully AOT-compatible.
     public WorkerMetricsConfig(MeterRegistry meterRegistry,
-                                @Lazy CollectionLifecycleManager lifecycleManager) {
+                                ObjectProvider<CollectionLifecycleManager> lifecycleManagerProvider) {
+        CollectionLifecycleManager lifecycleManager = lifecycleManagerProvider.getObject();
         // Active collections gauge — reads live count from the lifecycle manager
         Gauge.builder("kelta.worker.collections.active", lifecycleManager,
                         CollectionLifecycleManager::getActiveCollectionCount)

--- a/kelta-worker/src/main/java/io/kelta/worker/config/WorkerMetricsConfig.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/config/WorkerMetricsConfig.java
@@ -33,17 +33,18 @@ public class WorkerMetricsConfig {
     // and is fully AOT-compatible.
     public WorkerMetricsConfig(MeterRegistry meterRegistry,
                                 ObjectProvider<CollectionLifecycleManager> lifecycleManagerProvider) {
-        CollectionLifecycleManager lifecycleManager = lifecycleManagerProvider.getObject();
-        // Active collections gauge — reads live count from the lifecycle manager
-        Gauge.builder("kelta.worker.collections.active", lifecycleManager,
-                        CollectionLifecycleManager::getActiveCollectionCount)
+        // Active collections gauge — reads live count from the lifecycle manager.
+        // Uses the ObjectProvider lambda so resolution is deferred until the gauge
+        // is actually read, breaking the circular dependency with CollectionLifecycleManager.
+        Gauge.builder("kelta.worker.collections.active", lifecycleManagerProvider,
+                        p -> p.getObject().getActiveCollectionCount())
                 .description("Number of active collections hosted by this worker")
                 .register(meterRegistry);
 
         // HPA collection count gauge — same value, exposed as kelta_worker_collection_count
         // in Prometheus format for Kubernetes HPA custom metrics (target: 40 per pod)
-        Gauge.builder("kelta.worker.collection.count", lifecycleManager,
-                        CollectionLifecycleManager::getActiveCollectionCount)
+        Gauge.builder("kelta.worker.collection.count", lifecycleManagerProvider,
+                        p -> p.getObject().getActiveCollectionCount())
                 .description("Collection count for HPA scaling (target: 40 per pod)")
                 .register(meterRegistry);
 

--- a/kelta-worker/src/test/java/io/kelta/worker/config/WorkerMetricsConfigTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/config/WorkerMetricsConfigTest.java
@@ -6,6 +6,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -25,7 +26,11 @@ class WorkerMetricsConfigTest {
         lifecycleManager = mock(CollectionLifecycleManager.class);
         when(lifecycleManager.getActiveCollectionCount()).thenReturn(5);
 
-        metricsConfig = new WorkerMetricsConfig(meterRegistry, lifecycleManager);
+        @SuppressWarnings("unchecked")
+        ObjectProvider<CollectionLifecycleManager> provider = mock(ObjectProvider.class);
+        when(provider.getObject()).thenReturn(lifecycleManager);
+
+        metricsConfig = new WorkerMetricsConfig(meterRegistry, provider);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Replace `@Lazy CollectionLifecycleManager` with `ObjectProvider<CollectionLifecycleManager>` in `WorkerMetricsConfig`

## Why

`@Lazy` creates a CGLIB proxy at runtime. GraalVM native images don't support runtime CGLIB generation, causing:

```
UnsupportedOperationException: CGLIB runtime enhancement not supported on native image.
Make sure to enable Spring AOT processing to pre-generate
'CollectionLifecycleManager$$SpringCGLIB$$0' at build time.
```

`ObjectProvider<T>` defers bean resolution without a proxy — fully AOT-compatible and breaks the same circular dependency.

## Test plan
- [ ] CI passes
- [ ] Worker pod starts without AOT/CGLIB errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)