### PR TITLE
feat(auth): OAuth2 client_credentials for worker /internal/** calls

### DIFF
--- a/kelta-auth/src/main/java/io/kelta/auth/config/InternalWorkerClientConfig.java
+++ b/kelta-auth/src/main/java/io/kelta/auth/config/InternalWorkerClientConfig.java
@@ -1,0 +1,155 @@
+package io.kelta.auth.config;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.AuthorizedClientServiceOAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.client.InMemoryOAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.OAuth2AuthorizeRequest;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProviderBuilder;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.web.client.RestClient;
+
+import java.util.List;
+
+/**
+ * Wires kelta-auth's service-to-service OAuth2 client for {@code /internal/**}
+ * calls into the worker.
+ *
+ * <p>kelta-auth is the token issuer, so this client asks itself for tokens via
+ * {@code client_credentials}. The matching client is registered by
+ * {@link InternalClientRegistrar} at startup from
+ * {@code kelta.auth.internal-clients.auth-internal.secret}.
+ *
+ * <p>Exposes {@link #internalWorkerRestClient} — a pre-configured
+ * {@link RestClient} with a synchronous request-phase interceptor that attaches
+ * {@code Authorization: Bearer …} to every request whose path starts with
+ * {@code /internal/}. Non-internal calls pass through untouched, so callers
+ * that hit {@code /api/internal/email/send} (still on the legacy
+ * {@code X-Internal-Token} path) are unaffected.
+ *
+ * <p><b>Rollout flag.</b> Gated behind {@code kelta.auth.internal-auth.enabled=true}.
+ * When off (the default during rollout) no beans are created and
+ * {@link io.kelta.auth.service.WorkerClient} keeps using its pre-change
+ * {@code RestClient.builder()} construction — matching worker's own
+ * {@code kelta.worker.internal-auth.enabled=false} default state.
+ */
+@Configuration
+public class InternalWorkerClientConfig {
+
+    private static final Logger log = LoggerFactory.getLogger(InternalWorkerClientConfig.class);
+
+    /** Registration id used to look up the client in Spring Security. */
+    public static final String CLIENT_REGISTRATION_ID = "auth-internal";
+
+    /** Path prefix that triggers bearer-token attachment. */
+    private static final String INTERNAL_PATH_PREFIX = "/internal/";
+
+    /**
+     * Registers the {@code auth-internal} OAuth2 client. kelta-auth is its own
+     * token issuer so the token URI points at the local authorization server.
+     */
+    @Bean
+    @ConditionalOnProperty(name = "kelta.auth.internal-auth.enabled", havingValue = "true")
+    public ClientRegistrationRepository internalClientRegistrations(
+            @Value("${kelta.auth.internal-auth.client-id:auth-internal}") String clientId,
+            @Value("${kelta.auth.internal-auth.client-secret:}") String clientSecret,
+            AuthProperties authProperties) {
+
+        if (clientSecret == null || clientSecret.isBlank()) {
+            throw new IllegalStateException(
+                    "kelta.auth.internal-auth.enabled=true requires kelta.auth.internal-auth.client-secret "
+                            + "to be configured. It must match kelta.auth.internal-clients." + clientId + ".secret.");
+        }
+        String issuerUri = authProperties.getIssuerUri();
+        if (issuerUri == null || issuerUri.isBlank()) {
+            throw new IllegalStateException(
+                    "kelta.auth.issuer-uri must be configured when internal-auth is enabled.");
+        }
+
+        String tokenUri = issuerUri.endsWith("/") ? issuerUri + "oauth2/token" : issuerUri + "/oauth2/token";
+        ClientRegistration registration = ClientRegistration.withRegistrationId(CLIENT_REGISTRATION_ID)
+                .clientId(clientId)
+                .clientSecret(clientSecret)
+                .clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_BASIC)
+                .authorizationGrantType(AuthorizationGrantType.CLIENT_CREDENTIALS)
+                .tokenUri(tokenUri)
+                .scope("internal")
+                .build();
+
+        log.info("Registered OAuth2 client '{}' for worker /internal/** calls (token URI: {})",
+                clientId, tokenUri);
+        return new InMemoryClientRegistrationRepository(registration);
+    }
+
+    @Bean
+    @ConditionalOnProperty(name = "kelta.auth.internal-auth.enabled", havingValue = "true")
+    public OAuth2AuthorizedClientService internalAuthorizedClientService(
+            ClientRegistrationRepository clients) {
+        return new InMemoryOAuth2AuthorizedClientService(clients);
+    }
+
+    @Bean
+    @ConditionalOnProperty(name = "kelta.auth.internal-auth.enabled", havingValue = "true")
+    public AuthorizedClientServiceOAuth2AuthorizedClientManager internalAuthorizedClientManager(
+            ClientRegistrationRepository clients,
+            OAuth2AuthorizedClientService service) {
+        AuthorizedClientServiceOAuth2AuthorizedClientManager manager =
+                new AuthorizedClientServiceOAuth2AuthorizedClientManager(clients, service);
+        manager.setAuthorizedClientProvider(
+                OAuth2AuthorizedClientProviderBuilder.builder()
+                        .clientCredentials()
+                        .build());
+        return manager;
+    }
+
+    /**
+     * Pre-configured {@link RestClient} that attaches a bearer token to any
+     * request whose URL path starts with {@code /internal/}. Consumers inject
+     * this instead of building their own {@link RestClient.Builder}.
+     */
+    @Bean
+    @ConditionalOnProperty(name = "kelta.auth.internal-auth.enabled", havingValue = "true")
+    public RestClient internalWorkerRestClient(
+            AuthorizedClientServiceOAuth2AuthorizedClientManager clientManager,
+            AuthProperties authProperties) {
+
+        // client_credentials has no end-user principal; a stable service identity
+        // lets the cached authorized-client lookup hit on every request.
+        Authentication servicePrincipal = new AnonymousAuthenticationToken(
+                CLIENT_REGISTRATION_ID,
+                CLIENT_REGISTRATION_ID,
+                List.of(new SimpleGrantedAuthority("ROLE_SERVICE")));
+
+        return RestClient.builder()
+                .baseUrl(authProperties.getWorkerUrl())
+                .requestInterceptor((request, body, execution) -> {
+                    String path = request.getURI().getPath();
+                    if (path != null && path.startsWith(INTERNAL_PATH_PREFIX)) {
+                        var client = clientManager.authorize(
+                                OAuth2AuthorizeRequest
+                                        .withClientRegistrationId(CLIENT_REGISTRATION_ID)
+                                        .principal(servicePrincipal)
+                                        .build());
+                        if (client == null || client.getAccessToken() == null) {
+                            throw new IllegalStateException(
+                                    "client_credentials exchange returned no token for " + CLIENT_REGISTRATION_ID);
+                        }
+                        request.getHeaders().setBearerAuth(client.getAccessToken().getTokenValue());
+                    }
+                    return execution.execute(request, body);
+                })
+                .build();
+    }
+}

--- a/kelta-auth/src/main/java/io/kelta/auth/service/WorkerClient.java
+++ b/kelta-auth/src/main/java/io/kelta/auth/service/WorkerClient.java
@@ -5,8 +5,11 @@ import tools.jackson.databind.ObjectMapper;
 import io.kelta.auth.config.AuthProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClient;
 
@@ -26,10 +29,22 @@ public class WorkerClient {
 
     public WorkerClient(AuthProperties properties,
                         ObjectMapper objectMapper,
-                        @Value("${kelta.internal.token:}") String internalToken) {
-        this.restClient = RestClient.builder()
-                .baseUrl(properties.getWorkerUrl())
-                .build();
+                        @Value("${kelta.internal.token:}") String internalToken,
+                        @Autowired(required = false) @Qualifier("internalWorkerRestClient")
+                        @Nullable RestClient internalRestClient) {
+        // When the internal-auth rollout flag is on, InternalWorkerClientConfig
+        // provides a RestClient pre-wired with a client_credentials interceptor
+        // that attaches a bearer token to every /internal/** request. Fall back
+        // to a plain RestClient otherwise so the service keeps working while
+        // the flag is off or during rollout.
+        if (internalRestClient != null) {
+            log.info("WorkerClient using OAuth2 client_credentials for /internal/** calls");
+            this.restClient = internalRestClient;
+        } else {
+            this.restClient = RestClient.builder()
+                    .baseUrl(properties.getWorkerUrl())
+                    .build();
+        }
         this.objectMapper = objectMapper;
         this.internalToken = internalToken;
     }


### PR DESCRIPTION
## Summary

kelta-auth caller-side for the internal-auth scheme. Third and final service wired after [#750](https://github.com/cklinker/emf/pull/750) (worker acceptance) and [#751](https://github.com/cklinker/emf/pull/751) (gateway caller).

- **\`InternalWorkerClientConfig\`** — registers the \`auth-internal\` OAuth2 client against kelta-auth's own \`/oauth2/token\` endpoint (kelta-auth is the issuer so this is a loopback client_credentials call). Publishes a pre-configured \`RestClient\` with a synchronous request-phase interceptor that attaches \`Authorization: Bearer …\` only to requests whose URL path starts with \`/internal/\`.
- **\`WorkerClient\`** — prefers the injected \`internalWorkerRestClient\` when present; falls back to the plain \`RestClient.builder()\` construction when the flag is off. Non-internal calls (\`/api/internal/email/send\`, the legacy \`X-Internal-Token\` path) are untouched.
- **Rollout flag** — \`kelta.auth.internal-auth.enabled=true\` (default false). When off, no OAuth2 beans are created; callers behave exactly as before.

## Why servlet-side differs from gateway

kelta-auth is a Spring servlet app (not reactive), so wiring uses the non-reactive \`OAuth2AuthorizedClientManager\` + \`RestClient\` request interceptor instead of gateway's \`ReactiveOAuth2AuthorizedClientManager\` + \`ExchangeFilterFunction\`. Same end result, different API.

## kelta-ai intentionally NOT wired

Audited \`kelta-ai/WorkerApiClient\` — it calls worker's \`/api/collections\`, \`/api/fields\`, \`/api/page-layouts\`, etc. These are regular tenant-scoped endpoints, not \`/internal/**\`, so the internal-auth scheme doesn't apply. If we want service-identity auth on those paths it's a separate, larger decision (gateway currently terminates the user JWT and forwards tenant/user headers; ai bypasses that and calls worker directly with the same header pattern). Out of scope for this thread.

## Deploy sequence (consolidated for #750 + #751 + this PR)

1. Land all three flag-gated PRs. No-op by default.
2. In \`homelab-argo\` values:
   - \`KELTA_AUTH_INTERNAL_CLIENTS_GATEWAY_INTERNAL_SECRET=<secret-A>\`
   - \`KELTA_AUTH_INTERNAL_CLIENTS_AUTH_INTERNAL_SECRET=<secret-B>\`
   - \`KELTA_GATEWAY_INTERNAL_AUTH_CLIENT_SECRET=<secret-A>\` (gateway + auth see matching secret)
   - \`KELTA_AUTH_INTERNAL_AUTH_CLIENT_SECRET=<secret-B>\`
3. Flip \`kelta.gateway.internal-auth.enabled=true\` and \`kelta.auth.internal-auth.enabled=true\`. Verify both services log \`Registered OAuth2 client\`.
4. Flip \`kelta.worker.internal-auth.enabled=true\`. All four \`/internal/**\` endpoints from gateway + 5 from auth should now carry bearer tokens.
5. Monitor 401s on worker's \`/internal/**\` for 24h.

## Test plan

- [x] \`mvn test\` — kelta-auth 177 tests green (1 skipped, pre-existing)
- [ ] Staging soak with all three flags on: \`/internal/oidc/providers\`, \`/internal/user-identity\`, \`/internal/user-identity/jit\`, \`/internal/sms/send\`, \`/internal/sms/verify\` return 200
- [ ] Follow-up: deprecate \`X-Internal-Token\` on \`/api/internal/email/send\` once proven

🤖 Generated with [Claude Code](https://claude.com/claude-code)