### PR TITLE
fix(native): add build-time init for all Cerbos SDK protobuf packages

### DIFF
--- a/kelta-gateway/pom.xml
+++ b/kelta-gateway/pom.xml
@@ -378,11 +378,17 @@
                                   registration happen during the build where full JDK reflection
                                   is available; results are captured in the image heap.
                                 -->
+                                <!--
+                                  All protobuf-generated packages (Cerbos SDK + transitive
+                                  deps) must be initialized at build time so their descriptor
+                                  registration (which uses reflection) runs during the build.
+                                -->
                                 <buildArg>--initialize-at-build-time=com.google.protobuf</buildArg>
                                 <buildArg>--initialize-at-build-time=com.google.api</buildArg>
                                 <buildArg>--initialize-at-build-time=com.google.gson</buildArg>
-                                <buildArg>--initialize-at-build-time=dev.cerbos.api</buildArg>
+                                <buildArg>--initialize-at-build-time=dev.cerbos</buildArg>
                                 <buildArg>--initialize-at-build-time=build.buf.validate</buildArg>
+                                <buildArg>--initialize-at-build-time=grpc.gateway</buildArg>
                             </buildArgs>
                         </configuration>
                     </plugin>

--- a/kelta-worker/pom.xml
+++ b/kelta-worker/pom.xml
@@ -237,11 +237,17 @@
                                      init lets this happen during the build with full JDK
                                      reflection, avoiding reflection registration for every
                                      protobuf inner class. -->
+                                <!--
+                                  All protobuf-generated packages (Cerbos SDK + transitive
+                                  deps) must be initialized at build time so their descriptor
+                                  registration (which uses reflection) runs during the build.
+                                -->
                                 <buildArg>--initialize-at-build-time=com.google.protobuf</buildArg>
                                 <buildArg>--initialize-at-build-time=com.google.api</buildArg>
                                 <buildArg>--initialize-at-build-time=com.google.gson</buildArg>
-                                <buildArg>--initialize-at-build-time=dev.cerbos.api</buildArg>
+                                <buildArg>--initialize-at-build-time=dev.cerbos</buildArg>
                                 <buildArg>--initialize-at-build-time=build.buf.validate</buildArg>
+                                <buildArg>--initialize-at-build-time=grpc.gateway</buildArg>
                             </buildArgs>
                         </configuration>
                     </plugin>


### PR DESCRIPTION
## Summary
- Add `--initialize-at-build-time=grpc.gateway` for OpenAPI v2 protobuf annotations in Cerbos SDK
- Broaden `dev.cerbos.api` to `dev.cerbos` to also cover `dev.cerbos.sdk` and `dev.cerbos.sdk.builders`
- Complete list of build-time init packages now covers every protobuf-generated package in the Cerbos SDK dependency tree:
  - `com.google.protobuf`, `com.google.api`, `com.google.gson`
  - `dev.cerbos`, `build.buf.validate`, `grpc.gateway`

## Test plan
- [ ] CI passes
- [ ] Gateway and worker native image builds succeed
- [ ] Pods start and pass readiness probes

🤖 Generated with [Claude Code](https://claude.com/claude-code)