### PR TITLE
fix(native): add build-time init for com.google.gson

### DIFF
--- a/kelta-gateway/pom.xml
+++ b/kelta-gateway/pom.xml
@@ -369,6 +369,16 @@
                                 -->
                                 <buildArg>--initialize-at-build-time=ch.qos.logback</buildArg>
                                 <buildArg>--initialize-at-build-time=ch.qos.logback.classic.Logger</buildArg>
+                                <!--
+                                  Protobuf's descriptor system (GeneratedMessage.getMethodOrDie)
+                                  reflectively discovers accessor methods on generated message
+                                  classes during static initialization.  In native image, these
+                                  reflective calls fail because methods aren't registered.
+                                  Initializing protobuf at build time lets all descriptor
+                                  registration happen during the build where full JDK reflection
+                                  is available; results are captured in the image heap.
+                                -->
+                                <buildArg>--initialize-at-build-time=com.google.protobuf</buildArg>
                             </buildArgs>
                         </configuration>
                     </plugin>

--- a/kelta-gateway/pom.xml
+++ b/kelta-gateway/pom.xml
@@ -379,6 +379,7 @@
                                   is available; results are captured in the image heap.
                                 -->
                                 <buildArg>--initialize-at-build-time=com.google.protobuf</buildArg>
+                                <buildArg>--initialize-at-build-time=com.google.gson</buildArg>
                             </buildArgs>
                         </configuration>
                     </plugin>

--- a/kelta-gateway/src/main/resources/META-INF/native-image/io.kelta/kelta-gateway/reflect-config.json
+++ b/kelta-gateway/src/main/resources/META-INF/native-image/io.kelta/kelta-gateway/reflect-config.json
@@ -28,11 +28,5 @@
     "allDeclaredConstructors": true,
     "allDeclaredMethods": true,
     "allDeclaredFields": true
-  },
-  {
-    "name": "com.google.api.FieldBehavior",
-    "allDeclaredConstructors": true,
-    "allDeclaredMethods": true,
-    "allDeclaredFields": true
   }
 ]

--- a/kelta-worker/pom.xml
+++ b/kelta-worker/pom.xml
@@ -238,6 +238,7 @@
                                      reflection, avoiding reflection registration for every
                                      protobuf inner class. -->
                                 <buildArg>--initialize-at-build-time=com.google.protobuf</buildArg>
+                                <buildArg>--initialize-at-build-time=com.google.gson</buildArg>
                             </buildArgs>
                         </configuration>
                     </plugin>

--- a/kelta-worker/pom.xml
+++ b/kelta-worker/pom.xml
@@ -232,6 +232,12 @@
                                      build time; force logback to build-time init to resolve. -->
                                 <buildArg>--initialize-at-build-time=ch.qos.logback</buildArg>
                                 <buildArg>--initialize-at-build-time=ch.qos.logback.classic.Logger</buildArg>
+                                <!-- Protobuf descriptor system uses reflection to discover
+                                     accessor methods on generated message classes.  Build-time
+                                     init lets this happen during the build with full JDK
+                                     reflection, avoiding reflection registration for every
+                                     protobuf inner class. -->
+                                <buildArg>--initialize-at-build-time=com.google.protobuf</buildArg>
                             </buildArgs>
                         </configuration>
                     </plugin>

--- a/kelta-worker/src/main/resources/META-INF/native-image/io.kelta/kelta-worker/reflect-config.json
+++ b/kelta-worker/src/main/resources/META-INF/native-image/io.kelta/kelta-worker/reflect-config.json
@@ -4,11 +4,5 @@
     "methods": [
       { "name": "<init>", "parameterTypes": [] }
     ]
-  },
-  {
-    "name": "com.google.api.FieldBehavior",
-    "allDeclaredConstructors": true,
-    "allDeclaredMethods": true,
-    "allDeclaredFields": true
   }
 ]


### PR DESCRIPTION
## Summary
- Add `--initialize-at-build-time=com.google.gson` to gateway and worker native profiles
- protobuf-java-util depends on Gson for JSON format — when protobuf is initialized at build time (#730), Gson objects end up in the image heap but Gson defaults to runtime init, causing a fatal `UnsupportedFeatureException` during native image generation

## Test plan
- [ ] CI passes
- [ ] Gateway native image builds successfully
- [ ] Worker native image builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)