### PR TITLE
fix(native): add build-time init for com.google.gson

### DIFF
--- a/kelta-gateway/pom.xml
+++ b/kelta-gateway/pom.xml
@@ -379,6 +379,9 @@
                                   is available; results are captured in the image heap.
                                 -->
                                 <buildArg>--initialize-at-build-time=com.google.protobuf</buildArg>
+                                <!-- protobuf-java-util depends on Gson for JSON format;
+                                     build-time protobuf init pulls Gson into the image heap. -->
+                                <buildArg>--initialize-at-build-time=com.google.gson</buildArg>
                             </buildArgs>
                         </configuration>
                     </plugin>

--- a/kelta-worker/pom.xml
+++ b/kelta-worker/pom.xml
@@ -238,6 +238,9 @@
                                      reflection, avoiding reflection registration for every
                                      protobuf inner class. -->
                                 <buildArg>--initialize-at-build-time=com.google.protobuf</buildArg>
+                                <!-- protobuf-java-util depends on Gson for JSON format;
+                                     build-time protobuf init pulls Gson into the image heap. -->
+                                <buildArg>--initialize-at-build-time=com.google.gson</buildArg>
                             </buildArgs>
                         </configuration>
                     </plugin>


### PR DESCRIPTION
## Summary
- Add `--initialize-at-build-time=com.google.gson` to gateway and worker native profiles
- protobuf-java-util depends on Gson for JSON format — when protobuf is initialized at build time (#730), Gson objects end up in the image heap but Gson defaults to runtime init, causing a fatal `UnsupportedFeatureException` during native image generation

## Test plan
- [ ] CI passes
- [ ] Gateway native image builds successfully
- [ ] Worker native image builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)