### PR TITLE
feat(credentials): runtime resolver + cache + audit (PR 2/5)

### DIFF
--- a/kelta-worker/src/main/java/io/kelta/worker/config/NatsSubscriptionConfig.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/config/NatsSubscriptionConfig.java
@@ -4,6 +4,7 @@ import io.kelta.runtime.event.EventSubscription;
 import io.kelta.runtime.messaging.nats.NatsSubscriptionManager;
 import io.kelta.worker.listener.CerbosCacheInvalidationListener;
 import io.kelta.worker.listener.CollectionSchemaListener;
+import io.kelta.worker.listener.CredentialCacheInvalidationListener;
 import io.kelta.worker.listener.FlowEventListener;
 import io.kelta.worker.listener.SearchIndexListener;
 import io.kelta.worker.listener.SupersetCollectionSyncListener;
@@ -37,6 +38,7 @@ public class NatsSubscriptionConfig {
     private final CollectionSchemaListener collectionSchemaListener;
     private final ModuleEventListener moduleEventListener;
     private final CerbosCacheInvalidationListener cerbosCacheInvalidationListener;
+    private final CredentialCacheInvalidationListener credentialCacheInvalidationListener;
 
     @Autowired(required = false)
     private SupersetCollectionSyncListener supersetCollectionSyncListener;
@@ -49,13 +51,15 @@ public class NatsSubscriptionConfig {
                                    SearchIndexListener searchIndexListener,
                                    CollectionSchemaListener collectionSchemaListener,
                                    ModuleEventListener moduleEventListener,
-                                   CerbosCacheInvalidationListener cerbosCacheInvalidationListener) {
+                                   CerbosCacheInvalidationListener cerbosCacheInvalidationListener,
+                                   CredentialCacheInvalidationListener credentialCacheInvalidationListener) {
         this.subscriptionManager = subscriptionManager;
         this.flowEventListener = flowEventListener;
         this.searchIndexListener = searchIndexListener;
         this.collectionSchemaListener = collectionSchemaListener;
         this.moduleEventListener = moduleEventListener;
         this.cerbosCacheInvalidationListener = cerbosCacheInvalidationListener;
+        this.credentialCacheInvalidationListener = credentialCacheInvalidationListener;
     }
 
     @PostConstruct
@@ -82,6 +86,12 @@ public class NatsSubscriptionConfig {
                 "worker-cerbos", "kelta.cerbos.policies.changed.*",
                 cerbosCacheInvalidationListener::handlePolicyChanged));
 
+        // Credential cache invalidation — every pod drops local cache entries
+        // when a credential row changes upstream.
+        subscriptionManager.register(EventSubscription.broadcast(
+                "worker-credential-cache", "kelta.config.credential.changed.>",
+                credentialCacheInvalidationListener::handleCredentialChanged));
+
         // Optional queue group subscriptions — only registered when the integration is enabled
         if (supersetCollectionSyncListener != null) {
             subscriptionManager.register(EventSubscription.queueGroup(
@@ -97,7 +107,7 @@ public class NatsSubscriptionConfig {
             log.info("Registered NATS subscription for Svix webhook publisher");
         }
 
-        log.info("Registered {} worker NATS subscriptions", 5
+        log.info("Registered {} worker NATS subscriptions", 6
                 + (supersetCollectionSyncListener != null ? 1 : 0)
                 + (svixWebhookPublisher != null ? 1 : 0));
     }

--- a/kelta-worker/src/main/java/io/kelta/worker/listener/CredentialCacheInvalidationListener.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/listener/CredentialCacheInvalidationListener.java
@@ -1,0 +1,48 @@
+package io.kelta.worker.listener;
+
+import io.kelta.worker.service.credential.CredentialResolver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Subscribes to {@code kelta.config.credential.changed.>} (broadcast) and
+ * drops cached resolutions for the credential in question. Every worker pod
+ * runs this listener so cache stays consistent across the fleet.
+ */
+@Component
+public class CredentialCacheInvalidationListener {
+
+    private static final Logger log = LoggerFactory.getLogger(CredentialCacheInvalidationListener.class);
+
+    private final CredentialResolver resolver;
+    private final ObjectMapper objectMapper;
+
+    public CredentialCacheInvalidationListener(CredentialResolver resolver, ObjectMapper objectMapper) {
+        this.resolver = resolver;
+        this.objectMapper = objectMapper;
+    }
+
+    public void handleCredentialChanged(String message) {
+        try {
+            JsonNode root = objectMapper.readTree(message);
+            // Event envelope: { type, tenantId, payload: { id, name, type, changeType } }
+            JsonNode payload = root.get("payload");
+            if (payload == null || payload.isNull()) {
+                payload = root;
+            }
+            JsonNode idNode = payload.get("id");
+            if (idNode == null || idNode.isNull() || !idNode.isTextual()) {
+                log.warn("Skipping credential invalidation: missing id in payload");
+                return;
+            }
+            String credentialId = idNode.stringValue();
+            log.info("Credential {} changed — invalidating local resolver cache", credentialId);
+            resolver.invalidate(credentialId);
+        } catch (Exception e) {
+            log.error("Failed to process credential changed event: {}", e.getMessage(), e);
+        }
+    }
+}

--- a/kelta-worker/src/main/java/io/kelta/worker/service/credential/CredentialDecryptException.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/service/credential/CredentialDecryptException.java
@@ -1,0 +1,12 @@
+package io.kelta.worker.service.credential;
+
+/**
+ * Thrown when the credential blob cannot be decrypted or parsed. Usually
+ * indicates a key rotation gone wrong or a corrupted ciphertext.
+ */
+public class CredentialDecryptException extends RuntimeException {
+
+    public CredentialDecryptException(String credentialId, Throwable cause) {
+        super("Failed to decrypt credential " + credentialId, cause);
+    }
+}

--- a/kelta-worker/src/main/java/io/kelta/worker/service/credential/CredentialDisabledException.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/service/credential/CredentialDisabledException.java
@@ -1,0 +1,12 @@
+package io.kelta.worker.service.credential;
+
+/**
+ * Thrown when a credential is found but its {@code active} flag is false.
+ * The flow run should fail clearly rather than silently fall back to no auth.
+ */
+public class CredentialDisabledException extends RuntimeException {
+
+    public CredentialDisabledException(String credentialId, String name) {
+        super("Credential '" + name + "' (" + credentialId + ") is disabled");
+    }
+}

--- a/kelta-worker/src/main/java/io/kelta/worker/service/credential/CredentialNotFoundException.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/service/credential/CredentialNotFoundException.java
@@ -1,0 +1,13 @@
+package io.kelta.worker.service.credential;
+
+/**
+ * Thrown when a credential reference cannot be resolved within the current tenant.
+ * Action handlers can map this to a flow error code so users can write
+ * targeted catch policies (e.g., {@code Credential.NotFound}).
+ */
+public class CredentialNotFoundException extends RuntimeException {
+
+    public CredentialNotFoundException(String tenantId, String reference) {
+        super("Credential '" + reference + "' not found in tenant " + tenantId);
+    }
+}

--- a/kelta-worker/src/main/java/io/kelta/worker/service/credential/CredentialResolver.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/service/credential/CredentialResolver.java
@@ -1,0 +1,40 @@
+package io.kelta.worker.service.credential;
+
+import io.kelta.runtime.credential.ResolvedCredential;
+
+/**
+ * Resolves a credential reference (id or name) into a {@link ResolvedCredential}
+ * containing decrypted secret material. Implementations must:
+ * <ul>
+ *   <li>Enforce tenant scoping via {@code TenantContext} so RLS filters apply.</li>
+ *   <li>Decrypt the stored blob through {@link io.kelta.crypto.EncryptionService}.</li>
+ *   <li>Cache results per-pod with a short TTL.</li>
+ *   <li>Invalidate cache entries when the credential changes (driven by
+ *       {@code kelta.config.credential.changed.<id>} NATS events).</li>
+ *   <li>Write an audit row to {@code setup_audit_trail} for every successful
+ *       resolution — without ever logging the decrypted material.</li>
+ * </ul>
+ */
+public interface CredentialResolver {
+
+    /**
+     * Resolves a credential by ID or name, returning the decrypted material.
+     *
+     * @param tenantId  the owning tenant; resolution is scoped to this tenant only
+     * @param reference either the credential UUID or its tenant-unique {@code name}
+     * @param ctx       audit context captured in the {@code setup_audit_trail} row
+     * @throws CredentialNotFoundException  when no matching credential exists
+     * @throws CredentialDisabledException  when the credential exists but {@code active=false}
+     * @throws CredentialDecryptException   when decryption or JSON parsing fails
+     */
+    ResolvedCredential resolve(String tenantId, String reference, ResolutionContext ctx);
+
+    /**
+     * Drops every cached entry for {@code credentialId} across all tenants
+     * (driven by NATS events; pods see invalidations without round-trips).
+     */
+    void invalidate(String credentialId);
+
+    /** Drops the entire cache. Intended for tests and emergency operator action. */
+    void invalidateAll();
+}

--- a/kelta-worker/src/main/java/io/kelta/worker/service/credential/CredentialResolverImpl.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/service/credential/CredentialResolverImpl.java
@@ -1,0 +1,212 @@
+package io.kelta.worker.service.credential;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import io.kelta.crypto.EncryptionService;
+import io.kelta.runtime.context.TenantContext;
+import io.kelta.runtime.credential.ResolvedCredential;
+import io.kelta.worker.repository.CredentialRepository;
+import io.kelta.worker.service.SetupAuditService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Default {@link CredentialResolver}. Caches by
+ * {@code tenantId + ":" + credentialId} with a short TTL. Cache invalidation
+ * is driven by NATS events ({@code kelta.config.credential.changed.<id>}) via
+ * {@link io.kelta.worker.listener.CredentialCacheInvalidationListener}.
+ */
+@Service
+public class CredentialResolverImpl implements CredentialResolver {
+
+    private static final Logger log = LoggerFactory.getLogger(CredentialResolverImpl.class);
+    private static final String AUDIT_ACTION = "CREDENTIAL_RESOLVE";
+    private static final String AUDIT_SECTION = "credentials";
+
+    private final CredentialRepository credentialRepository;
+    private final EncryptionService encryptionService;
+    private final SetupAuditService auditService;
+    private final ObjectMapper objectMapper;
+
+    private final Cache<String, ResolvedCredential> cache;
+    /** Index of credentialId -> set of cache keys that reference it, for fast invalidation. */
+    private final ConcurrentMap<String, ConcurrentMap<String, Boolean>> idIndex =
+        new ConcurrentHashMap<>();
+
+    public CredentialResolverImpl(CredentialRepository credentialRepository,
+                                   EncryptionService encryptionService,
+                                   SetupAuditService auditService,
+                                   ObjectMapper objectMapper,
+                                   @Value("${kelta.credentials.cache.ttl-seconds:300}") long ttlSeconds,
+                                   @Value("${kelta.credentials.cache.max-size:1000}") long maxSize) {
+        this.credentialRepository = credentialRepository;
+        this.encryptionService = encryptionService;
+        this.auditService = auditService;
+        this.objectMapper = objectMapper;
+        this.cache = Caffeine.newBuilder()
+            .expireAfterWrite(Duration.ofSeconds(ttlSeconds))
+            .maximumSize(maxSize)
+            .build();
+    }
+
+    @Override
+    public ResolvedCredential resolve(String tenantId, String reference, ResolutionContext ctx) {
+        if (tenantId == null || tenantId.isBlank()) {
+            throw new IllegalArgumentException("tenantId required");
+        }
+        if (reference == null || reference.isBlank()) {
+            throw new IllegalArgumentException("credential reference required");
+        }
+
+        // RLS-scoped DB read. Run inside a tenant context so the policy filter applies.
+        Map<String, Object> row = TenantContext.callWithTenant(tenantId, () ->
+            credentialRepository.findById(reference, tenantId)
+                .or(() -> credentialRepository.findByName(reference, tenantId))
+                .orElse(null));
+        if (row == null) {
+            throw new CredentialNotFoundException(tenantId, reference);
+        }
+
+        String credentialId = (String) row.get("id");
+        String name = (String) row.get("name");
+        String type = (String) row.get("type");
+        Boolean active = (Boolean) row.get("active");
+        if (active != null && !active) {
+            throw new CredentialDisabledException(credentialId, name);
+        }
+
+        String cacheKey = tenantId + ":" + credentialId;
+        ResolvedCredential cached = cache.getIfPresent(cacheKey);
+        if (cached != null) {
+            writeAudit(tenantId, credentialId, name, ctx, true);
+            return cached;
+        }
+
+        Map<String, Object> secrets = decryptSecrets(credentialId, (String) row.get("data_enc"));
+        Map<String, Object> metadata = parseMetadata(row.get("metadata"));
+
+        ResolvedCredential resolved = new ResolvedCredential(
+            credentialId, name, type, secrets, metadata, Instant.now());
+
+        cache.put(cacheKey, resolved);
+        idIndex.computeIfAbsent(credentialId, k -> new ConcurrentHashMap<>())
+            .put(cacheKey, Boolean.TRUE);
+
+        writeAudit(tenantId, credentialId, name, ctx, false);
+        return resolved;
+    }
+
+    @Override
+    public void invalidate(String credentialId) {
+        ConcurrentMap<String, Boolean> keys = idIndex.remove(credentialId);
+        if (keys == null || keys.isEmpty()) {
+            return;
+        }
+        for (String key : keys.keySet()) {
+            cache.invalidate(key);
+        }
+        log.debug("Invalidated {} cache entries for credential {}", keys.size(), credentialId);
+    }
+
+    @Override
+    public void invalidateAll() {
+        cache.invalidateAll();
+        idIndex.clear();
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    private Map<String, Object> decryptSecrets(String credentialId, String dataEnc) {
+        if (dataEnc == null || dataEnc.isBlank()) {
+            return Map.of();
+        }
+        try {
+            String json = encryptionService.decrypt(dataEnc);
+            JsonNode node = objectMapper.readTree(json);
+            if (!node.isObject()) {
+                return Map.of();
+            }
+            Map<String, Object> result = new LinkedHashMap<>();
+            node.properties().forEach(entry ->
+                result.put(entry.getKey(), objectMapper.convertValue(entry.getValue(), Object.class)));
+            return result;
+        } catch (Exception e) {
+            throw new CredentialDecryptException(credentialId, e);
+        }
+    }
+
+    private Map<String, Object> parseMetadata(Object metadata) {
+        if (metadata == null) {
+            return Map.of();
+        }
+        if (metadata instanceof Map<?, ?> map) {
+            // Defensive copy with safe key/value types
+            Map<String, Object> out = new HashMap<>();
+            map.forEach((k, v) -> out.put(String.valueOf(k), v));
+            return out;
+        }
+        try {
+            JsonNode node = objectMapper.readTree(metadata.toString());
+            if (!node.isObject()) {
+                return Map.of();
+            }
+            Map<String, Object> result = new LinkedHashMap<>();
+            node.properties().forEach(entry ->
+                result.put(entry.getKey(), objectMapper.convertValue(entry.getValue(), Object.class)));
+            return result;
+        } catch (Exception e) {
+            return Map.of();
+        }
+    }
+
+    /** Records the resolution event without leaking decrypted material. */
+    private void writeAudit(String tenantId, String credentialId, String name,
+                             ResolutionContext ctx, boolean cacheHit) {
+        // Audit body is a tiny JSON snippet so reviewers can correlate the
+        // resolution with a flow run and a stated purpose. NEVER include
+        // secret fields here.
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("cacheHit", cacheHit);
+        if (ctx != null) {
+            if (ctx.workflowRuleId() != null) body.put("workflowRuleId", ctx.workflowRuleId());
+            if (ctx.executionLogId() != null) body.put("executionLogId", ctx.executionLogId());
+            if (ctx.purpose() != null) body.put("purpose", ctx.purpose());
+        }
+        String json;
+        try {
+            json = objectMapper.writeValueAsString(body);
+        } catch (Exception e) {
+            json = "{\"cacheHit\":" + cacheHit + "}";
+        }
+        auditService.log(
+            tenantId,
+            ctx == null ? null : ctx.userId(),
+            AUDIT_ACTION,
+            AUDIT_SECTION,
+            "credential",
+            credentialId,
+            name,
+            null,
+            json);
+    }
+
+    /** Test-only hook for asserting the cache is populated. */
+    Optional<ResolvedCredential> peek(String tenantId, String credentialId) {
+        return Optional.ofNullable(cache.getIfPresent(tenantId + ":" + credentialId));
+    }
+}

--- a/kelta-worker/src/main/java/io/kelta/worker/service/credential/ResolutionContext.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/service/credential/ResolutionContext.java
@@ -1,0 +1,28 @@
+package io.kelta.worker.service.credential;
+
+/**
+ * Audit context for a single credential resolution. Captures who is asking,
+ * which flow run is running, and a free-form purpose tag (e.g.
+ * {@code "CALL_API:salesforce-prod"}). The values flow into the
+ * {@code setup_audit_trail} row so security reviewers can trace every
+ * decryption back to a source.
+ *
+ * <p>Pass {@code null} for any value that is genuinely not available.
+ */
+public record ResolutionContext(
+    String workflowRuleId,
+    String executionLogId,
+    String userId,
+    String purpose
+) {
+
+    /** Convenience for cases that don't have flow context (e.g., admin tests). */
+    public static ResolutionContext forUser(String userId, String purpose) {
+        return new ResolutionContext(null, null, userId, purpose);
+    }
+
+    /** Convenience for flow-driven resolution. */
+    public static ResolutionContext forFlow(String workflowRuleId, String executionLogId, String purpose) {
+        return new ResolutionContext(workflowRuleId, executionLogId, null, purpose);
+    }
+}

--- a/kelta-worker/src/test/java/io/kelta/worker/service/credential/CredentialResolverImplTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/service/credential/CredentialResolverImplTest.java
@@ -1,0 +1,164 @@
+package io.kelta.worker.service.credential;
+
+import io.kelta.crypto.EncryptionService;
+import io.kelta.runtime.credential.ResolvedCredential;
+import io.kelta.worker.repository.CredentialRepository;
+import io.kelta.worker.service.SetupAuditService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+
+import java.util.Base64;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@DisplayName("CredentialResolverImpl")
+class CredentialResolverImplTest {
+
+    private static final String TEST_KEY =
+        Base64.getEncoder().encodeToString(new byte[32]);
+
+    private CredentialRepository credentialRepository;
+    private EncryptionService encryptionService;
+    private SetupAuditService auditService;
+    private ObjectMapper objectMapper;
+    private CredentialResolverImpl resolver;
+
+    @BeforeEach
+    void setUp() {
+        credentialRepository = mock(CredentialRepository.class);
+        encryptionService = new EncryptionService(TEST_KEY);
+        auditService = mock(SetupAuditService.class);
+        objectMapper = new ObjectMapper();
+        resolver = new CredentialResolverImpl(
+            credentialRepository, encryptionService, auditService, objectMapper,
+            300, 1000);
+    }
+
+    private Map<String, Object> rowFor(String credentialId, String name, String type,
+                                        boolean active, String secretJson) {
+        return Map.of(
+            "id", credentialId,
+            "name", name,
+            "type", type,
+            "active", active,
+            "data_enc", encryptionService.encrypt(secretJson),
+            "metadata", Map.of("headerName", "X-API-Key")
+        );
+    }
+
+    @Test
+    @DisplayName("Resolves a credential, decrypts secret material, and writes an audit row")
+    void resolvesAndAudits() {
+        Map<String, Object> row = rowFor("cred-1", "salesforce-prod", "api_key", true,
+            "{\"value\":\"sk_live_abc123\"}");
+        when(credentialRepository.findById("cred-1", "tenant-1")).thenReturn(Optional.of(row));
+
+        ResolvedCredential resolved = resolver.resolve(
+            "tenant-1", "cred-1",
+            ResolutionContext.forFlow("rule-9", "exec-42", "CALL_API:salesforce-prod"));
+
+        assertEquals("cred-1", resolved.id());
+        assertEquals("salesforce-prod", resolved.name());
+        assertEquals("api_key", resolved.type());
+        assertEquals("sk_live_abc123", resolved.secretFields().get("value"));
+        assertEquals("X-API-Key", resolved.metadataFields().get("headerName"));
+
+        // Audit row written, never logging the secret.
+        verify(auditService).log(
+            eq("tenant-1"),
+            isNull(),
+            eq("CREDENTIAL_RESOLVE"),
+            eq("credentials"),
+            eq("credential"),
+            eq("cred-1"),
+            eq("salesforce-prod"),
+            isNull(),
+            argThat(json -> json != null
+                && json.contains("\"cacheHit\":false")
+                && !json.contains("sk_live_abc123")));
+    }
+
+    @Test
+    @DisplayName("Second resolve hits cache and skips the database")
+    void cacheHitSkipsDatabase() {
+        Map<String, Object> row = rowFor("cred-1", "salesforce-prod", "api_key", true,
+            "{\"value\":\"sk_live_abc123\"}");
+        when(credentialRepository.findById("cred-1", "tenant-1")).thenReturn(Optional.of(row));
+
+        resolver.resolve("tenant-1", "cred-1", ResolutionContext.forUser("u-1", "first"));
+        resolver.resolve("tenant-1", "cred-1", ResolutionContext.forUser("u-1", "second"));
+
+        // Each lookup still re-reads the row to enforce active/disabled checks.
+        // Cache hit only avoids decryption + caching costs and is reflected in the audit row.
+        verify(credentialRepository, times(2)).findById("cred-1", "tenant-1");
+        verify(auditService, atLeast(2)).log(any(), any(), any(), any(), any(), any(), any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("Falls back to lookup-by-name when ID lookup misses")
+    void resolvesByName() {
+        Map<String, Object> row = rowFor("cred-2", "github-bot", "bearer_token", true,
+            "{\"token\":\"ghp_abc\"}");
+        when(credentialRepository.findById("github-bot", "tenant-1")).thenReturn(Optional.empty());
+        when(credentialRepository.findByName("github-bot", "tenant-1")).thenReturn(Optional.of(row));
+
+        ResolvedCredential resolved = resolver.resolve(
+            "tenant-1", "github-bot", ResolutionContext.forUser("u-1", "test"));
+
+        assertEquals("cred-2", resolved.id());
+        assertEquals("ghp_abc", resolved.secretFields().get("token"));
+    }
+
+    @Test
+    @DisplayName("Throws CredentialNotFoundException when nothing matches")
+    void throwsWhenMissing() {
+        when(credentialRepository.findById(anyString(), anyString())).thenReturn(Optional.empty());
+        when(credentialRepository.findByName(anyString(), anyString())).thenReturn(Optional.empty());
+
+        assertThrows(CredentialNotFoundException.class, () ->
+            resolver.resolve("tenant-1", "no-such", null));
+    }
+
+    @Test
+    @DisplayName("Throws CredentialDisabledException when active=false")
+    void throwsWhenDisabled() {
+        Map<String, Object> row = rowFor("cred-1", "old", "api_key", false,
+            "{\"value\":\"x\"}");
+        when(credentialRepository.findById("cred-1", "tenant-1")).thenReturn(Optional.of(row));
+
+        assertThrows(CredentialDisabledException.class, () ->
+            resolver.resolve("tenant-1", "cred-1",
+                ResolutionContext.forUser("u-1", "test")));
+    }
+
+    @Test
+    @DisplayName("invalidate(id) drops cached entries for that credential")
+    void invalidatesById() {
+        Map<String, Object> row = rowFor("cred-1", "salesforce-prod", "api_key", true,
+            "{\"value\":\"sk_live_abc123\"}");
+        when(credentialRepository.findById("cred-1", "tenant-1")).thenReturn(Optional.of(row));
+
+        resolver.resolve("tenant-1", "cred-1", ResolutionContext.forUser("u-1", "test"));
+        assertTrue(resolver.peek("tenant-1", "cred-1").isPresent(), "cache populated");
+
+        resolver.invalidate("cred-1");
+
+        assertTrue(resolver.peek("tenant-1", "cred-1").isEmpty(),
+            "cache entry dropped after invalidate");
+    }
+
+    @Test
+    @DisplayName("Rejects null/blank tenantId and reference")
+    void rejectsNullArgs() {
+        assertThrows(IllegalArgumentException.class, () ->
+            resolver.resolve(null, "cred-1", null));
+        assertThrows(IllegalArgumentException.class, () ->
+            resolver.resolve("tenant-1", "", null));
+    }
+}


### PR DESCRIPTION
## Summary

Stacked on top of [#766](https://github.com/cklinker/emf/pull/766) (PR 1 — credential vault foundation). Once PR 1 merges, this will rebase onto main and target `main` directly.

Adds the runtime path that future action handlers (PR 4) will use to fetch decrypted credentials at flow execution time. No flow integration yet — that lands in PR 4.

## Changes

- **`CredentialResolver` SPI + `CredentialResolverImpl`**
  - Resolves a credential by ID or by tenant-unique name (falls back from one to the other)
  - Caffeine cache keyed on `tenantId:credentialId` — 5-min TTL, 1000-entry max, config-tunable via `kelta.credentials.cache.{ttl-seconds,max-size}`
  - Wraps DB reads in `TenantContext.callWithTenant(...)` so RLS filters apply
  - Decrypts via the existing `EncryptionService` and surfaces the secret as a `ResolvedCredential` record (already in runtime-core from PR 1)
  - Writes a `setup_audit_trail` row on every resolution with action `CREDENTIAL_RESOLVE` — captures `cacheHit`, `workflowRuleId`, `executionLogId`, and a free-form `purpose` tag, but **never** the decrypted material
  - Throws typed exceptions (`CredentialNotFoundException`, `CredentialDisabledException`, `CredentialDecryptException`) so PR 4's handlers can map them to flow error names cleanly
- **`CredentialCacheInvalidationListener`** subscribes (broadcast, durable name `worker-credential-cache`) to `kelta.config.credential.changed.>` from PR 1 and drops local cache entries when credentials change anywhere in the fleet
- **`NatsSubscriptionConfig`** — registers the new broadcast subscription

## Tests

7 new unit tests in `CredentialResolverImplTest`:
- decrypt + audit row written
- cache hit on second resolve
- name-based fallback when ID lookup misses
- `CredentialNotFoundException` when nothing matches
- `CredentialDisabledException` when `active=false`
- `invalidate(id)` drops cached entries
- argument validation (null/blank tenant + reference)

30/30 credential-related tests pass together (PR 1 + PR 2).

## Test plan

- [ ] CI: build + tests green
- [ ] Smoke: spin up two worker pods, edit a credential on one, confirm both pods log "credential cache invalidated for <id>"
- [ ] Smoke: query `setup_audit_trail` after a resolution and confirm a `CREDENTIAL_RESOLVE` row exists with the purpose tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)