### PR TITLE
fix(superset): close SQL injection in SupersetDatabaseUserService

### DIFF
--- a/kelta-worker/src/main/java/io/kelta/worker/config/SupersetConfig.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/config/SupersetConfig.java
@@ -55,8 +55,12 @@ public class SupersetConfig {
     }
 
     @Bean
-    public SupersetDatabaseUserService supersetDatabaseUserService(JdbcTemplate jdbcTemplate) {
-        return new SupersetDatabaseUserService(jdbcTemplate);
+    public SupersetDatabaseUserService supersetDatabaseUserService(
+            JdbcTemplate jdbcTemplate,
+            @org.springframework.beans.factory.annotation.Value(
+                    "${kelta.worker.superset.database-name:${spring.datasource.name:emf_control_plane}}")
+            String databaseName) {
+        return new SupersetDatabaseUserService(jdbcTemplate, databaseName);
     }
 
     @Bean

--- a/kelta-worker/src/main/java/io/kelta/worker/service/SupersetDatabaseUserService.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/service/SupersetDatabaseUserService.java
@@ -2,10 +2,12 @@ package io.kelta.worker.service;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.jdbc.core.JdbcTemplate;
 
 import java.security.SecureRandom;
 import java.util.Base64;
+import java.util.regex.Pattern;
 
 /**
  * Manages per-tenant PostgreSQL users for Superset database connections.
@@ -19,17 +21,58 @@ import java.util.Base64;
  *   <li>A {@code search_path} restricted to the tenant schema + public</li>
  * </ul>
  *
- * @since 1.0.0
+ * <h3>Injection safety</h3>
+ *
+ * Postgres DDL (CREATE/ALTER/DROP ROLE, GRANT/REVOKE) cannot use JDBC parameter
+ * binding — identifiers and role names are not bindable. Every dynamic value
+ * used inside a statement here is therefore:
+ *
+ * <ol>
+ *   <li>strictly validated at the boundary ({@link #validateSlug},
+ *       {@link #validateTenantId}, {@link #validateDatabaseName}), so only
+ *       characters safe inside Postgres identifiers and string literals can
+ *       reach the SQL at all; and</li>
+ *   <li>escaped by {@link #quoteIdent} / {@link #quoteLiteral} before
+ *       concatenation, so even a validator regression cannot produce a
+ *       broken-quote condition.</li>
+ * </ol>
+ *
+ * Belt-and-suspenders — either layer alone would be sufficient; together they
+ * survive a future edit that loosens one of them.
  */
 public class SupersetDatabaseUserService {
 
     private static final Logger log = LoggerFactory.getLogger(SupersetDatabaseUserService.class);
     private static final SecureRandom RANDOM = new SecureRandom();
 
-    private final JdbcTemplate jdbcTemplate;
+    /**
+     * Tenant slug grammar — matches the slug validator used elsewhere in the
+     * platform. Lowercase letters, digits, and hyphens; 1–63 chars.
+     */
+    private static final Pattern SLUG_PATTERN = Pattern.compile("^[a-z][a-z0-9-]{0,62}$");
 
-    public SupersetDatabaseUserService(JdbcTemplate jdbcTemplate) {
+    /**
+     * UUID format — matches Postgres-style 8-4-4-4-12 hex quads.
+     */
+    private static final Pattern UUID_PATTERN =
+            Pattern.compile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$");
+
+    /**
+     * Postgres identifier grammar for database names — letters/digits/underscore,
+     * starting with a letter or underscore, max 63 chars.
+     */
+    private static final Pattern IDENT_PATTERN = Pattern.compile("^[A-Za-z_][A-Za-z0-9_]{0,62}$");
+
+    private final JdbcTemplate jdbcTemplate;
+    private final String databaseName;
+
+    public SupersetDatabaseUserService(
+            JdbcTemplate jdbcTemplate,
+            @Value("${kelta.worker.superset.database-name:${spring.datasource.name:emf_control_plane}}")
+            String databaseName) {
+        validateDatabaseName(databaseName);
         this.jdbcTemplate = jdbcTemplate;
+        this.databaseName = databaseName;
     }
 
     /**
@@ -39,64 +82,69 @@ public class SupersetDatabaseUserService {
      * @param tenantId   the tenant UUID (used for RLS)
      * @param tenantSlug the tenant slug (used as schema name and username suffix)
      * @return the generated password for the new user
+     * @throws IllegalArgumentException if {@code tenantId} or {@code tenantSlug}
+     *                                  fail validation
      */
     public String ensureTenantUser(String tenantId, String tenantSlug) {
+        validateTenantId(tenantId);
+        validateSlug(tenantSlug);
+
         String username = toUsername(tenantSlug);
         String password = generatePassword();
+        String userIdent = quoteIdent(username);
+        String schemaIdent = quoteIdent(tenantSlug);
+        String dbIdent = quoteIdent(databaseName);
 
         try {
-            // Create role if it doesn't exist
             boolean exists = Boolean.TRUE.equals(
                     jdbcTemplate.queryForObject(
                             "SELECT EXISTS(SELECT 1 FROM pg_roles WHERE rolname = ?)",
                             Boolean.class, username));
 
             if (exists) {
-                // Update password and settings in case they changed
-                jdbcTemplate.execute(String.format(
-                        "ALTER ROLE \"%s\" WITH PASSWORD '%s'", username, password));
+                jdbcTemplate.execute(
+                        "ALTER ROLE " + userIdent + " WITH PASSWORD " + quoteLiteral(password));
                 log.info("Updated existing Superset DB user '{}'", username);
             } else {
-                jdbcTemplate.execute(String.format(
-                        "CREATE ROLE \"%s\" WITH LOGIN PASSWORD '%s' NOSUPERUSER NOCREATEDB NOCREATEROLE",
-                        username, password));
+                jdbcTemplate.execute(
+                        "CREATE ROLE " + userIdent
+                                + " WITH LOGIN PASSWORD " + quoteLiteral(password)
+                                + " NOSUPERUSER NOCREATEDB NOCREATEROLE");
                 log.info("Created Superset DB user '{}'", username);
             }
 
             // Set default session variables on the role so RLS works automatically
-            jdbcTemplate.execute(String.format(
-                    "ALTER ROLE \"%s\" SET app.current_tenant_id = '%s'",
-                    username, tenantId));
+            jdbcTemplate.execute(
+                    "ALTER ROLE " + userIdent
+                            + " SET app.current_tenant_id = " + quoteLiteral(tenantId));
 
             // Set search_path so queries default to tenant schema + public
-            jdbcTemplate.execute(String.format(
-                    "ALTER ROLE \"%s\" SET search_path = \"%s\", public",
-                    username, tenantSlug));
+            jdbcTemplate.execute(
+                    "ALTER ROLE " + userIdent
+                            + " SET search_path = " + schemaIdent + ", public");
 
             // Grant CONNECT on the database
-            jdbcTemplate.execute(String.format(
-                    "GRANT CONNECT ON DATABASE emf_control_plane TO \"%s\"", username));
+            jdbcTemplate.execute(
+                    "GRANT CONNECT ON DATABASE " + dbIdent + " TO " + userIdent);
 
             // Grant USAGE on only public and tenant schema
-            jdbcTemplate.execute(String.format(
-                    "GRANT USAGE ON SCHEMA public TO \"%s\"", username));
-            jdbcTemplate.execute(String.format(
-                    "GRANT USAGE ON SCHEMA \"%s\" TO \"%s\"", tenantSlug, username));
+            jdbcTemplate.execute(
+                    "GRANT USAGE ON SCHEMA public TO " + userIdent);
+            jdbcTemplate.execute(
+                    "GRANT USAGE ON SCHEMA " + schemaIdent + " TO " + userIdent);
 
             // Grant SELECT on all existing tables
-            jdbcTemplate.execute(String.format(
-                    "GRANT SELECT ON ALL TABLES IN SCHEMA public TO \"%s\"", username));
-            jdbcTemplate.execute(String.format(
-                    "GRANT SELECT ON ALL TABLES IN SCHEMA \"%s\" TO \"%s\"",
-                    tenantSlug, username));
+            jdbcTemplate.execute(
+                    "GRANT SELECT ON ALL TABLES IN SCHEMA public TO " + userIdent);
+            jdbcTemplate.execute(
+                    "GRANT SELECT ON ALL TABLES IN SCHEMA " + schemaIdent + " TO " + userIdent);
 
             // Grant SELECT on future tables
-            jdbcTemplate.execute(String.format(
-                    "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO \"%s\"",
-                    username));
-            jdbcTemplate.execute(String.format(
-                    "ALTER DEFAULT PRIVILEGES IN SCHEMA \"%s\" GRANT SELECT ON TABLES TO \"%s\"",
-                    tenantSlug, username));
+            jdbcTemplate.execute(
+                    "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO " + userIdent);
+            jdbcTemplate.execute(
+                    "ALTER DEFAULT PRIVILEGES IN SCHEMA " + schemaIdent
+                            + " GRANT SELECT ON TABLES TO " + userIdent);
 
             log.info("Configured Superset DB user '{}' with tenant_id={}, schema={}",
                     username, tenantId, tenantSlug);
@@ -114,7 +162,11 @@ public class SupersetDatabaseUserService {
      * @param tenantSlug the tenant slug
      */
     public void dropTenantUser(String tenantSlug) {
+        validateSlug(tenantSlug);
+
         String username = toUsername(tenantSlug);
+        String userIdent = quoteIdent(username);
+        String schemaIdent = quoteIdent(tenantSlug);
         try {
             boolean exists = Boolean.TRUE.equals(
                     jdbcTemplate.queryForObject(
@@ -125,20 +177,66 @@ public class SupersetDatabaseUserService {
                 return;
             }
 
-            // Revoke all privileges before dropping
-            jdbcTemplate.execute(String.format(
-                    "REVOKE ALL ON ALL TABLES IN SCHEMA public FROM \"%s\"", username));
-            jdbcTemplate.execute(String.format(
-                    "REVOKE USAGE ON SCHEMA public FROM \"%s\"", username));
-            jdbcTemplate.execute(String.format(
-                    "REVOKE USAGE ON SCHEMA \"%s\" FROM \"%s\"", tenantSlug, username));
-            jdbcTemplate.execute(String.format(
-                    "DROP ROLE IF EXISTS \"%s\"", username));
+            jdbcTemplate.execute(
+                    "REVOKE ALL ON ALL TABLES IN SCHEMA public FROM " + userIdent);
+            jdbcTemplate.execute(
+                    "REVOKE USAGE ON SCHEMA public FROM " + userIdent);
+            jdbcTemplate.execute(
+                    "REVOKE USAGE ON SCHEMA " + schemaIdent + " FROM " + userIdent);
+            jdbcTemplate.execute(
+                    "DROP ROLE IF EXISTS " + userIdent);
 
             log.info("Dropped Superset DB user '{}'", username);
         } catch (Exception e) {
             log.error("Failed to drop Superset DB user '{}': {}", username, e.getMessage(), e);
         }
+    }
+
+    // =========================================================================
+    // Validators
+    // =========================================================================
+
+    static void validateSlug(String tenantSlug) {
+        if (tenantSlug == null || !SLUG_PATTERN.matcher(tenantSlug).matches()) {
+            throw new IllegalArgumentException(
+                    "Invalid tenant slug: must match " + SLUG_PATTERN.pattern());
+        }
+    }
+
+    static void validateTenantId(String tenantId) {
+        if (tenantId == null || !UUID_PATTERN.matcher(tenantId).matches()) {
+            throw new IllegalArgumentException(
+                    "Invalid tenant ID: must be a UUID");
+        }
+    }
+
+    static void validateDatabaseName(String databaseName) {
+        if (databaseName == null || !IDENT_PATTERN.matcher(databaseName).matches()) {
+            throw new IllegalArgumentException(
+                    "Invalid database name: must match " + IDENT_PATTERN.pattern());
+        }
+    }
+
+    // =========================================================================
+    // SQL quoting helpers — defense-in-depth. Validators catch malformed input
+    // before these run, but quoting guarantees that even a validator regression
+    // cannot produce a broken-quote condition.
+    // =========================================================================
+
+    /**
+     * Wraps an identifier in Postgres double-quotes and doubles any internal
+     * double quote. Safe to splice into a DDL statement.
+     */
+    static String quoteIdent(String ident) {
+        return "\"" + ident.replace("\"", "\"\"") + "\"";
+    }
+
+    /**
+     * Wraps a string literal in Postgres single-quotes and doubles any internal
+     * single quote. Safe to splice into a SQL statement.
+     */
+    static String quoteLiteral(String literal) {
+        return "'" + literal.replace("'", "''") + "'";
     }
 
     /**

--- a/kelta-worker/src/test/java/io/kelta/worker/service/SupersetDatabaseUserServiceTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/service/SupersetDatabaseUserServiceTest.java
@@ -12,13 +12,16 @@ import static org.mockito.Mockito.*;
 @DisplayName("SupersetDatabaseUserService")
 class SupersetDatabaseUserServiceTest {
 
+    private static final String TENANT_UUID = "11111111-2222-3333-4444-555555555555";
+    private static final String DATABASE_NAME = "emf_control_plane";
+
     private JdbcTemplate jdbcTemplate;
     private SupersetDatabaseUserService service;
 
     @BeforeEach
     void setUp() {
         jdbcTemplate = mock(JdbcTemplate.class);
-        service = new SupersetDatabaseUserService(jdbcTemplate);
+        service = new SupersetDatabaseUserService(jdbcTemplate, DATABASE_NAME);
     }
 
     @Test
@@ -38,7 +41,7 @@ class SupersetDatabaseUserServiceTest {
                 eq(Boolean.class), eq("superset_acme")))
                 .thenReturn(false);
 
-        String password = service.ensureTenantUser("tenant-uuid", "acme");
+        String password = service.ensureTenantUser(TENANT_UUID, "acme");
 
         assertNotNull(password);
         assertFalse(password.isEmpty());
@@ -59,6 +62,9 @@ class SupersetDatabaseUserServiceTest {
         // Verify SELECT grants
         verify(jdbcTemplate).execute(contains("GRANT SELECT ON ALL TABLES IN SCHEMA public"));
         verify(jdbcTemplate).execute(contains("GRANT SELECT ON ALL TABLES IN SCHEMA \"acme\""));
+
+        // Verify database name is quoted and matches the configured value
+        verify(jdbcTemplate).execute(contains("GRANT CONNECT ON DATABASE \"emf_control_plane\""));
     }
 
     @Test
@@ -69,7 +75,7 @@ class SupersetDatabaseUserServiceTest {
                 eq(Boolean.class), eq("superset_acme")))
                 .thenReturn(true);
 
-        String password = service.ensureTenantUser("tenant-uuid", "acme");
+        String password = service.ensureTenantUser(TENANT_UUID, "acme");
 
         assertNotNull(password);
 
@@ -113,9 +119,71 @@ class SupersetDatabaseUserServiceTest {
         when(jdbcTemplate.queryForObject(anyString(), eq(Boolean.class), anyString()))
                 .thenReturn(false);
 
-        String password1 = service.ensureTenantUser("tenant-1", "acme");
-        String password2 = service.ensureTenantUser("tenant-2", "other");
+        String password1 = service.ensureTenantUser(TENANT_UUID, "acme");
+        String password2 = service.ensureTenantUser(
+                "22222222-3333-4444-5555-666666666666", "other");
 
         assertNotEquals(password1, password2);
+    }
+
+    // =========================================================================
+    // Injection-safety tests
+    // =========================================================================
+
+    @Test
+    @DisplayName("rejects tenant slug containing SQL injection attempt")
+    void rejectsSlugWithInjectionAttempt() {
+        assertThrows(IllegalArgumentException.class,
+                () -> service.ensureTenantUser(TENANT_UUID, "acme\"; DROP ROLE postgres; --"));
+        assertThrows(IllegalArgumentException.class,
+                () -> service.ensureTenantUser(TENANT_UUID, "acme'; --"));
+        assertThrows(IllegalArgumentException.class,
+                () -> service.ensureTenantUser(TENANT_UUID, "ACME")); // uppercase
+        assertThrows(IllegalArgumentException.class,
+                () -> service.ensureTenantUser(TENANT_UUID, "")); // empty
+        assertThrows(IllegalArgumentException.class,
+                () -> service.ensureTenantUser(TENANT_UUID, null));
+
+        verifyNoInteractions(jdbcTemplate);
+    }
+
+    @Test
+    @DisplayName("rejects non-UUID tenant id")
+    void rejectsInvalidTenantId() {
+        assertThrows(IllegalArgumentException.class,
+                () -> service.ensureTenantUser("not-a-uuid", "acme"));
+        assertThrows(IllegalArgumentException.class,
+                () -> service.ensureTenantUser("'; DROP TABLE tenant; --", "acme"));
+        assertThrows(IllegalArgumentException.class,
+                () -> service.ensureTenantUser(null, "acme"));
+
+        verifyNoInteractions(jdbcTemplate);
+    }
+
+    @Test
+    @DisplayName("rejects invalid database name at construction time")
+    void rejectsInvalidDatabaseName() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new SupersetDatabaseUserService(jdbcTemplate, "db\"; DROP--"));
+        assertThrows(IllegalArgumentException.class,
+                () -> new SupersetDatabaseUserService(jdbcTemplate, ""));
+        assertThrows(IllegalArgumentException.class,
+                () -> new SupersetDatabaseUserService(jdbcTemplate, null));
+    }
+
+    @Test
+    @DisplayName("quoteIdent doubles internal double quotes")
+    void quoteIdentEscapesQuotes() {
+        assertEquals("\"plain\"", SupersetDatabaseUserService.quoteIdent("plain"));
+        assertEquals("\"with\"\"quote\"", SupersetDatabaseUserService.quoteIdent("with\"quote"));
+    }
+
+    @Test
+    @DisplayName("quoteLiteral doubles internal single quotes")
+    void quoteLiteralEscapesQuotes() {
+        assertEquals("'plain'", SupersetDatabaseUserService.quoteLiteral("plain"));
+        assertEquals("'it''s'", SupersetDatabaseUserService.quoteLiteral("it's"));
+        assertEquals("'''; DROP--'",
+                SupersetDatabaseUserService.quoteLiteral("'; DROP--"));
     }
 }


### PR DESCRIPTION
## Summary

Addresses the top-line *"SQL Injection in SupersetDatabaseUserService"* entry in [\`concerns.md\`](./.claude/docs/concerns.md). Every dynamic value spliced into a Postgres DDL statement is now protected by two independent layers.

1. **Strict validation at the boundary.** \`ensureTenantUser\` and \`dropTenantUser\` reject any \`tenantId\` that isn't a UUID and any \`tenantSlug\` that doesn't match \`^[a-z][a-z0-9-]{0,62}$\`. Invalid inputs throw \`IllegalArgumentException\` before any SQL runs. Same slug grammar used elsewhere in the platform, so no new rule to coordinate.

2. **Explicit quoting.** \`quoteIdent\` doubles internal double-quotes for identifiers (roles, schemas, database); \`quoteLiteral\` doubles internal single-quotes for the two string literals we splice (password, \`app.current_tenant_id\` session value). Either layer alone would be sufficient — together they survive a future edit that loosens one of them.

Postgres DDL can't use JDBC parameter binding for identifiers or role names, so these two layers are the complete mitigation.

## Bonus: closes the "hardcoded DB name" tech-debt entry

The \`GRANT CONNECT ON DATABASE emf_control_plane\` string is no longer hard-coded. The database name is now injected via \`kelta.worker.superset.database-name\` (falling back to \`spring.datasource.name\`, then \`emf_control_plane\` as the historical default). Validated at construction against the Postgres identifier grammar so config changes can't re-open the injection path.

## What changed

- \`SupersetDatabaseUserService\` — constructor takes a validated \`databaseName\`; every \`String.format(...)\` replaced with \`quoteIdent\`/\`quoteLiteral\` concatenation; public methods validate inputs first.
- \`SupersetConfig\` bean wiring passes the configured DB name.
- Existing test class updated for the new constructor + real UUIDs.
- Five new test methods cover \`'\` / \`"\` / \`;\` / \`DROP\` in slug and tenant-id, invalid DB names at construction, and quote-escaping correctness.

## Test plan

- [x] \`mvn test\` — kelta-worker 1007 tests green (6 previously-existing Superset tests + 5 new injection-safety tests all pass)
- [ ] Staging soak: confirm tenant provisioning still succeeds (hook in \`SupersetTenantLifecycleHook\` still flows end-to-end)
- [ ] Nothing to roll out in homelab-argo — no config changes required; the new \`kelta.worker.superset.database-name\` has a sensible default

🤖 Generated with [Claude Code](https://claude.com/claude-code)