### PR TITLE
feat(kelta-ui): adopt FieldLabel across builder surfaces (PR 4/5)

### DIFF
--- a/kelta-ui/app/src/pages/DashboardsPage/DashboardsPage.tsx
+++ b/kelta-ui/app/src/pages/DashboardsPage/DashboardsPage.tsx
@@ -1603,7 +1603,7 @@ function DashboardEditorInner({
                   <div className="p-3.5">
                     <div className="mb-1 text-sm font-semibold text-foreground">{comp.title}</div>
                     <div className="text-xs text-muted-foreground">
-                      Collection: {(comp.config.collection as string) || 'N/A'}
+                      Collection: {(comp.config.collection as string) || '—'}
                     </div>
                   </div>
                 </div>

--- a/kelta-ui/app/src/pages/FlowDesignerPage/components/TestFlowDialog.tsx
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/components/TestFlowDialog.tsx
@@ -9,7 +9,7 @@ import {
 } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
 import { Textarea } from '@/components/ui/textarea'
-import { Label } from '@/components/ui/label'
+import { FieldLabel } from '@/components/kelta'
 import { Play } from 'lucide-react'
 
 interface TestFlowDialogProps {
@@ -113,7 +113,7 @@ export function TestFlowDialog({
           </div>
 
           <div className="flex flex-col gap-1.5">
-            <Label className="text-xs">Initial State (JSON)</Label>
+            <FieldLabel className="text-xs">Initial State (JSON)</FieldLabel>
             <Textarea
               value={jsonValue}
               onChange={handleJsonChange}

--- a/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/CatchEditor.tsx
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/CatchEditor.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
+import { FieldLabel } from '@/components/kelta'
 import { Button } from '@/components/ui/button'
 import {
   Accordion,
@@ -57,7 +57,7 @@ export function CatchEditor({ catches, allNodeIds, onUpdate }: CatchEditorProps)
                 </Button>
               </div>
               <div>
-                <Label className="text-[10px]">Error Equals (comma-separated)</Label>
+                <FieldLabel className="text-[10px]">Error Equals (comma-separated)</FieldLabel>
                 <Input
                   value={rule.errorEquals.join(', ')}
                   onChange={(e) =>
@@ -72,7 +72,7 @@ export function CatchEditor({ catches, allNodeIds, onUpdate }: CatchEditorProps)
                 />
               </div>
               <div>
-                <Label className="text-[10px]">Result Path</Label>
+                <FieldLabel className="text-[10px]">Result Path</FieldLabel>
                 <Input
                   value={rule.resultPath}
                   onChange={(e) => updateCatch(i, 'resultPath', e.target.value)}
@@ -81,7 +81,7 @@ export function CatchEditor({ catches, allNodeIds, onUpdate }: CatchEditorProps)
                 />
               </div>
               <div>
-                <Label className="text-[10px]">Next State</Label>
+                <FieldLabel className="text-[10px]">Next State</FieldLabel>
                 <select
                   value={rule.next}
                   onChange={(e) => updateCatch(i, 'next', e.target.value)}

--- a/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/ChoiceProperties.tsx
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/ChoiceProperties.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Label } from '@/components/ui/label'
+import { FieldLabel } from '@/components/kelta'
 import { Button } from '@/components/ui/button'
 import { Plus } from 'lucide-react'
 import type { ChoiceRuleUI } from '../../types'
@@ -40,9 +40,9 @@ export function ChoiceProperties({ nodeId, data, allNodeIds, onUpdate }: ChoiceP
   return (
     <div className="flex flex-col gap-3">
       <div>
-        <Label htmlFor={`default-state-${nodeId}`} className="text-xs">
+        <FieldLabel htmlFor={`default-state-${nodeId}`} className="text-xs">
           Default State
-        </Label>
+        </FieldLabel>
         <select
           id={`default-state-${nodeId}`}
           value={defaultState}

--- a/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/ChoiceRuleEditor.tsx
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/ChoiceRuleEditor.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
+import { FieldLabel } from '@/components/kelta'
 import { Button } from '@/components/ui/button'
 import { Trash2 } from 'lucide-react'
 import type { ChoiceRuleUI, ChoiceOperator } from '../../types'
@@ -50,7 +50,7 @@ export function ChoiceRuleEditor({
       </div>
 
       <div>
-        <Label className="text-[10px]">Variable</Label>
+        <FieldLabel className="text-[10px]">Variable</FieldLabel>
         <Input
           value={rule.variable}
           onChange={(e) => onUpdate({ ...rule, variable: e.target.value })}
@@ -60,7 +60,7 @@ export function ChoiceRuleEditor({
       </div>
 
       <div>
-        <Label className="text-[10px]">Operator</Label>
+        <FieldLabel className="text-[10px]">Operator</FieldLabel>
         <select
           value={rule.operator}
           onChange={(e) => onUpdate({ ...rule, operator: e.target.value as ChoiceOperator })}
@@ -75,7 +75,7 @@ export function ChoiceRuleEditor({
       </div>
 
       <div>
-        <Label className="text-[10px]">Value</Label>
+        <FieldLabel className="text-[10px]">Value</FieldLabel>
         <Input
           value={rule.value}
           onChange={(e) => onUpdate({ ...rule, value: e.target.value })}
@@ -85,7 +85,7 @@ export function ChoiceRuleEditor({
       </div>
 
       <div>
-        <Label className="text-[10px]">Next State</Label>
+        <FieldLabel className="text-[10px]">Next State</FieldLabel>
         <select
           value={rule.next}
           onChange={(e) => onUpdate({ ...rule, next: e.target.value })}

--- a/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/CommonFields.tsx
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/CommonFields.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
 import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
 import { Badge } from '@/components/ui/badge'
+import { FieldLabel } from '@/components/kelta'
 
 interface CommonFieldsProps {
   nodeId: string
@@ -34,26 +34,26 @@ export function CommonFields({ nodeId, stateType, label, comment, onUpdate }: Co
       </div>
 
       <div>
-        <Label htmlFor={`node-name-${nodeId}`} className="text-xs">
+        <FieldLabel htmlFor={`node-name-${nodeId}`} className="mb-1">
           Name
-        </Label>
+        </FieldLabel>
         <Input
           id={`node-name-${nodeId}`}
           value={label}
           onChange={(e) => onUpdate({ label: e.target.value })}
-          className="mt-1 h-8 text-sm"
+          className="h-8 text-sm"
         />
       </div>
 
       <div>
-        <Label htmlFor={`node-comment-${nodeId}`} className="text-xs">
+        <FieldLabel htmlFor={`node-comment-${nodeId}`} className="mb-1">
           Comment
-        </Label>
+        </FieldLabel>
         <Textarea
           id={`node-comment-${nodeId}`}
           value={comment}
           onChange={(e) => onUpdate({ comment: e.target.value })}
-          className="mt-1 min-h-[60px] text-sm"
+          className="min-h-[60px] text-sm"
           placeholder="Optional description"
           rows={2}
         />

--- a/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/CreateRecordParams.tsx
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/CreateRecordParams.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
+import { FieldLabel } from '@/components/kelta'
 import { Button } from '@/components/ui/button'
 import {
   Accordion,
@@ -69,7 +69,7 @@ export function CreateRecordParams({ parameters, onUpdate }: CreateRecordParamsP
       </span>
 
       <div>
-        <Label className="text-[10px]">Target Collection Name</Label>
+        <FieldLabel className="text-[10px]">Target Collection Name</FieldLabel>
         <Input
           value={targetCollectionName}
           onChange={(e) => update('targetCollectionName', e.target.value)}
@@ -104,7 +104,7 @@ export function CreateRecordParams({ parameters, onUpdate }: CreateRecordParamsP
                     </Button>
                   </div>
                   <div>
-                    <Label className="text-[9px]">Field Name</Label>
+                    <FieldLabel className="text-[9px]">Field Name</FieldLabel>
                     <Input
                       value={mapping.field}
                       onChange={(e) => updateMapping(i, 'field', e.target.value)}
@@ -134,7 +134,7 @@ export function CreateRecordParams({ parameters, onUpdate }: CreateRecordParamsP
                   </div>
                   {isSourceMode ? (
                     <div>
-                      <Label className="text-[9px]">Source Field</Label>
+                      <FieldLabel className="text-[9px]">Source Field</FieldLabel>
                       <Input
                         value={mapping.sourceField || ''}
                         onChange={(e) => updateMapping(i, 'sourceField', e.target.value)}
@@ -144,7 +144,7 @@ export function CreateRecordParams({ parameters, onUpdate }: CreateRecordParamsP
                     </div>
                   ) : (
                     <div>
-                      <Label className="text-[9px]">Value</Label>
+                      <FieldLabel className="text-[9px]">Value</FieldLabel>
                       <Input
                         value={mapping.value || ''}
                         onChange={(e) => updateMapping(i, 'value', e.target.value)}

--- a/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/DataPathFields.tsx
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/DataPathFields.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
+import { FieldLabel } from '@/components/kelta'
 import {
   Accordion,
   AccordionContent,
@@ -31,9 +31,9 @@ export function DataPathFields({
         </AccordionTrigger>
         <AccordionContent className="flex flex-col gap-3 pb-0">
           <div>
-            <Label htmlFor={`input-path-${nodeId}`} className="text-xs">
+            <FieldLabel htmlFor={`input-path-${nodeId}`} className="text-xs">
               InputPath
-            </Label>
+            </FieldLabel>
             <Input
               id={`input-path-${nodeId}`}
               value={inputPath}
@@ -43,9 +43,9 @@ export function DataPathFields({
             />
           </div>
           <div>
-            <Label htmlFor={`output-path-${nodeId}`} className="text-xs">
+            <FieldLabel htmlFor={`output-path-${nodeId}`} className="text-xs">
               OutputPath
-            </Label>
+            </FieldLabel>
             <Input
               id={`output-path-${nodeId}`}
               value={outputPath}
@@ -55,9 +55,9 @@ export function DataPathFields({
             />
           </div>
           <div>
-            <Label htmlFor={`result-path-${nodeId}`} className="text-xs">
+            <FieldLabel htmlFor={`result-path-${nodeId}`} className="text-xs">
               ResultPath
-            </Label>
+            </FieldLabel>
             <Input
               id={`result-path-${nodeId}`}
               value={resultPath}

--- a/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/DeleteRecordParams.tsx
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/DeleteRecordParams.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
+import { FieldLabel } from '@/components/kelta'
 
 interface DeleteRecordParamsProps {
   parameters?: Record<string, unknown>
@@ -37,7 +37,7 @@ export function DeleteRecordParams({ parameters, onUpdate }: DeleteRecordParamsP
       </span>
 
       <div>
-        <Label className="text-[10px]">Target Collection Name</Label>
+        <FieldLabel className="text-[10px]">Target Collection Name</FieldLabel>
         <Input
           value={targetCollectionName}
           onChange={(e) => update('targetCollectionName', e.target.value)}
@@ -48,7 +48,7 @@ export function DeleteRecordParams({ parameters, onUpdate }: DeleteRecordParamsP
 
       {/* Record ID Source */}
       <div>
-        <Label className="text-[10px]">Record ID Source</Label>
+        <FieldLabel className="text-[10px]">Record ID Source</FieldLabel>
         <div className="mt-1 flex gap-2">
           <label className="flex items-center gap-1 text-[10px]">
             <input

--- a/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/EmailAlertParams.tsx
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/EmailAlertParams.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
+import { FieldLabel } from '@/components/kelta'
 import { Textarea } from '@/components/ui/textarea'
 
 interface EmailAlertParamsProps {
@@ -26,7 +26,7 @@ export function EmailAlertParams({ parameters, onUpdate }: EmailAlertParamsProps
       </span>
 
       <div>
-        <Label className="text-[10px]">To</Label>
+        <FieldLabel className="text-[10px]">To</FieldLabel>
         <Input
           value={to}
           onChange={(e) => update('to', e.target.value)}
@@ -36,7 +36,7 @@ export function EmailAlertParams({ parameters, onUpdate }: EmailAlertParamsProps
       </div>
 
       <div>
-        <Label className="text-[10px]">Subject</Label>
+        <FieldLabel className="text-[10px]">Subject</FieldLabel>
         <Input
           value={subject}
           onChange={(e) => update('subject', e.target.value)}
@@ -46,7 +46,7 @@ export function EmailAlertParams({ parameters, onUpdate }: EmailAlertParamsProps
       </div>
 
       <div>
-        <Label className="text-[10px]">Body</Label>
+        <FieldLabel className="text-[10px]">Body</FieldLabel>
         <Textarea
           value={body}
           onChange={(e) => update('body', e.target.value)}
@@ -57,7 +57,7 @@ export function EmailAlertParams({ parameters, onUpdate }: EmailAlertParamsProps
       </div>
 
       <div>
-        <Label className="text-[10px]">Template ID (optional)</Label>
+        <FieldLabel className="text-[10px]">Template ID (optional)</FieldLabel>
         <Input
           value={templateId}
           onChange={(e) => update('templateId', e.target.value)}

--- a/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/FailProperties.tsx
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/FailProperties.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
+import { FieldLabel } from '@/components/kelta'
 import { Textarea } from '@/components/ui/textarea'
 
 interface FailPropertiesProps {
@@ -13,9 +13,9 @@ export function FailProperties({ nodeId, data, onUpdate }: FailPropertiesProps) 
   return (
     <div className="flex flex-col gap-3">
       <div>
-        <Label htmlFor={`error-code-${nodeId}`} className="text-xs">
+        <FieldLabel htmlFor={`error-code-${nodeId}`} className="text-xs">
           Error Code
-        </Label>
+        </FieldLabel>
         <Input
           id={`error-code-${nodeId}`}
           value={(data.error as string) || ''}
@@ -26,9 +26,9 @@ export function FailProperties({ nodeId, data, onUpdate }: FailPropertiesProps) 
       </div>
 
       <div>
-        <Label htmlFor={`cause-${nodeId}`} className="text-xs">
+        <FieldLabel htmlFor={`cause-${nodeId}`} className="text-xs">
           Cause
-        </Label>
+        </FieldLabel>
         <Textarea
           id={`cause-${nodeId}`}
           value={(data.cause as string) || ''}

--- a/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/FieldUpdateParams.tsx
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/FieldUpdateParams.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
+import { FieldLabel } from '@/components/kelta'
 import { Button } from '@/components/ui/button'
 import {
   Accordion,
@@ -93,7 +93,7 @@ export function FieldUpdateParams({ parameters, onUpdate }: FieldUpdateParamsPro
                     </Button>
                   </div>
                   <div>
-                    <Label className="text-[9px]">Field Name</Label>
+                    <FieldLabel className="text-[9px]">Field Name</FieldLabel>
                     <Input
                       value={entry.field}
                       onChange={(e) => updateEntry(i, 'field', e.target.value)}
@@ -123,7 +123,7 @@ export function FieldUpdateParams({ parameters, onUpdate }: FieldUpdateParamsPro
                   </div>
                   {isSourceMode ? (
                     <div>
-                      <Label className="text-[9px]">Source Field</Label>
+                      <FieldLabel className="text-[9px]">Source Field</FieldLabel>
                       <Input
                         value={entry.sourceField || ''}
                         onChange={(e) => updateEntry(i, 'sourceField', e.target.value)}
@@ -133,7 +133,7 @@ export function FieldUpdateParams({ parameters, onUpdate }: FieldUpdateParamsPro
                     </div>
                   ) : (
                     <div>
-                      <Label className="text-[9px]">Value</Label>
+                      <FieldLabel className="text-[9px]">Value</FieldLabel>
                       <Input
                         value={entry.value || ''}
                         onChange={(e) => updateEntry(i, 'value', e.target.value)}

--- a/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/HttpCalloutParams.tsx
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/HttpCalloutParams.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
+import { FieldLabel } from '@/components/kelta'
 import { Button } from '@/components/ui/button'
 import { Textarea } from '@/components/ui/textarea'
 import {
@@ -72,7 +72,7 @@ export function HttpCalloutParams({ parameters, onUpdate }: HttpCalloutParamsPro
       </span>
 
       <div>
-        <Label className="text-[10px]">URL</Label>
+        <FieldLabel className="text-[10px]">URL</FieldLabel>
         <Input
           value={url}
           onChange={(e) => update('url', e.target.value)}
@@ -82,7 +82,7 @@ export function HttpCalloutParams({ parameters, onUpdate }: HttpCalloutParamsPro
       </div>
 
       <div>
-        <Label className="text-[10px]">Method</Label>
+        <FieldLabel className="text-[10px]">Method</FieldLabel>
         <select
           value={method}
           onChange={(e) => update('method', e.target.value)}
@@ -121,7 +121,7 @@ export function HttpCalloutParams({ parameters, onUpdate }: HttpCalloutParamsPro
                 </div>
                 <div className="grid grid-cols-2 gap-1">
                   <div>
-                    <Label className="text-[9px]">Key</Label>
+                    <FieldLabel className="text-[9px]">Key</FieldLabel>
                     <Input
                       value={header.key}
                       onChange={(e) => updateHeader(i, 'key', e.target.value)}
@@ -130,7 +130,7 @@ export function HttpCalloutParams({ parameters, onUpdate }: HttpCalloutParamsPro
                     />
                   </div>
                   <div>
-                    <Label className="text-[9px]">Value</Label>
+                    <FieldLabel className="text-[9px]">Value</FieldLabel>
                     <Input
                       value={header.value}
                       onChange={(e) => updateHeader(i, 'value', e.target.value)}
@@ -150,7 +150,7 @@ export function HttpCalloutParams({ parameters, onUpdate }: HttpCalloutParamsPro
       </Accordion>
 
       <div>
-        <Label className="text-[10px]">Body</Label>
+        <FieldLabel className="text-[10px]">Body</FieldLabel>
         <Textarea
           value={body}
           onChange={(e) => update('body', e.target.value)}

--- a/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/LogMessageParams.tsx
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/LogMessageParams.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Label } from '@/components/ui/label'
+import { FieldLabel } from '@/components/kelta'
 import { Textarea } from '@/components/ui/textarea'
 
 const LOG_LEVELS = ['DEBUG', 'INFO', 'WARNING', 'ERROR']
@@ -25,7 +25,7 @@ export function LogMessageParams({ parameters, onUpdate }: LogMessageParamsProps
       </span>
 
       <div>
-        <Label className="text-[10px]">Message</Label>
+        <FieldLabel className="text-[10px]">Message</FieldLabel>
         <Textarea
           value={message}
           onChange={(e) => update('message', e.target.value)}
@@ -36,7 +36,7 @@ export function LogMessageParams({ parameters, onUpdate }: LogMessageParamsProps
       </div>
 
       <div>
-        <Label className="text-[10px]">Level</Label>
+        <FieldLabel className="text-[10px]">Level</FieldLabel>
         <select
           value={level}
           onChange={(e) => update('level', e.target.value)}

--- a/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/MapProperties.tsx
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/MapProperties.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
+import { FieldLabel } from '@/components/kelta'
 import { DataPathFields } from './DataPathFields'
 
 interface MapPropertiesProps {
@@ -13,9 +13,9 @@ export function MapProperties({ nodeId, data, onUpdate }: MapPropertiesProps) {
   return (
     <div className="flex flex-col gap-3">
       <div>
-        <Label htmlFor={`items-path-${nodeId}`} className="text-xs">
+        <FieldLabel htmlFor={`items-path-${nodeId}`} className="text-xs">
           Items Path
-        </Label>
+        </FieldLabel>
         <Input
           id={`items-path-${nodeId}`}
           value={(data.itemsPath as string) || ''}
@@ -26,9 +26,9 @@ export function MapProperties({ nodeId, data, onUpdate }: MapPropertiesProps) {
       </div>
 
       <div>
-        <Label htmlFor={`max-concurrency-${nodeId}`} className="text-xs">
+        <FieldLabel htmlFor={`max-concurrency-${nodeId}`} className="text-xs">
           Max Concurrency
-        </Label>
+        </FieldLabel>
         <Input
           id={`max-concurrency-${nodeId}`}
           type="number"

--- a/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/ParallelProperties.tsx
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/ParallelProperties.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Label } from '@/components/ui/label'
+import { FieldLabel } from '@/components/kelta'
 import type { RetryRule, CatchRule } from '../../types'
 import { DataPathFields } from './DataPathFields'
 import { RetryEditor } from './RetryEditor'
@@ -23,7 +23,7 @@ export function ParallelProperties({
   return (
     <div className="flex flex-col gap-3">
       <div>
-        <Label className="text-xs">Branches</Label>
+        <FieldLabel className="text-xs">Branches</FieldLabel>
         <div className="mt-1 rounded-md border border-border bg-muted/50 p-2 text-xs text-muted-foreground">
           {branchCount} branch{branchCount !== 1 ? 'es' : ''} defined
         </div>

--- a/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/PassProperties.tsx
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/PassProperties.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Label } from '@/components/ui/label'
+import { FieldLabel } from '@/components/kelta'
 import { Textarea } from '@/components/ui/textarea'
 import { DataPathFields } from './DataPathFields'
 
@@ -13,9 +13,9 @@ export function PassProperties({ nodeId, data, onUpdate }: PassPropertiesProps) 
   return (
     <div className="flex flex-col gap-3">
       <div>
-        <Label htmlFor={`result-json-${nodeId}`} className="text-xs">
+        <FieldLabel htmlFor={`result-json-${nodeId}`} className="text-xs">
           Result (JSON)
-        </Label>
+        </FieldLabel>
         <Textarea
           id={`result-json-${nodeId}`}
           value={(data.result as string) || ''}

--- a/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/PublishEventParams.tsx
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/PublishEventParams.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
+import { FieldLabel } from '@/components/kelta'
 import { Textarea } from '@/components/ui/textarea'
 
 interface PublishEventParamsProps {
@@ -47,7 +47,7 @@ export function PublishEventParams({ parameters, onUpdate }: PublishEventParamsP
       </span>
 
       <div>
-        <Label className="text-[10px]">Topic</Label>
+        <FieldLabel className="text-[10px]">Topic</FieldLabel>
         <Input
           value={topic}
           onChange={(e) => update('topic', e.target.value)}
@@ -57,7 +57,7 @@ export function PublishEventParams({ parameters, onUpdate }: PublishEventParamsP
       </div>
 
       <div>
-        <Label className="text-[10px]">Event Type</Label>
+        <FieldLabel className="text-[10px]">Event Type</FieldLabel>
         <Input
           value={eventType}
           onChange={(e) => update('eventType', e.target.value)}
@@ -67,7 +67,7 @@ export function PublishEventParams({ parameters, onUpdate }: PublishEventParamsP
       </div>
 
       <div>
-        <Label className="text-[10px]">Data Payload (JSON)</Label>
+        <FieldLabel className="text-[10px]">Data Payload (JSON)</FieldLabel>
         <Textarea
           value={dataPayloadStr}
           onChange={(e) => updateDataPayload(e.target.value)}

--- a/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/QueryRecordsParams.tsx
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/QueryRecordsParams.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
+import { FieldLabel } from '@/components/kelta'
 import { Button } from '@/components/ui/button'
 import {
   Accordion,
@@ -88,7 +88,7 @@ export function QueryRecordsParams({ parameters, onUpdate }: QueryRecordsParamsP
       </span>
 
       <div>
-        <Label className="text-[10px]">Collection Name</Label>
+        <FieldLabel className="text-[10px]">Collection Name</FieldLabel>
         <Input
           value={targetCollectionName}
           onChange={(e) => update('targetCollectionName', e.target.value)}
@@ -122,7 +122,7 @@ export function QueryRecordsParams({ parameters, onUpdate }: QueryRecordsParamsP
                 </div>
                 <div className="grid grid-cols-3 gap-1">
                   <div>
-                    <Label className="text-[9px]">Field</Label>
+                    <FieldLabel className="text-[9px]">Field</FieldLabel>
                     <Input
                       value={filter.field}
                       onChange={(e) => updateFilter(i, 'field', e.target.value)}
@@ -131,7 +131,7 @@ export function QueryRecordsParams({ parameters, onUpdate }: QueryRecordsParamsP
                     />
                   </div>
                   <div>
-                    <Label className="text-[9px]">Operator</Label>
+                    <FieldLabel className="text-[9px]">Operator</FieldLabel>
                     <select
                       value={filter.operator}
                       onChange={(e) => updateFilter(i, 'operator', e.target.value)}
@@ -145,7 +145,7 @@ export function QueryRecordsParams({ parameters, onUpdate }: QueryRecordsParamsP
                     </select>
                   </div>
                   <div>
-                    <Label className="text-[9px]">Value</Label>
+                    <FieldLabel className="text-[9px]">Value</FieldLabel>
                     <Input
                       value={filter.value}
                       onChange={(e) => updateFilter(i, 'value', e.target.value)}
@@ -167,7 +167,7 @@ export function QueryRecordsParams({ parameters, onUpdate }: QueryRecordsParamsP
       {/* Sort & Page Size */}
       <div className="grid grid-cols-2 gap-2">
         <div>
-          <Label className="text-[10px]">Sort</Label>
+          <FieldLabel className="text-[10px]">Sort</FieldLabel>
           <Input
             value={sort}
             onChange={(e) => update('sort', e.target.value)}
@@ -176,7 +176,7 @@ export function QueryRecordsParams({ parameters, onUpdate }: QueryRecordsParamsP
           />
         </div>
         <div>
-          <Label className="text-[10px]">Page Size</Label>
+          <FieldLabel className="text-[10px]">Page Size</FieldLabel>
           <Input
             type="number"
             value={pageSize}
@@ -213,7 +213,7 @@ export function QueryRecordsParams({ parameters, onUpdate }: QueryRecordsParamsP
                 </div>
                 <div className="grid grid-cols-3 gap-1">
                   <div>
-                    <Label className="text-[9px]">Function</Label>
+                    <FieldLabel className="text-[9px]">Function</FieldLabel>
                     <select
                       value={agg.function}
                       onChange={(e) => updateAgg(i, 'function', e.target.value)}
@@ -227,7 +227,7 @@ export function QueryRecordsParams({ parameters, onUpdate }: QueryRecordsParamsP
                     </select>
                   </div>
                   <div>
-                    <Label className="text-[9px]">Field</Label>
+                    <FieldLabel className="text-[9px]">Field</FieldLabel>
                     <Input
                       value={agg.field || ''}
                       onChange={(e) => updateAgg(i, 'field', e.target.value)}
@@ -236,7 +236,7 @@ export function QueryRecordsParams({ parameters, onUpdate }: QueryRecordsParamsP
                     />
                   </div>
                   <div>
-                    <Label className="text-[9px]">Alias</Label>
+                    <FieldLabel className="text-[9px]">Alias</FieldLabel>
                     <Input
                       value={agg.alias}
                       onChange={(e) => updateAgg(i, 'alias', e.target.value)}

--- a/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/RetryEditor.tsx
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/RetryEditor.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
+import { FieldLabel } from '@/components/kelta'
 import { Button } from '@/components/ui/button'
 import {
   Accordion,
@@ -57,7 +57,7 @@ export function RetryEditor({ retry, onUpdate }: RetryEditorProps) {
                 </Button>
               </div>
               <div>
-                <Label className="text-[10px]">Error Equals (comma-separated)</Label>
+                <FieldLabel className="text-[10px]">Error Equals (comma-separated)</FieldLabel>
                 <Input
                   value={rule.errorEquals.join(', ')}
                   onChange={(e) =>
@@ -73,7 +73,7 @@ export function RetryEditor({ retry, onUpdate }: RetryEditorProps) {
               </div>
               <div className="grid grid-cols-3 gap-1.5">
                 <div>
-                  <Label className="text-[10px]">Interval (s)</Label>
+                  <FieldLabel className="text-[10px]">Interval (s)</FieldLabel>
                   <Input
                     type="number"
                     value={rule.intervalSeconds}
@@ -85,7 +85,7 @@ export function RetryEditor({ retry, onUpdate }: RetryEditorProps) {
                   />
                 </div>
                 <div>
-                  <Label className="text-[10px]">Max Attempts</Label>
+                  <FieldLabel className="text-[10px]">Max Attempts</FieldLabel>
                   <Input
                     type="number"
                     value={rule.maxAttempts}
@@ -95,7 +95,7 @@ export function RetryEditor({ retry, onUpdate }: RetryEditorProps) {
                   />
                 </div>
                 <div>
-                  <Label className="text-[10px]">Backoff</Label>
+                  <FieldLabel className="text-[10px]">Backoff</FieldLabel>
                   <Input
                     type="number"
                     value={rule.backoffRate}

--- a/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/SendNotificationParams.tsx
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/SendNotificationParams.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
+import { FieldLabel } from '@/components/kelta'
 import { Textarea } from '@/components/ui/textarea'
 
 const NOTIFICATION_LEVELS = ['INFO', 'WARNING', 'ERROR']
@@ -28,7 +28,7 @@ export function SendNotificationParams({ parameters, onUpdate }: SendNotificatio
       </span>
 
       <div>
-        <Label className="text-[10px]">User ID</Label>
+        <FieldLabel className="text-[10px]">User ID</FieldLabel>
         <Input
           value={userId}
           onChange={(e) => update('userId', e.target.value)}
@@ -38,7 +38,7 @@ export function SendNotificationParams({ parameters, onUpdate }: SendNotificatio
       </div>
 
       <div>
-        <Label className="text-[10px]">Title</Label>
+        <FieldLabel className="text-[10px]">Title</FieldLabel>
         <Input
           value={title}
           onChange={(e) => update('title', e.target.value)}
@@ -48,7 +48,7 @@ export function SendNotificationParams({ parameters, onUpdate }: SendNotificatio
       </div>
 
       <div>
-        <Label className="text-[10px]">Message</Label>
+        <FieldLabel className="text-[10px]">Message</FieldLabel>
         <Textarea
           value={message}
           onChange={(e) => update('message', e.target.value)}
@@ -59,7 +59,7 @@ export function SendNotificationParams({ parameters, onUpdate }: SendNotificatio
       </div>
 
       <div>
-        <Label className="text-[10px]">Level</Label>
+        <FieldLabel className="text-[10px]">Level</FieldLabel>
         <select
           value={level}
           onChange={(e) => update('level', e.target.value)}

--- a/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/TaskProperties.tsx
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/TaskProperties.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Label } from '@/components/ui/label'
+import { FieldLabel } from '@/components/kelta'
 import { Input } from '@/components/ui/input'
 import { RESOURCE_GROUPS } from '../../types'
 import type { RetryRule, CatchRule } from '../../types'
@@ -31,9 +31,9 @@ export function TaskProperties({ nodeId, data, allNodeIds, onUpdate }: TaskPrope
   return (
     <div className="flex flex-col gap-3">
       <div>
-        <Label htmlFor={`resource-${nodeId}`} className="text-xs">
+        <FieldLabel htmlFor={`resource-${nodeId}`} className="text-xs">
           Resource
-        </Label>
+        </FieldLabel>
         <select
           id={`resource-${nodeId}`}
           value={resource}
@@ -122,9 +122,9 @@ export function TaskProperties({ nodeId, data, allNodeIds, onUpdate }: TaskPrope
       )}
 
       <div>
-        <Label htmlFor={`timeout-${nodeId}`} className="text-xs">
+        <FieldLabel htmlFor={`timeout-${nodeId}`} className="text-xs">
           Timeout (seconds)
-        </Label>
+        </FieldLabel>
         <Input
           id={`timeout-${nodeId}`}
           type="number"

--- a/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/TriggerFlowParams.tsx
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/TriggerFlowParams.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
+import { FieldLabel } from '@/components/kelta'
 
 interface TriggerFlowParamsProps {
   parameters?: Record<string, unknown>
@@ -22,7 +22,7 @@ export function TriggerFlowParams({ parameters, onUpdate }: TriggerFlowParamsPro
       </span>
 
       <div>
-        <Label className="text-[10px]">Flow ID</Label>
+        <FieldLabel className="text-[10px]">Flow ID</FieldLabel>
         <Input
           value={flowId}
           onChange={(e) => update('flowId', e.target.value)}

--- a/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/UpdateRecordParams.tsx
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/UpdateRecordParams.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
+import { FieldLabel } from '@/components/kelta'
 import { Button } from '@/components/ui/button'
 import {
   Accordion,
@@ -85,7 +85,7 @@ export function UpdateRecordParams({ parameters, onUpdate }: UpdateRecordParamsP
       </span>
 
       <div>
-        <Label className="text-[10px]">Target Collection</Label>
+        <FieldLabel className="text-[10px]">Target Collection</FieldLabel>
         <Input
           value={targetCollectionName}
           onChange={(e) => update('targetCollectionName', e.target.value)}
@@ -96,7 +96,7 @@ export function UpdateRecordParams({ parameters, onUpdate }: UpdateRecordParamsP
 
       {/* Record ID Source */}
       <div>
-        <Label className="text-[10px]">Record ID Source</Label>
+        <FieldLabel className="text-[10px]">Record ID Source</FieldLabel>
         <div className="mt-1 flex gap-2">
           <label className="flex items-center gap-1 text-[10px]">
             <input
@@ -162,7 +162,7 @@ export function UpdateRecordParams({ parameters, onUpdate }: UpdateRecordParamsP
                     </Button>
                   </div>
                   <div>
-                    <Label className="text-[9px]">Target Field</Label>
+                    <FieldLabel className="text-[9px]">Target Field</FieldLabel>
                     <Input
                       value={upd.field}
                       onChange={(e) => updateFieldUpdate(i, 'field', e.target.value)}
@@ -192,7 +192,7 @@ export function UpdateRecordParams({ parameters, onUpdate }: UpdateRecordParamsP
                   </div>
                   {isSourceMode ? (
                     <div>
-                      <Label className="text-[9px]">Source Field</Label>
+                      <FieldLabel className="text-[9px]">Source Field</FieldLabel>
                       <Input
                         value={upd.sourceField || ''}
                         onChange={(e) => updateFieldUpdate(i, 'sourceField', e.target.value)}
@@ -202,7 +202,7 @@ export function UpdateRecordParams({ parameters, onUpdate }: UpdateRecordParamsP
                     </div>
                   ) : (
                     <div>
-                      <Label className="text-[9px]">Value</Label>
+                      <FieldLabel className="text-[9px]">Value</FieldLabel>
                       <Input
                         value={upd.value || ''}
                         onChange={(e) => updateFieldUpdate(i, 'value', e.target.value)}

--- a/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/WaitProperties.tsx
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/WaitProperties.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
+import { FieldLabel } from '@/components/kelta'
 import type { WaitMode } from '../../types'
 
 interface WaitPropertiesProps {
@@ -30,10 +30,12 @@ export function WaitProperties({ nodeId, data, onUpdate }: WaitPropertiesProps) 
   return (
     <div className="flex flex-col gap-3">
       <div>
-        <Label className="text-xs">Wait Mode</Label>
+        <FieldLabel className="text-xs">Wait Mode</FieldLabel>
         <div className="mt-1 flex flex-col gap-1.5">
           {WAIT_MODES.map((mode) => (
-            <Label
+            // jsx-a11y rule can't see the htmlFor↔id pairing across the dynamic key
+            // eslint-disable-next-line jsx-a11y/label-has-associated-control
+            <label
               key={mode.value}
               htmlFor={`wait-mode-${nodeId}-${mode.value}`}
               className="flex cursor-pointer items-start gap-2 rounded-md border border-border p-2 font-normal transition-colors hover:bg-muted has-[:checked]:border-primary has-[:checked]:bg-primary/5"
@@ -51,16 +53,16 @@ export function WaitProperties({ nodeId, data, onUpdate }: WaitPropertiesProps) 
                 <span className="text-xs font-medium">{mode.label}</span>
                 <span className="block text-[10px] text-muted-foreground">{mode.description}</span>
               </span>
-            </Label>
+            </label>
           ))}
         </div>
       </div>
 
       {waitMode === 'seconds' && (
         <div>
-          <Label htmlFor={`wait-seconds-${nodeId}`} className="text-xs">
+          <FieldLabel htmlFor={`wait-seconds-${nodeId}`} className="text-xs">
             Seconds
-          </Label>
+          </FieldLabel>
           <Input
             id={`wait-seconds-${nodeId}`}
             type="number"
@@ -77,9 +79,9 @@ export function WaitProperties({ nodeId, data, onUpdate }: WaitPropertiesProps) 
 
       {waitMode === 'timestamp' && (
         <div>
-          <Label htmlFor={`wait-timestamp-${nodeId}`} className="text-xs">
+          <FieldLabel htmlFor={`wait-timestamp-${nodeId}`} className="text-xs">
             Timestamp (ISO 8601)
-          </Label>
+          </FieldLabel>
           <Input
             id={`wait-timestamp-${nodeId}`}
             value={(data.timestamp as string) || ''}
@@ -92,9 +94,9 @@ export function WaitProperties({ nodeId, data, onUpdate }: WaitPropertiesProps) 
 
       {waitMode === 'timestampPath' && (
         <div>
-          <Label htmlFor={`wait-timestamp-path-${nodeId}`} className="text-xs">
+          <FieldLabel htmlFor={`wait-timestamp-path-${nodeId}`} className="text-xs">
             Timestamp Path
-          </Label>
+          </FieldLabel>
           <Input
             id={`wait-timestamp-path-${nodeId}`}
             value={(data.timestampPath as string) || ''}
@@ -107,9 +109,9 @@ export function WaitProperties({ nodeId, data, onUpdate }: WaitPropertiesProps) 
 
       {waitMode === 'eventName' && (
         <div>
-          <Label htmlFor={`wait-event-${nodeId}`} className="text-xs">
+          <FieldLabel htmlFor={`wait-event-${nodeId}`} className="text-xs">
             Event Name
-          </Label>
+          </FieldLabel>
           <Input
             id={`wait-event-${nodeId}`}
             value={(data.eventName as string) || ''}


### PR DESCRIPTION
## Summary

PR **4 of 5** in the kelta-ui design-system rollout. Tokens + component swaps inside the high-complexity builder pages (FlowDesigner properties + Dashboards). **No canvas/grid layouts restructured** — the builder canvas, dashboard widget grid, and flow graph all render exactly as before.

### FlowDesignerPage
- 24 files under `pages/FlowDesignerPage/` swap shadcn `<Label>` for kelta `<FieldLabel>`. The properties panel now renders the signature uppercase 11px field labels above every input/textarea/select.
- `CommonFields` keeps its colored state-type `<Badge>` (it's a category tag for Task/Choice/Wait/Pass/Parallel/Map/Fail/Succeed, not a status — DESIGN.md's 5-state rule doesn't apply).
- `WaitProperties` keeps a native `<label>` for the radio-card option pattern (with `eslint-disable-next-line jsx-a11y/label-has-associated-control` and a comment — the rule can't see the dynamic `htmlFor` ↔ `id` pairing).

### DashboardsPage
- Replace the literal `'N/A'` empty-collection string in widget tiles with `'—'`, matching `DESIGN.md §1`. (Inline em-dash here rather than `<EmptyValue/>` since it lives inside a string template, not a child node.)

### Method
The bulk replacement was done via `sed` (import + tag swap) for the 24 FlowDesigner files, then hand-fixed `WaitProperties` where the multi-line `<Label\n...` open tag needed care.

## Rollout
1. ~~PR 1 — Foundation~~ #760 ✅
2. ~~PR 2 — Runtime~~ #761 ✅
3. ~~PR 3 — Admin & Settings~~ #762 (auto-merge queued)
4. **PR 4 — Builder surfaces** *(this PR)*
5. PR 5 — Quality sweep (em-dash, hex audit, sentence case, emoji removal)

## Test plan

- [x] `npm run lint` — 0 errors
- [x] `npm run test:run` — 1764 passed, 34 skipped
- [x] `prettier --write` on all touched files
- [ ] Open the FlowDesigner; click each step type (Task / Choice / Wait / Pass / Parallel / Map / Fail / Succeed) and verify properties panel labels render in uppercase 11px
- [ ] Open the Dashboards page; verify widget tile shows `—` (not `N/A`) when collection is unset

🤖 Generated with [Claude Code](https://claude.com/claude-code)