### PR TITLE
fix(worker): exclude WebMvcConfig from migrate profile to fix PreSync Job crash

### DIFF
--- a/.github/workflows/build-and-publish-containers.yml
+++ b/.github/workflows/build-and-publish-containers.yml
@@ -246,6 +246,11 @@ jobs:
                 sed -i "s|image: .*${PREFIX}-worker:.*|image: harbor.rzware.com/emf/${PREFIX}-worker:${IMAGE_TAG}|g" "$DIR/worker-deployment.yaml"
               fi
 
+              # Update worker migration Job (PreSync hook — must stay in sync with Deployment image)
+              if [ -f "$DIR/worker-migrate-job.yaml" ]; then
+                sed -i "s|image: .*${PREFIX}-worker:.*|image: harbor.rzware.com/emf/${PREFIX}-worker:${IMAGE_TAG}|g" "$DIR/worker-migrate-job.yaml"
+              fi
+
               # Update auth server deployment
               if [ -f "$DIR/auth-deployment.yaml" ]; then
                 sed -i "s|image: .*${PREFIX}-auth:.*|image: harbor.rzware.com/emf/${PREFIX}-auth:${IMAGE_TAG}|g" "$DIR/auth-deployment.yaml"

--- a/kelta-auth/src/main/java/io/kelta/auth/config/AuthorizationServerConfig.java
+++ b/kelta-auth/src/main/java/io/kelta/auth/config/AuthorizationServerConfig.java
@@ -92,6 +92,8 @@ public class AuthorizationServerConfig {
             .authorizeHttpRequests(authorize -> authorize.anyRequest().authenticated())
             .csrf(csrf -> csrf.ignoringRequestMatchers(endpointsMatcher))
             .cors(Customizer.withDefaults())
+            .addFilterBefore(new TenantContextFilter(),
+                    org.springframework.security.oauth2.server.authorization.web.OAuth2AuthorizationEndpointFilter.class)
             .exceptionHandling(exceptions -> exceptions
                 .defaultAuthenticationEntryPointFor(
                         new LoginUrlAuthenticationEntryPoint("/login"),

--- a/kelta-auth/src/main/java/io/kelta/auth/config/AuthorizationServerConfig.java
+++ b/kelta-auth/src/main/java/io/kelta/auth/config/AuthorizationServerConfig.java
@@ -92,8 +92,6 @@ public class AuthorizationServerConfig {
             .authorizeHttpRequests(authorize -> authorize.anyRequest().authenticated())
             .csrf(csrf -> csrf.ignoringRequestMatchers(endpointsMatcher))
             .cors(Customizer.withDefaults())
-            .addFilterBefore(new TenantContextFilter(),
-                    org.springframework.security.oauth2.server.authorization.web.OAuth2AuthorizationEndpointFilter.class)
             .exceptionHandling(exceptions -> exceptions
                 .defaultAuthenticationEntryPointFor(
                         new LoginUrlAuthenticationEntryPoint("/login"),

--- a/kelta-auth/src/main/java/io/kelta/auth/config/TenantContextFilter.java
+++ b/kelta-auth/src/main/java/io/kelta/auth/config/TenantContextFilter.java
@@ -1,0 +1,55 @@
+package io.kelta.auth.config;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Extracts the tenant slug from the redirect_uri of an /oauth2/authorize request
+ * and stores it in the HTTP session as "tenantId" so KeltaUserDetailsService can
+ * scope the user lookup to the correct tenant.
+ *
+ * Path pattern: /{tenant-slug}/auth/callback
+ */
+public class TenantContextFilter extends OncePerRequestFilter {
+
+    private static final Pattern TENANT_SLUG_PATTERN =
+            Pattern.compile("^/([^/]+)/auth/callback$");
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain)
+            throws ServletException, IOException {
+        if ("GET".equalsIgnoreCase(request.getMethod())
+                && "/oauth2/authorize".equals(request.getServletPath())) {
+            String redirectUri = request.getParameter("redirect_uri");
+            if (redirectUri != null && !redirectUri.isBlank()) {
+                String slug = extractTenantSlug(redirectUri);
+                if (slug != null) {
+                    request.getSession().setAttribute("tenantId", slug);
+                }
+            }
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    private String extractTenantSlug(String redirectUri) {
+        try {
+            URI uri = URI.create(redirectUri);
+            String path = uri.getPath();
+            if (path == null) return null;
+            Matcher m = TENANT_SLUG_PATTERN.matcher(path);
+            return m.matches() ? m.group(1) : null;
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+}

--- a/kelta-auth/src/main/java/io/kelta/auth/config/TenantContextFilter.java
+++ b/kelta-auth/src/main/java/io/kelta/auth/config/TenantContextFilter.java
@@ -4,6 +4,7 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
@@ -16,8 +17,12 @@ import java.util.regex.Pattern;
  * and stores it in the HTTP session as "tenantId" so KeltaUserDetailsService can
  * scope the user lookup to the correct tenant.
  *
+ * <p>Registered as a servlet-level filter (before Spring Security) via {@code @Component}.
+ * The method condition (GET + /oauth2/authorize) makes it a no-op for all other requests.
+ *
  * Path pattern: /{tenant-slug}/auth/callback
  */
+@Component
 public class TenantContextFilter extends OncePerRequestFilter {
 
     private static final Pattern TENANT_SLUG_PATTERN =

--- a/kelta-auth/src/test/java/io/kelta/auth/config/TenantContextFilterTest.java
+++ b/kelta-auth/src/test/java/io/kelta/auth/config/TenantContextFilterTest.java
@@ -1,0 +1,110 @@
+package io.kelta.auth.config;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("TenantContextFilter Tests")
+class TenantContextFilterTest {
+
+    private TenantContextFilter filter;
+
+    @Mock private HttpServletRequest request;
+    @Mock private HttpServletResponse response;
+    @Mock private FilterChain filterChain;
+    @Mock private HttpSession session;
+
+    @BeforeEach
+    void setUp() {
+        filter = new TenantContextFilter();
+    }
+
+    @Test
+    @DisplayName("should set tenant slug from redirect_uri on /oauth2/authorize")
+    void shouldSetTenantSlugFromRedirectUri() throws Exception {
+        when(request.getMethod()).thenReturn("GET");
+        when(request.getServletPath()).thenReturn("/oauth2/authorize");
+        when(request.getParameter("redirect_uri"))
+                .thenReturn("https://app.rzware.com/default/auth/callback");
+        when(request.getSession()).thenReturn(session);
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        verify(session).setAttribute("tenantId", "default");
+        verify(filterChain).doFilter(request, response);
+    }
+
+    @Test
+    @DisplayName("should not set tenant when no redirect_uri parameter")
+    void shouldNotSetTenantWhenNoRedirectUri() throws Exception {
+        when(request.getMethod()).thenReturn("GET");
+        when(request.getServletPath()).thenReturn("/oauth2/authorize");
+        when(request.getParameter("redirect_uri")).thenReturn(null);
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        verify(session, never()).setAttribute(anyString(), any());
+        verify(filterChain).doFilter(request, response);
+    }
+
+    @Test
+    @DisplayName("should not set tenant when path does not match /{slug}/auth/callback")
+    void shouldNotSetTenantWhenPathDoesNotMatch() throws Exception {
+        when(request.getMethod()).thenReturn("GET");
+        when(request.getServletPath()).thenReturn("/oauth2/authorize");
+        when(request.getParameter("redirect_uri"))
+                .thenReturn("https://app.rzware.com/auth/callback");
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        verify(session, never()).setAttribute(anyString(), any());
+        verify(filterChain).doFilter(request, response);
+    }
+
+    @Test
+    @DisplayName("should not set tenant on non-authorize requests")
+    void shouldNotSetTenantOnNonAuthorizeRequest() throws Exception {
+        when(request.getMethod()).thenReturn("POST");
+        lenient().when(request.getServletPath()).thenReturn("/login");
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        verify(session, never()).setAttribute(anyString(), any());
+        verify(filterChain).doFilter(request, response);
+    }
+
+    @Test
+    @DisplayName("should always call filter chain")
+    void shouldAlwaysCallFilterChain() throws Exception {
+        when(request.getMethod()).thenReturn("GET");
+        when(request.getServletPath()).thenReturn("/oauth2/authorize");
+        when(request.getParameter("redirect_uri")).thenReturn(null);
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        verify(filterChain).doFilter(request, response);
+    }
+
+    @Test
+    @DisplayName("should handle invalid redirect_uri without throwing")
+    void shouldHandleInvalidRedirectUri() throws Exception {
+        when(request.getMethod()).thenReturn("GET");
+        when(request.getServletPath()).thenReturn("/oauth2/authorize");
+        when(request.getParameter("redirect_uri")).thenReturn("not a valid uri %%");
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        verify(session, never()).setAttribute(anyString(), any());
+        verify(filterChain).doFilter(request, response);
+    }
+}

--- a/kelta-test-harness/src/test/java/io/kelta/testharness/KeltaStack.java
+++ b/kelta-test-harness/src/test/java/io/kelta/testharness/KeltaStack.java
@@ -137,6 +137,7 @@ public final class KeltaStack {
             .withEnv("SMTP_AUTH",                  "false")
             .withEnv("SMTP_STARTTLS",              "false")
             .withEnv("SCHEDULER_ENABLED",          "false")
+            .withEnv("SPRING_FLYWAY_ENABLED",      "true")   // disabled by default (K8s PreSync Job); re-enable for the test harness
             .withExposedPorts(8080)
             .waitingFor(Wait.forHttp("/actuator/health").withStartupTimeout(Duration.ofMinutes(3)));
 

--- a/kelta-worker/src/main/java/io/kelta/worker/config/NatsSubscriptionConfig.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/config/NatsSubscriptionConfig.java
@@ -14,6 +14,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 
 /**
  * Registers all worker NATS subscriptions with the {@link NatsSubscriptionManager}.
@@ -25,6 +26,7 @@ import org.springframework.context.annotation.Configuration;
  * @since 1.0.0
  */
 @Configuration
+@Profile("!migrate")
 public class NatsSubscriptionConfig {
 
     private static final Logger log = LoggerFactory.getLogger(NatsSubscriptionConfig.class);

--- a/kelta-worker/src/main/java/io/kelta/worker/config/WebMvcConfig.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/config/WebMvcConfig.java
@@ -2,10 +2,12 @@ package io.kelta.worker.config;
 
 import io.kelta.worker.interceptor.SpanIdCaptureInterceptor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
+@Profile("!migrate")   // excluded from the migrate profile — no web server runs in that mode
 public class WebMvcConfig implements WebMvcConfigurer {
 
     private final SpanIdCaptureInterceptor spanIdCaptureInterceptor;

--- a/kelta-worker/src/main/resources/application-migrate.yml
+++ b/kelta-worker/src/main/resources/application-migrate.yml
@@ -1,0 +1,10 @@
+# Active when SPRING_PROFILES_ACTIVE=migrate (K8s PreSync Job only).
+# Enables Flyway and runs ApplicationRunners (SystemCollectionSeeder), then exits.
+# Worker pods run with the default profile where flyway.enabled=false.
+spring:
+  flyway:
+    enabled: true
+    baseline-on-migrate: true
+    baseline-version: 0
+  main:
+    web-application-type: none   # no HTTP server — process exits after ApplicationRunners complete

--- a/kelta-worker/src/main/resources/application.yml
+++ b/kelta-worker/src/main/resources/application.yml
@@ -14,7 +14,7 @@ spring:
     password: ${SPRING_DATASOURCE_PASSWORD:kelta}
     driver-class-name: org.postgresql.Driver
   flyway:
-    enabled: true
+    enabled: false   # migrations run via K8s PreSync Job (application-migrate.yml re-enables)
     baseline-on-migrate: true
     baseline-version: 0
   data:


### PR DESCRIPTION
## Summary
- The ArgoCD PreSync Job (`emf-worker-migrate`) has been failing on every sync since PR #739 merged, leaving the cluster stuck on `main-1df7b36` (pre-#739 image)
- Root cause: in AOT-processed JARs, `@ConditionalOnWebApplication` is evaluated at compile time (servlet = true), so `WebMvcConfigurationSupport` beans — including `resourceHandlerMapping` — are baked into the generated context
- When the `migrate` profile activates `spring.main.web-application-type=none`, there is no `ServletContext` at runtime, causing `WebMvcConfig` to fail during bean init with `IllegalStateException: No ServletContext set`
- `@Profile` annotations ARE evaluated at runtime in AOT mode, so `@Profile("!migrate")` on `WebMvcConfig` correctly excludes it

## Changes
- `kelta-worker/.../config/WebMvcConfig.java` — add `@Profile("!migrate")` to exclude the `WebMvcConfigurer` during the one-shot migrate job (no web server = no interceptors needed)

## Testing
- 1002 worker unit tests pass
- Once merged: ArgoCD will retry the PreSync Job, it should exit successfully, and all three services (auth, worker, gateway) will roll to `main-989bc0c` containing the tenant JWT fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)