### PR TITLE
fix(native): add build-time init for all protobuf-generated packages

### DIFF
--- a/kelta-gateway/pom.xml
+++ b/kelta-gateway/pom.xml
@@ -379,9 +379,10 @@
                                   is available; results are captured in the image heap.
                                 -->
                                 <buildArg>--initialize-at-build-time=com.google.protobuf</buildArg>
-                                <!-- protobuf-java-util depends on Gson for JSON format;
-                                     build-time protobuf init pulls Gson into the image heap. -->
+                                <buildArg>--initialize-at-build-time=com.google.api</buildArg>
                                 <buildArg>--initialize-at-build-time=com.google.gson</buildArg>
+                                <buildArg>--initialize-at-build-time=dev.cerbos.api</buildArg>
+                                <buildArg>--initialize-at-build-time=build.buf.validate</buildArg>
                             </buildArgs>
                         </configuration>
                     </plugin>

--- a/kelta-worker/pom.xml
+++ b/kelta-worker/pom.xml
@@ -238,9 +238,10 @@
                                      reflection, avoiding reflection registration for every
                                      protobuf inner class. -->
                                 <buildArg>--initialize-at-build-time=com.google.protobuf</buildArg>
-                                <!-- protobuf-java-util depends on Gson for JSON format;
-                                     build-time protobuf init pulls Gson into the image heap. -->
+                                <buildArg>--initialize-at-build-time=com.google.api</buildArg>
                                 <buildArg>--initialize-at-build-time=com.google.gson</buildArg>
+                                <buildArg>--initialize-at-build-time=dev.cerbos.api</buildArg>
+                                <buildArg>--initialize-at-build-time=build.buf.validate</buildArg>
                             </buildArgs>
                         </configuration>
                     </plugin>


### PR DESCRIPTION
## Summary
- Add `--initialize-at-build-time` for `com.google.api`, `dev.cerbos.api`, and `build.buf.validate`
- `com.google.api.FieldBehavior` is in `proto-google-common-protos` (package `com.google.api`), NOT `com.google.protobuf` — PR #730 removed it from reflect-config assuming protobuf build-time init covered it
- Cerbos SDK contains generated proto classes in `dev.cerbos.api` and `build.buf.validate` that also use protobuf descriptor reflection
- All proto-generated packages now initialized at build time: `com.google.protobuf`, `com.google.api`, `com.google.gson`, `dev.cerbos.api`, `build.buf.validate`

## Test plan
- [ ] CI passes
- [ ] Native image builds succeed
- [ ] Worker pod starts without FieldBehavior/protobuf reflection errors
- [ ] Gateway pod starts and passes readiness probe

🤖 Generated with [Claude Code](https://claude.com/claude-code)