### PR TITLE
feat(kelta-ui): adopt design system across runtime UI (PR 2/5)

### DIFF
--- a/kelta-ui/app/index.html
+++ b/kelta-ui/app/index.html
@@ -4,6 +4,12 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
     <title>app</title>
   </head>
   <body>

--- a/kelta-ui/app/src/components/AiChat/AiChatTrigger.tsx
+++ b/kelta-ui/app/src/components/AiChat/AiChatTrigger.tsx
@@ -1,18 +1,8 @@
-import { Button } from '@/components/ui/button'
-import { Sparkles } from 'lucide-react'
+import { AiAssistantFab } from '@/components/kelta'
 import { useAiChat } from './AiChatContext'
 
 export function AiChatTrigger() {
   const { togglePanel } = useAiChat()
 
-  return (
-    <Button
-      onClick={togglePanel}
-      size="icon"
-      className="fixed bottom-6 right-6 z-50 h-12 w-12 rounded-full shadow-lg"
-      title="AI Assistant (Ctrl+Shift+A)"
-    >
-      <Sparkles className="h-5 w-5" />
-    </Button>
-  )
+  return <AiAssistantFab onClick={togglePanel} title="AI assistant (Ctrl+Shift+A)" />
 }

--- a/kelta-ui/app/src/components/DetailSection/DetailSection.tsx
+++ b/kelta-ui/app/src/components/DetailSection/DetailSection.tsx
@@ -88,9 +88,7 @@ export function DetailSection({
 
                 return (
                   <div key={field.name} className="space-y-1">
-                    <dt className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                      {field.displayName || field.name}
-                    </dt>
+                    <dt className="kelta-field-label">{field.displayName || field.name}</dt>
                     <dd className="text-sm">
                       <FieldRenderer
                         type={field.type}

--- a/kelta-ui/app/src/components/FieldRenderer/FieldRenderer.tsx
+++ b/kelta-ui/app/src/components/FieldRenderer/FieldRenderer.tsx
@@ -26,6 +26,7 @@ import {
 } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
+import { EmptyValue } from '@/components/kelta'
 import { cn } from '@/lib/utils'
 import { componentRegistry } from '@/services/componentRegistry'
 import { PluginErrorBoundary } from '@/components/PluginErrorBoundary'
@@ -165,14 +166,7 @@ export function FieldRenderer({
 }: FieldRendererProps): React.ReactElement {
   // Null/undefined values
   if (value === null || value === undefined) {
-    return (
-      <span
-        className={cn('text-muted-foreground', className)}
-        aria-label={`${displayName || fieldName}: empty`}
-      >
-        —
-      </span>
-    )
+    return <EmptyValue className={className} aria-label={`${displayName || fieldName}: empty`} />
   }
 
   // Check for plugin-provided custom field renderer
@@ -214,7 +208,7 @@ export function FieldRenderer({
     }
 
     case 'number': {
-      return <span className={className}>{formatNumber(value)}</span>
+      return <span className={cn('font-mono tabular-nums', className)}>{formatNumber(value)}</span>
     }
 
     case 'boolean': {
@@ -256,11 +250,13 @@ export function FieldRenderer({
     }
 
     case 'currency': {
-      return <span className={className}>{formatCurrency(value)}</span>
+      return (
+        <span className={cn('font-mono tabular-nums', className)}>{formatCurrency(value)}</span>
+      )
     }
 
     case 'percent': {
-      return <span className={className}>{formatPercent(value)}</span>
+      return <span className={cn('font-mono tabular-nums', className)}>{formatPercent(value)}</span>
     }
 
     case 'email': {
@@ -404,7 +400,7 @@ export function FieldRenderer({
 
     case 'rollup_summary': {
       return (
-        <span className={cn('inline-flex items-center gap-1', className)}>
+        <span className={cn('inline-flex items-center gap-1 font-mono tabular-nums', className)}>
           <Sigma className="h-3.5 w-3.5 text-muted-foreground" aria-hidden="true" />
           {formatNumber(value)}
         </span>

--- a/kelta-ui/app/src/components/Header/Header.tsx
+++ b/kelta-ui/app/src/components/Header/Header.tsx
@@ -83,7 +83,7 @@ export function Header({ branding, user, onLogout }: HeaderProps): JSX.Element {
           )}
           {!isMobile && (
             <h1
-              className="m-0 text-xl font-semibold text-[var(--app-shell-text,var(--color-text,#1a1a1a))] whitespace-nowrap overflow-hidden text-ellipsis max-w-[300px] md:max-lg:max-w-[200px]"
+              className="m-0 max-w-[300px] overflow-hidden text-ellipsis whitespace-nowrap text-xl font-semibold text-foreground md:max-lg:max-w-[200px]"
               data-testid="header-app-name"
             >
               {branding.applicationName}
@@ -91,20 +91,20 @@ export function Header({ branding, user, onLogout }: HeaderProps): JSX.Element {
           )}
           <button
             type="button"
-            className="flex items-center gap-1 py-1 px-2 bg-transparent border border-[var(--app-shell-border,var(--color-border,#e0e0e0))] rounded cursor-pointer text-[var(--color-text-secondary,#666666)] text-[0.8125rem] font-medium whitespace-nowrap transition-[background-color,border-color] duration-150 ease-in-out hover:bg-[var(--color-surface-hover,rgba(0,0,0,0.05))] hover:border-[var(--color-text-secondary,#999999)] hover:text-[var(--app-shell-text,var(--color-text,#1a1a1a))] focus:outline-2 focus:outline-[var(--color-focus,#0066cc)] focus:outline-offset-2 [&:focus:not(:focus-visible)]:outline-none"
+            className="flex cursor-pointer items-center gap-1 whitespace-nowrap rounded border border-border bg-transparent px-2 py-1 text-[0.8125rem] font-medium text-muted-foreground transition-colors duration-150 ease-in-out hover:border-muted-foreground hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
             onClick={() => navigate(`/${tenantSlug}/app`)}
             aria-label="Back to application"
             data-testid="back-to-app-button"
           >
             <ArrowLeft size={14} aria-hidden="true" />
-            {!isMobile && <span>Back to App</span>}
+            {!isMobile && <span>Back to app</span>}
           </button>
         </div>
 
         {/* Search trigger */}
         <button
           type="button"
-          className="flex items-center gap-2 py-1 px-4 bg-[var(--color-surface-hover,rgba(0,0,0,0.03))] border border-[var(--app-shell-border,var(--color-border,#e0e0e0))] rounded cursor-pointer text-[var(--color-text-secondary,#666666)] text-sm min-w-[200px] transition-[border-color] duration-150 ease-in-out hover:border-[var(--color-text-secondary,#999999)] focus:outline-2 focus:outline-[var(--color-focus,#0066cc)] focus:outline-offset-2 [&:focus:not(:focus-visible)]:outline-none max-md:min-w-0 max-md:py-1 max-md:px-2 motion-reduce:transition-none"
+          className="flex min-w-[200px] cursor-pointer items-center gap-2 rounded border border-border bg-muted/40 px-4 py-1 text-sm text-muted-foreground transition-colors duration-150 ease-in-out hover:border-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 motion-reduce:transition-none max-md:min-w-0 max-md:px-2 max-md:py-1"
           onClick={() => setSearchOpen(true)}
           aria-label="Search (Cmd+K)"
           data-testid="search-trigger"
@@ -113,9 +113,9 @@ export function Header({ branding, user, onLogout }: HeaderProps): JSX.Element {
             <Search size={16} />
           </span>
           {!isMobile && (
-            <span className="flex items-center gap-4 flex-1">
+            <span className="flex flex-1 items-center gap-4">
               Search...
-              <kbd className="ml-auto inline-flex items-center py-px px-[5px] text-[0.6875rem] font-[inherit] text-[var(--color-text-secondary,#999999)] bg-[var(--app-shell-surface,var(--color-surface,#ffffff))] border border-[var(--app-shell-border,var(--color-border,#e0e0e0))] rounded-[3px]">
+              <kbd className="ml-auto inline-flex items-center rounded-[3px] border border-border bg-background px-[5px] py-px text-[0.6875rem] font-[inherit] text-muted-foreground">
                 &#x2318;K
               </kbd>
             </span>

--- a/kelta-ui/app/src/components/ListViewToolbar/ListViewToolbar.tsx
+++ b/kelta-ui/app/src/components/ListViewToolbar/ListViewToolbar.tsx
@@ -61,10 +61,12 @@ export function ListViewToolbar({
     <div className="space-y-2">
       {/* Main toolbar row */}
       <div className="flex items-center justify-between">
-        <h1 className="text-xl font-semibold tracking-tight text-foreground">
+        <h1 className="text-[26px] font-bold tracking-[-0.01em] text-foreground">
           {collectionLabel}
           {totalCount > 0 && (
-            <span className="ml-2 text-sm font-normal text-muted-foreground">({totalCount})</span>
+            <span className="ml-2 font-mono text-sm font-normal tabular-nums text-muted-foreground">
+              ({totalCount.toLocaleString()})
+            </span>
           )}
         </h1>
 

--- a/kelta-ui/app/src/components/ObjectDataTable/ObjectDataTable.tsx
+++ b/kelta-ui/app/src/components/ObjectDataTable/ObjectDataTable.tsx
@@ -145,7 +145,10 @@ function DataRow({
   return (
     <TableRow
       key={record.id}
-      className={cn('cursor-pointer', rowProps['data-focused'] && 'ring-2 ring-inset ring-ring')}
+      className={cn(
+        'cursor-pointer even:bg-muted/40 hover:bg-primary/10',
+        rowProps['data-focused'] && 'ring-2 ring-inset ring-ring'
+      )}
       data-state={isSelected ? 'selected' : undefined}
       tabIndex={rowProps.tabIndex}
       aria-selected={rowProps['aria-selected']}
@@ -330,10 +333,11 @@ export function ObjectDataTable({
     [sort]
   )
 
-  // Shared table header
+  // Shared table header — kelta-table-header applies the DESIGN.md §5 head styling
+  // (uppercase 11px, distinct background, tracking-0.09em).
   const tableHeader = (
     <TableHeader>
-      <TableRow>
+      <TableRow className="kelta-table-header hover:bg-transparent">
         {/* Checkbox column */}
         <TableHead className="w-[40px]">
           <Checkbox
@@ -382,7 +386,7 @@ export function ObjectDataTable({
 
     if (records.length === 0) {
       return (
-        <TableRow>
+        <TableRow className="hover:bg-transparent">
           <TableCell colSpan={fields.length + 2} className="h-24 text-center text-muted-foreground">
             No records found.
           </TableCell>
@@ -467,7 +471,7 @@ export function ObjectDataTable({
   if (useVirtual) {
     return (
       <div
-        className="rounded-md border"
+        className="overflow-hidden rounded-[10px] border border-border bg-card"
         ref={tableRef}
         onKeyDown={handleKeyDown}
         role="grid"

--- a/kelta-ui/app/src/components/Sidebar/Sidebar.tsx
+++ b/kelta-ui/app/src/components/Sidebar/Sidebar.tsx
@@ -216,10 +216,10 @@ function MenuItem({ item, level, collapsed, onItemClick }: MenuItemProps): JSX.E
           to={item.path}
           className={({ isActive: linkActive }) =>
             cn(
-              'flex items-center gap-2 w-full py-2 px-4 bg-transparent border-none rounded text-[var(--app-shell-text,var(--color-text,#1a1a1a))] text-sm font-medium no-underline text-left cursor-pointer transition-[background-color,color] duration-150 ease-in-out hover:bg-[var(--color-surface-hover,rgba(0,0,0,0.05))] focus:outline-2 focus:outline-[var(--color-focus,#0066cc)] focus:outline-offset-[-2px] [&:focus:not(:focus-visible)]:outline-none motion-reduce:transition-none forced-colors:focus:outline-2 forced-colors:focus:outline-current',
+              'flex w-full cursor-pointer items-center gap-2 rounded border-none bg-transparent px-4 py-2 text-left text-sm font-medium text-foreground no-underline transition-colors duration-150 ease-in-out hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring motion-reduce:transition-none forced-colors:focus:outline-2 forced-colors:focus:outline-current',
               linkActive &&
-                'bg-[var(--color-primary-light,rgba(0,102,204,0.1))] text-[var(--app-shell-primary,var(--color-primary,#0066cc))] font-semibold hover:bg-[var(--color-primary-light,rgba(0,102,204,0.15))] forced-colors:border-2 forced-colors:border-current menuItemContent--active',
-              collapsed && 'justify-center p-2 w-10 h-10'
+                'menuItemContent--active bg-primary/10 font-semibold text-primary hover:bg-primary/15 forced-colors:border-2 forced-colors:border-current',
+              collapsed && 'h-10 w-10 justify-center p-2'
             )
           }
           onClick={handleClick}
@@ -258,8 +258,8 @@ function MenuItem({ item, level, collapsed, onItemClick }: MenuItemProps): JSX.E
         <button
           type="button"
           className={cn(
-            'flex items-center gap-2 w-full py-2 px-4 bg-transparent border-none rounded text-[var(--app-shell-text,var(--color-text,#1a1a1a))] text-sm font-medium no-underline text-left cursor-pointer transition-[background-color,color] duration-150 ease-in-out hover:bg-[var(--color-surface-hover,rgba(0,0,0,0.05))] focus:outline-2 focus:outline-[var(--color-focus,#0066cc)] focus:outline-offset-[-2px] [&:focus:not(:focus-visible)]:outline-none motion-reduce:transition-none forced-colors:focus:outline-2 forced-colors:focus:outline-current',
-            collapsed && 'justify-center p-2 w-10 h-10'
+            'flex w-full cursor-pointer items-center gap-2 rounded border-none bg-transparent px-4 py-2 text-left text-sm font-medium text-foreground no-underline transition-colors duration-150 ease-in-out hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring motion-reduce:transition-none forced-colors:focus:outline-2 forced-colors:focus:outline-current',
+            collapsed && 'h-10 w-10 justify-center p-2'
           )}
           onClick={handleToggle}
           aria-expanded={isExpanded}
@@ -324,8 +324,8 @@ function MenuItem({ item, level, collapsed, onItemClick }: MenuItemProps): JSX.E
     >
       <span
         className={cn(
-          'flex items-center gap-2 w-full py-2 px-4 bg-transparent border-none rounded text-[var(--app-shell-text,var(--color-text,#1a1a1a))] text-sm font-medium no-underline text-left cursor-pointer',
-          collapsed && 'justify-center p-2 w-10 h-10'
+          'flex w-full cursor-pointer items-center gap-2 rounded border-none bg-transparent px-4 py-2 text-left text-sm font-medium text-foreground no-underline',
+          collapsed && 'h-10 w-10 justify-center p-2'
         )}
         title={collapsed ? item.label : undefined}
       >
@@ -443,7 +443,7 @@ export function Sidebar({ menus, collapsed, onToggle, onItemClick }: SidebarProp
       {/* ==================== MY WORKSPACE ==================== */}
       <div className="mb-4 last:mb-0" data-testid="workspace-section">
         {!collapsed && (
-          <h2 className="m-0 py-2 px-4 text-[0.6875rem] font-semibold uppercase tracking-wider text-[var(--color-text-secondary,#666666)] whitespace-nowrap overflow-hidden text-ellipsis">
+          <h2 className="m-0 overflow-hidden text-ellipsis whitespace-nowrap px-4 py-2 text-[0.6875rem] font-semibold uppercase tracking-wider text-muted-foreground">
             {t('sidebar.workspace')}
           </h2>
         )}
@@ -493,7 +493,7 @@ export function Sidebar({ menus, collapsed, onToggle, onItemClick }: SidebarProp
       {/* ==================== TOOLS ==================== */}
       <div className="mb-4 last:mb-0" data-testid="tools-section">
         {!collapsed && (
-          <h2 className="m-0 py-2 px-4 text-[0.6875rem] font-semibold uppercase tracking-wider text-[var(--color-text-secondary,#666666)] whitespace-nowrap overflow-hidden text-ellipsis">
+          <h2 className="m-0 overflow-hidden text-ellipsis whitespace-nowrap px-4 py-2 text-[0.6875rem] font-semibold uppercase tracking-wider text-muted-foreground">
             {t('sidebar.tools')}
           </h2>
         )}
@@ -517,14 +517,14 @@ export function Sidebar({ menus, collapsed, onToggle, onItemClick }: SidebarProp
         {!collapsed && (
           <button
             type="button"
-            className="flex items-center gap-2 w-full py-2 px-4 bg-transparent border-none cursor-pointer text-[var(--color-text-secondary,#666666)] transition-colors duration-150 ease-in-out hover:text-[var(--app-shell-text,var(--color-text,#1a1a1a))] focus:outline-2 focus:outline-[var(--color-focus,#0066cc)] focus:outline-offset-[-2px] [&:focus:not(:focus-visible)]:outline-none"
+            className="flex w-full cursor-pointer items-center gap-2 border-none bg-transparent px-4 py-2 text-muted-foreground transition-colors duration-150 ease-in-out hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             onClick={toggleSetup}
             aria-expanded={setupExpanded}
           >
             <span className="text-sm" aria-hidden="true">
               {getIcon('settings')}
             </span>
-            <span className="m-0 p-0 flex-1 text-left text-[0.6875rem] font-semibold uppercase tracking-wider text-[var(--color-text-secondary,#666666)] whitespace-nowrap overflow-hidden text-ellipsis">
+            <span className="m-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap p-0 text-left text-[0.6875rem] font-semibold uppercase tracking-wider text-muted-foreground">
               {t('sidebar.setup')}
             </span>
             <span
@@ -541,7 +541,7 @@ export function Sidebar({ menus, collapsed, onToggle, onItemClick }: SidebarProp
         {collapsed && (
           <button
             type="button"
-            className="flex items-center gap-2 w-full py-2 px-4 bg-transparent border-none rounded text-[var(--app-shell-text,var(--color-text,#1a1a1a))] text-sm font-medium no-underline text-left cursor-pointer justify-center p-2 w-10 h-10"
+            className="flex h-10 w-10 cursor-pointer items-center justify-center gap-2 rounded border-none bg-transparent p-2 text-left text-sm font-medium text-foreground no-underline"
             onClick={toggleSetup}
             title={t('sidebar.setup')}
           >
@@ -555,12 +555,12 @@ export function Sidebar({ menus, collapsed, onToggle, onItemClick }: SidebarProp
         )}
 
         {setupExpanded && !collapsed && (
-          <div className="border-t border-[var(--color-border,rgba(0,0,0,0.08))] pt-2 mt-1">
+          <div className="mt-1 border-t border-border pt-2">
             {/* Render bootstrap menus as setup subsections */}
             {menus.map((menu) => (
               <div key={menu.id} className="mb-2">
                 {menu.name && (
-                  <h3 className="m-0 py-1 px-4 text-[0.625rem] font-semibold uppercase tracking-wider text-[var(--color-text-secondary,#999999)]">
+                  <h3 className="m-0 px-4 py-1 text-[0.625rem] font-semibold uppercase tracking-wider text-muted-foreground">
                     {menu.name}
                   </h3>
                 )}
@@ -609,9 +609,7 @@ export function Sidebar({ menus, collapsed, onToggle, onItemClick }: SidebarProp
           data-testid="sidebar-empty"
         >
           {!collapsed && (
-            <p className="m-0 text-sm text-[var(--color-text-secondary,#666666)]">
-              {t('navigation.noMenus')}
-            </p>
+            <p className="m-0 text-sm text-muted-foreground">{t('navigation.noMenus')}</p>
           )}
         </div>
       )}

--- a/kelta-ui/app/src/components/kelta/AiAssistantFab.tsx
+++ b/kelta-ui/app/src/components/kelta/AiAssistantFab.tsx
@@ -1,9 +1,9 @@
 // AiAssistantFab.tsx — floating AI assistant button. The ONLY gradient surface.
-import * as React from 'react';
-import { Sparkles } from 'lucide-react';
-import { cn } from '@/lib/utils';
+import * as React from 'react'
+import { Sparkles } from 'lucide-react'
+import { cn } from '@/lib/utils'
 
-export interface AiAssistantFabProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {}
+export type AiAssistantFabProps = React.ButtonHTMLAttributes<HTMLButtonElement>
 
 /**
  * Floating AI assistant launcher. Lives bottom-right, always visible.
@@ -21,14 +21,14 @@ export const AiAssistantFab = React.forwardRef<HTMLButtonElement, AiAssistantFab
         'shadow-[0_10px_24px_-8px_rgba(59,130,246,0.6)]',
         'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
         'z-50',
-        className,
+        className
       )}
       style={{ background: 'linear-gradient(135deg, #06B6D4 0%, #3B82F6 100%)' }}
       {...props}
     >
       <Sparkles className="size-[22px]" aria-hidden="true" />
     </button>
-  ),
-);
+  )
+)
 
-AiAssistantFab.displayName = 'AiAssistantFab';
+AiAssistantFab.displayName = 'AiAssistantFab'

--- a/kelta-ui/app/src/components/kelta/EmptyValue.tsx
+++ b/kelta-ui/app/src/components/kelta/EmptyValue.tsx
@@ -1,8 +1,8 @@
 // EmptyValue.tsx — render an em-dash for null / undefined / empty values
-import * as React from 'react';
-import { cn } from '@/lib/utils';
+import * as React from 'react'
+import { cn } from '@/lib/utils'
 
-export interface EmptyValueProps extends React.HTMLAttributes<HTMLSpanElement> {}
+export type EmptyValueProps = React.HTMLAttributes<HTMLSpanElement>
 
 /**
  * Renders the Kelta empty-value glyph (em-dash). Use anywhere a value
@@ -21,7 +21,7 @@ export const EmptyValue = React.forwardRef<HTMLSpanElement, EmptyValueProps>(
     >
       —
     </span>
-  ),
-);
+  )
+)
 
-EmptyValue.displayName = 'EmptyValue';
+EmptyValue.displayName = 'EmptyValue'

--- a/kelta-ui/app/src/components/kelta/FieldLabel.tsx
+++ b/kelta-ui/app/src/components/kelta/FieldLabel.tsx
@@ -1,8 +1,8 @@
 // FieldLabel.tsx — the signature Kelta uppercase 11px field label
-import * as React from 'react';
-import { cn } from '@/lib/utils';
+import * as React from 'react'
+import { cn } from '@/lib/utils'
 
-export interface FieldLabelProps extends React.LabelHTMLAttributes<HTMLLabelElement> {}
+export type FieldLabelProps = React.LabelHTMLAttributes<HTMLLabelElement>
 
 /**
  * The Kelta field label. Use above every field value in a detail card,
@@ -14,15 +14,18 @@ export interface FieldLabelProps extends React.LabelHTMLAttributes<HTMLLabelElem
  */
 export const FieldLabel = React.forwardRef<HTMLLabelElement, FieldLabelProps>(
   ({ className, ...props }, ref) => (
+    // jsx-a11y/label-has-associated-control: callers pass htmlFor or wrap a control;
+    // we forward all label props so association is the consumer's concern.
+    // eslint-disable-next-line jsx-a11y/label-has-associated-control
     <label
       ref={ref}
       className={cn(
         'block text-[11px] font-semibold uppercase tracking-[0.08em] text-muted-foreground mb-1.5',
-        className,
+        className
       )}
       {...props}
     />
-  ),
-);
+  )
+)
 
-FieldLabel.displayName = 'FieldLabel';
+FieldLabel.displayName = 'FieldLabel'

--- a/kelta-ui/app/src/components/kelta/StatusBadge.tsx
+++ b/kelta-ui/app/src/components/kelta/StatusBadge.tsx
@@ -1,20 +1,20 @@
 // StatusBadge.tsx — five-state status pill with leading dot
-import * as React from 'react';
-import { cn } from '@/lib/utils';
+import * as React from 'react'
+import { cn } from '@/lib/utils'
 
-export type StatusVariant = 'active' | 'pending' | 'inactive' | 'failed' | 'paid';
+export type StatusVariant = 'active' | 'pending' | 'inactive' | 'failed' | 'paid'
 
 const variantClass: Record<StatusVariant, string> = {
-  active:   'bg-emerald-500/15 text-emerald-700 dark:text-emerald-300 border-emerald-500/55',
-  paid:     'bg-emerald-500/15 text-emerald-700 dark:text-emerald-300 border-emerald-500/55',
-  pending:  'bg-amber-500/15  text-amber-700  dark:text-amber-300  border-amber-500/55',
+  active: 'bg-emerald-500/15 text-emerald-700 dark:text-emerald-300 border-emerald-500/55',
+  paid: 'bg-emerald-500/15 text-emerald-700 dark:text-emerald-300 border-emerald-500/55',
+  pending: 'bg-amber-500/15  text-amber-700  dark:text-amber-300  border-amber-500/55',
   inactive: 'bg-slate-500/15  text-slate-700  dark:text-slate-300  border-slate-500/45',
-  failed:   'bg-destructive/15 text-destructive border-destructive/55',
-};
+  failed: 'bg-destructive/15 text-destructive border-destructive/55',
+}
 
 export interface StatusBadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
-  variant: StatusVariant;
-  label: string;
+  variant: StatusVariant
+  label: string
 }
 
 /**
@@ -33,14 +33,14 @@ export const StatusBadge = React.forwardRef<HTMLSpanElement, StatusBadgeProps>(
       className={cn(
         'inline-flex items-center gap-1.5 h-[22px] px-2.5 rounded text-[11px] font-semibold border',
         variantClass[variant],
-        className,
+        className
       )}
       {...props}
     >
       <span className="size-1.5 rounded-full bg-current" aria-hidden="true" />
       {label}
     </span>
-  ),
-);
+  )
+)
 
-StatusBadge.displayName = 'StatusBadge';
+StatusBadge.displayName = 'StatusBadge'

--- a/kelta-ui/app/src/components/kelta/index.ts
+++ b/kelta-ui/app/src/components/kelta/index.ts
@@ -1,12 +1,12 @@
 // index.ts — barrel for Kelta-specific components
-export { FieldLabel } from './FieldLabel';
-export type { FieldLabelProps } from './FieldLabel';
+export { FieldLabel } from './FieldLabel'
+export type { FieldLabelProps } from './FieldLabel'
 
-export { EmptyValue } from './EmptyValue';
-export type { EmptyValueProps } from './EmptyValue';
+export { EmptyValue } from './EmptyValue'
+export type { EmptyValueProps } from './EmptyValue'
 
-export { StatusBadge } from './StatusBadge';
-export type { StatusBadgeProps, StatusVariant } from './StatusBadge';
+export { StatusBadge } from './StatusBadge'
+export type { StatusBadgeProps, StatusVariant } from './StatusBadge'
 
-export { AiAssistantFab } from './AiAssistantFab';
-export type { AiAssistantFabProps } from './AiAssistantFab';
+export { AiAssistantFab } from './AiAssistantFab'
+export type { AiAssistantFabProps } from './AiAssistantFab'

--- a/kelta-ui/app/src/index.css
+++ b/kelta-ui/app/src/index.css
@@ -274,7 +274,15 @@
  * These styles support the existing CSS Modules-based admin pages.
  */
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  font-family:
+    'Inter',
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    'Segoe UI',
+    Helvetica,
+    Arial,
+    sans-serif;
   line-height: 1.5;
   font-weight: 400;
 

--- a/kelta-ui/app/src/pages/app/AppHomePage/AppHomePage.tsx
+++ b/kelta-ui/app/src/pages/app/AppHomePage/AppHomePage.tsx
@@ -94,10 +94,10 @@ export function AppHomePage(): React.ReactElement {
     <div className="mx-auto max-w-6xl space-y-6 p-6">
       {/* Welcome header */}
       <div className="space-y-1">
-        <h1 className="text-2xl font-semibold tracking-tight text-foreground">
+        <h1 className="text-[26px] font-bold tracking-[-0.01em] text-foreground">
           {greeting}, {firstName}
         </h1>
-        <p className="text-sm text-muted-foreground">
+        <p className="text-base text-muted-foreground">
           Here&apos;s an overview of your recent activity.
         </p>
       </div>
@@ -105,7 +105,7 @@ export function AppHomePage(): React.ReactElement {
       {/* Quick Actions */}
       <Card>
         <CardHeader className="pb-3">
-          <CardTitle className="text-base">Quick Actions</CardTitle>
+          <CardTitle className="text-base">Quick actions</CardTitle>
           <CardDescription>Create new records or navigate to collections</CardDescription>
         </CardHeader>
         <CardContent>
@@ -150,7 +150,7 @@ export function AppHomePage(): React.ReactElement {
           <CardHeader className="pb-3">
             <CardTitle className="flex items-center gap-2 text-base">
               <Clock className="h-4 w-4 text-muted-foreground" />
-              Recent Items
+              Recent items
             </CardTitle>
           </CardHeader>
           <CardContent>

--- a/kelta-ui/app/src/pages/app/ObjectDetailPage/ObjectDetailPage.tsx
+++ b/kelta-ui/app/src/pages/app/ObjectDetailPage/ObjectDetailPage.tsx
@@ -521,7 +521,7 @@ export function ObjectDetailPage(): React.ReactElement {
       <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div className="min-w-0 space-y-1">
           <div className="flex items-center gap-2">
-            <h1 className="truncate text-xl font-semibold tracking-tight text-foreground">
+            <h1 className="truncate text-[26px] font-bold tracking-[-0.01em] text-foreground">
               {recordTitle}
             </h1>
             {mutations.remove.isPending && (

--- a/kelta-ui/app/src/pages/app/ObjectFormPage/ObjectFormPage.tsx
+++ b/kelta-ui/app/src/pages/app/ObjectFormPage/ObjectFormPage.tsx
@@ -32,8 +32,8 @@ import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
+import { FieldLabel } from '@/components/kelta'
 import { Checkbox } from '@/components/ui/checkbox'
 import { Separator } from '@/components/ui/separator'
 import { LookupSelect } from '@/components/LookupSelect'
@@ -152,10 +152,10 @@ function FormField({
   const fieldId = `field-${field.name}`
 
   const labelEl = (
-    <Label htmlFor={fieldId} className="text-sm font-medium">
+    <FieldLabel htmlFor={fieldId}>
       {field.displayName || field.name}
       {field.required && <span className="ml-1 text-destructive">*</span>}
-    </Label>
+    </FieldLabel>
   )
 
   const errorEl = error ? (
@@ -196,10 +196,10 @@ function FormField({
             onCheckedChange={(checked) => onChange(field.name, checked)}
             disabled={isReadOnly}
           />
-          <Label htmlFor={fieldId} className="text-sm font-medium">
+          <FieldLabel htmlFor={fieldId} className="mb-0">
             {field.displayName || field.name}
             {field.required && <span className="ml-1 text-destructive">*</span>}
-          </Label>
+          </FieldLabel>
         </div>
         {errorEl}
       </div>
@@ -572,9 +572,9 @@ function ObjectFormBody({
         <Card data-testid="record-type-selector">
           <CardContent className="py-3">
             <div className="flex items-center gap-4">
-              <Label htmlFor="recordType" className="text-sm font-medium whitespace-nowrap">
-                Record Type
-              </Label>
+              <FieldLabel htmlFor="recordType" className="mb-0 whitespace-nowrap">
+                Record type
+              </FieldLabel>
               <select
                 id="recordType"
                 data-testid="record-type-select"

--- a/kelta-ui/app/src/styles/kelta-design.css
+++ b/kelta-ui/app/src/styles/kelta-design.css
@@ -12,17 +12,19 @@
  * Usage:  <label class="kelta-field-label">Email</label>
  */
 
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap');
+/* Fonts (Inter, JetBrains Mono) are loaded via <link> in app/index.html
+ * for better load performance (preconnect + parallel discovery). */
 
 :root {
   --kelta-font-sans: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   --kelta-font-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
 
   /* The brand gradient. Use ONLY on the logo mark and the AI assistant FAB. */
-  --kelta-gradient: linear-gradient(135deg, #06B6D4 0%, #3B82F6 100%);
+  --kelta-gradient: linear-gradient(135deg, #06b6d4 0%, #3b82f6 100%);
 }
 
-html, body {
+html,
+body {
   font-family: var(--kelta-font-sans);
 }
 
@@ -53,8 +55,10 @@ html, body {
 
 .dark .kelta-card {
   border-color: #334155;
-  background: #111C2E;
-  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.04) inset, 0 12px 28px -16px rgba(0, 0, 0, 0.7);
+  background: #111c2e;
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.04) inset,
+    0 12px 28px -16px rgba(0, 0, 0, 0.7);
 }
 
 /* Header band for collapsible sections / table tops */
@@ -79,7 +83,7 @@ html, body {
 }
 
 .dark .kelta-table-header {
-  background: #16243A;
+  background: #16243a;
 }
 
 .kelta-table-header th {


### PR DESCRIPTION
## Summary

PR **2 of 5** in the kelta-ui design-system rollout. Wires the new `kelta/*` components and DESIGN.md tokens through every screen a tenant user touches. **Layouts unchanged** — this is tokens + component swaps only, per the agreed depth.

### Highest-impact changes
- **ObjectDataTable** now follows the `DESIGN.md §5` recipe — `rounded-[10px]` bordered card wrapper, `kelta-table-header` (uppercase 11px, 0.09em tracking, distinct background), zebra rows via `even:bg-muted/40`, `hover:bg-primary/10` instead of the old darker neutral.
- **FieldRenderer** renders `<EmptyValue/>` for null/undefined and applies `font-mono tabular-nums` to `number`/`currency`/`percent`/`rollup_summary` cells — numbers finally line up.
- **DetailSection** uses `kelta-field-label` (11px / 600 / 0.08em uppercase) for every field name.
- **ObjectFormPage** every form label is now `<FieldLabel>`; `Record Type` → `Record type`.
- **ObjectDetailPage / AppHomePage / ListViewToolbar**: H1 follows the type scale (26 / 700 / -0.01em); record counts use `font-mono tabular-nums`.
- **Header / Sidebar**: ripped out the `var(--app-shell-text,var(--color-text,#1a1a1a))` chains in favor of `text-foreground` / `text-muted-foreground` / `bg-accent` / `border-border` / `focus-visible:ring-ring` tokens; sentence case on "Back to app".
- **AiChatTrigger** now wraps `<AiAssistantFab>`, so the cyan→blue gradient appears only on the FAB and the logo (`DESIGN.md §3`).

### Rollout plan recap
1. ~~PR 1 — Foundation~~ (merged: #760)
2. **PR 2 — Runtime** *(this PR)*
3. PR 3 — Admin & Setup pages
4. PR 4 — Builder surfaces (FlowDesigner / PageBuilder / Dashboards) — tokens + component swaps only
5. PR 5 — Quality sweep

## Test plan

- [x] `npm run lint` — 0 errors (9 pre-existing warnings)
- [x] `npm run test:run` — 1764 passed, 34 skipped
- [x] `prettier --write` on all touched files
- [ ] Manual smoke: list / detail / form / home in dev; verify table recipe, em-dashes, FAB gradient, field labels
- [ ] Verify dark + light themes side-by-side

🤖 Generated with [Claude Code](https://claude.com/claude-code)