### PR TITLE
fix(gateway): decouple internal kelta-auth issuer from OIDC_ISSUER_URI

### DIFF
--- a/kelta-gateway/src/main/java/io/kelta/gateway/config/SecurityConfig.java
+++ b/kelta-gateway/src/main/java/io/kelta/gateway/config/SecurityConfig.java
@@ -42,6 +42,9 @@ public class SecurityConfig {
     @Value("${spring.security.oauth2.resourceserver.jwt.issuer-uri}")
     private String issuerUri;
 
+    @Value("${kelta.gateway.security.internal-issuer-uri:#{null}}")
+    private String internalIssuerUri;
+
     @Value("${kelta.gateway.worker-service-url:http://kelta-worker:80}")
     private String workerServiceUrl;
 
@@ -125,7 +128,13 @@ public class SecurityConfig {
         WebClient workerClient = WebClient.builder()
                 .baseUrl(workerServiceUrl)
                 .build();
-        return new DynamicReactiveJwtDecoder(workerClient, redisTemplate, issuerUri,
+        // Use the dedicated internal-issuer-uri for the kelta-auth JWKS shortcut so it
+        // works even when OIDC_ISSUER_URI points to an external provider (e.g. Authentik).
+        String fallback = (internalIssuerUri != null && !internalIssuerUri.isBlank()) ? internalIssuerUri : issuerUri;
+        if (!fallback.equals(issuerUri)) {
+            log.info("Gateway internal kelta-auth issuer: {} (primary OIDC: {})", fallback, issuerUri);
+        }
+        return new DynamicReactiveJwtDecoder(workerClient, redisTemplate, fallback,
                 Duration.ofSeconds(jwtClockSkewSeconds));
     }
 }

--- a/kelta-gateway/src/main/resources/application.yml
+++ b/kelta-gateway/src/main/resources/application.yml
@@ -78,6 +78,10 @@ kelta:
     security:
       jwt-clock-skew-seconds: 30   # Tolerance for clock drift between gateway and IdP
       single-issuer: ${SINGLE_ISSUER:true}   # When true, all tokens must come from kelta-auth (recommended)
+      # Internal kelta-auth issuer URI — used for the JWKS shortcut so kelta-auth tokens
+      # always validate without a worker DB lookup, even when OIDC_ISSUER_URI points to
+      # an external provider (e.g. Authentik). Defaults to OIDC_ISSUER_URI if not set.
+      internal-issuer-uri: ${KELTA_AUTH_ISSUER_URI:${OIDC_ISSUER_URI:http://localhost:8080}}
       permissions-enabled: ${PERMISSIONS_ENABLED:true}   # Object-level permission enforcement (default: enabled)
       permissions-cache-ttl-minutes: ${PERMISSIONS_CACHE_TTL:5}   # Redis cache TTL for resolved permissions
       # Paths accessible without authentication (GET/HEAD only).


### PR DESCRIPTION
## Summary
- Kelta-auth tokens (iss=`https://auth.rzware.com`) were 401'ing because the internal-issuer JWKS shortcut in `DynamicReactiveJwtDecoder` only fires when `fallbackIssuerUri` matches the token's issuer. Previously that was driven off `OIDC_ISSUER_URI`, so pointing the primary OIDC at Authentik broke the shortcut for internal-login tokens and dropped them into the worker OIDC provider lookup (which returns 404 for kelta-auth).
- Adds a dedicated `kelta.gateway.security.internal-issuer-uri` property (env: `KELTA_AUTH_ISSUER_URI`) so kelta-auth tokens validate via the well-known `/oauth2/jwks` regardless of the primary OIDC.
- Companion change in `homelab-argo` sets `KELTA_AUTH_ISSUER_URI=https://auth.rzware.com` in the gateway configmap.

## Test plan
- [x] `mvn verify -f kelta-gateway/pom.xml` — 423 tests pass
- [x] `mvn verify -f kelta-worker/pom.xml` — 1002 tests pass
- [ ] After deploy, log in via kelta-auth and confirm `/default/api/me/permissions` returns 200
- [ ] Authentik SSO login path still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)