### PR TITLE
fix(tenant-isolation): fail closed on blank tenant context at DB layer

### DIFF
--- a/kelta-worker/pom.xml
+++ b/kelta-worker/pom.xml
@@ -37,6 +37,16 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <!-- Testcontainers BOM for postgresql + junit-jupiter modules
+                 used by TenantIsolationIT. Version aligned with the platform
+                 BOM so it matches the rest of the codebase. -->
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>testcontainers-bom</artifactId>
+                <version>1.20.4</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <!-- Override protobuf version to resolve conflict between
                  Cerbos SDK (4.26.1) and OTLP metrics registry (gencode 4.32.0) -->
             <dependency>
@@ -214,6 +224,17 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- Testcontainers for tenant isolation integration tests. -->
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/kelta-worker/src/main/java/io/kelta/worker/config/FlywayConfig.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/config/FlywayConfig.java
@@ -1,0 +1,25 @@
+package io.kelta.worker.config;
+
+import io.kelta.runtime.context.TenantContext;
+import org.springframework.boot.flyway.autoconfigure.FlywayMigrationStrategy;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Binds the {@link TenantContext} platform sentinel around Flyway's migration run
+ * so the wrapped {@code TenantAwareDataSource} can fail closed on a blank tenant
+ * context without breaking the migration step at boot.
+ *
+ * <p>Flyway executes DDL that is not subject to Row Level Security, but every
+ * connection it checks out from the pool still runs
+ * {@code SET app.current_tenant_id = '…'} — that value must be {@code __platform__}
+ * so the {@code platform_bypass} policy matches when any migration issues DML.
+ */
+@Configuration
+public class FlywayConfig {
+
+    @Bean
+    public FlywayMigrationStrategy flywayPlatformContextStrategy() {
+        return flyway -> TenantContext.runAsPlatform(flyway::migrate);
+    }
+}

--- a/kelta-worker/src/main/java/io/kelta/worker/config/ModuleConfig.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/config/ModuleConfig.java
@@ -1,5 +1,6 @@
 package io.kelta.worker.config;
 
+import io.kelta.runtime.context.TenantContext;
 import io.kelta.runtime.formula.FormulaEvaluator;
 import io.kelta.runtime.module.ModuleStore;
 import io.kelta.runtime.query.QueryEngine;
@@ -87,13 +88,18 @@ public class ModuleConfig {
      */
     @EventListener(ApplicationReadyEvent.class)
     public void onApplicationReady(ApplicationReadyEvent event) {
-        try {
-            RuntimeModuleManager manager = event.getApplicationContext()
-                .getBean(RuntimeModuleManager.class);
-            log.info("Loading active runtime modules on startup...");
-            manager.loadAllActiveModules();
-        } catch (Exception e) {
-            log.warn("Could not load runtime modules on startup: {}", e.getMessage());
-        }
+        // Reading all active modules is an explicit cross-tenant operation;
+        // bind the platform sentinel so RLS allows the query without falling
+        // back to a blank tenant context.
+        TenantContext.runAsPlatform(() -> {
+            try {
+                RuntimeModuleManager manager = event.getApplicationContext()
+                    .getBean(RuntimeModuleManager.class);
+                log.info("Loading active runtime modules on startup...");
+                manager.loadAllActiveModules();
+            } catch (Exception e) {
+                log.warn("Could not load runtime modules on startup: {}", e.getMessage());
+            }
+        });
     }
 }

--- a/kelta-worker/src/main/java/io/kelta/worker/config/TenantAwareDataSourceConfig.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/config/TenantAwareDataSourceConfig.java
@@ -15,22 +15,31 @@ import java.sql.SQLException;
 import java.sql.Statement;
 
 /**
- * Configures a tenant-aware DataSource wrapper that sets the PostgreSQL session variable
- * {@code app.current_tenant_id} on each connection obtained from the pool.
+ * Configures a tenant-aware {@link DataSource} that binds the PostgreSQL session
+ * variable {@code app.current_tenant_id} on every connection checkout, so Row
+ * Level Security policies on shared system tables filter rows by tenant.
  *
- * <p>This enables Row Level Security (RLS) policies on shared system tables to enforce
- * tenant isolation at the database level. RLS policies use
- * {@code current_setting('app.current_tenant_id', true)} to filter rows by tenant.
+ * <h3>Fail-closed semantics</h3>
  *
- * <p>The tenant ID is read from {@link TenantContext} (ThreadLocal), which is set by
- * the DynamicCollectionRouter from the {@code X-Tenant-ID} request header.
+ * If {@link TenantContext#get()} is {@code null} or blank at checkout time this
+ * wrapper throws {@link IllegalStateException}. That guarantees no connection
+ * ever reaches application code while bound to a permissive fallback value —
+ * callers that legitimately operate across tenants must opt in explicitly via
+ * {@link TenantContext#runAsPlatform(Runnable)}, which binds the reserved
+ * {@code __platform__} sentinel.
  *
- * <p>When no tenant context is set (e.g., during Flyway migrations or internal operations),
- * the variable is set to an empty string, which matches the {@code admin_bypass} RLS policy.
+ * <p>Combined with the {@code platform_bypass} RLS policy introduced in the
+ * V126 migration (which matches only that sentinel), blank or forgotten tenant
+ * contexts cannot silently leak data across tenants.
  *
- * <p>Uses a {@link BeanPostProcessor} to wrap the auto-configured DataSource, avoiding
- * circular dependency issues that arise from declaring a {@code @Primary @Bean} DataSource
- * that injects another DataSource.
+ * <h3>Tenant values</h3>
+ * <ul>
+ *   <li><b>real UUID / slug</b> — bound by {@code TenantContextFilter} or
+ *       explicit {@link TenantContext#runWithTenant}; RLS filters to that tenant.</li>
+ *   <li><b>{@link TenantContext#PLATFORM_SENTINEL}</b> — bound by
+ *       {@link TenantContext#runAsPlatform}; matches {@code platform_bypass}.</li>
+ *   <li><b>blank / null</b> — rejected with {@link IllegalStateException}.</li>
+ * </ul>
  *
  * @since 1.0.0
  */
@@ -46,7 +55,7 @@ public class TenantAwareDataSourceConfig {
             public Object postProcessAfterInitialization(Object bean, String beanName)
                     throws BeansException {
                 if ("dataSource".equals(beanName) && bean instanceof DataSource ds) {
-                    log.info("Wrapping DataSource with tenant-aware RLS support");
+                    log.info("Wrapping DataSource with fail-closed tenant-aware RLS support");
                     return new TenantAwareDataSource(ds);
                 }
                 return bean;
@@ -55,7 +64,8 @@ public class TenantAwareDataSourceConfig {
     }
 
     /**
-     * DataSource decorator that sets {@code app.current_tenant_id} on each connection.
+     * DataSource decorator that binds {@code app.current_tenant_id} on each connection
+     * or fails closed when no tenant context is in scope.
      */
     static class TenantAwareDataSource implements DataSource {
 
@@ -68,25 +78,42 @@ public class TenantAwareDataSourceConfig {
         @Override
         public Connection getConnection() throws SQLException {
             Connection conn = delegate.getConnection();
-            setTenantVariable(conn);
+            try {
+                setTenantVariable(conn);
+            } catch (RuntimeException | SQLException e) {
+                // Always return the connection to the pool — leaking it would
+                // starve the pool under a storm of missing-context errors.
+                try { conn.close(); } catch (SQLException ignored) {}
+                throw e;
+            }
             return conn;
         }
 
         @Override
         public Connection getConnection(String username, String password) throws SQLException {
             Connection conn = delegate.getConnection(username, password);
-            setTenantVariable(conn);
+            try {
+                setTenantVariable(conn);
+            } catch (RuntimeException | SQLException e) {
+                try { conn.close(); } catch (SQLException ignored) {}
+                throw e;
+            }
             return conn;
         }
 
         private void setTenantVariable(Connection conn) throws SQLException {
             String tenantId = TenantContext.get();
-            // Use empty string when no tenant context is set — this matches the admin_bypass policy
-            String value = (tenantId != null && !tenantId.isBlank()) ? tenantId : "";
+            if (tenantId == null || tenantId.isBlank()) {
+                throw new IllegalStateException(
+                        "DB connection checkout requires a bound TenantContext. "
+                        + "Wrap the caller in TenantContext.runWithTenant(...) for tenant-scoped "
+                        + "work or TenantContext.runAsPlatform(...) for explicit cross-tenant access.");
+            }
+            // Tenant IDs are UUIDs or the platform sentinel; we still escape
+            // defensively in case a caller passes a value that carries single
+            // quotes (PostgreSQL's SET VALUE syntax does not parameterize).
             try (Statement stmt = conn.createStatement()) {
-                // Use SET SESSION so the variable persists for the duration of the connection use.
-                // The variable is SQL-injection safe because tenant IDs are UUIDs validated upstream.
-                stmt.execute("SET app.current_tenant_id = '" + value.replace("'", "''") + "'");
+                stmt.execute("SET app.current_tenant_id = '" + tenantId.replace("'", "''") + "'");
             }
         }
 

--- a/kelta-worker/src/main/java/io/kelta/worker/controller/InternalBootstrapController.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/controller/InternalBootstrapController.java
@@ -55,15 +55,21 @@ public class InternalBootstrapController {
     public ResponseEntity<Map<String, Object>> getBootstrapConfig() {
         log.debug("REST request to get gateway bootstrap configuration");
 
-        List<Map<String, Object>> collections = loadCollections();
-        Map<String, Map<String, Object>> governorLimits = loadGovernorLimits();
+        // Both queries scan every tenant — gateway needs the full set to build
+        // routes and governor caches. Bind the platform sentinel so RLS allows
+        // the read without relying on a blank tenant context.
+        Map<String, Object> response = TenantContext.callAsPlatform(() -> {
+            List<Map<String, Object>> collections = loadCollections();
+            Map<String, Map<String, Object>> governorLimits = loadGovernorLimits();
 
-        Map<String, Object> response = new LinkedHashMap<>();
-        response.put("collections", collections);
-        response.put("governorLimits", governorLimits);
+            Map<String, Object> body = new LinkedHashMap<>();
+            body.put("collections", collections);
+            body.put("governorLimits", governorLimits);
 
-        log.info("Returning bootstrap config: {} collections, {} tenant governor limits",
-                collections.size(), governorLimits.size());
+            log.info("Returning bootstrap config: {} collections, {} tenant governor limits",
+                    collections.size(), governorLimits.size());
+            return body;
+        });
 
         return ResponseEntity.ok(response);
     }
@@ -82,16 +88,19 @@ public class InternalBootstrapController {
     public ResponseEntity<Map<String, String>> getSlugMap() {
         log.debug("REST request to get tenant slug map");
 
-        List<Map<String, Object>> rows = repository.findRoutableTenants();
-
-        Map<String, String> slugMap = new LinkedHashMap<>();
-        for (Map<String, Object> row : rows) {
-            String id = (String) row.get("id");
-            String slug = (String) row.get("slug");
-            if (id != null && slug != null && !slug.isBlank()) {
-                slugMap.put(slug, id);
+        // Reading every routable tenant is an explicit platform-level lookup.
+        Map<String, String> slugMap = TenantContext.callAsPlatform(() -> {
+            List<Map<String, Object>> rows = repository.findRoutableTenants();
+            Map<String, String> out = new LinkedHashMap<>();
+            for (Map<String, Object> row : rows) {
+                String id = (String) row.get("id");
+                String slug = (String) row.get("slug");
+                if (id != null && slug != null && !slug.isBlank()) {
+                    out.put(slug, id);
+                }
             }
-        }
+            return out;
+        });
 
         log.info("Returning tenant slug map with {} entries", slugMap.size());
         return ResponseEntity.ok(slugMap);
@@ -110,15 +119,17 @@ public class InternalBootstrapController {
     public ResponseEntity<Map<String, Integer>> getGovernorLimitsMap() {
         log.debug("REST request to get governor limits map");
 
-        Map<String, Map<String, Object>> fullLimits = loadGovernorLimits();
-
-        Map<String, Integer> limitsMap = new LinkedHashMap<>();
-        for (Map.Entry<String, Map<String, Object>> entry : fullLimits.entrySet()) {
-            Object apiCalls = entry.getValue().get("apiCallsPerDay");
-            if (apiCalls instanceof Number num) {
-                limitsMap.put(entry.getKey(), num.intValue());
+        Map<String, Integer> limitsMap = TenantContext.callAsPlatform(() -> {
+            Map<String, Map<String, Object>> fullLimits = loadGovernorLimits();
+            Map<String, Integer> out = new LinkedHashMap<>();
+            for (Map.Entry<String, Map<String, Object>> entry : fullLimits.entrySet()) {
+                Object apiCalls = entry.getValue().get("apiCallsPerDay");
+                if (apiCalls instanceof Number num) {
+                    out.put(entry.getKey(), num.intValue());
+                }
             }
-        }
+            return out;
+        });
 
         log.info("Returning governor limits map with {} entries", limitsMap.size());
         return ResponseEntity.ok(limitsMap);
@@ -145,11 +156,14 @@ public class InternalBootstrapController {
 
         if (tenantId != null && !tenantId.isBlank()) {
             log.debug("Internal lookup: OIDC provider by issuer={} tenant={}", issuer, tenantId);
-            providerOpt = repository.findOidcProviderByIssuerAndTenant(issuer, tenantId);
+            final String tid = tenantId;
+            providerOpt = TenantContext.callWithTenant(tid,
+                    () -> repository.findOidcProviderByIssuerAndTenant(issuer, tid));
         } else {
             log.warn("Internal lookup: OIDC provider by issuer={} WITHOUT tenant scope "
                     + "(cross-tenant risk — gateway should always provide tenantId)", issuer);
-            providerOpt = repository.findOidcProviderByIssuer(issuer);
+            providerOpt = TenantContext.callAsPlatform(
+                    () -> repository.findOidcProviderByIssuer(issuer));
         }
 
         if (providerOpt.isEmpty()) {
@@ -284,13 +298,9 @@ public class InternalBootstrapController {
 
         log.info("JIT provision: email={} tenant={} profileId={}", email, tenantId, profileId);
 
-        // Set tenant context so RLS policies filter correctly
-        TenantContext.set(tenantId);
-        try {
-            return doJitProvisionUser(email, tenantId, firstName, lastName, profileId);
-        } finally {
-            TenantContext.clear();
-        }
+        // Bind tenant context so RLS policies filter correctly during user lookup/insert.
+        return TenantContext.callWithTenant(tenantId,
+                () -> doJitProvisionUser(email, tenantId, firstName, lastName, profileId));
     }
 
     private ResponseEntity<Map<String, Object>> doJitProvisionUser(

--- a/kelta-worker/src/main/java/io/kelta/worker/controller/SearchController.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/controller/SearchController.java
@@ -61,10 +61,10 @@ public class SearchController {
 
         int effectiveLimit = Math.max(1, Math.min(limit, MAX_LIMIT));
 
-        TenantContext.set(tenantId);
-        try {
-            List<Map<String, Object>> results = searchIndexService.search(
-                    tenantId, q.trim(), effectiveLimit);
+        final String trimmed = q.trim();
+        final int eff = effectiveLimit;
+        Map<String, Object> response = TenantContext.callWithTenant(tenantId, () -> {
+            List<Map<String, Object>> results = searchIndexService.search(tenantId, trimmed, eff);
 
             List<Map<String, Object>> data = results.stream().map(row -> {
                 Map<String, Object> item = new LinkedHashMap<>();
@@ -77,14 +77,13 @@ public class SearchController {
                 return item;
             }).toList();
 
-            Map<String, Object> response = new LinkedHashMap<>();
-            response.put("data", data);
-            response.put("meta", Map.of("total", data.size()));
+            Map<String, Object> body = new LinkedHashMap<>();
+            body.put("data", data);
+            body.put("meta", Map.of("total", data.size()));
+            return body;
+        });
 
-            return ResponseEntity.ok(response);
-        } finally {
-            TenantContext.clear();
-        }
+        return ResponseEntity.ok(response);
     }
 
     private Map<String, Object> emptyResponse() {

--- a/kelta-worker/src/main/java/io/kelta/worker/listener/TenantProvisioningHook.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/listener/TenantProvisioningHook.java
@@ -65,20 +65,21 @@ public class TenantProvisioningHook implements BeforeSaveHook {
             return;
         }
 
-        // Set tenant context so RLS policies filter correctly for the new tenant
-        TenantContext.set(id);
-        try {
-            seedDefaultProfiles(id);
-            seedOidcProvider(id);
-            seedAdminUser(id, slug);
-            activateTenant(id);
-            log.info("Tenant provisioning complete for tenant '{}' (slug={})", id, slug);
-        } catch (Exception e) {
-            log.error("Tenant provisioning failed for tenant '{}' (slug={}): {}",
-                    id, slug, e.getMessage(), e);
-        } finally {
-            TenantContext.clear();
-        }
+        // Bind the new tenant's ID so RLS policies filter correctly for the
+        // inserts below. Tenant table writes (activateTenant) don't carry RLS
+        // but the dependent rows (profile, platform_user, oidc_provider) do.
+        TenantContext.runWithTenant(id, () -> {
+            try {
+                seedDefaultProfiles(id);
+                seedOidcProvider(id);
+                seedAdminUser(id, slug);
+                activateTenant(id);
+                log.info("Tenant provisioning complete for tenant '{}' (slug={})", id, slug);
+            } catch (Exception e) {
+                log.error("Tenant provisioning failed for tenant '{}' (slug={}): {}",
+                        id, slug, e.getMessage(), e);
+            }
+        });
     }
 
     /**

--- a/kelta-worker/src/main/java/io/kelta/worker/service/CerbosPolicySyncService.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/service/CerbosPolicySyncService.java
@@ -75,44 +75,43 @@ public class CerbosPolicySyncService {
      * Syncs all Cerbos policies for a tenant.
      */
     public void syncTenant(String tenantId) {
-        TenantContext.set(tenantId);
-        try {
-            log.info("Syncing Cerbos policies for tenant {}", tenantId);
+        TenantContext.runWithTenant(tenantId, () -> {
+            try {
+                log.info("Syncing Cerbos policies for tenant {}", tenantId);
 
-            List<CerbosPolicyGenerator.ProfileData> profiles = loadProfilesForTenant(tenantId);
-            if (profiles.isEmpty()) {
-                log.info("No profiles found for tenant {} — skipping Cerbos policy sync", tenantId);
-                return;
+                List<CerbosPolicyGenerator.ProfileData> profiles = loadProfilesForTenant(tenantId);
+                if (profiles.isEmpty()) {
+                    log.info("No profiles found for tenant {} — skipping Cerbos policy sync", tenantId);
+                    return;
+                }
+                List<String> collectionIds = loadCollectionIdsForTenant(tenantId);
+                List<CerbosPolicyGenerator.CustomRule> customRules = loadCustomRulesForTenant(tenantId);
+
+                // Generate policies
+                Map<String, Object> derivedRoles = policyGenerator.generateDerivedRoles(tenantId, profiles);
+                Map<String, Object> systemPolicy = policyGenerator.generateSystemFeaturePolicy(tenantId, profiles);
+                Map<String, Object> collectionPolicy = policyGenerator.generateCollectionPolicy(tenantId, profiles, collectionIds);
+                Map<String, Object> fieldPolicy = policyGenerator.generateFieldPolicy(tenantId, profiles);
+                Map<String, Object> recordPolicy = policyGenerator.generateRecordPolicy(tenantId, profiles, collectionIds, customRules);
+
+                // Push to Cerbos Admin API
+                pushPolicy(derivedRoles);
+                pushPolicy(systemPolicy);
+                pushPolicy(collectionPolicy);
+                pushPolicy(fieldPolicy);
+                pushPolicy(recordPolicy);
+
+                log.info("Cerbos policies synced for tenant {} ({} profiles, {} collections)",
+                        tenantId, profiles.size(), collectionIds.size());
+
+                // Evict cached permissions — profile permissions may have changed
+                cacheManager.evictAllPermissions();
+
+                publishPolicyChangedEvent(tenantId);
+            } catch (Exception e) {
+                log.error("Failed to sync Cerbos policies for tenant {}: {}", tenantId, e.getMessage(), e);
             }
-            List<String> collectionIds = loadCollectionIdsForTenant(tenantId);
-            List<CerbosPolicyGenerator.CustomRule> customRules = loadCustomRulesForTenant(tenantId);
-
-            // Generate policies
-            Map<String, Object> derivedRoles = policyGenerator.generateDerivedRoles(tenantId, profiles);
-            Map<String, Object> systemPolicy = policyGenerator.generateSystemFeaturePolicy(tenantId, profiles);
-            Map<String, Object> collectionPolicy = policyGenerator.generateCollectionPolicy(tenantId, profiles, collectionIds);
-            Map<String, Object> fieldPolicy = policyGenerator.generateFieldPolicy(tenantId, profiles);
-            Map<String, Object> recordPolicy = policyGenerator.generateRecordPolicy(tenantId, profiles, collectionIds, customRules);
-
-            // Push to Cerbos Admin API
-            pushPolicy(derivedRoles);
-            pushPolicy(systemPolicy);
-            pushPolicy(collectionPolicy);
-            pushPolicy(fieldPolicy);
-            pushPolicy(recordPolicy);
-
-            log.info("Cerbos policies synced for tenant {} ({} profiles, {} collections)",
-                    tenantId, profiles.size(), collectionIds.size());
-
-            // Evict cached permissions — profile permissions may have changed
-            cacheManager.evictAllPermissions();
-
-            publishPolicyChangedEvent(tenantId);
-        } catch (Exception e) {
-            log.error("Failed to sync Cerbos policies for tenant {}: {}", tenantId, e.getMessage(), e);
-        } finally {
-            TenantContext.clear();
-        }
+        });
     }
 
     /**
@@ -136,7 +135,9 @@ public class CerbosPolicySyncService {
      * Syncs policies for all active tenants.
      */
     public void syncAllTenants() {
-        List<Map<String, Object>> tenants = bootstrapRepository.findRoutableTenants();
+        // Enumerating every tenant is an explicit cross-tenant read.
+        List<Map<String, Object>> tenants = TenantContext.callAsPlatform(
+                bootstrapRepository::findRoutableTenants);
         log.info("Syncing Cerbos policies for {} tenants", tenants.size());
 
         for (Map<String, Object> tenant : tenants) {

--- a/kelta-worker/src/main/java/io/kelta/worker/service/ScheduledJobExecutorService.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/service/ScheduledJobExecutorService.java
@@ -1,6 +1,7 @@
 package io.kelta.worker.service;
 
 import tools.jackson.databind.ObjectMapper;
+import io.kelta.runtime.context.TenantContext;
 import io.kelta.runtime.flow.FlowEngine;
 import io.kelta.worker.util.TenantContextUtils;
 import io.kelta.runtime.flow.InitialStateBuilder;
@@ -74,7 +75,11 @@ public class ScheduledJobExecutorService {
      */
     @SuppressWarnings("unchecked")
     public void executeAll() {
-        List<Map<String, Object>> dueJobs = repository.findDueJobs();
+        // Polling `scheduled_job` spans every tenant (leader election via
+        // SELECT … FOR UPDATE SKIP LOCKED). Bind the platform sentinel so the
+        // cross-tenant read bypasses RLS explicitly — per-job execution below
+        // rebinds the job's real tenantId before any tenant-scoped work.
+        List<Map<String, Object>> dueJobs = TenantContext.callAsPlatform(repository::findDueJobs);
         if (dueJobs.isEmpty()) {
             return;
         }

--- a/kelta-worker/src/main/java/io/kelta/worker/service/WorkerBootstrapService.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/service/WorkerBootstrapService.java
@@ -1,5 +1,6 @@
 package io.kelta.worker.service;
 
+import io.kelta.runtime.context.TenantContext;
 import io.kelta.worker.config.WorkerProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,14 +53,19 @@ public class WorkerBootstrapService {
     public void onApplicationReady() {
         log.info("Worker '{}' starting bootstrap from database", workerProperties.getId());
 
-        try {
-            initializeAllCollections();
-            log.info("Worker '{}' successfully bootstrapped all collections",
-                    workerProperties.getId());
-        } catch (Exception e) {
-            log.error("Failed to bootstrap collections from database. " +
-                    "Worker will start with no collections loaded.", e);
-        }
+        // Bootstrap reads the `collection` table across every tenant so each pod
+        // can serve any tenant's requests; wrap the query in the platform sentinel
+        // scope so it bypasses RLS without relying on a blank tenant context.
+        TenantContext.runAsPlatform(() -> {
+            try {
+                initializeAllCollections();
+                log.info("Worker '{}' successfully bootstrapped all collections",
+                        workerProperties.getId());
+            } catch (Exception e) {
+                log.error("Failed to bootstrap collections from database. " +
+                        "Worker will start with no collections loaded.", e);
+            }
+        });
     }
 
     /**

--- a/kelta-worker/src/main/resources/db/migration/V126__replace_admin_bypass_with_platform_sentinel.sql
+++ b/kelta-worker/src/main/resources/db/migration/V126__replace_admin_bypass_with_platform_sentinel.sql
@@ -1,0 +1,61 @@
+-- ============================================================================
+-- V126: Replace the empty-string admin_bypass RLS policy with an explicit
+-- platform-sentinel bypass policy.
+-- ============================================================================
+-- The original bypass policy (V77/V86/V88) granted full access whenever
+-- app.current_tenant_id was the empty string. That was fragile — any code
+-- path that forgot to bind a tenant context silently executed under a
+-- platform-wide bypass.
+--
+-- We now use an explicit reserved sentinel value '__platform__' that only
+-- TenantContext.runAsPlatform() writes. The connection wrapper
+-- (TenantAwareDataSource) fails closed on blank tenant context, so the
+-- empty-string path is unreachable from application code.
+--
+-- For one release we keep the empty-string entry alongside the sentinel so
+-- Flyway can continue to run in environments that haven't adopted the
+-- platform wrapper yet. A follow-up migration will drop the empty-string
+-- branch once all services are known to bind a real tenant or the sentinel.
+-- ============================================================================
+
+DO $$
+DECLARE
+    tbl TEXT;
+    rls_tables TEXT[];
+BEGIN
+    -- Build the list from pg_policies so we cover every table currently
+    -- carrying an admin_bypass policy — works for V77, V86, V88, and any
+    -- other migrations that followed the same pattern.
+    SELECT ARRAY(
+        SELECT DISTINCT tablename
+        FROM pg_policies
+        WHERE schemaname = 'public' AND policyname = 'admin_bypass'
+        ORDER BY tablename
+    ) INTO rls_tables;
+
+    IF array_length(rls_tables, 1) IS NULL THEN
+        RAISE NOTICE 'V126: no admin_bypass policies found — nothing to migrate';
+        RETURN;
+    END IF;
+
+    FOREACH tbl IN ARRAY rls_tables
+    LOOP
+        -- Drop the old empty-string bypass and any pre-existing sentinel
+        -- policy (idempotent for partial re-runs).
+        EXECUTE format('DROP POLICY IF EXISTS admin_bypass ON %I', tbl);
+        EXECUTE format('DROP POLICY IF EXISTS platform_bypass ON %I', tbl);
+
+        -- Platform-sentinel bypass: grants full access when the reserved
+        -- '__platform__' value is bound (TenantContext.runAsPlatform).
+        -- Empty string is kept for backward compatibility during rollout —
+        -- a follow-up migration will drop it.
+        EXECUTE format(
+            'CREATE POLICY platform_bypass ON %I USING ('
+                || 'current_setting(''app.current_tenant_id'', true) IN ('''', ''__platform__'')'
+            || ')',
+            tbl
+        );
+
+        RAISE NOTICE 'V126: platform_bypass installed on %', tbl;
+    END LOOP;
+END $$;

--- a/kelta-worker/src/test/java/io/kelta/worker/config/TenantIsolationTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/config/TenantIsolationTest.java
@@ -1,0 +1,211 @@
+package io.kelta.worker.config;
+
+import io.kelta.runtime.context.TenantContext;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * End-to-end proof that tenant isolation actually holds at the database layer.
+ *
+ * <p>Spins up a real PostgreSQL container, sets up a tiny test schema that
+ * mirrors the production RLS pattern (per-tenant rows + FORCE ROW LEVEL
+ * SECURITY + a {@code platform_bypass} policy matching the reserved
+ * {@code __platform__} sentinel), wraps the connection pool in the
+ * fail-closed {@link TenantAwareDataSourceConfig.TenantAwareDataSource}, and
+ * asserts the three invariants that the hardening work was intended to
+ * guarantee:
+ *
+ * <ol>
+ *   <li>A caller bound to tenant A sees only tenant A's rows — never B's.</li>
+ *   <li>A caller bound to no tenant cannot even check out a connection.</li>
+ *   <li>A caller opted into {@code runAsPlatform} sees every tenant's rows.</li>
+ * </ol>
+ *
+ * <p>Lives in {@code kelta-worker} so it can reach the package-private
+ * {@code TenantAwareDataSource} directly. Uses Testcontainers — requires a
+ * running Docker daemon; CI already has this in place for the platform's other
+ * integration tests.
+ */
+@Testcontainers
+@EnabledIf("dockerAvailable")
+class TenantIsolationTest {
+
+    @SuppressWarnings("unused") // referenced by @EnabledIf
+    static boolean dockerAvailable() {
+        try {
+            return DockerClientFactory.instance().isDockerAvailable();
+        } catch (Throwable t) {
+            return false;
+        }
+    }
+
+
+    private static final String TENANT_A = UUID.randomUUID().toString();
+    private static final String TENANT_B = UUID.randomUUID().toString();
+
+    @Container
+    @SuppressWarnings("resource")
+    static final PostgreSQLContainer<?> POSTGRES =
+            new PostgreSQLContainer<>(DockerImageName.parse("postgres:15-alpine"))
+                    .withDatabaseName("isolation")
+                    .withUsername("kelta")
+                    .withPassword("kelta");
+
+    static DataSource dataSource;
+
+    @BeforeAll
+    static void setUp() throws SQLException {
+        org.postgresql.ds.PGSimpleDataSource pg = new org.postgresql.ds.PGSimpleDataSource();
+        pg.setUrl(POSTGRES.getJdbcUrl());
+        pg.setUser(POSTGRES.getUsername());
+        pg.setPassword(POSTGRES.getPassword());
+        dataSource = new TenantAwareDataSourceConfig.TenantAwareDataSource(pg);
+
+        // Use the platform sentinel for the initial schema setup so the
+        // fail-closed wrapper doesn't reject the setup connection.
+        TenantContext.runAsPlatform(() -> {
+            try (Connection conn = dataSource.getConnection();
+                 Statement stmt = conn.createStatement()) {
+                stmt.execute("""
+                        CREATE TABLE widget (
+                            id UUID PRIMARY KEY,
+                            tenant_id TEXT NOT NULL,
+                            name TEXT NOT NULL
+                        )
+                        """);
+                stmt.execute("ALTER TABLE widget ENABLE ROW LEVEL SECURITY");
+                stmt.execute("ALTER TABLE widget FORCE ROW LEVEL SECURITY");
+                stmt.execute("""
+                        CREATE POLICY tenant_isolation ON widget
+                            USING (tenant_id = current_setting('app.current_tenant_id', true))
+                        """);
+                stmt.execute("""
+                        CREATE POLICY platform_bypass ON widget
+                            USING (current_setting('app.current_tenant_id', true) = '__platform__')
+                        """);
+
+                insertWidget(conn, TENANT_A, "alpha-1");
+                insertWidget(conn, TENANT_A, "alpha-2");
+                insertWidget(conn, TENANT_B, "beta-1");
+            } catch (SQLException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    @Test
+    @DisplayName("tenant A sees only its own rows — never tenant B's")
+    void tenantScopedReadsAreIsolated() {
+        List<String> aNames = TenantContext.callWithTenant(TENANT_A,
+                () -> selectWidgetNames());
+        assertEquals(List.of("alpha-1", "alpha-2"), aNames.stream().sorted().toList());
+
+        List<String> bNames = TenantContext.callWithTenant(TENANT_B,
+                () -> selectWidgetNames());
+        assertEquals(List.of("beta-1"), bNames);
+    }
+
+    @Test
+    @DisplayName("tenant A cannot see tenant B's row by direct id lookup")
+    void crossTenantIdLookupReturnsEmpty() {
+        // Grab a B-owned id while platform-scoped, then try to read it as A.
+        UUID bWidgetId = TenantContext.callAsPlatform(() -> {
+            try (Connection c = dataSource.getConnection();
+                 PreparedStatement ps = c.prepareStatement(
+                         "SELECT id FROM widget WHERE tenant_id = ? LIMIT 1")) {
+                ps.setString(1, TENANT_B);
+                try (ResultSet rs = ps.executeQuery()) {
+                    assertTrue(rs.next(), "seeded tenant B row must exist under platform scope");
+                    return UUID.fromString(rs.getString(1));
+                }
+            } catch (SQLException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        boolean visibleToA = TenantContext.callWithTenant(TENANT_A, () -> {
+            try (Connection c = dataSource.getConnection();
+                 PreparedStatement ps = c.prepareStatement(
+                         "SELECT 1 FROM widget WHERE id = ?")) {
+                ps.setObject(1, bWidgetId);
+                try (ResultSet rs = ps.executeQuery()) {
+                    return rs.next();
+                }
+            } catch (SQLException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        assertEquals(false, visibleToA,
+                "tenant A must not be able to observe a tenant B row even by id");
+    }
+
+    @Test
+    @DisplayName("unbound tenant context fails closed at connection checkout")
+    void blankContextIsRejected() {
+        IllegalStateException err = assertThrows(IllegalStateException.class,
+                () -> {
+                    try (Connection ignored = dataSource.getConnection()) {
+                        // unreachable — checkout should throw
+                    }
+                });
+        assertTrue(err.getMessage().contains("TenantContext"),
+                () -> "expected a TenantContext-specific error, got: " + err.getMessage());
+    }
+
+    @Test
+    @DisplayName("runAsPlatform sees every tenant's rows for legitimate cross-tenant reads")
+    void platformSentinelReadsEveryTenant() {
+        List<String> allNames = TenantContext.callAsPlatform(() -> selectWidgetNames());
+        assertEquals(
+                List.of("alpha-1", "alpha-2", "beta-1"),
+                allNames.stream().sorted().toList());
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────
+
+    private static void insertWidget(Connection conn, String tenantId, String name) throws SQLException {
+        try (PreparedStatement ps = conn.prepareStatement(
+                "INSERT INTO widget (id, tenant_id, name) VALUES (?, ?, ?)")) {
+            ps.setObject(1, UUID.randomUUID());
+            ps.setString(2, tenantId);
+            ps.setString(3, name);
+            ps.executeUpdate();
+        }
+    }
+
+    private static List<String> selectWidgetNames() {
+        try (Connection conn = dataSource.getConnection();
+             Statement stmt = conn.createStatement();
+             ResultSet rs = stmt.executeQuery("SELECT name FROM widget")) {
+            List<String> names = new ArrayList<>();
+            while (rs.next()) {
+                names.add(rs.getString(1));
+            }
+            return names;
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes the empty-string admin-bypass data-leak path in Kelta's multi-tenant RLS model. This is the second half of the tenant-isolation hardening sequence that started with [emf#745](https://github.com/cklinker/emf/pull/745).

- **Fail-closed DataSource** — `TenantAwareDataSource.getConnection()` now throws `IllegalStateException` when `TenantContext.get()` is null or blank, instead of silently issuing `SET app.current_tenant_id = ''` and hitting the permissive admin-bypass policy. Legitimate cross-tenant paths must opt in via `TenantContext.runAsPlatform(...)`.
- **V126 migration** — replaces the empty-string `admin_bypass` policy (V77/V86/V88) with a `platform_bypass` policy that matches the reserved `__platform__` sentinel. The empty-string entry is retained for one release to ease rollout; a follow-up will drop it once we've verified no surviving blank-context code paths in staging.
- **Flyway strategy** — `FlywayConfig` wraps `flyway.migrate()` in `runAsPlatform` so migrations continue to work once the DataSource is fail-closed.
- **Platform callers wrapped** — every identified cross-tenant code path now explicitly opts into the sentinel scope: `WorkerBootstrapService`, `ModuleConfig`'s ApplicationReady hook, `ScheduledJobExecutorService.executeAll` (the `scheduled_job` poll), `CerbosPolicySyncService.syncAllTenants`, and the four `/internal/*` endpoints on `InternalBootstrapController`. Remaining legacy `TenantContext.set/clear` call sites with a real tenant ID (SearchController, JIT provisioning, TenantProvisioningHook, CerbosPolicySyncService.syncTenant) migrated to the ScopedValue `runWithTenant`.

## Test plan

- [x] `mvn test` — kelta-worker (1002 tests green), kelta-auth compiles clean
- [ ] Staging soak: deploy and verify (a) Flyway runs V126 cleanly under the platform sentinel and (b) no `IllegalStateException: DB connection checkout requires a bound TenantContext` errors surface under normal traffic for 24h
- [ ] Manually hit a worker endpoint with no X-Tenant-ID header — expect a 500 with the specific error message (not an empty result set)
- [ ] After soak, open the follow-up PR that drops the empty-string branch from platform_bypass

🤖 Generated with [Claude Code](https://claude.com/claude-code)