### PR TITLE
feat(kelta-ui): adopt design system in admin & settings pages (PR 3/5)

### DIFF
--- a/kelta-ui/app/src/pages/AiSettingsPage/AiSettingsPage.tsx
+++ b/kelta-ui/app/src/pages/AiSettingsPage/AiSettingsPage.tsx
@@ -7,8 +7,8 @@ import { LoadingSpinner, ErrorMessage } from '../../components'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
 import { Switch } from '@/components/ui/switch'
+import { FieldLabel, StatusBadge } from '@/components/kelta'
 import {
   Select,
   SelectContent,
@@ -92,16 +92,16 @@ export function AiSettingsPage({ className }: AiSettingsPageProps): React.ReactE
         <div className="flex items-center gap-3">
           <Bot className="h-6 w-6 text-primary" />
           <div>
-            <h1 className="text-2xl font-bold">AI Settings</h1>
+            <h1 className="text-[26px] font-bold tracking-[-0.01em]">AI settings</h1>
             <p className="text-sm text-muted-foreground">
-              Configure AI assistant model, limits, and monitoring
+              Configure AI assistant model, limits, and monitoring.
             </p>
           </div>
         </div>
         {canManage && !isEditing && (
           <Button onClick={() => setEditConfig(config ?? null)}>
             <Settings className="mr-2 h-4 w-4" />
-            Edit Settings
+            Edit settings
           </Button>
         )}
       </div>
@@ -110,12 +110,12 @@ export function AiSettingsPage({ className }: AiSettingsPageProps): React.ReactE
         {/* Model Configuration */}
         <Card>
           <CardHeader>
-            <CardTitle className="text-base">Model Configuration</CardTitle>
-            <CardDescription>Select the AI model and parameters</CardDescription>
+            <CardTitle className="text-base">Model configuration</CardTitle>
+            <CardDescription>Select the AI model and parameters.</CardDescription>
           </CardHeader>
           <CardContent className="space-y-4">
             <div className="space-y-2">
-              <Label>Model</Label>
+              <FieldLabel>Model</FieldLabel>
               {isEditing ? (
                 <Select
                   value={currentConfig?.model}
@@ -143,7 +143,7 @@ export function AiSettingsPage({ className }: AiSettingsPageProps): React.ReactE
             </div>
 
             <div className="space-y-2">
-              <Label>Max Tokens</Label>
+              <FieldLabel>Max tokens</FieldLabel>
               {isEditing ? (
                 <Input
                   type="number"
@@ -158,7 +158,7 @@ export function AiSettingsPage({ className }: AiSettingsPageProps): React.ReactE
             </div>
 
             <div className="space-y-2">
-              <Label>Temperature</Label>
+              <FieldLabel>Temperature</FieldLabel>
               {isEditing ? (
                 <Input
                   type="number"
@@ -182,12 +182,12 @@ export function AiSettingsPage({ className }: AiSettingsPageProps): React.ReactE
         {/* Token Limits */}
         <Card>
           <CardHeader>
-            <CardTitle className="text-base">Token Limits</CardTitle>
-            <CardDescription>Configure monthly token usage limits</CardDescription>
+            <CardTitle className="text-base">Token limits</CardTitle>
+            <CardDescription>Configure monthly token usage limits.</CardDescription>
           </CardHeader>
           <CardContent className="space-y-4">
             <div className="flex items-center justify-between">
-              <Label>AI Enabled</Label>
+              <FieldLabel className="mb-0">AI enabled</FieldLabel>
               {isEditing ? (
                 <Switch
                   checked={currentConfig?.aiEnabled === 'true'}
@@ -195,22 +195,15 @@ export function AiSettingsPage({ className }: AiSettingsPageProps): React.ReactE
                     setEditConfig((prev) => (prev ? { ...prev, aiEnabled: String(checked) } : null))
                   }
                 />
+              ) : currentConfig?.aiEnabled === 'true' ? (
+                <StatusBadge variant="active" label="Enabled" />
               ) : (
-                <span
-                  className={cn(
-                    'rounded-full px-2 py-0.5 text-xs font-medium',
-                    currentConfig?.aiEnabled === 'true'
-                      ? 'bg-green-100 text-green-800'
-                      : 'bg-red-100 text-red-800'
-                  )}
-                >
-                  {currentConfig?.aiEnabled === 'true' ? 'Enabled' : 'Disabled'}
-                </span>
+                <StatusBadge variant="inactive" label="Disabled" />
               )}
             </div>
 
             <div className="space-y-2">
-              <Label>Monthly Token Limit</Label>
+              <FieldLabel>Monthly token limit</FieldLabel>
               {isEditing ? (
                 <Input
                   type="number"
@@ -235,7 +228,7 @@ export function AiSettingsPage({ className }: AiSettingsPageProps): React.ReactE
           <CardHeader>
             <CardTitle className="flex items-center gap-2 text-base">
               <Zap className="h-4 w-4" />
-              Current Month Usage
+              Current month usage
             </CardTitle>
           </CardHeader>
           <CardContent>
@@ -244,8 +237,8 @@ export function AiSettingsPage({ className }: AiSettingsPageProps): React.ReactE
             ) : usage ? (
               <div className="space-y-4">
                 <div className="flex items-center justify-between">
-                  <span className="text-sm text-muted-foreground">Tokens Used</span>
-                  <span className="text-lg font-semibold">
+                  <span className="text-sm text-muted-foreground">Tokens used</span>
+                  <span className="font-mono text-lg font-semibold tabular-nums">
                     {formatTokenCount(usage.currentMonthUsage)} /{' '}
                     {formatTokenCount(usage.tokenLimit)}
                   </span>
@@ -270,16 +263,18 @@ export function AiSettingsPage({ className }: AiSettingsPageProps): React.ReactE
                 {/* Monthly history */}
                 {Object.keys(usage.history).length > 0 && (
                   <div className="mt-4">
-                    <h4 className="text-sm font-medium mb-2">Monthly History</h4>
+                    <h4 className="mb-2 text-sm font-medium">Monthly history</h4>
                     <div className="grid grid-cols-3 gap-2 text-xs">
-                      <div className="font-medium text-muted-foreground">Month</div>
-                      <div className="font-medium text-muted-foreground">Tokens</div>
-                      <div className="font-medium text-muted-foreground">Requests</div>
+                      <div className="kelta-field-label !mb-0">Month</div>
+                      <div className="kelta-field-label !mb-0">Tokens</div>
+                      <div className="kelta-field-label !mb-0">Requests</div>
                       {Object.entries(usage.history).map(([month, data]) => (
                         <React.Fragment key={month}>
                           <div>{month}</div>
-                          <div>{formatTokenCount(data.inputTokens + data.outputTokens)}</div>
-                          <div>{data.requestCount}</div>
+                          <div className="font-mono tabular-nums">
+                            {formatTokenCount(data.inputTokens + data.outputTokens)}
+                          </div>
+                          <div className="font-mono tabular-nums">{data.requestCount}</div>
                         </React.Fragment>
                       ))}
                     </div>
@@ -303,7 +298,7 @@ export function AiSettingsPage({ className }: AiSettingsPageProps): React.ReactE
             onClick={() => editConfig && saveMutation.mutate(editConfig)}
             disabled={saveMutation.isPending}
           >
-            {saveMutation.isPending ? 'Saving...' : 'Save Changes'}
+            {saveMutation.isPending ? 'Saving...' : 'Save changes'}
           </Button>
         </div>
       )}

--- a/kelta-ui/app/src/pages/FlowsPage/steps/NameAndCreateStep.tsx
+++ b/kelta-ui/app/src/pages/FlowsPage/steps/NameAndCreateStep.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
+import { FieldLabel } from '@/components/kelta'
 import { Database, Clock, Globe, Radio } from 'lucide-react'
 import type { FlowType } from '@/pages/FlowDesignerPage/types'
 
@@ -14,10 +14,10 @@ interface NameAndCreateStepProps {
 }
 
 const FLOW_TYPE_META: Record<FlowType, { label: string; icon: React.ElementType }> = {
-  RECORD_TRIGGERED: { label: 'Record Change', icon: Database },
+  RECORD_TRIGGERED: { label: 'Record change', icon: Database },
   SCHEDULED: { label: 'Scheduled', icon: Clock },
-  AUTOLAUNCHED: { label: 'API / Webhook', icon: Globe },
-  KAFKA_TRIGGERED: { label: 'Kafka Event', icon: Radio },
+  AUTOLAUNCHED: { label: 'API / webhook', icon: Globe },
+  KAFKA_TRIGGERED: { label: 'Kafka event', icon: Radio },
 }
 
 export function NameAndCreateStep({
@@ -41,13 +41,13 @@ export function NameAndCreateStep({
 
       <div className="flex items-center gap-2 rounded-md border border-border bg-muted/30 p-3">
         <Icon className="h-4 w-4 text-muted-foreground" />
-        <span className="text-sm text-muted-foreground">{meta.label} Flow</span>
+        <span className="text-sm text-muted-foreground">{meta.label} flow</span>
       </div>
 
       <div>
-        <Label htmlFor="wizard-flow-name" className="text-sm">
+        <FieldLabel htmlFor="wizard-flow-name">
           Name <span className="text-destructive">*</span>
-        </Label>
+        </FieldLabel>
         <Input
           id="wizard-flow-name"
           value={name}
@@ -58,9 +58,7 @@ export function NameAndCreateStep({
       </div>
 
       <div>
-        <Label htmlFor="wizard-flow-description" className="text-sm">
-          Description
-        </Label>
+        <FieldLabel htmlFor="wizard-flow-description">Description</FieldLabel>
         <Textarea
           id="wizard-flow-description"
           value={description}

--- a/kelta-ui/app/src/pages/ProfileDetailPage/ProfileDetailPage.tsx
+++ b/kelta-ui/app/src/pages/ProfileDetailPage/ProfileDetailPage.tsx
@@ -28,7 +28,7 @@ import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
-import { Label } from '@/components/ui/label'
+import { FieldLabel } from '@/components/kelta'
 
 interface ProfileDetail {
   id: string
@@ -518,9 +518,7 @@ export function ProfileDetailPage({
             {isEditingBasicInfo ? (
               <div className="space-y-2">
                 <div>
-                  <Label htmlFor="edit-profile-name" className="text-xs text-muted-foreground">
-                    Name
-                  </Label>
+                  <FieldLabel htmlFor="edit-profile-name">Name</FieldLabel>
                   <Input
                     id="edit-profile-name"
                     value={editName}
@@ -530,12 +528,7 @@ export function ProfileDetailPage({
                   />
                 </div>
                 <div>
-                  <Label
-                    htmlFor="edit-profile-description"
-                    className="text-xs text-muted-foreground"
-                  >
-                    Description
-                  </Label>
+                  <FieldLabel htmlFor="edit-profile-description">Description</FieldLabel>
                   <Textarea
                     id="edit-profile-description"
                     value={editDescription}

--- a/kelta-ui/app/src/pages/WebhooksPage/WebhooksPage.tsx
+++ b/kelta-ui/app/src/pages/WebhooksPage/WebhooksPage.tsx
@@ -22,7 +22,7 @@ import {
   DialogDescription,
 } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
+import { FieldLabel, StatusBadge } from '@/components/kelta'
 
 export interface WebhooksPageProps {
   testId?: string
@@ -198,7 +198,7 @@ function EndpointList({ onSelect }: { onSelect: (ep: EndpointOut) => void }) {
                 <span className="font-medium text-foreground truncate">
                   {ep.description || ep.url}
                 </span>
-                {ep.disabled && <Badge variant="secondary">Disabled</Badge>}
+                {ep.disabled && <StatusBadge variant="inactive" label="Disabled" />}
               </div>
               <p className="mt-1 text-sm text-muted-foreground truncate">{ep.url}</p>
               {ep.filterTypes && ep.filterTypes.length > 0 && (
@@ -322,7 +322,7 @@ function EndpointDetail({ endpoint, onBack }: { endpoint: EndpointOut; onBack: (
         <InfoCard label="Created" value={new Date(endpoint.createdAt).toLocaleString()} />
         {endpoint.filterTypes && endpoint.filterTypes.length > 0 && (
           <div className="rounded-lg border bg-card p-4">
-            <p className="text-sm font-medium text-muted-foreground">Event Types</p>
+            <p className="kelta-field-label">Event types</p>
             <div className="mt-1 flex flex-wrap gap-1">
               {endpoint.filterTypes.map((t) => (
                 <Badge key={t} variant="outline" className="text-xs">
@@ -334,7 +334,7 @@ function EndpointDetail({ endpoint, onBack }: { endpoint: EndpointOut; onBack: (
         )}
         {endpoint.channels && endpoint.channels.length > 0 && (
           <div className="rounded-lg border bg-card p-4">
-            <p className="text-sm font-medium text-muted-foreground">Collection Filter</p>
+            <p className="kelta-field-label">Collection filter</p>
             <div className="mt-1 flex flex-wrap gap-1">
               {endpoint.channels.map((ch) => (
                 <Badge key={ch} variant="secondary" className="text-xs">
@@ -349,7 +349,7 @@ function EndpointDetail({ endpoint, onBack }: { endpoint: EndpointOut; onBack: (
       {/* Message attempts */}
       <div>
         <div className="mb-3 flex items-center justify-between">
-          <h3 className="text-lg font-medium text-foreground">Recent Deliveries</h3>
+          <h3 className="text-lg font-medium text-foreground">Recent deliveries</h3>
           <Button variant="ghost" size="sm" onClick={attempts.reload}>
             Refresh
           </Button>
@@ -361,7 +361,7 @@ function EndpointDetail({ endpoint, onBack }: { endpoint: EndpointOut; onBack: (
       <Dialog open={showDeleteConfirm} onOpenChange={setShowDeleteConfirm}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Delete Endpoint</DialogTitle>
+            <DialogTitle>Delete endpoint</DialogTitle>
             <DialogDescription>
               Are you sure you want to delete this endpoint? This action cannot be undone. All
               future webhook deliveries to this URL will stop.
@@ -422,7 +422,7 @@ function AttemptTable({ attempts }: { attempts: ReturnType<typeof useEndpointMes
           <thead className="border-b bg-muted/50">
             <tr>
               <th className="px-4 py-2 text-left font-medium text-muted-foreground">Status</th>
-              <th className="px-4 py-2 text-left font-medium text-muted-foreground">Event Type</th>
+              <th className="px-4 py-2 text-left font-medium text-muted-foreground">Event type</th>
               <th className="px-4 py-2 text-left font-medium text-muted-foreground">Response</th>
               <th className="px-4 py-2 text-left font-medium text-muted-foreground">Timestamp</th>
             </tr>
@@ -474,27 +474,15 @@ function AttemptStatusBadge({ status }: { status: number }) {
   // Svix MessageStatus: 0 = Success, 1 = Pending, 2 = Fail, 3 = Sending
   switch (status) {
     case 0:
-      return (
-        <Badge className="bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400">
-          Success
-        </Badge>
-      )
+      return <StatusBadge variant="active" label="Success" />
     case 1:
-      return (
-        <Badge className="bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400">
-          Pending
-        </Badge>
-      )
+      return <StatusBadge variant="pending" label="Pending" />
     case 2:
-      return <Badge variant="destructive">Failed</Badge>
+      return <StatusBadge variant="failed" label="Failed" />
     case 3:
-      return (
-        <Badge className="bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400">
-          Sending
-        </Badge>
-      )
+      return <StatusBadge variant="pending" label="Sending" />
     default:
-      return <Badge variant="secondary">Unknown</Badge>
+      return <StatusBadge variant="inactive" label="Unknown" />
   }
 }
 
@@ -572,7 +560,7 @@ function CreateEndpointDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-lg">
         <DialogHeader>
-          <DialogTitle>Add Webhook Endpoint</DialogTitle>
+          <DialogTitle>Add webhook endpoint</DialogTitle>
           <DialogDescription>
             Create a new endpoint to receive webhook notifications.
           </DialogDescription>
@@ -580,7 +568,7 @@ function CreateEndpointDialog({
 
         <div className="space-y-4 py-2">
           <div className="space-y-2">
-            <Label htmlFor="endpoint-url">Endpoint URL</Label>
+            <FieldLabel htmlFor="endpoint-url">Endpoint URL</FieldLabel>
             <Input
               id="endpoint-url"
               placeholder="https://example.com/webhooks"
@@ -590,7 +578,7 @@ function CreateEndpointDialog({
           </div>
 
           <div className="space-y-2">
-            <Label htmlFor="endpoint-description">Description</Label>
+            <FieldLabel htmlFor="endpoint-description">Description</FieldLabel>
             <Input
               id="endpoint-description"
               placeholder="My webhook endpoint"
@@ -601,7 +589,7 @@ function CreateEndpointDialog({
 
           {eventTypes.data && eventTypes.data.length > 0 && (
             <div className="space-y-2">
-              <Label>Event Types</Label>
+              <FieldLabel>Event types</FieldLabel>
               <p className="text-xs text-muted-foreground">
                 Select which events this endpoint should receive. Leave empty for all events.
               </p>
@@ -635,7 +623,7 @@ function CreateEndpointDialog({
 
           {collections && collections.length > 0 && (
             <div className="space-y-2">
-              <Label>Collection Filter</Label>
+              <FieldLabel>Collection filter</FieldLabel>
               <p className="text-xs text-muted-foreground">
                 Only receive events for selected collections. Leave empty for all collections.
               </p>


### PR DESCRIPTION
## Summary

PR **3 of 5** in the kelta-ui design-system rollout. Brings the admin / settings surface in line with `DESIGN.md` — `Label` → `FieldLabel`, ad-hoc colored pills → `StatusBadge`, sentence case + type scale on page headers. **No layout restructuring**.

### WebhooksPage
- `AttemptStatusBadge` now renders `<StatusBadge>` (Success → `active`, Pending/Sending → `pending`, Failed → `failed`, Unknown → `inactive`). Removes the hand-rolled `bg-green-100/yellow-100/blue-100` pills that violated the dark-mode separation rule.
- "Disabled" endpoint marker → `<StatusBadge variant="inactive" />`
- All shadcn `<Label>` → `<FieldLabel>`; sentence case sweep on dialog and section titles ("Add webhook endpoint", "Recent deliveries", "Event types", "Collection filter", etc.)
- `InfoCard` field labels use the `kelta-field-label` class

### AiSettingsPage
- All `<Label>` → `<FieldLabel>`; "AI Settings" H1 uses the type scale (26 / 700 / -0.01em); the green/red ad-hoc Enabled/Disabled span replaced with `<StatusBadge>`
- Sentence case on "Token limits", "Model configuration", "Monthly history", "Save changes", etc.
- Token usage figure renders `font-mono tabular-nums`; monthly history grid uses `kelta-field-label` headers and `font-mono tabular-nums` for the numeric cells

### ProfileDetailPage
- Edit-form `<Label>` → `<FieldLabel>`

### FlowsPage NameAndCreateStep
- `<Label>` → `<FieldLabel>`; flow-type meta labels in sentence case ("Record change", "API / webhook", "Kafka event")

## Rollout
1. ~~PR 1 — Foundation~~ #760 ✅
2. ~~PR 2 — Runtime~~ #761 ✅
3. **PR 3 — Admin & Settings** *(this PR)*
4. PR 4 — Builder surfaces (FlowDesigner / PageBuilder / Dashboards) tokens + component swaps
5. PR 5 — Quality sweep (em-dash, hex audit, sentence case, emoji removal)

## Test plan

- [x] `npm run lint` — 0 errors
- [x] `npm run test:run` — 1764 passed, 34 skipped
- [x] `prettier --write` on all touched files
- [ ] Visit /setup/webhooks, /setup/ai-settings, profile detail in dev; verify status badges, field labels, dark + light themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)