### PR TITLE
fix(auth,worker): resolve federated user profile so SSO users can log in

### DIFF
--- a/kelta-auth/src/main/java/io/kelta/auth/federation/FederatedUserMapper.java
+++ b/kelta-auth/src/main/java/io/kelta/auth/federation/FederatedUserMapper.java
@@ -25,15 +25,26 @@ import java.util.*;
  *   <li>Returns a {@link KeltaUserDetails} for token minting</li>
  * </ol>
  *
- * <p>If no profile can be resolved from groups, the user is created as
- * {@code PENDING_ACTIVATION} and cannot access the platform until an admin
- * assigns a profile.
+ * <p>Profile resolution order: (1) the provider's {@code groups_profile_mapping}
+ * — for any group present on the external token, look up the mapped profile by
+ * name in the tenant's {@code profile} table; (2) fall back to the seeded
+ * {@value #FALLBACK_PROFILE_NAME} profile so every federated user can log in
+ * with a login-only role even if none of their groups are mapped. If the
+ * fallback profile itself is missing (unprovisioned tenant) the user is created
+ * as {@code PENDING_ACTIVATION} and an admin must assign a profile manually.
  */
 @Service
 @ConditionalOnBean(EncryptionService.class)
 public class FederatedUserMapper {
 
     private static final Logger log = LoggerFactory.getLogger(FederatedUserMapper.class);
+
+    /**
+     * Seeded login-only profile from {@code TenantProvisioningHook}. Grants no
+     * data access on its own — admins must layer Permission Sets on top — so
+     * assigning it to every unmapped federated user is safe by default.
+     */
+    static final String FALLBACK_PROFILE_NAME = "Minimum Access";
 
     private final WorkerClient workerClient;
     private final ObjectMapper objectMapper;
@@ -63,9 +74,19 @@ public class FederatedUserMapper {
         String firstName = extractFirstName(oidcUser, displayName);
         String lastName = extractLastName(oidcUser, displayName);
 
-        // Resolve profile from groups
+        // Resolve profile from groups, falling back to the "Minimum Access"
+        // seed profile so unmapped federated users can still log in.
         List<String> groups = extractGroups(oidcUser, provider.groupsClaim());
-        String profileId = resolveProfileFromGroups(groups, provider.groupsProfileMapping());
+        String profileId = resolveProfileFromGroups(groups, provider.groupsProfileMapping(), tenantId);
+        if (profileId == null) {
+            profileId = workerClient.findProfileByName(FALLBACK_PROFILE_NAME, tenantId)
+                    .map(WorkerClient.ProfileInfo::id)
+                    .orElse(null);
+            if (profileId != null) {
+                log.info("No group-based profile match for email={} — assigning {} fallback",
+                        email, FALLBACK_PROFILE_NAME);
+            }
+        }
 
         log.info("Federated user mapping: email={} groups={} profileId={} tenant={}",
                 email, groups, profileId, tenantId);
@@ -142,7 +163,9 @@ public class FederatedUserMapper {
         return List.of();
     }
 
-    private String resolveProfileFromGroups(List<String> groups, String groupsProfileMappingJson) {
+    private String resolveProfileFromGroups(List<String> groups,
+                                             String groupsProfileMappingJson,
+                                             String tenantId) {
         if (groups.isEmpty() || groupsProfileMappingJson == null || groupsProfileMappingJson.isBlank()) {
             return null;
         }
@@ -154,14 +177,16 @@ public class FederatedUserMapper {
             // Priority: System Administrator first
             for (Map.Entry<String, String> entry : mapping.entrySet()) {
                 if (groups.contains(entry.getKey()) && "System Administrator".equals(entry.getValue())) {
-                    return lookupProfileId(entry.getValue());
+                    String id = lookupProfileId(entry.getValue(), tenantId);
+                    if (id != null) return id;
                 }
             }
 
             // First matching group
             for (Map.Entry<String, String> entry : mapping.entrySet()) {
                 if (groups.contains(entry.getKey())) {
-                    return lookupProfileId(entry.getValue());
+                    String id = lookupProfileId(entry.getValue(), tenantId);
+                    if (id != null) return id;
                 }
             }
         } catch (Exception e) {
@@ -171,10 +196,14 @@ public class FederatedUserMapper {
         return null;
     }
 
-    private String lookupProfileId(String profileName) {
-        // For now, return the profile name and let the JIT endpoint resolve it
-        // TODO: Add profile lookup by name to WorkerClient
-        return null;
+    private String lookupProfileId(String profileName, String tenantId) {
+        return workerClient.findProfileByName(profileName, tenantId)
+                .map(WorkerClient.ProfileInfo::id)
+                .orElseGet(() -> {
+                    log.warn("Group mapping refers to profile '{}' which is not present in tenant {}",
+                            profileName, tenantId);
+                    return null;
+                });
     }
 
     private String extractFirstName(OidcUser oidcUser, String displayName) {

--- a/kelta-auth/src/main/java/io/kelta/auth/service/WorkerClient.java
+++ b/kelta-auth/src/main/java/io/kelta/auth/service/WorkerClient.java
@@ -78,6 +78,37 @@ public class WorkerClient {
             String userId, String profileId, String profileName
     ) {}
 
+    public record ProfileInfo(String id, String name) {}
+
+    /**
+     * Resolves a profile by display name, scoped to the tenant. Returns
+     * {@link Optional#empty()} if the tenant has no profile with that name or
+     * if the worker lookup fails — callers treat both as "unknown profile" and
+     * should fall back to PENDING_ACTIVATION or the Minimum Access profile.
+     */
+    public Optional<ProfileInfo> findProfileByName(String name, String tenantId) {
+        if (name == null || name.isBlank() || tenantId == null || tenantId.isBlank()) {
+            return Optional.empty();
+        }
+        try {
+            JsonNode response = restClient.get()
+                    .uri("/internal/profile/by-name?name={name}&tenantId={tenantId}", name, tenantId)
+                    .retrieve()
+                    .body(JsonNode.class);
+            if (response == null) {
+                return Optional.empty();
+            }
+            return Optional.of(new ProfileInfo(
+                    response.path("id").asText(null),
+                    response.path("name").asText(null)));
+        } catch (org.springframework.web.client.HttpClientErrorException.NotFound nf) {
+            return Optional.empty();
+        } catch (Exception e) {
+            log.warn("Failed to look up profile '{}' for tenant {}: {}", name, tenantId, e.getMessage());
+            return Optional.empty();
+        }
+    }
+
     public Optional<OidcProviderInfo> findOidcProviderByIssuer(String issuer, String tenantId) {
         try {
             String url = tenantId != null

--- a/kelta-worker/src/main/java/io/kelta/worker/controller/InternalBootstrapController.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/controller/InternalBootstrapController.java
@@ -256,6 +256,39 @@ public class InternalBootstrapController {
     }
 
     /**
+     * Resolves a profile by display name within a tenant.
+     *
+     * <p>Used by kelta-auth's federated user mapper to translate the
+     * {@code groups_profile_mapping} config (keyed by profile name) into the
+     * stable profile ID that the JIT endpoint needs. Also used to look up the
+     * "Minimum Access" fallback profile when no group-based match is found.
+     *
+     * @param name     the profile display name (e.g. "Standard User")
+     * @param tenantId the tenant UUID
+     * @return the matching profile's {@code id} and {@code name}, or 404 if
+     *         the tenant has no profile with that name
+     */
+    @GetMapping("/profile/by-name")
+    public ResponseEntity<Map<String, Object>> getProfileByName(
+            @RequestParam String name,
+            @RequestParam String tenantId) {
+        log.debug("Internal profile-by-name lookup: name={} tenant={}", name, tenantId);
+
+        Optional<Map<String, Object>> profile = TenantContext.callWithTenant(tenantId,
+                () -> repository.findProfileByName(name, tenantId));
+
+        if (profile.isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+
+        Map<String, Object> row = profile.get();
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("id", row.get("id"));
+        response.put("name", row.get("name"));
+        return ResponseEntity.ok(response);
+    }
+
+    /**
      * Creates or updates a user during JIT (Just-In-Time) provisioning from SSO login.
      *
      * <p>If the user already exists:

--- a/kelta-worker/src/main/java/io/kelta/worker/repository/BootstrapRepository.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/repository/BootstrapRepository.java
@@ -106,6 +106,12 @@ public class BootstrapRepository {
             WHERE member_type = 'USER' AND member_id = ?
             """;
 
+    private static final String SELECT_PROFILE_BY_NAME = """
+            SELECT id, name FROM profile
+            WHERE tenant_id = ? AND name = ?
+            LIMIT 1
+            """;
+
     private final JdbcTemplate jdbcTemplate;
 
     public BootstrapRepository(JdbcTemplate jdbcTemplate) {
@@ -181,6 +187,18 @@ public class BootstrapRepository {
     public Optional<Map<String, Object>> findUserIdentity(String email, String tenantId) {
         List<Map<String, Object>> rows = jdbcTemplate.queryForList(
                 SELECT_USER_IDENTITY, email, tenantId);
+        return rows.isEmpty() ? Optional.empty() : Optional.of(rows.get(0));
+    }
+
+    /**
+     * Resolves a profile by its display name, scoped to the given tenant. Used
+     * by kelta-auth's {@link io.kelta.auth.federation.FederatedUserMapper} to
+     * translate OIDC group-to-profile mapping values into stable profile IDs
+     * before JIT-provisioning a user.
+     */
+    public Optional<Map<String, Object>> findProfileByName(String name, String tenantId) {
+        List<Map<String, Object>> rows = jdbcTemplate.queryForList(
+                SELECT_PROFILE_BY_NAME, tenantId, name);
         return rows.isEmpty() ? Optional.empty() : Optional.of(rows.get(0));
     }
 }


### PR DESCRIPTION
## Summary

Closes the *"Federated users stuck as PENDING_ACTIVATION"* entry in [\`concerns.md\`](./.claude/docs/concerns.md). \`FederatedUserMapper.lookupProfileId\` was a stub that always returned \`null\`, so every federated OIDC login — even ones whose groups matched the provider's \`groups_profile_mapping\` — was created as \`PENDING_ACTIVATION\` and bounced out of \`mapUser\` as \`Optional.empty()\`. The provider mapping config was effectively dead.

Implements the **Q1-B + Q2-C** combination agreed in the planning pass:
- **Q1-B** — new worker endpoint \`GET /internal/profile/by-name?name={name}&tenantId={tenantId}\` resolves a profile name → ID. Auth calls it from \`WorkerClient.findProfileByName\`.
- **Q2-C** — when no group matches, fall back to the seeded **"Minimum Access"** profile so users still get a session and can be granted Permission Sets later. If that profile is missing (unprovisioned tenant), user is created as \`PENDING_ACTIVATION\` for manual admin activation.

## Worker side

- \`BootstrapRepository.findProfileByName(name, tenantId)\` — new JDBC query scoped by tenant.
- \`InternalBootstrapController\` gains \`GET /profile/by-name\` — wraps the query in \`TenantContext.callWithTenant(tenantId, …)\` so RLS filters, returns \`{id, name}\` or 404. Inherits the \`/internal/**\` JWT filter from [#750](https://github.com/cklinker/emf/pull/750) when the rollout flag is on.

## Auth side

- \`WorkerClient.findProfileByName\` — handles 404 cleanly as \`Optional.empty()\` rather than bubbling. Routes through the \`internalWorkerRestClient\` from [#752](https://github.com/cklinker/emf/pull/752) when the auth-side flag is on.
- \`FederatedUserMapper.lookupProfileId(name, tenantId)\` — actually resolves now. Group-matching keeps its existing priority order (System Administrator first, then first match); each match verifies the name resolves before returning.
- \`FederatedUserMapper.mapUser\` — after group resolution, if \`profileId\` is still null, looks up \`FALLBACK_PROFILE_NAME = "Minimum Access"\`. The name mirrors the constant seeded in \`TenantProvisioningHook\`.

## Test plan

- [x] \`mvn test\` — worker 1002, auth 177 (1 skipped, pre-existing); both green
- [ ] Staging soak: trigger a federated login from an IdP whose groups map to \`Standard User\` → verify the user is created ACTIVE with the right profile ID, not PENDING_ACTIVATION
- [ ] Trigger a federated login with no mapped groups → verify user is ACTIVE with \`Minimum Access\` profile
- [ ] Drop the Minimum Access profile from a test tenant, trigger a login → verify PENDING_ACTIVATION fallback
- [ ] Follow-up PR could add a unit test for \`FederatedUserMapper\` using a mocked \`WorkerClient\` — the class currently has none, so this PR doesn't add one either

## Rollout

No new config. Works regardless of the internal-auth rollout flag state: when the flag is off the new \`/internal/profile/by-name\` endpoint is reachable without a bearer (worker's filter chain is permit-all); when it's on, auth's \`internalWorkerRestClient\` attaches the token automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)