### PR TITLE
fix: close remaining concerns.md security-adjacent items

### DIFF
--- a/kelta-gateway/src/main/java/io/kelta/gateway/config/SecurityConfig.java
+++ b/kelta-gateway/src/main/java/io/kelta/gateway/config/SecurityConfig.java
@@ -91,18 +91,40 @@ public class SecurityConfig {
 
     /**
      * Configures the security filter chain.
-     * Since we're using a custom GlobalFilter for authentication,
-     * we disable the default Spring Security filters to avoid conflicts.
-     * CORS is enabled and delegates to the CorsConfigurationSource bean.
+     *
+     * <p>API auth is still handled by the custom {@code GlobalFilter}s
+     * ({@code JwtAuthenticationFilter}, {@code CerbosAuthorizationFilter}, …)
+     * rather than by Spring Security, so {@code anyExchange().permitAll()}
+     * stays the default — a regression that bypasses those filters still gets
+     * caught downstream, but Spring Security itself does not re-authenticate
+     * API traffic.
+     *
+     * <p>The exception is Spring Boot Actuator. {@code /actuator/health}
+     * (Kubernetes liveness/readiness probes) and {@code /actuator/info} stay
+     * public; everything else under {@code /actuator/**} — {@code metrics},
+     * {@code env}, {@code loggers}, etc. — now requires an OAuth2 bearer
+     * token, validated by the platform's existing {@link ReactiveJwtDecoder}
+     * via the {@code oauth2ResourceServer} DSL. Closes the
+     * "SecurityConfig permits all exchanges" defense-in-depth gap flagged in
+     * {@code concerns.md}: even if actuator exposure was accidentally widened
+     * in the management config, it can no longer be scraped anonymously.
+     *
+     * <p>CORS is enabled and delegates to the {@link CorsConfigurationSource}
+     * bean so error responses that short-circuit before gateway routing still
+     * carry CORS headers.
      */
     @Bean
-    public SecurityWebFilterChain securityWebFilterChain(ServerHttpSecurity http) {
+    public SecurityWebFilterChain securityWebFilterChain(ServerHttpSecurity http,
+                                                          ReactiveJwtDecoder reactiveJwtDecoder) {
         return http
             .csrf(ServerHttpSecurity.CsrfSpec::disable)
             .cors(cors -> cors.configurationSource(corsConfigurationSource()))
             .authorizeExchange(exchanges -> exchanges
+                .pathMatchers("/actuator/health/**", "/actuator/info").permitAll()
+                .pathMatchers("/actuator/**").authenticated()
                 .anyExchange().permitAll()
             )
+            .oauth2ResourceServer(oauth -> oauth.jwt(jwt -> jwt.jwtDecoder(reactiveJwtDecoder)))
             .build();
     }
 

--- a/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/storage/PhysicalTableStorageAdapter.java
+++ b/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/storage/PhysicalTableStorageAdapter.java
@@ -19,6 +19,7 @@ import org.springframework.dao.DuplicateKeyException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
 
+import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -29,6 +30,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.zip.CRC32;
 
 /**
  * Storage adapter that maps each collection to a physical PostgreSQL table
@@ -102,9 +104,33 @@ public class PhysicalTableStorageAdapter implements StorageAdapter {
         TableRef tableRef = getTableRef(definition);
         String qualifiedName = tableRef.toSql();
 
-        // Ensure the tenant schema exists before creating the table
+        // Ensure the tenant schema exists before creating the table. Use
+        // information_schema to verify the CREATE actually took effect — a
+        // permission error on CREATE would bubble out of jdbcTemplate.execute,
+        // but a post-condition check turns a silently-missing schema (e.g.
+        // CREATE raced against a concurrent DROP) into an explicit, actionable
+        // StorageException instead of a confusing "relation does not exist"
+        // failure later during the CREATE TABLE itself.
         if (!tableRef.isPublicSchema()) {
-            jdbcTemplate.execute("CREATE SCHEMA IF NOT EXISTS \"" + tableRef.schema() + "\"");
+            String schemaName = tableRef.schema();
+            try {
+                jdbcTemplate.execute("CREATE SCHEMA IF NOT EXISTS \""
+                        + schemaName.replace("\"", "\"\"") + "\"");
+            } catch (DataAccessException e) {
+                throw new StorageException(
+                        "Failed to create tenant schema '" + schemaName
+                                + "' (check the worker's DB role has CREATE on the target database): "
+                                + e.getMessage(), e);
+            }
+            Integer exists = jdbcTemplate.queryForObject(
+                    "SELECT 1 FROM information_schema.schemata WHERE schema_name = ?",
+                    Integer.class, schemaName);
+            if (exists == null) {
+                throw new StorageException(
+                        "Tenant schema '" + schemaName + "' was not created and is not visible "
+                                + "to the worker's DB role — refusing to create table '"
+                                + tableRef.tableName() + "'");
+            }
         }
 
         StringBuilder sql = new StringBuilder("CREATE TABLE IF NOT EXISTS ");
@@ -154,8 +180,9 @@ public class PhysicalTableStorageAdapter implements StorageAdapter {
 
             // Unique index for EXTERNAL_ID
             if (field.type() == FieldType.EXTERNAL_ID) {
-                String idxName = "idx_" + sanitizeIdentifier(getBaseTableName(definition))
-                    + "_" + sanitizeIdentifier(columnName);
+                String idxName = buildBoundedIdentifier(
+                        "idx_", sanitizeIdentifier(getBaseTableName(definition)),
+                        sanitizeIdentifier(columnName));
                 postCreateStatements.add(
                     "CREATE UNIQUE INDEX IF NOT EXISTS " + idxName
                     + " ON " + qualifiedName + "(" + sanitizeIdentifier(columnName) + ")"
@@ -172,7 +199,8 @@ public class PhysicalTableStorageAdapter implements StorageAdapter {
                         ? TableRef.publicSchema(targetTableName)
                         : TableRef.tenantSchema(tableRef.schema(), targetTableName);
                 String targetCol = sanitizeIdentifier(field.referenceConfig().targetField());
-                String fkName = "fk_" + sanitizeIdentifier(baseName) + "_" + sanitizeIdentifier(columnName);
+                String fkName = buildBoundedIdentifier(
+                        "fk_", sanitizeIdentifier(baseName), sanitizeIdentifier(columnName));
                 String onDelete = field.type() == FieldType.MASTER_DETAIL
                         ? "ON DELETE CASCADE" : "ON DELETE SET NULL";
 
@@ -603,6 +631,37 @@ public class PhysicalTableStorageAdapter implements StorageAdapter {
             throw new IllegalArgumentException("Invalid identifier: " + identifier);
         }
         return identifier;
+    }
+
+    /** PostgreSQL's identifier length limit. Longer names are silently truncated. */
+    private static final int PG_IDENT_MAX_LEN = 63;
+
+    /**
+     * Builds a deterministic identifier of the form
+     * {@code prefix + baseName + "_" + suffix}, rewriting to
+     * {@code prefix + trunc + "_" + crc} when the plain join would exceed
+     * PostgreSQL's 63-char identifier limit.
+     *
+     * <p>Without this, two FK constraints on long collection+field pairs would
+     * truncate to identical server-side names — the first {@code IF NOT EXISTS}
+     * check would match the wrong constraint and the second FK would silently
+     * never be created. Using CRC32 of the full joined name as a stable 8-hex
+     * suffix guarantees uniqueness while keeping the result recognisable.
+     */
+    static String buildBoundedIdentifier(String prefix, String baseName, String suffix) {
+        String full = prefix + baseName + "_" + suffix;
+        if (full.length() <= PG_IDENT_MAX_LEN) {
+            return full;
+        }
+        CRC32 crc = new CRC32();
+        crc.update((baseName + "_" + suffix).getBytes(StandardCharsets.UTF_8));
+        String hashSuffix = String.format("_%08x", crc.getValue());
+        // Budget: prefix + truncated-baseName + hashSuffix, exactly 63 chars.
+        int budget = PG_IDENT_MAX_LEN - prefix.length() - hashSuffix.length();
+        String trimmedBase = baseName.length() <= budget
+                ? baseName
+                : baseName.substring(0, Math.max(0, budget));
+        return prefix + trimmedBase + hashSuffix;
     }
 
     /**


### PR DESCRIPTION
## Summary

Wraps up the last three security-adjacent entries in [\`concerns.md\`](./.claude/docs/concerns.md) in a single PR. Three independent hardenings in two files.

### 1. Tenant schema isolation silent failure (\`PhysicalTableStorageAdapter\`)

**Before:**
\`\`\`java
jdbcTemplate.execute("CREATE SCHEMA IF NOT EXISTS \\"" + tableRef.schema() + "\\"");
\`\`\`
A permission error bubbled as a generic \`DataAccessException\` wrapped in a generic \`StorageException\` at the outer catch. If CREATE was a no-op (rare: concurrent DROP) downstream \`CREATE TABLE\` failed with a confusing "relation does not exist".

**After:** catch the DDL exception specifically and rethrow with an actionable message that names the likely cause, plus a post-condition check against \`information_schema.schemata\` that turns a silently-missing schema into an explicit \`StorageException\` before the table creation runs. Double-quote escaping added on the schema name for paranoia even though \`TableRef\` already validates it.

### 2. FK / unique-index name collisions on long identifiers (\`PhysicalTableStorageAdapter\`)

Postgres silently truncates identifiers to 63 chars. Two different FKs on collection+field pairs whose joined name exceeds 63 chars would truncate to the same server-side name — the \`IF NOT EXISTS (SELECT ... FROM pg_constraint WHERE conname = ?)\` check would match the first FK and the second would never be created.

**After:** new \`buildBoundedIdentifier(prefix, baseName, suffix)\` emits the plain join when it fits, or \`{prefix}{truncated-base}_{crc32-of-original}\` when it doesn't. CRC32 is stable across JVM runs (unlike \`String.hashCode\`), fast, and the resulting name is still human-recognisable. Applied to both the \`fk_\` FK constraint name and the \`idx_\` EXTERNAL_ID unique index.

### 3. Gateway \`permitAll()\` defense-in-depth (\`SecurityConfig\`)

Gateway's API auth is still handled by the custom \`GlobalFilter\` chain (\`JwtAuthenticationFilter\`, \`CerbosAuthorizationFilter\`, …) — \`anyExchange().permitAll()\` stays the default for API traffic. The new layer tightens Spring Boot Actuator specifically:

- \`/actuator/health/**\` and \`/actuator/info\` stay public (k8s probes + service discovery).
- Everything else under \`/actuator/**\` now requires an OAuth2 bearer token, validated by the existing \`ReactiveJwtDecoder\` via \`oauth2ResourceServer\`.

Closes the risk that \`management.endpoints.web.exposure\` ever widens in a future config change and silently publishes \`metrics\`, \`env\`, \`loggers\`, etc. to anonymous scraping.

## Test plan

- [x] \`mvn test\` — platform 71, gateway 423, worker 1002 all green
- [ ] Staging: verify k8s health/readiness probes still work (\`/actuator/health\` unauthenticated)
- [ ] Staging: verify monitoring scrape of \`/actuator/prometheus\` succeeds with its existing bearer token (if any monitoring currently hits a non-health actuator endpoint without auth, it will 401 — that's the intended change, they need to present a token)
- [ ] Create a collection with a 60+ char name and a 60+ char FK field — verify both FK and unique-index names fit inside the 63-char limit with distinct CRC32 suffixes
- [ ] Verify an RLS-denied CREATE SCHEMA surfaces with the new "check the worker's DB role has CREATE" message rather than a generic stack trace

## concerns.md status after this PR

All security-risk entries and all security-adjacent fragile-area entries are now closed. Remaining open items are tech debt, performance, or test coverage — not security.

🤖 Generated with [Claude Code](https://claude.com/claude-code)