### PR TITLE
fix(native): initialize protobuf at build time for native image

### DIFF
--- a/kelta-gateway/pom.xml
+++ b/kelta-gateway/pom.xml
@@ -369,6 +369,16 @@
                                 -->
                                 <buildArg>--initialize-at-build-time=ch.qos.logback</buildArg>
                                 <buildArg>--initialize-at-build-time=ch.qos.logback.classic.Logger</buildArg>
+                                <!--
+                                  Protobuf's descriptor system (GeneratedMessage.getMethodOrDie)
+                                  reflectively discovers accessor methods on generated message
+                                  classes during static initialization.  In native image, these
+                                  reflective calls fail because methods aren't registered.
+                                  Initializing protobuf at build time lets all descriptor
+                                  registration happen during the build where full JDK reflection
+                                  is available; results are captured in the image heap.
+                                -->
+                                <buildArg>--initialize-at-build-time=com.google.protobuf</buildArg>
                             </buildArgs>
                         </configuration>
                     </plugin>

--- a/kelta-gateway/src/main/resources/META-INF/native-image/io.kelta/kelta-gateway/reflect-config.json
+++ b/kelta-gateway/src/main/resources/META-INF/native-image/io.kelta/kelta-gateway/reflect-config.json
@@ -28,11 +28,5 @@
     "allDeclaredConstructors": true,
     "allDeclaredMethods": true,
     "allDeclaredFields": true
-  },
-  {
-    "name": "com.google.api.FieldBehavior",
-    "allDeclaredConstructors": true,
-    "allDeclaredMethods": true,
-    "allDeclaredFields": true
   }
 ]

--- a/kelta-worker/pom.xml
+++ b/kelta-worker/pom.xml
@@ -232,6 +232,12 @@
                                      build time; force logback to build-time init to resolve. -->
                                 <buildArg>--initialize-at-build-time=ch.qos.logback</buildArg>
                                 <buildArg>--initialize-at-build-time=ch.qos.logback.classic.Logger</buildArg>
+                                <!-- Protobuf descriptor system uses reflection to discover
+                                     accessor methods on generated message classes.  Build-time
+                                     init lets this happen during the build with full JDK
+                                     reflection, avoiding reflection registration for every
+                                     protobuf inner class. -->
+                                <buildArg>--initialize-at-build-time=com.google.protobuf</buildArg>
                             </buildArgs>
                         </configuration>
                     </plugin>

--- a/kelta-worker/src/main/resources/META-INF/native-image/io.kelta/kelta-worker/reflect-config.json
+++ b/kelta-worker/src/main/resources/META-INF/native-image/io.kelta/kelta-worker/reflect-config.json
@@ -4,11 +4,5 @@
     "methods": [
       { "name": "<init>", "parameterTypes": [] }
     ]
-  },
-  {
-    "name": "com.google.api.FieldBehavior",
-    "allDeclaredConstructors": true,
-    "allDeclaredMethods": true,
-    "allDeclaredFields": true
   }
 ]


### PR DESCRIPTION
## Summary
- Add `--initialize-at-build-time=com.google.protobuf` to both gateway and worker native profiles
- Protobuf's descriptor system uses `GeneratedMessage.getMethodOrDie` which reflectively calls `Class.getMethod()` on dozens of generated inner classes during static init — each missing class in reflect-config reveals the next (`FieldBehavior` → `DescriptorProtos$FeatureSet` → ...)
- Build-time init runs all protobuf descriptor registration during the native image build where full JDK reflection is available; results are captured in the image heap
- Removed now-redundant `com.google.api.FieldBehavior` entries from reflect-config.json

## Test plan
- [ ] CI build passes
- [ ] Native image builds succeed (gateway and worker)
- [ ] Gateway pod starts, loads routes from worker, passes readiness probe
- [ ] Worker pod starts, runs Flyway migrations, passes readiness probe
- [ ] No more `NoSuchMethodException` in pod logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)