### PR TITLE
chore(kelta-ui): sentence-case sweep across page headers (PR 5/5)

### DIFF
--- a/kelta-ui/app/src/components/InsufficientPrivileges/InsufficientPrivileges.tsx
+++ b/kelta-ui/app/src/components/InsufficientPrivileges/InsufficientPrivileges.tsx
@@ -51,7 +51,7 @@ export function InsufficientPrivileges({
               <ShieldAlert className="h-6 w-6 text-destructive" />
             </div>
             <div className="space-y-2">
-              <h2 className="text-lg font-semibold text-foreground">Insufficient Privileges</h2>
+              <h2 className="text-lg font-semibold text-foreground">Insufficient privileges</h2>
               <p className="text-sm text-muted-foreground">{displayMessage}</p>
             </div>
             <Button variant="outline" onClick={handleGoBack}>

--- a/kelta-ui/app/src/components/RequirePermission/RequirePermission.tsx
+++ b/kelta-ui/app/src/components/RequirePermission/RequirePermission.tsx
@@ -31,7 +31,7 @@ export function RequirePermission({
     if (fallback) return <>{fallback}</>
     return (
       <div className="flex flex-col items-center justify-center p-12 text-center">
-        <h2 className="text-lg font-semibold text-gray-900">Insufficient Permissions</h2>
+        <h2 className="text-lg font-semibold text-foreground">Insufficient permissions</h2>
         <p className="mt-2 text-sm text-gray-500">
           You do not have the required permission to access this page.
         </p>

--- a/kelta-ui/app/src/components/SecurityEditor/CustomPolicyEditor.tsx
+++ b/kelta-ui/app/src/components/SecurityEditor/CustomPolicyEditor.tsx
@@ -231,7 +231,7 @@ export function CustomPolicyEditor({
   return (
     <div className="space-y-4" data-testid={testId}>
       <div className="flex items-center justify-between">
-        <h3 className="text-sm font-medium text-foreground">Custom Authorization Rules</h3>
+        <h3 className="text-sm font-medium text-foreground">Custom authorization rules</h3>
         {!readOnly && (
           <Button
             variant="outline"

--- a/kelta-ui/app/src/components/SecurityEditor/PolicyTestPanel.tsx
+++ b/kelta-ui/app/src/components/SecurityEditor/PolicyTestPanel.tsx
@@ -85,7 +85,7 @@ export function PolicyTestPanel({
 
   return (
     <div className="space-y-4" data-testid={testId}>
-      <h3 className="text-sm font-medium text-foreground">Test Policy</h3>
+      <h3 className="text-sm font-medium text-foreground">Test policy</h3>
 
       <div className="space-y-3 rounded-lg border border-border bg-card p-4">
         <div className="grid grid-cols-2 gap-3">

--- a/kelta-ui/app/src/pages/ApiTokensPage/ApiTokensPage.tsx
+++ b/kelta-ui/app/src/pages/ApiTokensPage/ApiTokensPage.tsx
@@ -370,7 +370,7 @@ function TokenCreatedDialog({
         data-testid="token-created-dialog-modal"
       >
         <div className="flex items-center justify-between border-b border-border p-6">
-          <h2 className="m-0 text-xl font-semibold text-foreground">Token Created</h2>
+          <h2 className="m-0 text-xl font-semibold text-foreground">Token created</h2>
           <button
             type="button"
             className="rounded p-2 text-2xl leading-none text-muted-foreground hover:bg-muted hover:text-foreground"

--- a/kelta-ui/app/src/pages/ApprovalProcessesPage/ApprovalProcessesPage.tsx
+++ b/kelta-ui/app/src/pages/ApprovalProcessesPage/ApprovalProcessesPage.tsx
@@ -777,7 +777,7 @@ export function ApprovalProcessesPage({
   return (
     <div className="mx-auto max-w-[1400px] space-y-6 p-6 lg:p-8" data-testid={testId}>
       <header className="flex items-center justify-between">
-        <h1 className="text-2xl font-semibold text-foreground">Approval Processes</h1>
+        <h1 className="text-2xl font-semibold text-foreground">Approval processes</h1>
         <Button
           type="button"
           onClick={handleCreate}

--- a/kelta-ui/app/src/pages/ConnectedAppsPage/ConnectedAppsPage.tsx
+++ b/kelta-ui/app/src/pages/ConnectedAppsPage/ConnectedAppsPage.tsx
@@ -726,7 +726,7 @@ export function ConnectedAppsPage({
   return (
     <div className="mx-auto max-w-[1400px] space-y-6 p-6 lg:p-8" data-testid={testId}>
       <header className="flex items-center justify-between">
-        <h1 className="m-0 text-2xl font-semibold text-foreground">Connected Apps</h1>
+        <h1 className="m-0 text-2xl font-semibold text-foreground">Connected apps</h1>
         <button
           type="button"
           className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"

--- a/kelta-ui/app/src/pages/EmailTemplatesPage/EmailTemplatesPage.tsx
+++ b/kelta-ui/app/src/pages/EmailTemplatesPage/EmailTemplatesPage.tsx
@@ -612,7 +612,7 @@ export function EmailTemplatesPage({
   return (
     <div className="mx-auto max-w-[1400px] space-y-6 p-6 lg:p-8" data-testid={testId}>
       <header className="flex items-center justify-between">
-        <h1 className="text-2xl font-semibold text-foreground">Email Templates</h1>
+        <h1 className="text-2xl font-semibold text-foreground">Email templates</h1>
         <Button
           type="button"
           onClick={handleCreate}

--- a/kelta-ui/app/src/pages/FlowsPage/CreateFlowWizard.tsx
+++ b/kelta-ui/app/src/pages/FlowsPage/CreateFlowWizard.tsx
@@ -115,7 +115,7 @@ export function CreateFlowWizard({ open, onOpenChange }: CreateFlowWizardProps) 
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="max-w-[640px]">
         <DialogHeader>
-          <DialogTitle>Create Flow</DialogTitle>
+          <DialogTitle>Create flow</DialogTitle>
         </DialogHeader>
 
         {/* Step indicator */}

--- a/kelta-ui/app/src/pages/OIDCProvidersPage/OIDCProvidersPage.tsx
+++ b/kelta-ui/app/src/pages/OIDCProvidersPage/OIDCProvidersPage.tsx
@@ -683,7 +683,7 @@ function OIDCProviderForm({
 
             {/* OIDC Discovery Endpoint Overrides */}
             <div className="mt-2 border-t border-border pt-4">
-              <h3 className="mb-3 text-sm font-semibold text-foreground">Endpoint Overrides</h3>
+              <h3 className="mb-3 text-sm font-semibold text-foreground">Endpoint overrides</h3>
               <p className="mb-3 text-xs text-muted-foreground">
                 Leave blank to auto-discover from the issuer URL. Override when Discovery is
                 unavailable.

--- a/kelta-ui/app/src/pages/ProfileDetailPage/ProfileDetailPage.tsx
+++ b/kelta-ui/app/src/pages/ProfileDetailPage/ProfileDetailPage.tsx
@@ -794,7 +794,7 @@ export function ProfileDetailPage({
       {/* Custom Authorization Rules */}
       {isEditable && (
         <section data-testid="custom-rules-section">
-          <h2 className="mb-4 text-lg font-semibold text-foreground">Custom Authorization Rules</h2>
+          <h2 className="mb-4 text-lg font-semibold text-foreground">Custom authorization rules</h2>
           <CustomPolicyEditor
             profileId={id!}
             tenantId=""

--- a/kelta-ui/app/src/pages/ReportsPage/ReportsPage.tsx
+++ b/kelta-ui/app/src/pages/ReportsPage/ReportsPage.tsx
@@ -955,7 +955,7 @@ export function ReportsPage({ testId = 'reports-page' }: ReportsPageProps): Reac
 
     const renderStep2Columns = () => (
       <div>
-        <h2 className="text-xl font-semibold text-foreground mb-2">Select Columns</h2>
+        <h2 className="mb-2 text-xl font-semibold text-foreground">Select columns</h2>
         <p className="text-sm text-muted-foreground mb-6">
           Choose which fields to display in the report. At least one column is required.
         </p>

--- a/kelta-ui/app/src/pages/ScheduledJobsPage/ScheduledJobsPage.tsx
+++ b/kelta-ui/app/src/pages/ScheduledJobsPage/ScheduledJobsPage.tsx
@@ -584,7 +584,7 @@ export function ScheduledJobsPage({
   return (
     <div className="mx-auto max-w-[1400px] space-y-6 p-6 lg:p-8" data-testid={testId}>
       <header className="flex items-center justify-between">
-        <h1 className="text-2xl font-semibold text-foreground">Scheduled Jobs</h1>
+        <h1 className="text-2xl font-semibold text-foreground">Scheduled jobs</h1>
         <Button
           type="button"
           onClick={handleCreate}

--- a/kelta-ui/app/src/pages/SecurityAuditPage/SecurityAuditPage.tsx
+++ b/kelta-ui/app/src/pages/SecurityAuditPage/SecurityAuditPage.tsx
@@ -86,7 +86,7 @@ export function SecurityAuditPage({ className }: SecurityAuditPageProps): React.
     <div className={cn('mx-auto max-w-[1200px] p-6', className)}>
       <header className="mb-6 flex items-center gap-3">
         <Shield className="h-6 w-6 text-muted-foreground" />
-        <h1 className="m-0 text-2xl font-semibold">Security Audit Log</h1>
+        <h1 className="m-0 text-2xl font-semibold">Security audit log</h1>
       </header>
 
       {isLoading ? (

--- a/kelta-ui/app/src/pages/SecuritySettingsPage/MfaPolicyPanel.tsx
+++ b/kelta-ui/app/src/pages/SecuritySettingsPage/MfaPolicyPanel.tsx
@@ -131,7 +131,7 @@ export function MfaPolicyPanel(): React.ReactElement {
 
         {/* Grace Period */}
         <section className="rounded-lg border border-border p-6 space-y-4">
-          <h2 className="text-lg font-medium text-foreground">Enrollment Grace Period</h2>
+          <h2 className="text-lg font-medium text-foreground">Enrollment grace period</h2>
           <div>
             <label htmlFor="gracePeriodDays" className="block text-sm font-medium text-foreground">
               Grace period (days, empty = immediate enforcement)

--- a/kelta-ui/app/src/pages/app/CustomPage/CustomPage.test.tsx
+++ b/kelta-ui/app/src/pages/app/CustomPage/CustomPage.test.tsx
@@ -56,7 +56,7 @@ describe('CustomPage', () => {
     )
 
     await waitFor(() => {
-      expect(screen.getByText('Page Not Found')).toBeDefined()
+      expect(screen.getByText('Page not found')).toBeDefined()
     })
   })
 
@@ -79,7 +79,7 @@ describe('CustomPage', () => {
     )
 
     await waitFor(() => {
-      expect(screen.getByText('Component Not Available')).toBeDefined()
+      expect(screen.getByText('Component not available')).toBeDefined()
     })
   })
 
@@ -152,9 +152,9 @@ describe('CustomPage', () => {
       </TestWrapper>
     )
 
-    // When the API fails, the query catch returns null, so we get "Page Not Found"
+    // When the API fails, the query catch returns null, so we get "Page not found"
     await waitFor(() => {
-      expect(screen.getByText('Page Not Found')).toBeDefined()
+      expect(screen.getByText('Page not found')).toBeDefined()
     })
   })
 })

--- a/kelta-ui/app/src/pages/app/CustomPage/CustomPage.tsx
+++ b/kelta-ui/app/src/pages/app/CustomPage/CustomPage.tsx
@@ -157,7 +157,7 @@ export function CustomPage(): React.ReactElement {
           <CardContent className="flex flex-col items-center gap-4 py-12 text-center">
             <FileQuestion className="h-12 w-12 text-muted-foreground" />
             <div className="space-y-2">
-              <h2 className="text-lg font-semibold text-foreground">Page Not Found</h2>
+              <h2 className="text-lg font-semibold text-foreground">Page not found</h2>
               <p className="text-sm text-muted-foreground">
                 The page &quot;{pageSlug}&quot; is not configured. Check the page definition in
                 Setup or contact your administrator.
@@ -190,7 +190,7 @@ export function CustomPage(): React.ReactElement {
           <CardContent className="flex flex-col items-center gap-4 py-12 text-center">
             <FileQuestion className="h-12 w-12 text-muted-foreground" />
             <div className="space-y-2">
-              <h2 className="text-lg font-semibold text-foreground">Component Not Available</h2>
+              <h2 className="text-lg font-semibold text-foreground">Component not available</h2>
               <p className="text-sm text-muted-foreground">
                 The component &quot;{pageDefinition.component}&quot; required by this page is not
                 registered. It may need to be installed via a plugin.


### PR DESCRIPTION
## Summary

PR **5 of 5** — final pass on the kelta-ui design-system rollout. A focused sweep on the high-visibility page H1s, dialog titles, and panel H2/H3s, converting Title Case to sentence case per `DESIGN.md §1`.

### Pages
- `SecurityAuditPage`: "Security Audit Log" → "Security audit log"
- `ApprovalProcessesPage`: "Approval Processes" → "Approval processes"
- `ScheduledJobsPage`: "Scheduled Jobs" → "Scheduled jobs"
- `ConnectedAppsPage`: "Connected Apps" → "Connected apps"
- `EmailTemplatesPage`: "Email Templates" → "Email templates"
- `ApiTokensPage`: "Token Created" → "Token created"
- `ReportsPage`: "Select Columns" → "Select columns"
- `CustomPage`: "Page Not Found" + "Component Not Available" (test assertions updated)
- `ProfileDetailPage`: "Custom Authorization Rules"
- `OIDCProvidersPage`: "Endpoint Overrides"
- `MfaPolicyPanel`: "Enrollment Grace Period"
- `CreateFlowWizard`: DialogTitle "Create Flow" → "Create flow"

### Components
- `InsufficientPrivileges`, `RequirePermission`: sentence case (also drops a stray `text-gray-900` in favor of `text-foreground`)
- `SecurityEditor` `PolicyTestPanel` + `CustomPolicyEditor`: section H3s

### Quality-sweep findings that did NOT require changes
- Hardcoded `#3b82f6` in `MetricsPage` / `MonitoringOverviewPage` / `FlowExecutionViewer` is chart-palette accent color, not the brand cyan→blue gradient. Acceptable per `DESIGN.md`.
- Emoji in `src/styles/accessibility.test.tsx` are inside contrast-ratio documentation comments — not user-facing UI.
- "None" label in `AutolaunchedTriggerForm` and `MenuBuilderPage` is a legitimate select option ("no auth required" / "no parent menu"), not an empty-value render.

## Rollout (all 5 PRs)
1. ~~PR 1 — Foundation~~ #760 ✅
2. ~~PR 2 — Runtime~~ #761 ✅
3. ~~PR 3 — Admin & Settings~~ #762 ✅
4. PR 4 — Builder surfaces #763 (auto-merge queued)
5. **PR 5 — Quality sweep** *(this PR)*

## Test plan

- [x] `npm run lint` — 0 errors
- [x] `npm run test:run` — 1764 passed (CustomPage test assertions updated to match new copy)
- [ ] Spot-check the touched pages in dev to confirm copy renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)