### PR TITLE
fix(native): add reflection and resource configs for native image

### DIFF
--- a/kelta-gateway/src/main/resources/META-INF/native-image/io.kelta/kelta-gateway/reflect-config.json
+++ b/kelta-gateway/src/main/resources/META-INF/native-image/io.kelta/kelta-gateway/reflect-config.json
@@ -4,5 +4,35 @@
     "methods": [
       { "name": "<init>", "parameterTypes": [] }
     ]
+  },
+  {
+    "name": "io.kelta.gateway.config.BootstrapConfig",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "io.kelta.gateway.config.CollectionConfig",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "io.kelta.gateway.config.FieldConfig",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "io.kelta.gateway.config.GovernorLimitConfig",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "com.google.api.FieldBehavior",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
   }
 ]

--- a/kelta-worker/src/main/resources/META-INF/native-image/io.kelta/kelta-worker/reflect-config.json
+++ b/kelta-worker/src/main/resources/META-INF/native-image/io.kelta/kelta-worker/reflect-config.json
@@ -4,5 +4,11 @@
     "methods": [
       { "name": "<init>", "parameterTypes": [] }
     ]
+  },
+  {
+    "name": "com.google.api.FieldBehavior",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
   }
 ]

--- a/kelta-worker/src/main/resources/META-INF/native-image/io.kelta/kelta-worker/resource-config.json
+++ b/kelta-worker/src/main/resources/META-INF/native-image/io.kelta/kelta-worker/resource-config.json
@@ -1,0 +1,9 @@
+{
+  "resources": {
+    "includes": [
+      {
+        "pattern": "db/migration/.*\\.sql$"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Register gateway bootstrap DTOs (`BootstrapConfig`, `CollectionConfig`, `FieldConfig`, `GovernorLimitConfig`) for Jackson reflection in native image — fixes route loading 503
- Register `com.google.api.FieldBehavior` for protobuf reflection in both gateway and worker — fixes Cerbos gRPC initialization
- Add `resource-config.json` for worker to include Flyway SQL migrations in native image — fixes `unsupported protocol: resource` scan error

## Test plan
- [ ] CI build passes (compilation, unit tests)
- [ ] Native image builds succeed for gateway and worker
- [ ] Gateway pod starts and passes readiness probe
- [ ] Worker pod starts, runs Flyway migrations, and passes readiness probe

🤖 Generated with [Claude Code](https://claude.com/claude-code)