### PR TITLE
fix(auth): harden PasswordController against two known crash bugs

### DIFF
--- a/kelta-auth/src/main/java/io/kelta/auth/controller/PasswordController.java
+++ b/kelta-auth/src/main/java/io/kelta/auth/controller/PasswordController.java
@@ -9,6 +9,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.security.core.Authentication;
@@ -66,13 +67,22 @@ public class PasswordController {
 
         String email = authentication.getName();
 
-        // Verify current password
-        String currentHash = jdbcTemplate.queryForObject(
-                "SELECT uc.password_hash FROM user_credential uc " +
-                        "JOIN platform_user pu ON pu.id = uc.user_id " +
-                        "WHERE pu.email = ?",
-                String.class, email
-        );
+        // Verify current password. If no user/credential row matches the
+        // authenticated principal — shouldn't happen in normal flows but can if
+        // the account was deleted mid-session — return the same generic error
+        // as a wrong password rather than bubbling an unchecked 500.
+        String currentHash;
+        try {
+            currentHash = jdbcTemplate.queryForObject(
+                    "SELECT uc.password_hash FROM user_credential uc " +
+                            "JOIN platform_user pu ON pu.id = uc.user_id " +
+                            "WHERE pu.email = ?",
+                    String.class, email
+            );
+        } catch (EmptyResultDataAccessException e) {
+            log.warn("Password change attempted for unknown email: {}", email);
+            return ResponseEntity.badRequest().body(Map.of("error", "Current password is incorrect"));
+        }
 
         if (currentHash == null || !passwordEncoder.matches(request.currentPassword(), currentHash)) {
             return ResponseEntity.badRequest().body(Map.of("error", "Current password is incorrect"));
@@ -168,7 +178,15 @@ public class PasswordController {
         }
 
         var row = results.get(0);
-        Instant expiresAt = ((java.sql.Timestamp) row.get("reset_token_expires_at")).toInstant();
+        // Defensive: a row with a reset_token but no expires_at is an invariant
+        // violation. Treat it as invalid rather than NPE on the .toInstant() cast.
+        java.sql.Timestamp expiresTs = (java.sql.Timestamp) row.get("reset_token_expires_at");
+        if (expiresTs == null) {
+            log.warn("Reset token row has null expires_at — treating as invalid (user_id={})",
+                    row.get("user_id"));
+            return ResponseEntity.badRequest().body(Map.of("error", "Invalid or expired reset token"));
+        }
+        Instant expiresAt = expiresTs.toInstant();
         if (Instant.now().isAfter(expiresAt)) {
             return ResponseEntity.badRequest().body(Map.of("error", "Invalid or expired reset token"));
         }

--- a/kelta-auth/src/test/java/io/kelta/auth/controller/PasswordControllerTest.java
+++ b/kelta-auth/src/test/java/io/kelta/auth/controller/PasswordControllerTest.java
@@ -10,11 +10,14 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.HashMap;
 
 import java.sql.Timestamp;
 import java.time.Instant;
@@ -93,6 +96,23 @@ class PasswordControllerTest {
         }
 
         @Test
+        @DisplayName("returns 400 when the user's credential row is missing (EmptyResult)")
+        void returns400WhenCredentialRowMissing() {
+            when(authentication.getName()).thenReturn("ghost@test.com");
+            when(jdbcTemplate.queryForObject(contains("password_hash"), eq(String.class), eq("ghost@test.com")))
+                    .thenThrow(new EmptyResultDataAccessException(1));
+
+            var request = new PasswordController.ChangePasswordRequest("anything", "newpassword123");
+            ResponseEntity<Map<String, String>> result = controller.changePassword(request, authentication);
+
+            assertThat(result.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+            // Same generic message as a wrong password — don't leak account existence.
+            assertThat(result.getBody().get("error")).contains("incorrect");
+            // No subsequent DB work should have happened.
+            verify(jdbcTemplate, never()).update(anyString(), any(), any(), any(), any());
+        }
+
+        @Test
         @DisplayName("changes password successfully")
         void changesPasswordSuccessfully() {
             when(authentication.getName()).thenReturn("user@test.com");
@@ -163,6 +183,26 @@ class PasswordControllerTest {
             ResponseEntity<Map<String, String>> result = controller.resetPassword(request);
 
             assertThat(result.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        }
+
+        @Test
+        @DisplayName("returns 400 (no NPE) when stored expires_at is NULL")
+        void returns400WhenExpiresAtNull() {
+            // A reset_token row with null expires_at is a DB invariant violation;
+            // we must treat it as invalid rather than NPE on the cast/.toInstant().
+            Map<String, Object> row = new HashMap<>();
+            row.put("user_id", "user-1");
+            row.put("reset_token_expires_at", null);
+            when(jdbcTemplate.queryForList(contains("reset_token"), eq("null-expires-token")))
+                    .thenReturn(List.of(row));
+
+            var request = new PasswordController.ResetPasswordRequest("null-expires-token", "newpassword123");
+            ResponseEntity<Map<String, String>> result = controller.resetPassword(request);
+
+            assertThat(result.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+            assertThat(result.getBody().get("error")).contains("expired");
+            verify(jdbcTemplate, never()).update(contains("password_hash = ?"),
+                    any(), any(), any(), any());
         }
 
         @Test


### PR DESCRIPTION
## Summary

Addresses two long-standing bugs flagged in [\`concerns.md\`](./.claude/docs/concerns.md) in a single small PR.

### Bug 1 — \`EmptyResultDataAccessException\` on \`changePassword\`

The current-hash lookup used \`JdbcTemplate.queryForObject\`, which throws \`EmptyResultDataAccessException\` whenever the principal's credential row isn't found (account deleted mid-session, race with a tenant delete, etc.). Previously this bubbled as an unchecked 500. Now caught and converted to the same generic \`400 "Current password is incorrect"\` that a wrong password returns — no crash, no account-existence oracle.

### Bug 2 — NPE when stored \`reset_token_expires_at\` is NULL

\`resetPassword\` cast the timestamp column directly to \`java.sql.Timestamp\` and called \`.toInstant()\` without a null check. A row carrying a \`reset_token\` with a null \`expires_at\` is a DB invariant violation, but defensive code shouldn't NPE on it. The null case now logs a warning and returns the same \`400 "Invalid or expired reset token"\` response as an actually-expired token.

### Tests

- New: \`returns 400 when the user's credential row is missing (EmptyResult)\`
- New: \`returns 400 (no NPE) when stored expires_at is NULL\`
- Existing 7 test methods unaffected. Full kelta-auth suite: 179 tests, 0 failures.

### Deliberately out of scope

- **"Federated users stuck as PENDING_ACTIVATION"** — that one lives in \`FederatedUserMapper.lookupProfileId()\` returning \`null\` (still a \`TODO\`); requires designing the profile-resolution rule and belongs in its own PR.
- **"Password reset sends no email"** — reading the current \`sendPasswordResetEmail\` implementation, the email IS dispatched via \`workerClient.sendEmail(...)\`. The concerns.md entry appears stale — probably fixed in a prior change that didn't update the doc. Not altering that flow here to keep the blast radius minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)