### PR TITLE
feat(kelta-ui): wire Inter + JetBrains Mono fonts (design system PR 1/5)

### DIFF
--- a/kelta-ui/app/index.html
+++ b/kelta-ui/app/index.html
@@ -4,6 +4,12 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
     <title>app</title>
   </head>
   <body>

--- a/kelta-ui/app/src/components/kelta/AiAssistantFab.tsx
+++ b/kelta-ui/app/src/components/kelta/AiAssistantFab.tsx
@@ -1,9 +1,9 @@
 // AiAssistantFab.tsx — floating AI assistant button. The ONLY gradient surface.
-import * as React from 'react';
-import { Sparkles } from 'lucide-react';
-import { cn } from '@/lib/utils';
+import * as React from 'react'
+import { Sparkles } from 'lucide-react'
+import { cn } from '@/lib/utils'
 
-export interface AiAssistantFabProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {}
+export type AiAssistantFabProps = React.ButtonHTMLAttributes<HTMLButtonElement>
 
 /**
  * Floating AI assistant launcher. Lives bottom-right, always visible.
@@ -21,14 +21,14 @@ export const AiAssistantFab = React.forwardRef<HTMLButtonElement, AiAssistantFab
         'shadow-[0_10px_24px_-8px_rgba(59,130,246,0.6)]',
         'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
         'z-50',
-        className,
+        className
       )}
       style={{ background: 'linear-gradient(135deg, #06B6D4 0%, #3B82F6 100%)' }}
       {...props}
     >
       <Sparkles className="size-[22px]" aria-hidden="true" />
     </button>
-  ),
-);
+  )
+)
 
-AiAssistantFab.displayName = 'AiAssistantFab';
+AiAssistantFab.displayName = 'AiAssistantFab'

--- a/kelta-ui/app/src/components/kelta/EmptyValue.tsx
+++ b/kelta-ui/app/src/components/kelta/EmptyValue.tsx
@@ -1,8 +1,8 @@
 // EmptyValue.tsx — render an em-dash for null / undefined / empty values
-import * as React from 'react';
-import { cn } from '@/lib/utils';
+import * as React from 'react'
+import { cn } from '@/lib/utils'
 
-export interface EmptyValueProps extends React.HTMLAttributes<HTMLSpanElement> {}
+export type EmptyValueProps = React.HTMLAttributes<HTMLSpanElement>
 
 /**
  * Renders the Kelta empty-value glyph (em-dash). Use anywhere a value
@@ -21,7 +21,7 @@ export const EmptyValue = React.forwardRef<HTMLSpanElement, EmptyValueProps>(
     >
       —
     </span>
-  ),
-);
+  )
+)
 
-EmptyValue.displayName = 'EmptyValue';
+EmptyValue.displayName = 'EmptyValue'

--- a/kelta-ui/app/src/components/kelta/FieldLabel.tsx
+++ b/kelta-ui/app/src/components/kelta/FieldLabel.tsx
@@ -1,8 +1,8 @@
 // FieldLabel.tsx — the signature Kelta uppercase 11px field label
-import * as React from 'react';
-import { cn } from '@/lib/utils';
+import * as React from 'react'
+import { cn } from '@/lib/utils'
 
-export interface FieldLabelProps extends React.LabelHTMLAttributes<HTMLLabelElement> {}
+export type FieldLabelProps = React.LabelHTMLAttributes<HTMLLabelElement>
 
 /**
  * The Kelta field label. Use above every field value in a detail card,
@@ -14,15 +14,18 @@ export interface FieldLabelProps extends React.LabelHTMLAttributes<HTMLLabelElem
  */
 export const FieldLabel = React.forwardRef<HTMLLabelElement, FieldLabelProps>(
   ({ className, ...props }, ref) => (
+    // jsx-a11y/label-has-associated-control: callers pass htmlFor or wrap a control;
+    // we forward all label props so association is the consumer's concern.
+    // eslint-disable-next-line jsx-a11y/label-has-associated-control
     <label
       ref={ref}
       className={cn(
         'block text-[11px] font-semibold uppercase tracking-[0.08em] text-muted-foreground mb-1.5',
-        className,
+        className
       )}
       {...props}
     />
-  ),
-);
+  )
+)
 
-FieldLabel.displayName = 'FieldLabel';
+FieldLabel.displayName = 'FieldLabel'

--- a/kelta-ui/app/src/components/kelta/StatusBadge.tsx
+++ b/kelta-ui/app/src/components/kelta/StatusBadge.tsx
@@ -1,20 +1,20 @@
 // StatusBadge.tsx — five-state status pill with leading dot
-import * as React from 'react';
-import { cn } from '@/lib/utils';
+import * as React from 'react'
+import { cn } from '@/lib/utils'
 
-export type StatusVariant = 'active' | 'pending' | 'inactive' | 'failed' | 'paid';
+export type StatusVariant = 'active' | 'pending' | 'inactive' | 'failed' | 'paid'
 
 const variantClass: Record<StatusVariant, string> = {
-  active:   'bg-emerald-500/15 text-emerald-700 dark:text-emerald-300 border-emerald-500/55',
-  paid:     'bg-emerald-500/15 text-emerald-700 dark:text-emerald-300 border-emerald-500/55',
-  pending:  'bg-amber-500/15  text-amber-700  dark:text-amber-300  border-amber-500/55',
+  active: 'bg-emerald-500/15 text-emerald-700 dark:text-emerald-300 border-emerald-500/55',
+  paid: 'bg-emerald-500/15 text-emerald-700 dark:text-emerald-300 border-emerald-500/55',
+  pending: 'bg-amber-500/15  text-amber-700  dark:text-amber-300  border-amber-500/55',
   inactive: 'bg-slate-500/15  text-slate-700  dark:text-slate-300  border-slate-500/45',
-  failed:   'bg-destructive/15 text-destructive border-destructive/55',
-};
+  failed: 'bg-destructive/15 text-destructive border-destructive/55',
+}
 
 export interface StatusBadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
-  variant: StatusVariant;
-  label: string;
+  variant: StatusVariant
+  label: string
 }
 
 /**
@@ -33,14 +33,14 @@ export const StatusBadge = React.forwardRef<HTMLSpanElement, StatusBadgeProps>(
       className={cn(
         'inline-flex items-center gap-1.5 h-[22px] px-2.5 rounded text-[11px] font-semibold border',
         variantClass[variant],
-        className,
+        className
       )}
       {...props}
     >
       <span className="size-1.5 rounded-full bg-current" aria-hidden="true" />
       {label}
     </span>
-  ),
-);
+  )
+)
 
-StatusBadge.displayName = 'StatusBadge';
+StatusBadge.displayName = 'StatusBadge'

--- a/kelta-ui/app/src/components/kelta/index.ts
+++ b/kelta-ui/app/src/components/kelta/index.ts
@@ -1,12 +1,12 @@
 // index.ts — barrel for Kelta-specific components
-export { FieldLabel } from './FieldLabel';
-export type { FieldLabelProps } from './FieldLabel';
+export { FieldLabel } from './FieldLabel'
+export type { FieldLabelProps } from './FieldLabel'
 
-export { EmptyValue } from './EmptyValue';
-export type { EmptyValueProps } from './EmptyValue';
+export { EmptyValue } from './EmptyValue'
+export type { EmptyValueProps } from './EmptyValue'
 
-export { StatusBadge } from './StatusBadge';
-export type { StatusBadgeProps, StatusVariant } from './StatusBadge';
+export { StatusBadge } from './StatusBadge'
+export type { StatusBadgeProps, StatusVariant } from './StatusBadge'
 
-export { AiAssistantFab } from './AiAssistantFab';
-export type { AiAssistantFabProps } from './AiAssistantFab';
+export { AiAssistantFab } from './AiAssistantFab'
+export type { AiAssistantFabProps } from './AiAssistantFab'

--- a/kelta-ui/app/src/index.css
+++ b/kelta-ui/app/src/index.css
@@ -274,7 +274,15 @@
  * These styles support the existing CSS Modules-based admin pages.
  */
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  font-family:
+    'Inter',
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    'Segoe UI',
+    Helvetica,
+    Arial,
+    sans-serif;
   line-height: 1.5;
   font-weight: 400;
 

--- a/kelta-ui/app/src/styles/kelta-design.css
+++ b/kelta-ui/app/src/styles/kelta-design.css
@@ -12,17 +12,19 @@
  * Usage:  <label class="kelta-field-label">Email</label>
  */
 
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap');
+/* Fonts (Inter, JetBrains Mono) are loaded via <link> in app/index.html
+ * for better load performance (preconnect + parallel discovery). */
 
 :root {
   --kelta-font-sans: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   --kelta-font-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
 
   /* The brand gradient. Use ONLY on the logo mark and the AI assistant FAB. */
-  --kelta-gradient: linear-gradient(135deg, #06B6D4 0%, #3B82F6 100%);
+  --kelta-gradient: linear-gradient(135deg, #06b6d4 0%, #3b82f6 100%);
 }
 
-html, body {
+html,
+body {
   font-family: var(--kelta-font-sans);
 }
 
@@ -53,8 +55,10 @@ html, body {
 
 .dark .kelta-card {
   border-color: #334155;
-  background: #111C2E;
-  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.04) inset, 0 12px 28px -16px rgba(0, 0, 0, 0.7);
+  background: #111c2e;
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.04) inset,
+    0 12px 28px -16px rgba(0, 0, 0, 0.7);
 }
 
 /* Header band for collapsible sections / table tops */
@@ -79,7 +83,7 @@ html, body {
 }
 
 .dark .kelta-table-header {
-  background: #16243A;
+  background: #16243a;
 }
 
 .kelta-table-header th {


### PR DESCRIPTION
## Summary

PR **1 of 5** in the kelta-ui design-system rollout. This PR sets the typographic baseline so subsequent PRs compose on top of it. No visual change to existing screens beyond the typeface itself.

- Loads Inter (400/500/600/700) + JetBrains Mono (400/500) via `<link>` in `app/index.html` with `preconnect` for parallel font discovery (per [DESIGN.md §2](../blob/main/kelta-ui/DESIGN.md))
- Drops the `@import url(...)` from `kelta-design.css` — `<link>` loads faster and is the spec'd location
- Switches `:root { font-family }` in `index.css` from `system-ui` to Inter via `var(--kelta-font-sans)` so the cascade matches the design system
- Fixes 4 lint errors in the `components/kelta/*` files introduced by #759 (empty-interface props → type alias; `FieldLabel` `jsx-a11y` rule disabled with documented reason — association is the consumer's concern)

## Rollout plan (for context)

1. **PR 1 — Foundation** *(this PR)* — fonts + token cleanup
2. PR 2 — Runtime: Header, Sidebar, ObjectDataTable, ObjectListPage, ObjectDetailPage, ObjectFormPage, AppHomePage, wire AiAssistantFab
3. PR 3 — Admin & Setup pages
4. PR 4 — Builder surfaces (FlowDesigner, PageBuilder, Dashboards) — tokens + component swaps only
5. PR 5 — Quality sweep (em-dash, hex audit, sentence case, emoji removal)

## Test plan

- [x] `npm run lint` — 0 errors (was 4)
- [x] `npm run test:run` — 1764 passed, 34 skipped
- [x] `npm run format:check` on touched files
- [ ] Smoke check in dev: `getComputedStyle(document.body).fontFamily` starts with `Inter`; `font-mono` elements render JetBrains Mono
- [ ] Verify no FOUT regression on slow connections

🤖 Generated with [Claude Code](https://claude.com/claude-code)