### PR TITLE
fix(worker): bypass Svix Java SDK entirely under Jackson 3

### DIFF
--- a/kelta-worker/pom.xml
+++ b/kelta-worker/pom.xml
@@ -192,13 +192,6 @@
             <artifactId>caffeine</artifactId>
         </dependency>
 
-        <!-- Svix SDK for webhook delivery -->
-        <dependency>
-            <groupId>com.svix</groupId>
-            <artifactId>svix</artifactId>
-            <version>1.68.0</version>
-        </dependency>
-
         <!-- Jackson 3 -->
         <dependency>
             <groupId>tools.jackson.core</groupId>

--- a/kelta-worker/src/main/java/io/kelta/worker/config/SvixConfig.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/config/SvixConfig.java
@@ -15,6 +15,8 @@ import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.event.EventListener;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.client.RestClient;
 
 import java.util.List;
 
@@ -56,9 +58,17 @@ public class SvixConfig {
         return this.svixClient;
     }
 
+    @Bean("svixRestClient")
+    public RestClient svixRestClient() {
+        return RestClient.builder()
+                .baseUrl(serverUrl)
+                .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + authToken)
+                .build();
+    }
+
     @Bean
-    public SvixTenantService svixTenantService(Svix svix) {
-        return new SvixTenantService(svix);
+    public SvixTenantService svixTenantService(RestClient svixRestClient) {
+        return new SvixTenantService(svixRestClient);
     }
 
     @Bean

--- a/kelta-worker/src/main/java/io/kelta/worker/config/SvixConfig.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/config/SvixConfig.java
@@ -1,8 +1,6 @@
 package io.kelta.worker.config;
 
 import tools.jackson.databind.ObjectMapper;
-import com.svix.Svix;
-import com.svix.models.EventTypeIn;
 import io.kelta.runtime.workflow.BeforeSaveHookRegistry;
 import io.kelta.worker.listener.SvixTenantLifecycleHook;
 import io.kelta.worker.listener.SvixWebhookPublisher;
@@ -16,15 +14,21 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.event.EventListener;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.web.client.RestClient;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * Spring configuration for the Svix webhook service client.
  *
- * <p>Creates a {@link Svix} client bean and registers webhook event types
- * on application startup.
+ * <p>Builds a {@link RestClient} bean pre-authenticated against the Svix
+ * server and registers webhook event types on application startup.
+ *
+ * <p>Talks to the Svix REST API directly rather than using the Svix Java
+ * SDK 1.68.0 — the SDK ships Jackson-2 model annotations and doesn't
+ * deserialize cleanly under Spring Boot 4 / Jackson 3.
  *
  * <p>Enabled when {@code kelta.svix.auth-token} is set.
  *
@@ -47,23 +51,16 @@ public class SvixConfig {
     @Value("${kelta.svix.auth-token}")
     private String authToken;
 
-    private Svix svixClient;
-
-    @Bean
-    public Svix svix() {
-        log.info("Configuring Svix client with server URL: {}", serverUrl);
-        var options = new com.svix.SvixOptions();
-        options.setServerUrl(serverUrl);
-        this.svixClient = new Svix(authToken, options);
-        return this.svixClient;
-    }
+    private RestClient svixRestClient;
 
     @Bean("svixRestClient")
     public RestClient svixRestClient() {
-        return RestClient.builder()
+        log.info("Configuring Svix RestClient with server URL: {}", serverUrl);
+        this.svixRestClient = RestClient.builder()
                 .baseUrl(serverUrl)
                 .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + authToken)
                 .build();
+        return this.svixRestClient;
     }
 
     @Bean
@@ -81,30 +78,34 @@ public class SvixConfig {
     }
 
     @Bean
-    public SvixWebhookPublisher svixWebhookPublisher(Svix svix, ObjectMapper objectMapper) {
-        return new SvixWebhookPublisher(svix, objectMapper);
+    public SvixWebhookPublisher svixWebhookPublisher(RestClient svixRestClient, ObjectMapper objectMapper) {
+        return new SvixWebhookPublisher(svixRestClient, objectMapper);
     }
 
     /**
-     * Registers webhook event types with Svix on startup.
-     * Idempotent — Svix allows re-registering existing types.
+     * Registers webhook event types with Svix on startup. Idempotent —
+     * Svix returns 409 for an existing type, which we log and ignore.
      */
     @EventListener(ApplicationReadyEvent.class)
     public void registerEventTypes() {
-        if (svixClient == null) {
-            log.warn("Svix client not initialized — skipping event type registration");
+        if (svixRestClient == null) {
+            log.warn("Svix RestClient not initialized — skipping event type registration");
             return;
         }
-
         for (String eventType : EVENT_TYPES) {
             try {
-                var eventTypeIn = new EventTypeIn();
-                eventTypeIn.setName(eventType);
-                eventTypeIn.setDescription("Collection " + eventType.split("\\.")[1] + " event");
-                svixClient.getEventType().create(eventTypeIn);
+                Map<String, Object> body = Map.of(
+                        "name", eventType,
+                        "description", "Collection " + eventType.split("\\.")[1] + " event"
+                );
+                svixRestClient.post()
+                        .uri("/api/v1/event-type/")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body(body)
+                        .retrieve()
+                        .toBodilessEntity();
                 log.info("Registered Svix event type: {}", eventType);
             } catch (Exception e) {
-                // Svix returns 409 if event type already exists — this is expected
                 log.debug("Svix event type '{}' already exists or registration failed: {}",
                         eventType, e.getMessage());
             }

--- a/kelta-worker/src/main/java/io/kelta/worker/controller/SvixPortalController.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/controller/SvixPortalController.java
@@ -1,15 +1,15 @@
 package io.kelta.worker.controller;
 
-import com.svix.Svix;
-import com.svix.models.AppPortalAccessIn;
 import io.kelta.worker.service.SvixTenantService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.client.RestClientResponseException;
 
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.Map;
@@ -31,14 +31,11 @@ public class SvixPortalController {
 
     private static final Logger log = LoggerFactory.getLogger(SvixPortalController.class);
 
-    private final Svix svix;
     private final SvixTenantService svixTenantService;
     private final String svixServerUrl;
 
-    public SvixPortalController(Svix svix,
-                                SvixTenantService svixTenantService,
+    public SvixPortalController(SvixTenantService svixTenantService,
                                 @Value("${kelta.svix.public-url:${kelta.svix.server-url}}") String svixServerUrl) {
-        this.svix = svix;
         this.svixTenantService = svixTenantService;
         this.svixServerUrl = svixServerUrl;
     }
@@ -53,15 +50,20 @@ public class SvixPortalController {
 
         try {
             svixTenantService.ensureApplication(tenantId, tenantId);
-            var accessIn = new AppPortalAccessIn();
-            var accessOut = svix.getAuthentication().appPortalAccess(tenantId, accessIn);
+            var access = svixTenantService.getPortalAccess(tenantId);
             return ResponseEntity.ok(Map.of(
-                    "token", accessOut.getToken(),
+                    "token", access.token(),
                     "appId", tenantId,
                     "serverUrl", svixServerUrl
             ));
+        } catch (RestClientResponseException e) {
+            log.error("Svix returned {} for tenant '{}': {}",
+                    e.getStatusCode(), tenantId, e.getResponseBodyAsString());
+            return ResponseEntity.status(HttpStatus.BAD_GATEWAY).body(Map.of(
+                    "error", "Svix returned " + e.getStatusCode().value()
+            ));
         } catch (Exception e) {
-            log.error("Failed to generate Svix portal access for tenant '{}': {}", tenantId, e.getMessage());
+            log.error("Failed to generate Svix portal access for tenant '{}'", tenantId, e);
             return ResponseEntity.internalServerError()
                     .body(Map.of("error", "Failed to generate webhook portal access"));
         }

--- a/kelta-worker/src/main/java/io/kelta/worker/listener/SvixWebhookPublisher.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/listener/SvixWebhookPublisher.java
@@ -2,23 +2,26 @@ package io.kelta.worker.listener;
 
 import tools.jackson.core.type.TypeReference;
 import tools.jackson.databind.ObjectMapper;
-import com.svix.Svix;
-import com.svix.models.MessageIn;
 import io.kelta.runtime.event.ChangeType;
 import io.kelta.runtime.event.CollectionChangedPayload;
 import io.kelta.runtime.event.PlatformEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.MediaType;
+import org.springframework.web.client.RestClient;
+
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 
 /**
- * Kafka consumer that bridges collection change events to Svix for
- * outbound webhook delivery.
+ * Bridges collection-change platform events to Svix for outbound webhook
+ * delivery, scoped to the appropriate tenant.
  *
- * <p>Listens to the {@code kelta.config.collection.changed} topic and
- * publishes webhook messages to Svix, scoped to the appropriate tenant.
+ * <p>Talks to the Svix REST API directly via {@link RestClient} rather than
+ * the Svix Java SDK 1.68.0 — the SDK ships Jackson-2 model annotations and
+ * doesn't deserialize cleanly under Spring Boot 4 / Jackson 3.
  *
  * @since 1.0.0
  */
@@ -31,11 +34,11 @@ public class SvixWebhookPublisher {
             ChangeType.UPDATED, "collection.updated"
     );
 
-    private final Svix svix;
+    private final RestClient svixRestClient;
     private final ObjectMapper objectMapper;
 
-    public SvixWebhookPublisher(Svix svix, ObjectMapper objectMapper) {
-        this.svix = svix;
+    public SvixWebhookPublisher(RestClient svixRestClient, ObjectMapper objectMapper) {
+        this.svixRestClient = svixRestClient;
         this.objectMapper = objectMapper;
     }
 
@@ -71,19 +74,21 @@ public class SvixWebhookPublisher {
             webhookPayload.put("changeType", payload.getChangeType().name());
             webhookPayload.put("timestamp", event.getTimestamp() != null ? event.getTimestamp().toString() : null);
 
-            String payloadJson = objectMapper.writeValueAsString(webhookPayload);
-
-            var messageIn = new MessageIn();
-            messageIn.setEventType(eventType);
-            messageIn.setPayload(payloadJson);
-            messageIn.setEventId(event.getEventId());
-
-            // Include collection name as a channel so endpoints can filter by collection
+            Map<String, Object> body = new LinkedHashMap<>();
+            body.put("eventType", eventType);
+            body.put("payload", webhookPayload);
+            body.put("eventId", event.getEventId());
             if (payload.getName() != null && !payload.getName().isBlank()) {
-                messageIn.setChannels(Set.of(payload.getName()));
+                body.put("channels", Set.of(payload.getName()));
             }
 
-            svix.getMessage().create(tenantId, messageIn);
+            svixRestClient.post()
+                    .uri("/api/v1/app/{appId}/msg/", tenantId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(body)
+                    .retrieve()
+                    .toBodilessEntity();
+
             log.info("Published Svix webhook: type={}, tenant={}, collection={}",
                     eventType, tenantId, payload.getName());
 

--- a/kelta-worker/src/main/java/io/kelta/worker/service/SvixTenantService.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/service/SvixTenantService.java
@@ -1,15 +1,20 @@
 package io.kelta.worker.service;
 
-import com.svix.Svix;
-import com.svix.models.ApplicationIn;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.MediaType;
+import org.springframework.web.client.RestClient;
+
+import java.util.Map;
 
 /**
- * Manages the lifecycle of Svix applications per tenant.
+ * Manages the lifecycle of Svix applications per tenant and brokers
+ * Svix portal-access tokens.
  *
- * <p>Each tenant maps to a Svix application (using the tenant ID as the uid),
- * providing full isolation of webhook endpoints, messages, and delivery logs.
+ * <p>Calls Svix via REST directly rather than through the Svix Java SDK:
+ * the SDK 1.68.0 ships Jackson-2 model annotations and doesn't deserialize
+ * cleanly under Spring Boot 4 / Jackson 3.
  *
  * @since 1.0.0
  */
@@ -17,28 +22,37 @@ public class SvixTenantService {
 
     private static final Logger log = LoggerFactory.getLogger(SvixTenantService.class);
 
-    private final Svix svix;
+    private final RestClient svixRestClient;
 
-    public SvixTenantService(Svix svix) {
-        this.svix = svix;
+    public SvixTenantService(RestClient svixRestClient) {
+        this.svixRestClient = svixRestClient;
     }
 
     /**
-     * Ensures a Svix application exists for the given tenant.
-     * Creates one if it doesn't exist, or updates the name if it does.
+     * Ensures a Svix application exists for the given tenant. Uses Svix's
+     * {@code get_if_exists=true} flag so a pre-existing app is returned
+     * instead of producing a 422.
      *
-     * @param tenantId   the tenant UUID
+     * @param tenantId   the tenant UUID (used as the Svix app uid)
      * @param tenantName the tenant display name
      */
     public void ensureApplication(String tenantId, String tenantName) {
         try {
-            var appIn = new ApplicationIn();
-            appIn.setName(tenantName != null ? tenantName : tenantId);
-            appIn.setUid(tenantId);
-            svix.getApplication().getOrCreate(appIn);
+            Map<String, Object> body = Map.of(
+                    "name", tenantName != null ? tenantName : tenantId,
+                    "uid", tenantId
+            );
+            svixRestClient.post()
+                    .uri(uri -> uri.path("/api/v1/app/")
+                            .queryParam("get_if_exists", "true")
+                            .build())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(body)
+                    .retrieve()
+                    .toBodilessEntity();
             log.info("Ensured Svix application for tenant '{}' (id={})", tenantName, tenantId);
         } catch (Exception e) {
-            log.error("Failed to create Svix application for tenant '{}' (id={}): {}",
+            log.error("Failed to ensure Svix application for tenant '{}' (id={}): {}",
                     tenantName, tenantId, e.getMessage());
         }
     }
@@ -46,15 +60,44 @@ public class SvixTenantService {
     /**
      * Deletes the Svix application for a tenant.
      *
-     * @param tenantId the tenant UUID
+     * @param tenantId the tenant UUID (matches the Svix app uid)
      */
     public void deleteApplication(String tenantId) {
         try {
-            svix.getApplication().delete(tenantId);
+            svixRestClient.delete()
+                    .uri("/api/v1/app/{appId}/", tenantId)
+                    .retrieve()
+                    .toBodilessEntity();
             log.info("Deleted Svix application for tenant '{}'", tenantId);
         } catch (Exception e) {
             log.error("Failed to delete Svix application for tenant '{}': {}",
                     tenantId, e.getMessage());
         }
     }
+
+    /**
+     * Generates a short-lived portal access token for the given tenant's
+     * Svix application. Throws on upstream failure so the caller can map
+     * the error.
+     *
+     * @param tenantId the tenant UUID (matches the Svix app uid)
+     * @return the portal token and URL
+     */
+    public PortalAccess getPortalAccess(String tenantId) {
+        Map<String, Object> response = svixRestClient.post()
+                .uri("/api/v1/auth/app-portal-access/{appId}/", tenantId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(Map.of())
+                .retrieve()
+                .body(new ParameterizedTypeReference<>() {});
+        if (response == null) {
+            throw new IllegalStateException("Empty response from Svix portal-access endpoint");
+        }
+        return new PortalAccess(
+                (String) response.get("token"),
+                (String) response.get("url")
+        );
+    }
+
+    public record PortalAccess(String token, String url) {}
 }

--- a/kelta-worker/src/test/java/io/kelta/worker/controller/SvixPortalControllerTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/controller/SvixPortalControllerTest.java
@@ -1,10 +1,7 @@
 package io.kelta.worker.controller;
 
-import com.svix.Svix;
-import com.svix.api.Authentication;
-import com.svix.models.AppPortalAccessIn;
-import com.svix.models.AppPortalAccessOut;
 import io.kelta.worker.service.SvixTenantService;
+import io.kelta.worker.service.SvixTenantService.PortalAccess;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -12,12 +9,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.client.RestClientResponseException;
 
 import jakarta.servlet.http.HttpServletRequest;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -25,13 +21,7 @@ import static org.mockito.Mockito.*;
 class SvixPortalControllerTest {
 
     @Mock
-    private Svix svix;
-
-    @Mock
     private SvixTenantService svixTenantService;
-
-    @Mock
-    private Authentication authentication;
 
     @Mock
     private HttpServletRequest request;
@@ -40,7 +30,7 @@ class SvixPortalControllerTest {
 
     @BeforeEach
     void setUp() {
-        controller = new SvixPortalController(svix, svixTenantService, "http://localhost:8071");
+        controller = new SvixPortalController(svixTenantService, "http://localhost:8071");
     }
 
     @Test
@@ -55,14 +45,10 @@ class SvixPortalControllerTest {
 
     @Test
     @DisplayName("ensures Svix application exists before requesting portal access")
-    void ensuresApplicationBeforePortalAccess() throws Exception {
+    void ensuresApplicationBeforePortalAccess() {
         when(request.getHeader("X-Tenant-ID")).thenReturn("tenant-123");
-        when(svix.getAuthentication()).thenReturn(authentication);
-
-        var accessOut = new AppPortalAccessOut();
-        accessOut.setToken("test-token");
-        when(authentication.appPortalAccess(eq("tenant-123"), any(AppPortalAccessIn.class)))
-                .thenReturn(accessOut);
+        when(svixTenantService.getPortalAccess("tenant-123"))
+                .thenReturn(new PortalAccess("test-token", "https://svix.example/portal"));
 
         var response = controller.getPortalAccess(request);
 
@@ -74,12 +60,24 @@ class SvixPortalControllerTest {
     }
 
     @Test
-    @DisplayName("returns server error when Svix API fails")
-    void returnsServerErrorOnSvixFailure() throws Exception {
+    @DisplayName("returns 502 when Svix responds with an HTTP error")
+    void returnsBadGatewayOnUpstreamHttpError() {
         when(request.getHeader("X-Tenant-ID")).thenReturn("tenant-123");
-        when(svix.getAuthentication()).thenReturn(authentication);
-        when(authentication.appPortalAccess(eq("tenant-123"), any(AppPortalAccessIn.class)))
-                .thenThrow(new RuntimeException("Svix unavailable"));
+        when(svixTenantService.getPortalAccess("tenant-123"))
+                .thenThrow(new RestClientResponseException(
+                        "401 Unauthorized", HttpStatus.UNAUTHORIZED, "Unauthorized", null, null, null));
+
+        var response = controller.getPortalAccess(request);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_GATEWAY);
+    }
+
+    @Test
+    @DisplayName("returns 500 on unexpected failures")
+    void returnsServerErrorOnUnexpectedFailure() {
+        when(request.getHeader("X-Tenant-ID")).thenReturn("tenant-123");
+        when(svixTenantService.getPortalAccess("tenant-123"))
+                .thenThrow(new RuntimeException("boom"));
 
         var response = controller.getPortalAccess(request);
 

--- a/kelta-worker/src/test/java/io/kelta/worker/listener/SvixWebhookPublisherTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/listener/SvixWebhookPublisherTest.java
@@ -1,44 +1,42 @@
 package io.kelta.worker.listener;
 
 import tools.jackson.databind.ObjectMapper;
-import com.svix.Svix;
-import com.svix.api.Message;
-import com.svix.models.MessageIn;
 import io.kelta.runtime.event.ChangeType;
 import io.kelta.runtime.event.CollectionChangedPayload;
 import io.kelta.runtime.event.PlatformEvent;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
 
 import java.time.Instant;
-import java.util.Set;
 import java.util.UUID;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.*;
 
 @DisplayName("SvixWebhookPublisher")
 class SvixWebhookPublisherTest {
 
-    private Svix svix;
-    private Message messageApi;
+    private MockRestServiceServer server;
     private ObjectMapper objectMapper;
     private SvixWebhookPublisher publisher;
 
     @BeforeEach
     void setUp() {
-        svix = mock(Svix.class);
-        messageApi = mock(Message.class);
-        when(svix.getMessage()).thenReturn(messageApi);
+        var builder = RestClient.builder()
+                .baseUrl("http://svix.test")
+                .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer test-token");
+        server = MockRestServiceServer.bindTo(builder).build();
         objectMapper = new ObjectMapper();
-        publisher = new SvixWebhookPublisher(svix, objectMapper);
+        publisher = new SvixWebhookPublisher(builder.build(), objectMapper);
     }
 
-    private String buildEventJson(String tenantId, String collectionName, ChangeType changeType) throws Exception {
+    private String buildEventJson(String tenantId, String collectionName, ChangeType changeType) {
         var payload = new CollectionChangedPayload();
         payload.setId(UUID.randomUUID().toString());
         payload.setName(collectionName);
@@ -56,69 +54,84 @@ class SvixWebhookPublisherTest {
 
     @Test
     @DisplayName("publishes collection name as channel on the message")
-    void publishesCollectionNameAsChannel() throws Exception {
+    void publishesCollectionNameAsChannel() {
         String json = buildEventJson("tenant-1", "accounts", ChangeType.CREATED);
+
+        server.expect(requestTo("http://svix.test/api/v1/app/tenant-1/msg/"))
+                .andExpect(method(HttpMethod.POST))
+                .andExpect(header(HttpHeaders.AUTHORIZATION, "Bearer test-token"))
+                .andExpect(jsonPath("$.eventType").value("collection.created"))
+                .andExpect(jsonPath("$.channels[0]").value("accounts"))
+                .andExpect(jsonPath("$.payload.collectionName").value("accounts"))
+                .andRespond(withSuccess());
 
         publisher.onCollectionChanged(json);
 
-        ArgumentCaptor<MessageIn> captor = ArgumentCaptor.forClass(MessageIn.class);
-        verify(messageApi).create(eq("tenant-1"), captor.capture());
-
-        MessageIn sent = captor.getValue();
-        assertEquals("collection.created", sent.getEventType());
-        assertNotNull(sent.getChannels());
-        assertTrue(sent.getChannels().contains("accounts"));
+        server.verify();
     }
 
     @Test
     @DisplayName("publishes updated event with collection channel")
-    void publishesUpdatedEventWithChannel() throws Exception {
+    void publishesUpdatedEventWithChannel() {
         String json = buildEventJson("tenant-2", "contacts", ChangeType.UPDATED);
+
+        server.expect(requestTo("http://svix.test/api/v1/app/tenant-2/msg/"))
+                .andExpect(jsonPath("$.eventType").value("collection.updated"))
+                .andExpect(jsonPath("$.channels[0]").value("contacts"))
+                .andRespond(withSuccess());
 
         publisher.onCollectionChanged(json);
 
-        ArgumentCaptor<MessageIn> captor = ArgumentCaptor.forClass(MessageIn.class);
-        verify(messageApi).create(eq("tenant-2"), captor.capture());
-
-        MessageIn sent = captor.getValue();
-        assertEquals("collection.updated", sent.getEventType());
-        assertEquals(Set.of("contacts"), sent.getChannels());
+        server.verify();
     }
 
     @Test
     @DisplayName("does not publish when tenant ID is missing")
-    void skipsMissingTenantId() throws Exception {
+    void skipsMissingTenantId() {
         String json = buildEventJson(null, "accounts", ChangeType.CREATED);
 
         publisher.onCollectionChanged(json);
 
-        verify(messageApi, never()).create(anyString(), any(MessageIn.class));
+        server.verify();
     }
 
     @Test
     @DisplayName("does not publish for unhandled change type")
-    void skipsUnhandledChangeType() throws Exception {
+    void skipsUnhandledChangeType() {
         String json = buildEventJson("tenant-1", "accounts", ChangeType.DELETED);
 
         publisher.onCollectionChanged(json);
 
-        verify(messageApi, never()).create(anyString(), any(MessageIn.class));
+        server.verify();
     }
 
     @Test
     @DisplayName("payload contains collection metadata")
-    void payloadContainsCollectionMetadata() throws Exception {
+    void payloadContainsCollectionMetadata() {
         String json = buildEventJson("tenant-1", "orders", ChangeType.CREATED);
+
+        server.expect(requestTo("http://svix.test/api/v1/app/tenant-1/msg/"))
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.payload.collectionName").value("orders"))
+                .andExpect(jsonPath("$.payload.displayName").value("orders"))
+                .andExpect(jsonPath("$.payload.changeType").value("CREATED"))
+                .andRespond(withSuccess());
 
         publisher.onCollectionChanged(json);
 
-        ArgumentCaptor<MessageIn> captor = ArgumentCaptor.forClass(MessageIn.class);
-        verify(messageApi).create(eq("tenant-1"), captor.capture());
+        server.verify();
+    }
 
-        String payloadJson = captor.getValue().getPayload();
-        var payloadMap = objectMapper.readValue(payloadJson, java.util.Map.class);
-        assertEquals("orders", payloadMap.get("collectionName"));
-        assertEquals("orders", payloadMap.get("displayName"));
-        assertEquals("CREATED", payloadMap.get("changeType"));
+    @Test
+    @DisplayName("swallows Svix errors and does not throw")
+    void swallowsErrors() {
+        String json = buildEventJson("tenant-1", "accounts", ChangeType.CREATED);
+
+        server.expect(requestTo("http://svix.test/api/v1/app/tenant-1/msg/"))
+                .andRespond(withServerError());
+
+        publisher.onCollectionChanged(json);
+
+        server.verify();
     }
 }

--- a/kelta-worker/src/test/java/io/kelta/worker/service/SvixTenantServiceTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/service/SvixTenantServiceTest.java
@@ -1,36 +1,32 @@
 package io.kelta.worker.service;
 
-import com.svix.Svix;
-import com.svix.api.Application;
-import com.svix.models.ApplicationIn;
-import com.svix.models.ApplicationOut;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.*;
 
-@ExtendWith(MockitoExtension.class)
 @DisplayName("SvixTenantService")
 class SvixTenantServiceTest {
 
-    @Mock
-    private Svix svix;
-
-    @Mock
-    private Application applicationEndpoint;
-
+    private MockRestServiceServer server;
     private SvixTenantService service;
 
     @BeforeEach
     void setUp() {
-        when(svix.getApplication()).thenReturn(applicationEndpoint);
-        service = new SvixTenantService(svix);
+        var builder = RestClient.builder()
+                .baseUrl("http://svix.test")
+                .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer test-token");
+        server = MockRestServiceServer.bindTo(builder).build();
+        service = new SvixTenantService(builder.build());
     }
 
     @Nested
@@ -38,24 +34,41 @@ class SvixTenantServiceTest {
     class EnsureApplication {
 
         @Test
-        @DisplayName("creates application with tenant name")
-        void createsWithTenantName() throws Exception {
-            when(applicationEndpoint.getOrCreate(any(ApplicationIn.class))).thenReturn(new ApplicationOut());
+        @DisplayName("POSTs to /api/v1/app/ with get_if_exists=true")
+        void postsWithGetIfExistsFlag() {
+            server.expect(requestTo("http://svix.test/api/v1/app/?get_if_exists=true"))
+                    .andExpect(method(org.springframework.http.HttpMethod.POST))
+                    .andExpect(header(HttpHeaders.AUTHORIZATION, "Bearer test-token"))
+                    .andExpect(jsonPath("$.uid").value("tenant-1"))
+                    .andExpect(jsonPath("$.name").value("Acme Corp"))
+                    .andRespond(withSuccess("{\"id\":\"app_xyz\"}", MediaType.APPLICATION_JSON));
 
             service.ensureApplication("tenant-1", "Acme Corp");
 
-            verify(applicationEndpoint).getOrCreate(any(ApplicationIn.class));
+            server.verify();
         }
 
         @Test
-        @DisplayName("handles Svix API errors gracefully")
-        void handlesErrors() throws Exception {
-            when(applicationEndpoint.getOrCreate(any(ApplicationIn.class)))
-                    .thenThrow(new RuntimeException("API error"));
+        @DisplayName("falls back to tenant id when name is null")
+        void fallsBackToIdWhenNameMissing() {
+            server.expect(requestTo("http://svix.test/api/v1/app/?get_if_exists=true"))
+                    .andExpect(jsonPath("$.name").value("tenant-1"))
+                    .andRespond(withSuccess());
 
-            service.ensureApplication("tenant-1", "Test");
+            service.ensureApplication("tenant-1", null);
 
-            // Should not throw
+            server.verify();
+        }
+
+        @Test
+        @DisplayName("swallows Svix errors and does not throw")
+        void swallowsErrors() {
+            server.expect(requestTo("http://svix.test/api/v1/app/?get_if_exists=true"))
+                    .andRespond(withServerError());
+
+            service.ensureApplication("tenant-1", "Acme Corp");
+
+            server.verify();
         }
     }
 
@@ -64,21 +77,56 @@ class SvixTenantServiceTest {
     class DeleteApplication {
 
         @Test
-        @DisplayName("deletes application by tenant ID")
-        void deletesApplication() throws Exception {
+        @DisplayName("DELETEs /api/v1/app/{id}/")
+        void deletesApplication() {
+            server.expect(requestTo("http://svix.test/api/v1/app/tenant-1/"))
+                    .andExpect(method(org.springframework.http.HttpMethod.DELETE))
+                    .andRespond(withNoContent());
+
             service.deleteApplication("tenant-1");
 
-            verify(applicationEndpoint).delete("tenant-1");
+            server.verify();
         }
 
         @Test
-        @DisplayName("handles deletion errors gracefully")
-        void handlesErrors() throws Exception {
-            doThrow(new RuntimeException("Not found")).when(applicationEndpoint).delete("tenant-1");
+        @DisplayName("swallows Svix errors and does not throw")
+        void swallowsErrors() {
+            server.expect(requestTo("http://svix.test/api/v1/app/tenant-1/"))
+                    .andRespond(withServerError());
 
             service.deleteApplication("tenant-1");
 
-            // Should not throw
+            server.verify();
+        }
+    }
+
+    @Nested
+    @DisplayName("getPortalAccess")
+    class GetPortalAccess {
+
+        @Test
+        @DisplayName("returns the token and url from Svix")
+        void returnsToken() {
+            server.expect(requestTo("http://svix.test/api/v1/auth/app-portal-access/tenant-1/"))
+                    .andExpect(method(org.springframework.http.HttpMethod.POST))
+                    .andRespond(withSuccess(
+                            "{\"token\":\"portal-token\",\"url\":\"https://svix.test/portal\"}",
+                            MediaType.APPLICATION_JSON));
+
+            var access = service.getPortalAccess("tenant-1");
+
+            assertThat(access.token()).isEqualTo("portal-token");
+            assertThat(access.url()).isEqualTo("https://svix.test/portal");
+        }
+
+        @Test
+        @DisplayName("propagates upstream HTTP errors so the caller can map them")
+        void propagatesHttpErrors() {
+            server.expect(requestTo("http://svix.test/api/v1/auth/app-portal-access/tenant-1/"))
+                    .andRespond(withUnauthorizedRequest());
+
+            assertThatThrownBy(() -> service.getPortalAccess("tenant-1"))
+                    .isInstanceOf(org.springframework.web.client.RestClientResponseException.class);
         }
     }
 }


### PR DESCRIPTION
## Summary

The Svix Java SDK 1.68.0 ships **Jackson 2** model annotations (`com.fasterxml.jackson.annotation.JsonProperty`, `@JsonAutoDetect(getterVisibility=NONE, setterVisibility=NONE)`). Under Spring Boot 4 / Jackson 3 (`tools.jackson.databind`), Svix returns valid JSON but the SDK can't deserialize its own models — Jackson 3 doesn't recognize the Jackson 2 annotations and fails with `Cannot construct instance of … no delegate- or property-based Creator`.

This was breaking three things, all caused by the same root issue:

1. **Visible**: `GET /{tenant}/api/svix/portal` 500-ed (the Webhooks page in kelta-ui), because `appPortalAccess()` returns `AppPortalAccessOut`.
2. **Silent**: every `collection.created` / `collection.updated` event silently failed to publish — `SvixWebhookPublisher` swallowed the SDK exception. Webhook delivery has been broken since the Spring Boot 4 upgrade.
3. **Silent**: startup event-type registration silently failed, falling back to a debug log.

This PR removes the Svix Java SDK from the worker entirely and replaces it with Spring's `RestClient` round-tripping plain `Map<String, Object>` JSON. Three call sites migrated:

- `SvixPortalController` / `SvixTenantService` → portal access, app get-or-create, app delete
- `SvixWebhookPublisher` → message create
- `SvixConfig#registerEventTypes` → event-type create on app startup

Also:
- Adds `?get_if_exists=true` on the create-app call so existing apps don't 422 (the SDK's `getOrCreate` was either omitting it or sending it as a body param).
- Surfaces upstream Svix errors as **502 Bad Gateway** with the real status code logged, instead of the original generic 500.
- Drops the `com.svix:svix:1.68.0` Maven dependency. Nothing in the worker references the SDK anymore.

## Test plan
- [x] `mvn test -f kelta-worker/pom.xml` — 1012/1012 green.
- [x] New `SvixTenantServiceTest`, rewritten `SvixWebhookPublisherTest`, and updated `SvixPortalControllerTest` all use `MockRestServiceServer` to assert exact URL, headers, JSON body, and error propagation.
- [ ] After merge + image build + ArgoCD sync:
   - `https://emf.rzware.com/threadline-clothing/api/svix/portal` returns 200 with `{token, appId, serverUrl}`.
   - Webhooks page renders the embedded `svix-react` portal.
   - Trigger a collection create/update; confirm the webhook fires (worker logs `Published Svix webhook…`, Svix dashboard shows the message).

🤖 Generated with [Claude Code](https://claude.com/claude-code)