### PR TITLE
add design system

### DIFF
--- a/kelta-ui/DESIGN.md
+++ b/kelta-ui/DESIGN.md
@@ -1,0 +1,163 @@
+# Kelta UI — Design Guidelines
+
+This document is the source of truth for *how Kelta looks and feels*. The CSS variables and shadcn primitives in `app/src/index.css` define the **system**; this document defines the **rules** for using it.
+
+The full design-system project (interactive previews, brand assets, mocks) lives at `https://claude.ai/p/kelta-design-system` (or whichever Claude project is current). When that project is updated, sync the changes back to this file.
+
+---
+
+## 1 · Voice & content
+
+Kelta talks to operators who know their data. The tone is calm, direct, and a little dry. Like a senior coworker pointing at a number.
+
+- **Sentence case everywhere.** "New customer," not "New Customer."
+- **No exclamation points** in product copy.
+- **No emoji.** Use Lucide icons or nothing.
+- **Empty values** are rendered as a literal em-dash `—`. Never "N/A," "None," or a blank cell.
+- **Numbers are nouns.** `1,247 records · synced 2 minutes ago`, not `1247 records were last synced 2 minutes ago.`
+- **No marketing-speak in product surfaces.** Save "supercharge," "AI-powered," "delight" for `kelta-marketing`.
+- **Error messages name the thing and the next step.** *"Couldn't reach the API. Retry, or check Settings → Integrations."*
+
+## 2 · Type
+
+The repo uses the system stack today; we're standardizing on:
+
+- **UI:** Inter (variable, weights 400–700)
+- **Mono:** JetBrains Mono (record IDs, totals, timestamps, code, anything that needs columnar alignment)
+
+Add Google Fonts to `app/index.html`:
+
+```html
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+```
+
+And in `index.css` `:root`:
+
+```css
+font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+```
+
+Mono via Tailwind: `font-mono` is already wired up; we just need the import.
+
+### The field-label rule
+
+The signature Kelta detail/list treatment is **uppercase 11 px field labels**. Every field label in a form, detail card, KPI tile, or stat block uses this:
+
+```tsx
+<label className="text-[11px] font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+  Email
+</label>
+```
+
+This is the single most distinctive piece of Kelta visual identity. Apply it consistently.
+
+### Type scale
+
+| Token | px | Use |
+|---|---|---|
+| Display | 48 / 700 | Marketing hero only |
+| H1 | 26 / 700 / -0.01em | Page titles |
+| H2 | 20 / 600 | Section headers |
+| Lead | 16 / 400 | Page intro under H1 |
+| Body | 14 / 400 / 1.55 | Default |
+| Small | 13 | Secondary copy, table cells |
+| Field label | 11 / 600 / 0.08em uppercase | The rule above |
+
+## 3 · Color
+
+Tokens live in `app/src/index.css` (already correct — slate base, Blue 600 light / Blue 400 dark). **Always** reference them as `bg-background`, `text-foreground`, `border-border`, etc. **Never hardcode hex** in components — if you find yourself reaching for `#0F172A`, you want `bg-card` instead.
+
+### The gradient rule
+
+The cyan→blue gradient `linear-gradient(135deg, #06B6D4 0%, #3B82F6 100%)` appears in exactly two places:
+
+1. **The logo mark** (`app/public/logo.svg`)
+2. **The AI assistant FAB** (and only the FAB — never the chat panel chrome)
+
+Never use it as a page background, card fill, button, or hero. It loses meaning when it's everywhere.
+
+### Status colors
+
+Use the existing `--success`, `--warning`, `--destructive` tokens. Never invent new semantic colors per page. Status badges should match the pattern in §6.
+
+## 4 · Layout & space
+
+- **4 px base unit.** Tailwind already enforces this; stay on the scale.
+- **Cards: 10 px radius**, 1 px border, no shadow in dark mode (separation is by border + a slightly raised surface like `#111C2E`).
+- **Page width: 1180 px max** centered. Pages should breathe at 1440 px, not stretch.
+- **Section header band**: cards with collapsible/header sections get a 14–16 px tall header strip with a subtle gradient `linear-gradient(180deg, rgba(148,163,184,0.06), rgba(148,163,184,0))` and a divider below. See `RecordDetail` in the design-system mocks.
+
+## 5 · Tables
+
+Data tables are the heart of the runtime. They follow this exact recipe:
+
+- Wrapper: `border-1 border-border rounded-[10px] overflow-hidden bg-card`
+- Header row: distinct background (`#16243A` dark / `#F1F5F9` light), uppercase 11 px heads with `tracking-[0.09em]` and `text-foreground/80`
+- Body rows: zebra (every even row gets `bg-muted/40`), bottom 1 px `border-border`
+- Hover: accent tint `bg-primary/10`, *not* a darker neutral
+- Numerics: `font-mono tabular-nums text-right`
+- Status: pill with leading dot (see §6)
+
+The full markup is in the design-system mocks — `mocks/CustomersPage.jsx`.
+
+## 6 · Components
+
+For shadcn primitives (Button, Input, Select, Table, Dialog, etc.), use the repo's existing `components/ui/*`. Do not re-import shadcn or create parallel components.
+
+For app-level patterns, prefer building on top of the primitives. The reference implementations are in the design-system project under `ui_kits/kelta-app/`:
+
+| Pattern | Reference | Notes |
+|---|---|---|
+| `<TopNavBar>` | `TopNavBar.jsx` | 54 px sticky, app launcher → tenant name → tabs → admin → search/bell → avatar |
+| `<RecordDetail>` / `<CollapsibleSection>` | `DetailView.jsx` | Header band, breadcrumb, uppercase field labels, em-dash empties |
+| `<DataTable>` | `ListView.jsx` | The recipe in §5 |
+| `<HomeView>` | `HomePage.jsx` (mocks) | KPI tiles + sparkline + recent items + activity feed |
+| `<AiFab>` | `AiFab.jsx` | The only gradient surface; floats bottom-right |
+
+### Status badge
+
+```tsx
+<span className="inline-flex items-center gap-1.5 h-[22px] px-2.5 rounded text-[11px] font-semibold border bg-emerald-500/15 text-emerald-300 border-emerald-500/55">
+  <span className="size-1.5 rounded-full bg-current" /> Active
+</span>
+```
+
+Variants: `Active/Paid → emerald`, `Pending → amber`, `Refunded/Inactive → slate`, `Failed → destructive`. Never invent a sixth.
+
+## 7 · Iconography
+
+[Lucide React](https://lucide.dev/) only. Default size 16 px in product UI, 14 px inline with text, 18–20 px in tile headers. Stroke 2 px (Lucide default). No filled or two-tone icons; no emoji.
+
+## 8 · Brand assets
+
+Logos live in `app/public/brand/`:
+
+- `logo-primary.svg` — full mark on light backgrounds (marketing site, login on light theme)
+- `logo-dark-bg.svg` — full mark on dark backgrounds (the runtime — use this in `TopNavBar`)
+- `app/public/logo.svg` — square icon mark (browser tabs, app icons, OG images)
+- `app/public/favicon.svg`
+
+The mark is an SVG with the cyan→blue gradient. Don't recolor or rotate it.
+
+## 9 · Accessibility
+
+- WCAG 2.1 AA for all text (already enforced by the existing token contrast — keep it that way)
+- Focus rings are non-negotiable. The `:focus-visible` styles in `index.css` are the floor.
+- Every interactive element gets an accessible name (`aria-label` for icon-only buttons)
+- Tables get proper `<thead>` / `<th scope="col">`
+- Color is never the sole signal — status badges always pair color + dot + text
+
+## 10 · Don't
+
+- Don't add a sixth status color
+- Don't invent gradients beyond the brand cyan→blue
+- Don't use shadows in dark mode for separation (use border + surface lift)
+- Don't use rounded-corner + left-border-accent containers (the AI-slop trope)
+- Don't use Inter for marketing hero copy at <16 px (it gets thin); reach for a heavier weight or a display face
+- Don't write "N/A" — always `—`
+
+---
+
+*Questions? Drop them in #design or open an issue tagged `design-system`.*

--- a/kelta-ui/README.md
+++ b/kelta-ui/README.md
@@ -103,3 +103,7 @@ npm run test:coverage    # With coverage report
 - Vitest 4.0.18, Testing Library, MSW 2.12.7
 - ESLint 9.39.1 (with jsx-a11y), Prettier 3.8.1
 - @kelta/sdk, @kelta/components, @kelta/plugin-sdk
+
+## Design
+See [DESIGN.md](./DESIGN.md) for visual rules, component patterns, and the
+field-label / empty-value / gradient conventions.

--- a/kelta-ui/app/public/brand/logo-dark-bg.svg
+++ b/kelta-ui/app/public/brand/logo-dark-bg.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 180 40">
+  <defs>
+    <linearGradient id="kelta-grad" x1="0%" y1="0%" x2="100%" y2="100%" gradientTransform="rotate(135)">
+      <stop offset="0%" stop-color="#06B6D4"></stop>
+      <stop offset="100%" stop-color="#3B82F6"></stop>
+    </linearGradient>
+  </defs>
+  
+  <rect x="2" y="4" width="6" height="32" rx="2" fill="url(#kelta-grad)"></rect>
+  <polygon points="8,20 24,4 30,4 14,20" fill="url(#kelta-grad)"></polygon>
+  <polygon points="8,20 24,36 30,36 14,20" fill="url(#kelta-grad)"></polygon>
+  <circle cx="26" cy="8" r="3" fill="#06B6D4"></circle>
+  <circle cx="26" cy="32" r="3" fill="#3B82F6"></circle>
+  
+  <text x="42" y="29" font-family="Inter, system-ui, sans-serif" font-size="22" font-weight="700" fill="#FFFFFF" letter-spacing="-0.5">Kelta</text>
+</svg>

--- a/kelta-ui/app/public/brand/logo-primary.svg
+++ b/kelta-ui/app/public/brand/logo-primary.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 180 40">
+  <defs>
+    <linearGradient id="kelta-grad" x1="0%" y1="0%" x2="100%" y2="100%" gradientTransform="rotate(135)">
+      <stop offset="0%" stop-color="#06B6D4"></stop>
+      <stop offset="100%" stop-color="#3B82F6"></stop>
+    </linearGradient>
+  </defs>
+  
+  <rect x="2" y="4" width="6" height="32" rx="2" fill="url(#kelta-grad)"></rect>
+  <polygon points="8,20 24,4 30,4 14,20" fill="url(#kelta-grad)"></polygon>
+  <polygon points="8,20 24,36 30,36 14,20" fill="url(#kelta-grad)"></polygon>
+  <circle cx="26" cy="8" r="3" fill="#06B6D4"></circle>
+  <circle cx="26" cy="32" r="3" fill="#3B82F6"></circle>
+  
+  <text x="42" y="29" font-family="Inter, system-ui, sans-serif" font-size="22" font-weight="700" fill="#0F172A" letter-spacing="-0.5">Kelta</text>
+</svg>

--- a/kelta-ui/app/public/favicon.svg
+++ b/kelta-ui/app/public/favicon.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <defs>
+    <linearGradient id="kelta-grad" x1="0%" y1="0%" x2="100%" y2="100%" gradientTransform="rotate(135)">
+      <stop offset="0%" stop-color="#06B6D4"></stop>
+      <stop offset="100%" stop-color="#3B82F6"></stop>
+    </linearGradient>
+  </defs>
+  <rect width="32" height="32" rx="6" fill="#0F172A"></rect>
+  
+  <rect x="6" y="4" width="4" height="24" rx="1.5" fill="url(#kelta-grad)"></rect>
+  <polygon points="10,16 22,4 26,4 14,16" fill="url(#kelta-grad)"></polygon>
+  <polygon points="10,16 22,28 26,28 14,16" fill="url(#kelta-grad)"></polygon>
+  <circle cx="23" cy="6" r="2.5" fill="#06B6D4"></circle>
+  <circle cx="23" cy="26" r="2.5" fill="#3B82F6"></circle>
+</svg>

--- a/kelta-ui/app/public/logo.svg
+++ b/kelta-ui/app/public/logo.svg
@@ -1,34 +1,14 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="160" height="160" viewBox="0 0 160 160" role="img" aria-label="Enterprise microservice framework icon">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
   <defs>
-    <linearGradient id="g2" x1="0" x2="1" y1="0" y2="1">
-      <stop offset="0" stop-color="#0f62fe"/>
-      <stop offset="1" stop-color="#00bfa6"/>
+    <linearGradient id="kelta-grad" x1="0%" y1="0%" x2="100%" y2="100%" gradientTransform="rotate(135)">
+      <stop offset="0%" stop-color="#06B6D4"></stop>
+      <stop offset="100%" stop-color="#3B82F6"></stop>
     </linearGradient>
   </defs>
-
-  <!-- outer rounded square -->
-  <rect x="8" y="8" width="144" height="144" rx="18" fill="#071233" opacity="0.06"/>
-
-  <!-- centre circle -->
-  <circle cx="80" cy="58" r="26" fill="url(#g2)"/>
-
-  <!-- nodes -->
-  <g stroke="#022045" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" fill="#ffffff">
-    <circle cx="80" cy="58" r="9" />
-    <circle cx="44" cy="98" r="7" />
-    <circle cx="116" cy="98" r="7" />
-  </g>
-
-  <!-- connections -->
-  <g fill="none" stroke="#ffffff" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" opacity="0.9">
-    <path d="M80 67 L52 92" />
-    <path d="M80 67 L108 92" />
-    <path d="M52 92 L108 92" stroke-dasharray="4 5" stroke-opacity="0.75"/>
-  </g>
-
-  <!-- small enterprise gear hint -->
-  <g transform="translate(124,14) rotate(15)">
-    <circle cx="0" cy="0" r="10" fill="#0f62fe" opacity="0.12"/>
-    <path d="M-6 -2 L-10 -2 L-8 -6 L-10 -10 L-6 -8 L-2 -10 L-2 -6 L6 -6 L6 -2 L2 -2 L2 6 L-2 6 L-2 2 L-6 2 Z" fill="#0f62fe" opacity="0.22"/>
-  </g>
+  
+  <rect x="12" y="8" width="8" height="48" rx="3" fill="url(#kelta-grad)"></rect>
+  <polygon points="20,32 44,8 52,8 28,32" fill="url(#kelta-grad)"></polygon>
+  <polygon points="20,32 44,56 52,56 28,32" fill="url(#kelta-grad)"></polygon>
+  <circle cx="46" cy="12" r="5" fill="#06B6D4"></circle>
+  <circle cx="46" cy="52" r="5" fill="#3B82F6"></circle>
 </svg>

--- a/kelta-ui/app/src/components/kelta/AiAssistantFab.tsx
+++ b/kelta-ui/app/src/components/kelta/AiAssistantFab.tsx
@@ -1,0 +1,34 @@
+// AiAssistantFab.tsx — floating AI assistant button. The ONLY gradient surface.
+import * as React from 'react';
+import { Sparkles } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+export interface AiAssistantFabProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {}
+
+/**
+ * Floating AI assistant launcher. Lives bottom-right, always visible.
+ * The cyan→blue gradient appears here and on the logo mark — nowhere else.
+ */
+export const AiAssistantFab = React.forwardRef<HTMLButtonElement, AiAssistantFabProps>(
+  ({ className, ...props }, ref) => (
+    <button
+      ref={ref}
+      type="button"
+      aria-label="Open AI assistant"
+      className={cn(
+        'fixed bottom-6 right-6 size-[52px] rounded-full',
+        'flex items-center justify-center text-white',
+        'shadow-[0_10px_24px_-8px_rgba(59,130,246,0.6)]',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+        'z-50',
+        className,
+      )}
+      style={{ background: 'linear-gradient(135deg, #06B6D4 0%, #3B82F6 100%)' }}
+      {...props}
+    >
+      <Sparkles className="size-[22px]" aria-hidden="true" />
+    </button>
+  ),
+);
+
+AiAssistantFab.displayName = 'AiAssistantFab';

--- a/kelta-ui/app/src/components/kelta/EmptyValue.tsx
+++ b/kelta-ui/app/src/components/kelta/EmptyValue.tsx
@@ -1,0 +1,27 @@
+// EmptyValue.tsx — render an em-dash for null / undefined / empty values
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+export interface EmptyValueProps extends React.HTMLAttributes<HTMLSpanElement> {}
+
+/**
+ * Renders the Kelta empty-value glyph (em-dash). Use anywhere a value
+ * could be missing. Never show "N/A," "None," or a blank cell.
+ *
+ * @example
+ *   {customer.phone ?? <EmptyValue />}
+ */
+export const EmptyValue = React.forwardRef<HTMLSpanElement, EmptyValueProps>(
+  ({ className, ...props }, ref) => (
+    <span
+      ref={ref}
+      aria-label="empty"
+      className={cn('text-muted-foreground/70', className)}
+      {...props}
+    >
+      —
+    </span>
+  ),
+);
+
+EmptyValue.displayName = 'EmptyValue';

--- a/kelta-ui/app/src/components/kelta/FieldLabel.tsx
+++ b/kelta-ui/app/src/components/kelta/FieldLabel.tsx
@@ -1,0 +1,28 @@
+// FieldLabel.tsx — the signature Kelta uppercase 11px field label
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+export interface FieldLabelProps extends React.LabelHTMLAttributes<HTMLLabelElement> {}
+
+/**
+ * The Kelta field label. Use above every field value in a detail card,
+ * KPI tile, stat block, or form. Tracking and casing are part of the brand.
+ *
+ * @example
+ *   <FieldLabel htmlFor="email">Email</FieldLabel>
+ *   <Input id="email" />
+ */
+export const FieldLabel = React.forwardRef<HTMLLabelElement, FieldLabelProps>(
+  ({ className, ...props }, ref) => (
+    <label
+      ref={ref}
+      className={cn(
+        'block text-[11px] font-semibold uppercase tracking-[0.08em] text-muted-foreground mb-1.5',
+        className,
+      )}
+      {...props}
+    />
+  ),
+);
+
+FieldLabel.displayName = 'FieldLabel';

--- a/kelta-ui/app/src/components/kelta/StatusBadge.tsx
+++ b/kelta-ui/app/src/components/kelta/StatusBadge.tsx
@@ -1,0 +1,46 @@
+// StatusBadge.tsx — five-state status pill with leading dot
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+export type StatusVariant = 'active' | 'pending' | 'inactive' | 'failed' | 'paid';
+
+const variantClass: Record<StatusVariant, string> = {
+  active:   'bg-emerald-500/15 text-emerald-700 dark:text-emerald-300 border-emerald-500/55',
+  paid:     'bg-emerald-500/15 text-emerald-700 dark:text-emerald-300 border-emerald-500/55',
+  pending:  'bg-amber-500/15  text-amber-700  dark:text-amber-300  border-amber-500/55',
+  inactive: 'bg-slate-500/15  text-slate-700  dark:text-slate-300  border-slate-500/45',
+  failed:   'bg-destructive/15 text-destructive border-destructive/55',
+};
+
+export interface StatusBadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
+  variant: StatusVariant;
+  label: string;
+}
+
+/**
+ * Status pill with a leading dot. Color is never the sole signal — the dot
+ * + text label make the state legible in monochrome too.
+ *
+ * Variants are fixed at five. If you need a sixth, talk to design first.
+ *
+ * @example
+ *   <StatusBadge variant="active" label="Active" />
+ */
+export const StatusBadge = React.forwardRef<HTMLSpanElement, StatusBadgeProps>(
+  ({ variant, label, className, ...props }, ref) => (
+    <span
+      ref={ref}
+      className={cn(
+        'inline-flex items-center gap-1.5 h-[22px] px-2.5 rounded text-[11px] font-semibold border',
+        variantClass[variant],
+        className,
+      )}
+      {...props}
+    >
+      <span className="size-1.5 rounded-full bg-current" aria-hidden="true" />
+      {label}
+    </span>
+  ),
+);
+
+StatusBadge.displayName = 'StatusBadge';

--- a/kelta-ui/app/src/components/kelta/index.ts
+++ b/kelta-ui/app/src/components/kelta/index.ts
@@ -1,0 +1,12 @@
+// index.ts — barrel for Kelta-specific components
+export { FieldLabel } from './FieldLabel';
+export type { FieldLabelProps } from './FieldLabel';
+
+export { EmptyValue } from './EmptyValue';
+export type { EmptyValueProps } from './EmptyValue';
+
+export { StatusBadge } from './StatusBadge';
+export type { StatusBadgeProps, StatusVariant } from './StatusBadge';
+
+export { AiAssistantFab } from './AiAssistantFab';
+export type { AiAssistantFabProps } from './AiAssistantFab';

--- a/kelta-ui/app/src/main.tsx
+++ b/kelta-ui/app/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
+import './styles/kelta-design.css';
 import { initTelemetry } from './telemetry'
 import { migrateLocalStorage } from './migrateLocalStorage'
 import App from './App.tsx'

--- a/kelta-ui/app/src/styles/kelta-design.css
+++ b/kelta-ui/app/src/styles/kelta-design.css
@@ -1,0 +1,123 @@
+/* kelta-design.css — additive Kelta visual rules (load AFTER index.css)
+ *
+ * This file adds Inter + JetBrains Mono and a small set of utility classes
+ * for Kelta-specific patterns that aren't shadcn primitives:
+ *   - .kelta-field-label   uppercase 11px field labels
+ *   - .kelta-mono          tabular-nums monospace
+ *   - .kelta-card          stronger card surface for detail/list views
+ *   - .kelta-card-head     header band with subtle gradient + divider
+ *   - .kelta-table-header  distinct header row background for data tables
+ *   - .kelta-status-dot    leading dot inside status badges
+ *
+ * Usage:  <label class="kelta-field-label">Email</label>
+ */
+
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap');
+
+:root {
+  --kelta-font-sans: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --kelta-font-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+
+  /* The brand gradient. Use ONLY on the logo mark and the AI assistant FAB. */
+  --kelta-gradient: linear-gradient(135deg, #06B6D4 0%, #3B82F6 100%);
+}
+
+html, body {
+  font-family: var(--kelta-font-sans);
+}
+
+.kelta-mono,
+.font-mono {
+  font-family: var(--kelta-font-mono);
+  font-variant-numeric: tabular-nums;
+}
+
+/* The signature Kelta field label */
+.kelta-field-label {
+  display: block;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: hsl(var(--muted-foreground));
+  margin-bottom: 6px;
+}
+
+/* Stronger detail/list card surface */
+.kelta-card {
+  border: 1px solid hsl(var(--border));
+  border-radius: 10px;
+  background: hsl(var(--card));
+  overflow: hidden;
+}
+
+.dark .kelta-card {
+  border-color: #334155;
+  background: #111C2E;
+  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.04) inset, 0 12px 28px -16px rgba(0, 0, 0, 0.7);
+}
+
+/* Header band for collapsible sections / table tops */
+.kelta-card-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 14px 18px;
+  font-size: 14px;
+  font-weight: 600;
+  background: linear-gradient(180deg, rgba(148, 163, 184, 0.06), rgba(148, 163, 184, 0));
+  border-bottom: 1px solid hsl(var(--border));
+}
+
+.dark .kelta-card-head {
+  border-bottom-color: #233044;
+}
+
+/* Data-table header row */
+.kelta-table-header {
+  background: hsl(var(--muted));
+}
+
+.dark .kelta-table-header {
+  background: #16243A;
+}
+
+.kelta-table-header th {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: hsl(var(--foreground));
+  padding: 12px 14px;
+  text-align: left;
+  border-bottom: 1px solid hsl(var(--border));
+}
+
+/* Status pill leading dot — apply inside any badge */
+.kelta-status-dot {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: currentColor;
+  margin-right: 6px;
+  vertical-align: middle;
+}
+
+/* The AI FAB — the only place the brand gradient appears outside the logo */
+.kelta-ai-fab {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  width: 52px;
+  height: 52px;
+  border-radius: 999px;
+  border: none;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--kelta-gradient);
+  box-shadow: 0 10px 24px -8px rgba(59, 130, 246, 0.6);
+  z-index: 100;
+}


### PR DESCRIPTION
# Adopt Kelta design system

## What
Formalizes the Kelta design system in code: a top-level `DESIGN.md` rulebook, brand assets, the Inter + JetBrains Mono type stack, and four small components for the Kelta-specific patterns that aren't shadcn primitives.

## Why
The runtime already has a strong shadcn/Tailwind theme — but the *rules* for using it (uppercase 11 px field labels, em-dash empty values, where the brand gradient is allowed, how status pills look) live in screenshots and Slack. This PR puts them in the repo so:
- Contributors don't have to guess
- Claude Code (via `DESIGN.md`) has explicit guardrails
- Future patterns can be PR'd against documented norms instead of vibes

## Scope
Additive. Does **not** modify `index.css`, any existing component, dependencies, routing, services, or tests. Replaces `app/public/logo.svg` with the published brand mark.

## What's added
- `kelta-ui/DESIGN.md` — the rulebook (voice, type, color, layout, components, accessibility, do-nots)
- `kelta-ui/app/public/brand/logo-primary.svg`, `logo-dark-bg.svg` — full marks
- `kelta-ui/app/public/favicon.svg` — Kelta favicon
- `kelta-ui/app/public/logo.svg` — **replaced** with the Kelta brand mark
- `kelta-ui/app/src/styles/kelta-design.css` — Inter + JetBrains Mono import + utility classes
- `kelta-ui/app/src/components/kelta/FieldLabel.tsx` — the signature uppercase label
- `kelta-ui/app/src/components/kelta/EmptyValue.tsx` — the em-dash empty
- `kelta-ui/app/src/components/kelta/StatusBadge.tsx` — five-state pill with leading dot
- `kelta-ui/app/src/components/kelta/AiAssistantFab.tsx` — the FAB (the only gradient surface)
- `kelta-ui/app/src/components/kelta/index.ts` — barrel

## How to use after merge
```tsx
import { FieldLabel, EmptyValue, StatusBadge, AiAssistantFab } from '@/components/kelta';

<FieldLabel htmlFor="email">Email</FieldLabel>
{customer.phone ?? <EmptyValue />}
<StatusBadge variant="active" label="Active" />
```

## Required wiring
After merge, add this one import in `kelta-ui/app/src/main.tsx`:
```ts
import './styles/kelta-design.css';
```

## Follow-up PRs (not in this PR)
1. Audit existing pages for drift from `DESIGN.md`
2. Migrate inline status text → `<StatusBadge>`
3. Add `<AiAssistantFab>` to the runtime shell
4. Storybook stories for `components/kelta/*`

## Test plan
- [ ] `npm run build` succeeds in `kelta-ui/app`
- [ ] `npm run lint` passes
- [ ] Existing tests still green (`npm test`)
- [ ] Inter renders on all pages after wiring `kelta-design.css`
- [ ] Logo replacement looks correct in nav and browser tab