### PR TITLE
fix(worker): exclude WebMvc/Security autoconfiguration from migrate profile

### DIFF
--- a/kelta-auth/src/main/java/io/kelta/auth/config/AuthorizationServerConfig.java
+++ b/kelta-auth/src/main/java/io/kelta/auth/config/AuthorizationServerConfig.java
@@ -92,6 +92,8 @@ public class AuthorizationServerConfig {
             .authorizeHttpRequests(authorize -> authorize.anyRequest().authenticated())
             .csrf(csrf -> csrf.ignoringRequestMatchers(endpointsMatcher))
             .cors(Customizer.withDefaults())
+            .addFilterBefore(new TenantContextFilter(),
+                    org.springframework.security.oauth2.server.authorization.web.OAuth2AuthorizationEndpointFilter.class)
             .exceptionHandling(exceptions -> exceptions
                 .defaultAuthenticationEntryPointFor(
                         new LoginUrlAuthenticationEntryPoint("/login"),

--- a/kelta-auth/src/main/java/io/kelta/auth/config/AuthorizationServerConfig.java
+++ b/kelta-auth/src/main/java/io/kelta/auth/config/AuthorizationServerConfig.java
@@ -92,8 +92,6 @@ public class AuthorizationServerConfig {
             .authorizeHttpRequests(authorize -> authorize.anyRequest().authenticated())
             .csrf(csrf -> csrf.ignoringRequestMatchers(endpointsMatcher))
             .cors(Customizer.withDefaults())
-            .addFilterBefore(new TenantContextFilter(),
-                    org.springframework.security.oauth2.server.authorization.web.OAuth2AuthorizationEndpointFilter.class)
             .exceptionHandling(exceptions -> exceptions
                 .defaultAuthenticationEntryPointFor(
                         new LoginUrlAuthenticationEntryPoint("/login"),

--- a/kelta-worker/src/main/resources/application-migrate.yml
+++ b/kelta-worker/src/main/resources/application-migrate.yml
@@ -8,3 +8,9 @@ spring:
     baseline-version: 0
   main:
     web-application-type: none   # no HTTP server — process exits after ApplicationRunners complete
+  autoconfigure:
+    exclude:
+      - org.springframework.boot.autoconfigure.web.servlet.WebMvcAutoConfiguration
+      - org.springframework.boot.autoconfigure.web.servlet.error.ErrorMvcAutoConfiguration
+      - org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration
+      - org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration


### PR DESCRIPTION
## Summary
- The `emf-worker-migrate` PreSync Job was crashing with `No ServletContext set` from `WebMvcConfigurationSupport.resourceHandlerMapping`
- Root cause: AOT compiles `WebMvcAutoConfiguration` into the bean factory at build time (default profile = servlet app). At runtime with `migrate` profile, `web-application-type: none` prevents the HTTP server but does **not** stop AOT-registered beans like `resourceHandlerMapping` from instantiating — which fails because there is no `ServletContext`
- Explicitly excluding the servlet/security auto-configurations via `spring.autoconfigure.exclude` causes them to be filtered out even in AOT mode

## Changes
- `kelta-worker/src/main/resources/application-migrate.yml` — added `spring.autoconfigure.exclude` for `WebMvcAutoConfiguration`, `ErrorMvcAutoConfiguration`, `SecurityAutoConfiguration`, and `SecurityFilterAutoConfiguration`

## Testing
- Observed pod logs confirming the crash; fix targets the exact stack frame (`WebMvcConfigurationSupport.resourceHandlerMapping`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)