### PR TITLE
chore(worker): run Flyway migrations via K8s PreSync Job

### DIFF
--- a/.github/workflows/build-and-publish-containers.yml
+++ b/.github/workflows/build-and-publish-containers.yml
@@ -246,6 +246,11 @@ jobs:
                 sed -i "s|image: .*${PREFIX}-worker:.*|image: harbor.rzware.com/emf/${PREFIX}-worker:${IMAGE_TAG}|g" "$DIR/worker-deployment.yaml"
               fi
 
+              # Update worker migration Job (PreSync hook — must stay in sync with Deployment image)
+              if [ -f "$DIR/worker-migrate-job.yaml" ]; then
+                sed -i "s|image: .*${PREFIX}-worker:.*|image: harbor.rzware.com/emf/${PREFIX}-worker:${IMAGE_TAG}|g" "$DIR/worker-migrate-job.yaml"
+              fi
+
               # Update auth server deployment
               if [ -f "$DIR/auth-deployment.yaml" ]; then
                 sed -i "s|image: .*${PREFIX}-auth:.*|image: harbor.rzware.com/emf/${PREFIX}-auth:${IMAGE_TAG}|g" "$DIR/auth-deployment.yaml"

--- a/kelta-test-harness/src/test/java/io/kelta/testharness/KeltaStack.java
+++ b/kelta-test-harness/src/test/java/io/kelta/testharness/KeltaStack.java
@@ -137,6 +137,7 @@ public final class KeltaStack {
             .withEnv("SMTP_AUTH",                  "false")
             .withEnv("SMTP_STARTTLS",              "false")
             .withEnv("SCHEDULER_ENABLED",          "false")
+            .withEnv("SPRING_FLYWAY_ENABLED",      "true")   // disabled by default (K8s PreSync Job); re-enable for the test harness
             .withExposedPorts(8080)
             .waitingFor(Wait.forHttp("/actuator/health").withStartupTimeout(Duration.ofMinutes(3)));
 

--- a/kelta-worker/src/main/java/io/kelta/worker/config/NatsSubscriptionConfig.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/config/NatsSubscriptionConfig.java
@@ -14,6 +14,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 
 /**
  * Registers all worker NATS subscriptions with the {@link NatsSubscriptionManager}.
@@ -25,6 +26,7 @@ import org.springframework.context.annotation.Configuration;
  * @since 1.0.0
  */
 @Configuration
+@Profile("!migrate")
 public class NatsSubscriptionConfig {
 
     private static final Logger log = LoggerFactory.getLogger(NatsSubscriptionConfig.class);

--- a/kelta-worker/src/main/resources/application-migrate.yml
+++ b/kelta-worker/src/main/resources/application-migrate.yml
@@ -1,0 +1,10 @@
+# Active when SPRING_PROFILES_ACTIVE=migrate (K8s PreSync Job only).
+# Enables Flyway and runs ApplicationRunners (SystemCollectionSeeder), then exits.
+# Worker pods run with the default profile where flyway.enabled=false.
+spring:
+  flyway:
+    enabled: true
+    baseline-on-migrate: true
+    baseline-version: 0
+  main:
+    web-application-type: none   # no HTTP server — process exits after ApplicationRunners complete

--- a/kelta-worker/src/main/resources/application.yml
+++ b/kelta-worker/src/main/resources/application.yml
@@ -14,7 +14,7 @@ spring:
     password: ${SPRING_DATASOURCE_PASSWORD:kelta}
     driver-class-name: org.postgresql.Driver
   flyway:
-    enabled: true
+    enabled: false   # migrations run via K8s PreSync Job (application-migrate.yml re-enables)
     baseline-on-migrate: true
     baseline-version: 0
   data:


### PR DESCRIPTION
## Summary
- Disables Flyway in the worker's default Spring profile — migrations no longer run 3× (once per replica) on every deploy
- Adds an `application-migrate.yml` profile that re-enables Flyway with `web-application-type=none`, causing the process to exit cleanly after migrations and `SystemCollectionSeeder` complete
- Annotates `NatsSubscriptionConfig` with `@Profile("!migrate")` so NATS work-queue subscriptions are skipped during the one-shot migration Job
- Updates CI to bump the migration Job image tag in homelab-argo alongside the worker Deployment

## Changes
- `kelta-worker/src/main/resources/application.yml` — `spring.flyway.enabled: false`
- `kelta-worker/src/main/resources/application-migrate.yml` (new) — migrate profile: Flyway enabled + `web-application-type=none`
- `kelta-worker/src/main/java/io/kelta/worker/config/NatsSubscriptionConfig.java` — `@Profile("!migrate")`
- `.github/workflows/build-and-publish-containers.yml` — bump image tag in `worker-migrate-job.yaml`

## Testing
- Worker tests pass with Flyway disabled (tests mock the DataSource / use H2)
- Companion PR in homelab-argo adds the `worker-migrate-job.yaml` K8s Job with `argocd.argoproj.io/hook: PreSync`; ArgoCD will run it before the Deployment rolls out on next sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)