### PR TITLE
feat(api-specs): OpenAPI spec library + operation index (PR 3/5)

### DIFF
--- a/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/model/system/SystemCollectionDefinitions.java
+++ b/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/model/system/SystemCollectionDefinitions.java
@@ -108,6 +108,8 @@ public final class SystemCollectionDefinitions {
         definitions.add(oidcProviders());
         definitions.add(credentials());
         definitions.add(credentialOauthTokens());
+        definitions.add(apiSpecs());
+        definitions.add(apiOperations());
 
         // Reports & Dashboards
         definitions.add(reports());
@@ -580,6 +582,65 @@ public final class SystemCollectionDefinitions {
                 .withColumnName("refresh_failure_count"))
             .addField(FieldDefinition.text("lastRefreshError").withColumnName("last_refresh_error"))
             .addField(FieldDefinition.text("scope"))
+            .build();
+    }
+
+    public static CollectionDefinition apiSpecs() {
+        return systemBuilder("api-specs", "API Specs", "api_spec")
+            .displayFieldName("name")
+            .addField(FieldDefinition.requiredString("name", 200))
+            .addField(FieldDefinition.string("description", 1000))
+            .addField(FieldDefinition.requiredString("specVersion", 20)
+                .withColumnName("spec_version"))
+            .addField(FieldDefinition.string("apiTitle", 500).withColumnName("api_title"))
+            .addField(FieldDefinition.string("apiVersion", 50).withColumnName("api_version"))
+            .addField(FieldDefinition.string("baseUrl", 1000).withColumnName("base_url"))
+            .addField(FieldDefinition.json("servers"))
+            .addField(FieldDefinition.json("securitySchemes").withColumnName("security_schemes"))
+            .addField(FieldDefinition.requiredString("sourceType", 20)
+                .withColumnName("source_type"))
+            .addField(FieldDefinition.string("sourceUrl", 2000).withColumnName("source_url"))
+            // raw_spec / parsed_spec are exposed but immutable through the
+            // dynamic router — imports go through ApiSpecController which runs
+            // the parser. Keeping them here lets the system-collection viewer
+            // render the spec's metadata without bouncing to a second endpoint.
+            .addField(FieldDefinition.requiredText("rawSpec")
+                .withColumnName("raw_spec").withImmutable(true))
+            .addField(FieldDefinition.requiredString("rawFormat", 10)
+                .withColumnName("raw_format").withImmutable(true))
+            .addField(FieldDefinition.requiredJson("parsedSpec")
+                .withColumnName("parsed_spec").withImmutable(true))
+            .addField(FieldDefinition.requiredString("specHash", 64)
+                .withColumnName("spec_hash").withImmutable(true))
+            .addField(FieldDefinition.integer("revision").withDefault(1))
+            .addField(FieldDefinition.bool("isActive").withColumnName("is_active")
+                .withDefault(true))
+            .addField(FieldDefinition.datetime("lastImportedAt")
+                .withColumnName("last_imported_at"))
+            .build();
+    }
+
+    public static CollectionDefinition apiOperations() {
+        return readOnlySystemBuilder("api-operations", "API Operations", "api_operation")
+            .addField(FieldDefinition.lookup("specId", "api-specs", "Spec")
+                .withColumnName("spec_id"))
+            .addField(FieldDefinition.string("operationId", 200).withColumnName("operation_id"))
+            .addField(FieldDefinition.requiredString("syntheticOpId", 200)
+                .withColumnName("synthetic_op_id"))
+            .addField(FieldDefinition.requiredString("httpMethod", 10)
+                .withColumnName("http_method"))
+            .addField(FieldDefinition.requiredString("pathTemplate", 1000)
+                .withColumnName("path_template"))
+            .addField(FieldDefinition.string("summary", 500))
+            .addField(FieldDefinition.text("description"))
+            .addField(FieldDefinition.json("tags"))
+            .addField(FieldDefinition.json("parametersSchema").withColumnName("parameters_schema"))
+            .addField(FieldDefinition.json("requestBodySchema")
+                .withColumnName("request_body_schema"))
+            .addField(FieldDefinition.json("responseSchemas").withColumnName("response_schemas"))
+            .addField(FieldDefinition.json("securityRequired").withColumnName("security_required"))
+            .addField(FieldDefinition.bool("deprecated"))
+            .addField(FieldDefinition.text("searchText").withColumnName("search_text"))
             .build();
     }
 

--- a/kelta-platform/runtime/runtime-module-integration/pom.xml
+++ b/kelta-platform/runtime/runtime-module-integration/pom.xml
@@ -42,6 +42,16 @@
             <artifactId>spring-web</artifactId>
         </dependency>
 
+        <!-- swagger-parser-v3: parses + validates OpenAPI 3.0/3.1 specs in JSON or YAML.
+             Used by OpenApiSpecParser to seed the api_spec / api_operation tables.
+             Brings its own Jackson 2 transitively for internal deserialization;
+             we re-serialize results into the platform's Jackson 3 trees ourselves. -->
+        <dependency>
+            <groupId>io.swagger.parser.v3</groupId>
+            <artifactId>swagger-parser</artifactId>
+            <version>2.1.22</version>
+        </dependency>
+
         <!-- GraalVM Polyglot API for JavaScript script execution -->
         <dependency>
             <groupId>org.graalvm.polyglot</groupId>

--- a/kelta-platform/runtime/runtime-module-integration/src/main/java/io/kelta/runtime/module/integration/api/ApiOperation.java
+++ b/kelta-platform/runtime/runtime-module-integration/src/main/java/io/kelta/runtime/module/integration/api/ApiOperation.java
@@ -1,0 +1,31 @@
+package io.kelta.runtime.module.integration.api;
+
+import tools.jackson.databind.JsonNode;
+
+/**
+ * One callable operation extracted from an {@link ApiSpec}. Operations are
+ * persisted as their own row so the picker can search across many specs in a
+ * single trigram-backed query without parsing JSON at request time.
+ *
+ * @param syntheticOpId the canonical, always-present identifier — equal to
+ *                      {@code operationId} when the spec provides one, otherwise
+ *                      synthesized as {@code <METHOD>_<sanitized path>}
+ */
+public record ApiOperation(
+    String id,
+    String tenantId,
+    String specId,
+    String operationId,
+    String syntheticOpId,
+    String httpMethod,
+    String pathTemplate,
+    String summary,
+    String description,
+    JsonNode tags,
+    JsonNode parametersSchema,
+    JsonNode requestBodySchema,
+    JsonNode responseSchemas,
+    JsonNode securityRequired,
+    boolean deprecated
+) {
+}

--- a/kelta-platform/runtime/runtime-module-integration/src/main/java/io/kelta/runtime/module/integration/api/ApiSpec.java
+++ b/kelta-platform/runtime/runtime-module-integration/src/main/java/io/kelta/runtime/module/integration/api/ApiSpec.java
@@ -1,0 +1,33 @@
+package io.kelta.runtime.module.integration.api;
+
+import tools.jackson.databind.JsonNode;
+
+import java.time.Instant;
+
+/**
+ * Tenant-scoped record describing an imported OpenAPI 3.x specification. The
+ * {@code parsedSpec} field carries the fully-resolved spec ($refs already
+ * dereferenced) so handlers and the picker UI can read it without re-parsing.
+ */
+public record ApiSpec(
+    String id,
+    String tenantId,
+    String name,
+    String description,
+    String specVersion,
+    String apiTitle,
+    String apiVersion,
+    String baseUrl,
+    JsonNode servers,
+    JsonNode securitySchemes,
+    String sourceType,
+    String sourceUrl,
+    String rawSpec,
+    String rawFormat,
+    JsonNode parsedSpec,
+    String specHash,
+    int revision,
+    boolean active,
+    Instant lastImportedAt
+) {
+}

--- a/kelta-platform/runtime/runtime-module-integration/src/main/java/io/kelta/runtime/module/integration/api/OpenApiParseException.java
+++ b/kelta-platform/runtime/runtime-module-integration/src/main/java/io/kelta/runtime/module/integration/api/OpenApiParseException.java
@@ -1,0 +1,17 @@
+package io.kelta.runtime.module.integration.api;
+
+/**
+ * Thrown by {@link OpenApiSpecParser} when the supplied document is not a
+ * valid OpenAPI 3.x specification. The message is safe to surface in API
+ * responses — it contains parser diagnostics, never raw secrets.
+ */
+public class OpenApiParseException extends RuntimeException {
+
+    public OpenApiParseException(String message) {
+        super(message);
+    }
+
+    public OpenApiParseException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/kelta-platform/runtime/runtime-module-integration/src/main/java/io/kelta/runtime/module/integration/api/OpenApiSpecParser.java
+++ b/kelta-platform/runtime/runtime-module-integration/src/main/java/io/kelta/runtime/module/integration/api/OpenApiSpecParser.java
@@ -1,0 +1,215 @@
+package io.kelta.runtime.module.integration.api;
+
+import io.swagger.parser.OpenAPIParser;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.PathItem;
+import io.swagger.v3.oas.models.servers.Server;
+import io.swagger.v3.parser.core.models.ParseOptions;
+import io.swagger.v3.parser.core.models.SwaggerParseResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ObjectNode;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.HexFormat;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Parses an OpenAPI 3.x spec (JSON or YAML) into a {@link ParsedSpec} ready
+ * for persistence. {@code $ref}s are resolved fully so handlers and the UI
+ * never need to chase pointers across documents.
+ *
+ * <p>swagger-parser-v3 internally uses Jackson 2 — this class re-serializes
+ * its output through the platform's Jackson 3 {@link ObjectMapper} so the
+ * rest of the runtime can treat operation schemas as native {@code JsonNode}s.
+ */
+public class OpenApiSpecParser {
+
+    private static final Logger log = LoggerFactory.getLogger(OpenApiSpecParser.class);
+
+    private final ObjectMapper objectMapper;
+
+    public OpenApiSpecParser(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    /**
+     * Parses {@code raw} (JSON or YAML; auto-detected) and returns the
+     * normalized form. Throws {@link OpenApiParseException} when the spec is
+     * unparseable or fails OpenAPI 3.x structural validation.
+     */
+    public ParsedSpec parse(String raw) {
+        ParseOptions opts = new ParseOptions();
+        opts.setResolve(true);
+        opts.setResolveFully(true);
+        opts.setResolveCombinators(true);
+        opts.setValidateExternalRefs(false);
+
+        SwaggerParseResult result = new OpenAPIParser().readContents(raw, null, opts);
+        if (result.getOpenAPI() == null) {
+            throw new OpenApiParseException(
+                "Failed to parse OpenAPI spec: "
+                    + (result.getMessages() == null ? "<no messages>" : result.getMessages()));
+        }
+        if (result.getMessages() != null && !result.getMessages().isEmpty()) {
+            log.debug("OpenAPI parser warnings: {}", result.getMessages());
+        }
+        OpenAPI openApi = result.getOpenAPI();
+
+        String specVersion = openApi.getOpenapi() != null
+            ? openApi.getOpenapi() : "3.0.0";
+        String apiTitle = openApi.getInfo() != null ? openApi.getInfo().getTitle() : null;
+        String apiVersion = openApi.getInfo() != null ? openApi.getInfo().getVersion() : null;
+        String baseUrl = pickBaseUrl(openApi);
+
+        JsonNode servers = serializeServers(openApi);
+        JsonNode securitySchemes = openApi.getComponents() != null
+            && openApi.getComponents().getSecuritySchemes() != null
+            ? convert(openApi.getComponents().getSecuritySchemes())
+            : null;
+        JsonNode parsedSpec = convert(openApi);
+
+        List<ParsedSpec.ParsedOperation> operations = extractOperations(openApi);
+
+        return new ParsedSpec(
+            specVersion, apiTitle, apiVersion, baseUrl,
+            servers, securitySchemes, parsedSpec, operations);
+    }
+
+    /** Returns a hex-encoded sha-256 of {@code raw}. Used to detect re-imports. */
+    public String hash(String raw) {
+        try {
+            MessageDigest sha = MessageDigest.getInstance("SHA-256");
+            byte[] digest = sha.digest(raw.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(digest);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 unavailable", e);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+
+    private String pickBaseUrl(OpenAPI openApi) {
+        List<Server> servers = openApi.getServers();
+        if (servers == null || servers.isEmpty()) {
+            return null;
+        }
+        // Take the first server URL. Variables in the URL stay as-is — handlers
+        // resolve them via the action config at execution time.
+        Server first = servers.get(0);
+        return first == null ? null : first.getUrl();
+    }
+
+    private JsonNode serializeServers(OpenAPI openApi) {
+        if (openApi.getServers() == null || openApi.getServers().isEmpty()) {
+            return null;
+        }
+        return convert(openApi.getServers());
+    }
+
+    private List<ParsedSpec.ParsedOperation> extractOperations(OpenAPI openApi) {
+        List<ParsedSpec.ParsedOperation> ops = new ArrayList<>();
+        if (openApi.getPaths() == null) {
+            return ops;
+        }
+        for (Map.Entry<String, PathItem> entry : openApi.getPaths().entrySet()) {
+            String pathTemplate = entry.getKey();
+            PathItem item = entry.getValue();
+            for (Map.Entry<PathItem.HttpMethod, Operation> opEntry :
+                    item.readOperationsMap().entrySet()) {
+                ops.add(buildOperation(pathTemplate, opEntry.getKey().name(), opEntry.getValue()));
+            }
+        }
+        return ops;
+    }
+
+    private ParsedSpec.ParsedOperation buildOperation(String pathTemplate,
+                                                       String method,
+                                                       Operation op) {
+        String operationId = op.getOperationId();
+        String syntheticOpId = operationId != null && !operationId.isBlank()
+            ? operationId
+            : synthesizeOpId(method, pathTemplate);
+
+        JsonNode tags = op.getTags() != null ? convert(op.getTags()) : null;
+        JsonNode parameters = op.getParameters() != null ? convert(op.getParameters()) : null;
+        JsonNode requestBody = op.getRequestBody() != null ? convert(op.getRequestBody()) : null;
+        JsonNode responses = op.getResponses() != null ? convert(op.getResponses()) : null;
+        JsonNode security = op.getSecurity() != null ? convert(op.getSecurity()) : null;
+
+        boolean deprecated = Boolean.TRUE.equals(op.getDeprecated());
+        String searchText = buildSearchText(method, pathTemplate, op);
+
+        return new ParsedSpec.ParsedOperation(
+            operationId, syntheticOpId, method, pathTemplate,
+            op.getSummary(), op.getDescription(),
+            tags, parameters, requestBody, responses, security,
+            deprecated, searchText);
+    }
+
+    private static String synthesizeOpId(String method, String path) {
+        StringBuilder sb = new StringBuilder(method);
+        for (int i = 0; i < path.length(); i++) {
+            char c = path.charAt(i);
+            if (Character.isLetterOrDigit(c)) {
+                sb.append(c);
+            } else if (c == '/' || c == '{' || c == '}' || c == '-' || c == '_') {
+                if (sb.length() > 0 && sb.charAt(sb.length() - 1) != '_') {
+                    sb.append('_');
+                }
+            }
+        }
+        // trim trailing underscore
+        while (sb.length() > 0 && sb.charAt(sb.length() - 1) == '_') {
+            sb.deleteCharAt(sb.length() - 1);
+        }
+        return sb.toString();
+    }
+
+    private static String buildSearchText(String method, String path, Operation op) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(method).append(' ').append(path);
+        if (op.getOperationId() != null) sb.append(' ').append(op.getOperationId());
+        if (op.getSummary() != null)     sb.append(' ').append(op.getSummary());
+        if (op.getDescription() != null) sb.append(' ').append(op.getDescription());
+        if (op.getTags() != null) {
+            for (String tag : op.getTags()) {
+                sb.append(' ').append(tag);
+            }
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Converts a swagger-parser model object (Jackson-2 backed POJOs / Maps /
+     * Lists) into a Jackson-3 {@link JsonNode}. We round-trip via a Map so we
+     * don't need to share an ObjectMapper between the two Jackson versions.
+     */
+    @SuppressWarnings("unchecked")
+    private JsonNode convert(Object value) {
+        if (value == null) {
+            return null;
+        }
+        // swagger-parser hands back Jackson-2 POJOs; their toString isn't JSON,
+        // so we serialize via Jackson-2 first, then parse with Jackson-3.
+        try {
+            com.fasterxml.jackson.databind.ObjectMapper jackson2 =
+                new com.fasterxml.jackson.databind.ObjectMapper();
+            String json = jackson2.writeValueAsString(value);
+            return objectMapper.readTree(json);
+        } catch (Exception e) {
+            // As a fallback, stuff the toString into an empty object — better
+            // to lose detail than fail the entire import.
+            ObjectNode fallback = objectMapper.createObjectNode();
+            fallback.put("_unparsable", value.toString());
+            return fallback;
+        }
+    }
+}

--- a/kelta-platform/runtime/runtime-module-integration/src/main/java/io/kelta/runtime/module/integration/api/ParsedSpec.java
+++ b/kelta-platform/runtime/runtime-module-integration/src/main/java/io/kelta/runtime/module/integration/api/ParsedSpec.java
@@ -1,0 +1,43 @@
+package io.kelta.runtime.module.integration.api;
+
+import tools.jackson.databind.JsonNode;
+
+import java.util.List;
+
+/**
+ * Output of {@link OpenApiSpecParser#parse}: the normalized spec metadata,
+ * the dereferenced spec tree, and the full list of operations to upsert.
+ */
+public record ParsedSpec(
+    String specVersion,
+    String apiTitle,
+    String apiVersion,
+    String baseUrl,
+    JsonNode servers,
+    JsonNode securitySchemes,
+    JsonNode parsedSpec,
+    List<ParsedOperation> operations
+) {
+
+    /**
+     * In-memory representation of an operation returned by the parser.
+     * The {@code id} and {@code tenantId} on the persisted {@link ApiOperation}
+     * are filled in by the storage layer.
+     */
+    public record ParsedOperation(
+        String operationId,
+        String syntheticOpId,
+        String httpMethod,
+        String pathTemplate,
+        String summary,
+        String description,
+        JsonNode tags,
+        JsonNode parametersSchema,
+        JsonNode requestBodySchema,
+        JsonNode responseSchemas,
+        JsonNode securityRequired,
+        boolean deprecated,
+        String searchText
+    ) {
+    }
+}

--- a/kelta-platform/runtime/runtime-module-integration/src/main/java/io/kelta/runtime/module/integration/spi/ApiSpecStore.java
+++ b/kelta-platform/runtime/runtime-module-integration/src/main/java/io/kelta/runtime/module/integration/spi/ApiSpecStore.java
@@ -1,0 +1,25 @@
+package io.kelta.runtime.module.integration.spi;
+
+import io.kelta.runtime.module.integration.api.ApiOperation;
+import io.kelta.runtime.module.integration.api.ApiSpec;
+
+import java.util.Optional;
+
+/**
+ * SPI for looking up imported OpenAPI specs and their operations at runtime.
+ * The worker provides a JDBC-backed implementation; integration handlers
+ * (PR 4's {@code CALL_API}) consume this to translate
+ * {@code (specId, operationId)} into URL/method/schemas without re-parsing
+ * the raw spec on every invocation.
+ */
+public interface ApiSpecStore {
+
+    /** Looks up a spec by id within the supplied tenant. */
+    Optional<ApiSpec> findSpec(String tenantId, String specId);
+
+    /**
+     * Looks up an operation by its {@code synthetic_op_id} within a given spec.
+     * Returns empty when either the spec or the operation does not exist.
+     */
+    Optional<ApiOperation> findOperation(String tenantId, String specId, String syntheticOpId);
+}

--- a/kelta-platform/runtime/runtime-module-integration/src/test/java/io/kelta/runtime/module/integration/api/OpenApiSpecParserTest.java
+++ b/kelta-platform/runtime/runtime-module-integration/src/test/java/io/kelta/runtime/module/integration/api/OpenApiSpecParserTest.java
@@ -1,0 +1,198 @@
+package io.kelta.runtime.module.integration.api;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("OpenApiSpecParser")
+class OpenApiSpecParserTest {
+
+    private OpenApiSpecParser parser;
+
+    @BeforeEach
+    void setUp() {
+        parser = new OpenApiSpecParser(new ObjectMapper());
+    }
+
+    private static final String PETSTORE_YAML = """
+        openapi: 3.0.3
+        info:
+          title: Swagger Petstore
+          version: 1.0.6
+          description: A sample API for unit tests
+        servers:
+          - url: https://petstore.swagger.io/v2
+        paths:
+          /pet:
+            post:
+              tags: [pet]
+              summary: Add a new pet to the store
+              operationId: addPet
+              requestBody:
+                required: true
+                content:
+                  application/json:
+                    schema:
+                      $ref: '#/components/schemas/Pet'
+              responses:
+                '200':
+                  description: ok
+            put:
+              tags: [pet]
+              summary: Update an existing pet
+              operationId: updatePet
+              responses:
+                '200':
+                  description: ok
+          /pet/{petId}:
+            get:
+              tags: [pet]
+              summary: Find pet by ID
+              operationId: getPetById
+              parameters:
+                - name: petId
+                  in: path
+                  required: true
+                  schema:
+                    type: integer
+                    format: int64
+              responses:
+                '200':
+                  description: ok
+            delete:
+              tags: [pet]
+              summary: Delete a pet
+              # operationId intentionally omitted to test synthetic id
+              parameters:
+                - name: petId
+                  in: path
+                  required: true
+                  schema:
+                    type: integer
+              responses:
+                '204':
+                  description: deleted
+        components:
+          schemas:
+            Pet:
+              type: object
+              required: [name]
+              properties:
+                id:
+                  type: integer
+                name:
+                  type: string
+                status:
+                  type: string
+                  enum: [available, pending, sold]
+        """;
+
+    @Test
+    @DisplayName("Parses a valid OpenAPI 3.0 spec into normalized fields")
+    void parsesValidSpec() {
+        ParsedSpec parsed = parser.parse(PETSTORE_YAML);
+
+        assertEquals("3.0.3", parsed.specVersion());
+        assertEquals("Swagger Petstore", parsed.apiTitle());
+        assertEquals("1.0.6", parsed.apiVersion());
+        assertEquals("https://petstore.swagger.io/v2", parsed.baseUrl());
+        assertEquals(4, parsed.operations().size(),
+            "should extract 4 operations across /pet and /pet/{petId}");
+    }
+
+    @Test
+    @DisplayName("Synthesizes an operationId when the spec omits one")
+    void synthesizesMissingOperationId() {
+        ParsedSpec parsed = parser.parse(PETSTORE_YAML);
+        ParsedSpec.ParsedOperation deletePet = parsed.operations().stream()
+            .filter(op -> "DELETE".equals(op.httpMethod())
+                && op.pathTemplate().equals("/pet/{petId}"))
+            .findFirst()
+            .orElseThrow();
+
+        assertNull(deletePet.operationId(), "spec did not provide operationId");
+        assertNotNull(deletePet.syntheticOpId());
+        assertTrue(deletePet.syntheticOpId().startsWith("DELETE"),
+            "synthetic id should start with the HTTP method");
+    }
+
+    @Test
+    @DisplayName("Resolves $ref pointers so handlers don't need to chase them")
+    void resolvesRefs() {
+        ParsedSpec parsed = parser.parse(PETSTORE_YAML);
+        ParsedSpec.ParsedOperation addPet = parsed.operations().stream()
+            .filter(op -> "addPet".equals(op.operationId()))
+            .findFirst()
+            .orElseThrow();
+
+        // The Pet schema's actual properties should be inlined into the body
+        // even if swagger-parser leaves stub $refs for cycle protection.
+        assertNotNull(addPet.requestBodySchema(), "request body should be present");
+        String json = addPet.requestBodySchema().toString();
+        assertTrue(json.contains("photoUrls") || json.contains("status")
+                || json.contains("\"name\""),
+            "Pet schema properties should be inlined into the operation body");
+    }
+
+    @Test
+    @DisplayName("Builds a search_text that includes method, path, summary, and tags")
+    void buildsSearchText() {
+        ParsedSpec parsed = parser.parse(PETSTORE_YAML);
+        ParsedSpec.ParsedOperation addPet = parsed.operations().stream()
+            .filter(op -> "addPet".equals(op.operationId()))
+            .findFirst()
+            .orElseThrow();
+
+        String text = addPet.searchText();
+        assertTrue(text.contains("POST"));
+        assertTrue(text.contains("/pet"));
+        assertTrue(text.contains("Add a new pet"));
+        assertTrue(text.contains("pet"));   // tag
+    }
+
+    @Test
+    @DisplayName("hash() returns a stable hex digest")
+    void hashIsStable() {
+        String first = parser.hash(PETSTORE_YAML);
+        String second = parser.hash(PETSTORE_YAML);
+        assertEquals(first, second);
+        assertEquals(64, first.length(), "sha-256 hex digest is 64 chars");
+    }
+
+    @Test
+    @DisplayName("Throws OpenApiParseException for an unparseable document")
+    void throwsForGarbage() {
+        // Empty string and known-bad YAML both surface as parse errors via
+        // swagger-parser's null-OpenAPI return; the parser turns that into
+        // OpenApiParseException.
+        assertThrows(OpenApiParseException.class, () -> parser.parse(""));
+    }
+
+    @Test
+    @DisplayName("Accepts JSON and YAML interchangeably")
+    void acceptsJson() {
+        String json = """
+            { "openapi": "3.0.3",
+              "info": {"title": "t", "version": "1"},
+              "paths": {"/x": {"get": {"responses": {"200": {"description": "ok"}}}}} }
+            """;
+        ParsedSpec parsed = parser.parse(json);
+        assertEquals(1, parsed.operations().size());
+        assertEquals("GET", parsed.operations().get(0).httpMethod());
+    }
+
+    @Test
+    @DisplayName("Operations preserve tag info as JSON arrays")
+    void preservesTags() {
+        ParsedSpec parsed = parser.parse(PETSTORE_YAML);
+        List<ParsedSpec.ParsedOperation> petOps = parsed.operations().stream()
+            .filter(op -> op.tags() != null && op.tags().toString().contains("pet"))
+            .toList();
+        assertEquals(4, petOps.size(), "all 4 operations are tagged 'pet'");
+    }
+}

--- a/kelta-ui/app/src/App.tsx
+++ b/kelta-ui/app/src/App.tsx
@@ -93,6 +93,8 @@ import {
   EmailTemplatesPage,
   ScriptsPage,
   WebhooksPage,
+  ApiSpecsPage,
+  ApiSpecDetailPage,
   ConnectedAppsPage,
   CredentialsPage,
   ApiTokensPage,
@@ -1022,6 +1024,30 @@ function TenantRoutes(): React.ReactElement {
           <AdminPageRoute>
             <RequirePermission permission="VIEW_CREDENTIALS">
               <CredentialsPage />
+            </RequirePermission>
+          </AdminPageRoute>
+        }
+      />
+
+      {/* OpenAPI Spec Library — list + import */}
+      <Route
+        path="api-specs"
+        element={
+          <AdminPageRoute>
+            <RequirePermission permission="VIEW_API_SPECS">
+              <ApiSpecsPage />
+            </RequirePermission>
+          </AdminPageRoute>
+        }
+      />
+
+      {/* Spec detail — overview, operations browser, raw */}
+      <Route
+        path="api-specs/:specId"
+        element={
+          <AdminPageRoute>
+            <RequirePermission permission="VIEW_API_SPECS">
+              <ApiSpecDetailPage />
             </RequirePermission>
           </AdminPageRoute>
         }

--- a/kelta-ui/app/src/components/FileDropzone/FileDropzone.tsx
+++ b/kelta-ui/app/src/components/FileDropzone/FileDropzone.tsx
@@ -1,0 +1,94 @@
+import React, { useCallback, useRef, useState } from 'react'
+import { Upload } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+export interface FileDropzoneProps {
+  /** Comma-separated list of accepted MIME types or extensions, e.g. ".json,.yaml,.yml". */
+  accept?: string
+  /** Maximum allowed file size in bytes. Files larger are rejected with onError. */
+  maxBytes?: number
+  /** Called with the dropped or selected file. */
+  onFile: (file: File) => void
+  /** Called when a file is rejected (too large, wrong type, read failure). */
+  onError?: (message: string) => void
+  /** Override the default helper text. */
+  hint?: React.ReactNode
+  className?: string
+}
+
+/**
+ * Minimal drag-and-drop / click-to-browse file input. Native — no extra deps.
+ * Used by the OpenAPI spec import dialog (and reusable for any future
+ * upload-style flow).
+ */
+export function FileDropzone({
+  accept,
+  maxBytes,
+  onFile,
+  onError,
+  hint,
+  className,
+}: FileDropzoneProps): React.ReactElement {
+  const [isOver, setIsOver] = useState(false)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const handleFile = useCallback(
+    (file: File | null | undefined) => {
+      if (!file) return
+      if (maxBytes && file.size > maxBytes) {
+        onError?.(`File is too large (${(file.size / 1024 / 1024).toFixed(1)} MB)`)
+        return
+      }
+      onFile(file)
+    },
+    [maxBytes, onError, onFile]
+  )
+
+  const onDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault()
+    setIsOver(false)
+    if (e.dataTransfer.files.length === 0) return
+    handleFile(e.dataTransfer.files.item(0))
+  }
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={() => inputRef.current?.click()}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          inputRef.current?.click()
+        }
+      }}
+      onDragOver={(e) => {
+        e.preventDefault()
+        setIsOver(true)
+      }}
+      onDragLeave={() => setIsOver(false)}
+      onDrop={onDrop}
+      className={cn(
+        'flex flex-col items-center justify-center gap-2 rounded-md border-2 border-dashed p-6 text-center transition-colors',
+        isOver ? 'border-primary bg-primary/5' : 'border-border bg-muted/30',
+        'hover:bg-muted/50 cursor-pointer focus:outline-none focus:ring-2 focus:ring-ring',
+        className
+      )}
+    >
+      <Upload className="h-8 w-8 text-muted-foreground" aria-hidden="true" />
+      <div className="space-y-0.5">
+        <p className="text-sm font-medium">Drop a file or click to browse</p>
+        <p className="text-xs text-muted-foreground">
+          {hint ?? (accept ? `Accepted: ${accept}` : 'Any file type')}
+        </p>
+      </div>
+      <input
+        ref={inputRef}
+        type="file"
+        accept={accept}
+        className="hidden"
+        onChange={(e) => handleFile(e.target.files?.item(0))}
+      />
+    </div>
+  )
+}

--- a/kelta-ui/app/src/components/apiSpec/OperationPicker.tsx
+++ b/kelta-ui/app/src/components/apiSpec/OperationPicker.tsx
@@ -1,0 +1,103 @@
+import React, { useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import type { ApiOperationSummary } from '@kelta/sdk'
+
+import { useApi } from '../../context/ApiContext'
+import { Input } from '@/components/ui/input'
+import { FieldLabel } from '@/components/kelta'
+import { cn } from '@/lib/utils'
+
+const METHOD_COLORS: Record<string, string> = {
+  GET: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-200',
+  POST: 'bg-sky-100 text-sky-800 dark:bg-sky-900/40 dark:text-sky-200',
+  PUT: 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200',
+  PATCH: 'bg-orange-100 text-orange-800 dark:bg-orange-900/40 dark:text-orange-200',
+  DELETE: 'bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-200',
+}
+
+export interface OperationPickerProps {
+  /** Restricts the search to operations within this spec. Empty searches across all specs. */
+  specId?: string
+  value?: string
+  onChange: (syntheticOpId: string, op: ApiOperationSummary | null) => void
+  label?: string
+  className?: string
+}
+
+/**
+ * Searchable picker for OpenAPI operations. Backed by the trigram-indexed
+ * search endpoint on the worker.
+ */
+export function OperationPicker({
+  specId,
+  value,
+  onChange,
+  label = 'Operation',
+  className,
+}: OperationPickerProps): React.ReactElement {
+  const { keltaClient } = useApi()
+  const [query, setQuery] = useState('')
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['api-operations', { specId, query }],
+    queryFn: () =>
+      keltaClient.admin.apiSpecs.searchOperations({
+        q: query || undefined,
+        specId: specId || undefined,
+        limit: 50,
+      }),
+  })
+
+  const operations = data ?? []
+
+  return (
+    <div className={className ?? 'space-y-2'}>
+      <FieldLabel>{label}</FieldLabel>
+      <Input
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        placeholder="Search operations by path, summary, or tag…"
+      />
+      <div className="max-h-72 overflow-y-auto rounded-md border">
+        {isLoading && <p className="p-3 text-xs text-muted-foreground">Searching…</p>}
+        {!isLoading && operations.length === 0 && (
+          <p className="p-3 text-xs text-muted-foreground">No operations match.</p>
+        )}
+        {operations.map((op) => {
+          const isSelected = value === op.syntheticOpId
+          return (
+            <button
+              type="button"
+              key={op.id}
+              onClick={() => onChange(op.syntheticOpId, op)}
+              className={cn(
+                'flex w-full items-center gap-2 px-3 py-2 text-left hover:bg-muted/60 border-b last:border-b-0',
+                isSelected && 'bg-primary/10'
+              )}
+            >
+              <span
+                className={cn(
+                  'rounded px-1.5 py-0.5 text-[10px] font-mono font-bold',
+                  METHOD_COLORS[op.httpMethod] ?? 'bg-muted'
+                )}
+              >
+                {op.httpMethod}
+              </span>
+              <span className="font-mono text-xs">{op.pathTemplate}</span>
+              {op.summary && (
+                <span className="text-xs text-muted-foreground truncate">
+                  — {op.summary}
+                </span>
+              )}
+              {op.deprecated && (
+                <span className="ml-auto text-[10px] text-muted-foreground">
+                  deprecated
+                </span>
+              )}
+            </button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/kelta-ui/app/src/components/apiSpec/SpecPicker.tsx
+++ b/kelta-ui/app/src/components/apiSpec/SpecPicker.tsx
@@ -1,0 +1,76 @@
+import React from 'react'
+import { useQuery } from '@tanstack/react-query'
+import type { ApiSpecSummary } from '@kelta/sdk'
+
+import { useApi } from '../../context/ApiContext'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { FieldLabel } from '@/components/kelta'
+
+export interface SpecPickerProps {
+  value: string
+  onChange: (specId: string, spec: ApiSpecSummary | null) => void
+  label?: string
+  placeholder?: string
+  className?: string
+}
+
+/**
+ * Picks an imported OpenAPI spec from the library. Used by PR 4's CALL_API
+ * step properties panel and any other surface that needs to attach a request
+ * to a spec.
+ */
+export function SpecPicker({
+  value,
+  onChange,
+  label = 'API Spec',
+  placeholder = 'Select an imported spec…',
+  className,
+}: SpecPickerProps): React.ReactElement {
+  const { keltaClient } = useApi()
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['api-specs'],
+    queryFn: () => keltaClient.admin.apiSpecs.list(),
+  })
+
+  const specs = data ?? []
+
+  return (
+    <div className={className ?? 'space-y-1'}>
+      <FieldLabel>{label}</FieldLabel>
+      <Select
+        value={value || ''}
+        onValueChange={(v) => {
+          const spec = specs.find((s) => s.id === v) ?? null
+          onChange(v, spec)
+        }}
+        disabled={isLoading || Boolean(error)}
+      >
+        <SelectTrigger>
+          <SelectValue placeholder={placeholder} />
+        </SelectTrigger>
+        <SelectContent>
+          {specs.map((s) => (
+            <SelectItem key={s.id} value={s.id}>
+              <div className="flex flex-col">
+                <span>{s.apiTitle || s.name}</span>
+                <span className="text-xs text-muted-foreground font-mono">
+                  {s.name} · v{s.apiVersion ?? '—'} · rev {s.revision}
+                </span>
+              </div>
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      {error && <p className="text-xs text-red-600">Failed to load specs</p>}
+      {!isLoading && specs.length === 0 && !error && (
+        <p className="text-xs text-muted-foreground">No specs imported yet.</p>
+      )}
+    </div>
+  )
+}

--- a/kelta-ui/app/src/pages/ApiSpecsPage/ApiSpecDetailPage.tsx
+++ b/kelta-ui/app/src/pages/ApiSpecsPage/ApiSpecDetailPage.tsx
@@ -1,0 +1,304 @@
+import React, { useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { Link, useParams } from 'react-router-dom'
+import { ArrowLeft, BookOpen, ChevronRight } from 'lucide-react'
+import type { ApiOperationDetail, ApiOperationSummary } from '@kelta/sdk'
+
+import { useApi } from '../../context/ApiContext'
+import { LoadingSpinner, ErrorMessage } from '../../components'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { FieldLabel } from '@/components/kelta'
+import { cn } from '@/lib/utils'
+
+export interface ApiSpecDetailPageProps {
+  className?: string
+}
+
+const METHOD_COLORS: Record<string, string> = {
+  GET: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-200',
+  POST: 'bg-sky-100 text-sky-800 dark:bg-sky-900/40 dark:text-sky-200',
+  PUT: 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200',
+  PATCH: 'bg-orange-100 text-orange-800 dark:bg-orange-900/40 dark:text-orange-200',
+  DELETE: 'bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-200',
+}
+
+export function ApiSpecDetailPage({ className }: ApiSpecDetailPageProps): React.ReactElement {
+  const { specId } = useParams<{ specId: string }>()
+  const { keltaClient } = useApi()
+
+  const specQuery = useQuery({
+    queryKey: ['api-spec', specId],
+    queryFn: () => keltaClient.admin.apiSpecs.get(specId!),
+    enabled: Boolean(specId),
+  })
+
+  const operationsQuery = useQuery({
+    queryKey: ['api-spec-operations', specId],
+    queryFn: () => keltaClient.admin.apiSpecs.listOperations(specId!),
+    enabled: Boolean(specId),
+  })
+
+  const rawQuery = useQuery({
+    queryKey: ['api-spec-raw', specId],
+    queryFn: () => keltaClient.admin.apiSpecs.raw(specId!),
+    enabled: Boolean(specId),
+  })
+
+  const [selected, setSelected] = useState<string | null>(null)
+  const [filter, setFilter] = useState('')
+
+  if (specQuery.isLoading) return <LoadingSpinner />
+  if (specQuery.error || !specQuery.data) {
+    return <ErrorMessage error="Failed to load spec" />
+  }
+
+  const spec = specQuery.data
+  const operations = operationsQuery.data ?? []
+  const filtered = filter
+    ? operations.filter(
+        (op) =>
+          op.pathTemplate.toLowerCase().includes(filter.toLowerCase()) ||
+          (op.summary?.toLowerCase().includes(filter.toLowerCase()) ?? false) ||
+          op.httpMethod.toLowerCase().includes(filter.toLowerCase())
+      )
+    : operations
+
+  const grouped = groupByTag(filtered)
+  const selectedOp = selected
+    ? operations.find((op) => op.syntheticOpId === selected) ?? null
+    : null
+
+  return (
+    <div className={cn('space-y-4', className)}>
+      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+        <Link to="/api-specs" className="inline-flex items-center gap-1 hover:text-foreground">
+          <ArrowLeft className="h-3.5 w-3.5" /> API Specs
+        </Link>
+        <ChevronRight className="h-3.5 w-3.5" />
+        <span className="text-foreground font-medium">{spec.apiTitle || spec.name}</span>
+      </div>
+
+      <div className="flex items-center gap-3">
+        <BookOpen className="h-6 w-6 text-primary" />
+        <div className="min-w-0">
+          <h1 className="text-[26px] font-bold tracking-[-0.01em] truncate">
+            {spec.apiTitle || spec.name}
+          </h1>
+          <p className="text-sm text-muted-foreground truncate">
+            <code className="font-mono">{spec.name}</code> · v{spec.apiVersion ?? '—'} ·
+            OpenAPI {spec.specVersion} · revision {spec.revision}
+          </p>
+        </div>
+      </div>
+
+      <Tabs defaultValue="operations">
+        <TabsList>
+          <TabsTrigger value="overview">Overview</TabsTrigger>
+          <TabsTrigger value="operations">Operations ({operations.length})</TabsTrigger>
+          <TabsTrigger value="raw">Raw</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="overview" className="space-y-4">
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">Spec details</CardTitle>
+            </CardHeader>
+            <CardContent className="grid gap-4 sm:grid-cols-2">
+              <KeyValue label="Name" value={spec.name} mono />
+              <KeyValue label="API title" value={spec.apiTitle ?? '—'} />
+              <KeyValue label="API version" value={spec.apiVersion ?? '—'} />
+              <KeyValue label="OpenAPI version" value={spec.specVersion} mono />
+              <KeyValue label="Base URL" value={spec.baseUrl ?? '—'} mono />
+              <KeyValue label="Source" value={spec.sourceType} mono />
+              {spec.sourceUrl && <KeyValue label="Source URL" value={spec.sourceUrl} mono />}
+              <KeyValue
+                label="Last imported"
+                value={
+                  spec.lastImportedAt ? new Date(spec.lastImportedAt).toLocaleString() : '—'
+                }
+              />
+              <KeyValue label="Active" value={spec.active ? 'Yes' : 'No'} />
+              <KeyValue label="Revision" value={String(spec.revision)} mono />
+              {spec.description && (
+                <div className="sm:col-span-2">
+                  <FieldLabel>Description</FieldLabel>
+                  <p className="text-sm">{spec.description}</p>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="operations" className="grid gap-4 lg:grid-cols-[minmax(0,2fr)_minmax(0,3fr)]">
+          <Card>
+            <CardContent className="p-3 space-y-2">
+              <Input
+                value={filter}
+                onChange={(e) => setFilter(e.target.value)}
+                placeholder="Filter by path, method, or summary"
+              />
+              <div className="max-h-[60vh] overflow-y-auto space-y-3 pt-1">
+                {Object.entries(grouped).map(([tag, ops]) => (
+                  <div key={tag}>
+                    <p className="px-1 text-[10px] uppercase tracking-wider text-muted-foreground">
+                      {tag}
+                    </p>
+                    <div className="rounded-md border">
+                      {ops.map((op) => (
+                        <button
+                          key={op.id}
+                          onClick={() => setSelected(op.syntheticOpId)}
+                          className={cn(
+                            'flex w-full items-center gap-2 px-2 py-1.5 text-left text-sm hover:bg-muted/50 border-b last:border-b-0',
+                            selected === op.syntheticOpId && 'bg-primary/10'
+                          )}
+                        >
+                          <span
+                            className={cn(
+                              'rounded px-1.5 py-0.5 text-[10px] font-mono font-bold',
+                              METHOD_COLORS[op.httpMethod] ?? 'bg-muted'
+                            )}
+                          >
+                            {op.httpMethod}
+                          </span>
+                          <span className="font-mono text-xs truncate">
+                            {op.pathTemplate}
+                          </span>
+                          {op.deprecated && (
+                            <span className="ml-auto text-[10px] text-muted-foreground">
+                              deprecated
+                            </span>
+                          )}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                ))}
+                {filtered.length === 0 && (
+                  <p className="p-3 text-xs text-muted-foreground">
+                    No operations match.
+                  </p>
+                )}
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardContent className="p-4">
+              {selectedOp ? (
+                <OperationDetailView specId={spec.id} op={selectedOp} />
+              ) : (
+                <p className="text-sm text-muted-foreground">
+                  Select an operation to view its details.
+                </p>
+              )}
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="raw">
+          <Card>
+            <CardContent className="p-0">
+              <pre className="max-h-[70vh] overflow-auto bg-muted/30 p-4 text-xs font-mono">
+                {rawQuery.isLoading ? 'Loading…' : (rawQuery.data ?? '')}
+              </pre>
+            </CardContent>
+          </Card>
+        </TabsContent>
+      </Tabs>
+    </div>
+  )
+}
+
+function groupByTag(operations: ApiOperationSummary[]): Record<string, ApiOperationSummary[]> {
+  const groups: Record<string, ApiOperationSummary[]> = {}
+  for (const op of operations) {
+    const tags = Array.isArray(op.tags) ? (op.tags as string[]) : []
+    const key = tags[0] || 'untagged'
+    if (!groups[key]) groups[key] = []
+    groups[key].push(op)
+  }
+  return groups
+}
+
+function KeyValue({
+  label,
+  value,
+  mono,
+}: {
+  label: string
+  value: string
+  mono?: boolean
+}) {
+  return (
+    <div className="space-y-1">
+      <FieldLabel>{label}</FieldLabel>
+      <p className={cn('text-sm break-all', mono && 'font-mono text-xs')}>{value}</p>
+    </div>
+  )
+}
+
+interface OperationDetailViewProps {
+  specId: string
+  op: ApiOperationSummary
+}
+
+function OperationDetailView({ specId, op }: OperationDetailViewProps) {
+  const { keltaClient } = useApi()
+  const detailQuery = useQuery({
+    queryKey: ['api-operation', specId, op.syntheticOpId],
+    queryFn: () => keltaClient.admin.apiSpecs.getOperation(specId, op.syntheticOpId),
+  })
+
+  if (detailQuery.isLoading || !detailQuery.data) {
+    return <p className="text-sm text-muted-foreground">Loading operation…</p>
+  }
+  const detail: ApiOperationDetail = detailQuery.data
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-2">
+        <span
+          className={cn(
+            'rounded px-2 py-0.5 text-xs font-mono font-bold',
+            METHOD_COLORS[detail.httpMethod] ?? 'bg-muted'
+          )}
+        >
+          {detail.httpMethod}
+        </span>
+        <span className="font-mono text-sm">{detail.pathTemplate}</span>
+        {detail.deprecated && (
+          <span className="text-xs text-muted-foreground">deprecated</span>
+        )}
+      </div>
+      {detail.summary && <p className="text-sm font-medium">{detail.summary}</p>}
+      {detail.description && (
+        <p className="text-sm text-muted-foreground whitespace-pre-wrap">
+          {detail.description}
+        </p>
+      )}
+      {detail.parametersSchema != null && (
+        <SchemaSection title="Parameters" schema={detail.parametersSchema} />
+      )}
+      {detail.requestBodySchema != null && (
+        <SchemaSection title="Request body" schema={detail.requestBodySchema} />
+      )}
+      {detail.responseSchemas != null && (
+        <SchemaSection title="Responses" schema={detail.responseSchemas} />
+      )}
+    </div>
+  )
+}
+
+function SchemaSection({ title, schema }: { title: string; schema: unknown }) {
+  return (
+    <div>
+      <FieldLabel>{title}</FieldLabel>
+      <pre className="mt-1 overflow-x-auto rounded-md border bg-muted/30 p-3 text-[11px] font-mono leading-snug">
+        {JSON.stringify(schema, null, 2)}
+      </pre>
+    </div>
+  )
+}

--- a/kelta-ui/app/src/pages/ApiSpecsPage/ApiSpecsPage.tsx
+++ b/kelta-ui/app/src/pages/ApiSpecsPage/ApiSpecsPage.tsx
@@ -1,0 +1,427 @@
+import React, { useState } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useNavigate } from 'react-router-dom'
+import { BookOpen, FileJson, Globe2, Plus, Trash2 } from 'lucide-react'
+import type { ApiSpecSummary, ApiSpecValidateResult, ImportApiSpecRequest } from '@kelta/sdk'
+
+import { useApi } from '../../context/ApiContext'
+import { useSystemPermissions } from '../../hooks/useSystemPermissions'
+import { useToast } from '../../components/Toast'
+import { LoadingSpinner, ErrorMessage } from '../../components'
+import { FileDropzone } from '../../components/FileDropzone/FileDropzone'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+import { Card, CardContent } from '@/components/ui/card'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { FieldLabel, StatusBadge } from '@/components/kelta'
+import { cn } from '@/lib/utils'
+
+export interface ApiSpecsPageProps {
+  className?: string
+}
+
+export function ApiSpecsPage({ className }: ApiSpecsPageProps): React.ReactElement {
+  const { keltaClient } = useApi()
+  const { hasPermission } = useSystemPermissions()
+  const { showToast } = useToast()
+  const queryClient = useQueryClient()
+  const navigate = useNavigate()
+
+  const canManage = hasPermission('MANAGE_API_SPECS')
+  const [importOpen, setImportOpen] = useState(false)
+
+  const specsQuery = useQuery({
+    queryKey: ['api-specs'],
+    queryFn: () => keltaClient.admin.apiSpecs.list(),
+  })
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => keltaClient.admin.apiSpecs.delete(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['api-specs'] })
+      showToast('Spec deleted', 'success')
+    },
+    onError: () => showToast('Delete failed', 'error'),
+  })
+
+  if (specsQuery.isLoading) return <LoadingSpinner />
+  if (specsQuery.error) return <ErrorMessage error="Failed to load specs" />
+
+  const specs = specsQuery.data ?? []
+
+  return (
+    <div className={cn('space-y-6', className)}>
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <BookOpen className="h-6 w-6 text-primary" />
+          <div>
+            <h1 className="text-[26px] font-bold tracking-[-0.01em]">API Specs</h1>
+            <p className="text-sm text-muted-foreground">
+              OpenAPI 3.x specs imported into the platform. Pick operations from
+              these in the flow builder.
+            </p>
+          </div>
+        </div>
+        {canManage && (
+          <Button onClick={() => setImportOpen(true)}>
+            <Plus className="mr-2 h-4 w-4" />
+            Import spec
+          </Button>
+        )}
+      </div>
+
+      {specs.length === 0 ? (
+        <Card>
+          <CardContent className="flex flex-col items-center justify-center gap-4 py-16 text-center">
+            <FileJson className="h-12 w-12 text-muted-foreground" />
+            <div className="space-y-1">
+              <p className="text-base font-medium">No API specs yet</p>
+              <p className="text-sm text-muted-foreground">
+                Import an OpenAPI 3.x spec to start using its operations in workflows.
+              </p>
+            </div>
+            {canManage && (
+              <Button onClick={() => setImportOpen(true)}>
+                <Plus className="mr-2 h-4 w-4" />
+                Import your first spec
+              </Button>
+            )}
+          </CardContent>
+        </Card>
+      ) : (
+        <SpecList
+          specs={specs}
+          canManage={canManage}
+          onOpen={(s) => navigate(`/api-specs/${s.id}`)}
+          onDelete={(s) => {
+            if (
+              confirm(
+                `Delete spec '${s.name}'? Flows that reference its operations will fail until updated.`
+              )
+            ) {
+              deleteMutation.mutate(s.id)
+            }
+          }}
+        />
+      )}
+
+      {importOpen && (
+        <ImportSpecDialog
+          onClose={() => setImportOpen(false)}
+          onImported={() => {
+            queryClient.invalidateQueries({ queryKey: ['api-specs'] })
+            setImportOpen(false)
+          }}
+        />
+      )}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Spec list
+// ---------------------------------------------------------------------------
+
+interface SpecListProps {
+  specs: ApiSpecSummary[]
+  canManage: boolean
+  onOpen: (s: ApiSpecSummary) => void
+  onDelete: (s: ApiSpecSummary) => void
+}
+
+function SpecList({ specs, canManage, onOpen, onDelete }: SpecListProps) {
+  return (
+    <Card>
+      <CardContent className="p-0">
+        <table className="w-full text-sm">
+          <thead className="border-b bg-muted/30">
+            <tr className="text-left">
+              <th className="px-4 py-3 font-medium">Title</th>
+              <th className="px-4 py-3 font-medium">Base URL</th>
+              <th className="px-4 py-3 font-medium">Source</th>
+              <th className="px-4 py-3 font-medium">Revision</th>
+              <th className="px-4 py-3 font-medium">Status</th>
+              <th className="px-4 py-3" />
+            </tr>
+          </thead>
+          <tbody>
+            {specs.map((s) => (
+              <tr key={s.id} className="border-b last:border-b-0">
+                <td className="px-4 py-3">
+                  <button
+                    onClick={() => onOpen(s)}
+                    className="text-left hover:underline"
+                  >
+                    <div className="font-medium">{s.apiTitle || s.name}</div>
+                    <div className="text-xs text-muted-foreground font-mono">
+                      {s.name} · v{s.apiVersion ?? '—'} · OpenAPI {s.specVersion}
+                    </div>
+                  </button>
+                </td>
+                <td className="px-4 py-3 text-xs font-mono text-muted-foreground">
+                  {s.baseUrl ?? '—'}
+                </td>
+                <td className="px-4 py-3 text-xs">
+                  <span className="inline-flex items-center gap-1">
+                    {s.sourceType === 'URL' ? (
+                      <>
+                        <Globe2 className="h-3 w-3" /> URL
+                      </>
+                    ) : (
+                      <>
+                        <FileJson className="h-3 w-3" /> Inline
+                      </>
+                    )}
+                  </span>
+                </td>
+                <td className="px-4 py-3 text-xs font-mono">{s.revision}</td>
+                <td className="px-4 py-3">
+                  <StatusBadge
+                    variant={s.active ? 'active' : 'inactive'}
+                    label={s.active ? 'Active' : 'Inactive'}
+                  />
+                </td>
+                <td className="px-4 py-3">
+                  <div className="flex gap-2 justify-end">
+                    <Button size="sm" variant="outline" onClick={() => onOpen(s)}>
+                      Open
+                    </Button>
+                    {canManage && (
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={() => onDelete(s)}
+                        title="Delete spec"
+                      >
+                        <Trash2 className="h-3.5 w-3.5" />
+                      </Button>
+                    )}
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </CardContent>
+    </Card>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Import dialog
+// ---------------------------------------------------------------------------
+
+interface ImportSpecDialogProps {
+  onClose: () => void
+  onImported: () => void
+}
+
+function ImportSpecDialog({ onClose, onImported }: ImportSpecDialogProps) {
+  const { keltaClient } = useApi()
+  const { showToast } = useToast()
+
+  const [tab, setTab] = useState<'url' | 'paste' | 'file'>('url')
+  const [name, setName] = useState('')
+  const [description, setDescription] = useState('')
+  const [sourceUrl, setSourceUrl] = useState('')
+  const [raw, setRaw] = useState('')
+  const [rawFormat, setRawFormat] = useState<'json' | 'yaml'>('json')
+  const [validationResult, setValidationResult] = useState<ApiSpecValidateResult | null>(null)
+  const [submitting, setSubmitting] = useState(false)
+
+  const handleFile = async (file: File) => {
+    const text = await file.text()
+    setRaw(text)
+    setRawFormat(file.name.toLowerCase().endsWith('.json') ? 'json' : 'yaml')
+    setTab('paste')
+    setValidationResult(null)
+  }
+
+  const validate = async () => {
+    try {
+      const body: { raw?: string; sourceUrl?: string } =
+        tab === 'url' ? { sourceUrl } : { raw }
+      const result = await keltaClient.admin.apiSpecs.validate(body)
+      setValidationResult(result)
+    } catch (e) {
+      setValidationResult({
+        ok: false,
+        error: e instanceof Error ? e.message : 'Validation failed',
+      })
+    }
+  }
+
+  const submit = async () => {
+    if (!name.trim()) {
+      showToast('Name is required', 'error')
+      return
+    }
+    setSubmitting(true)
+    try {
+      const request: ImportApiSpecRequest =
+        tab === 'url'
+          ? {
+              name,
+              description: description || undefined,
+              sourceType: 'URL',
+              sourceUrl,
+            }
+          : {
+              name,
+              description: description || undefined,
+              sourceType: rawFormat === 'json' ? 'INLINE_JSON' : 'INLINE_YAML',
+              raw,
+              rawFormat,
+            }
+      const result = await keltaClient.admin.apiSpecs.importSpec(request)
+      showToast(
+        `Imported '${result.spec.apiTitle ?? result.spec.name}' (${result.diff.added + result.diff.changed} operations)`,
+        'success'
+      )
+      onImported()
+    } catch (e) {
+      const message = e instanceof Error ? e.message : 'Import failed'
+      showToast(message, 'error')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <Dialog open onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Import OpenAPI spec</DialogTitle>
+          <DialogDescription>
+            Import an OpenAPI 3.x spec from a URL, paste it inline, or drop a file.
+            The platform indexes every operation so they can be picked from the flow
+            builder.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div className="space-y-1">
+              <FieldLabel>Name</FieldLabel>
+              <Input
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="e.g., petstore"
+              />
+              <p className="text-xs text-muted-foreground">
+                Tenant-unique identifier referenced from flows.
+              </p>
+            </div>
+            <div className="space-y-1">
+              <FieldLabel>Description (optional)</FieldLabel>
+              <Input
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="Production Petstore catalog"
+              />
+            </div>
+          </div>
+
+          <Tabs value={tab} onValueChange={(v) => setTab(v as 'url' | 'paste' | 'file')}>
+            <TabsList>
+              <TabsTrigger value="url">From URL</TabsTrigger>
+              <TabsTrigger value="paste">Paste</TabsTrigger>
+              <TabsTrigger value="file">Drop file</TabsTrigger>
+            </TabsList>
+            <TabsContent value="url" className="space-y-1">
+              <FieldLabel>Spec URL</FieldLabel>
+              <Input
+                value={sourceUrl}
+                onChange={(e) => {
+                  setSourceUrl(e.target.value)
+                  setValidationResult(null)
+                }}
+                placeholder="https://petstore3.swagger.io/api/v3/openapi.json"
+              />
+              <p className="text-xs text-muted-foreground">
+                The worker fetches the URL server-side; the spec is parsed and stored.
+              </p>
+            </TabsContent>
+            <TabsContent value="paste" className="space-y-2">
+              <div className="flex items-center gap-2">
+                <FieldLabel>Format</FieldLabel>
+                <select
+                  value={rawFormat}
+                  onChange={(e) => setRawFormat(e.target.value as 'json' | 'yaml')}
+                  className="h-7 rounded border bg-background px-2 text-xs"
+                >
+                  <option value="json">JSON</option>
+                  <option value="yaml">YAML</option>
+                </select>
+              </div>
+              <Textarea
+                rows={12}
+                value={raw}
+                onChange={(e) => {
+                  setRaw(e.target.value)
+                  setValidationResult(null)
+                }}
+                placeholder={
+                  rawFormat === 'json'
+                    ? '{ "openapi": "3.0.3", ... }'
+                    : 'openapi: 3.0.3\\ninfo:\\n  title: ...'
+                }
+                className="font-mono text-xs"
+              />
+            </TabsContent>
+            <TabsContent value="file">
+              <FileDropzone
+                accept=".json,.yaml,.yml,application/json,application/yaml,text/yaml"
+                maxBytes={5_000_000}
+                onFile={handleFile}
+                onError={(msg) => showToast(msg, 'error')}
+                hint="OpenAPI 3.x JSON or YAML, up to 5 MB"
+              />
+              {raw && (
+                <p className="mt-2 text-xs text-muted-foreground">
+                  {(raw.length / 1024).toFixed(1)} KB loaded · format: {rawFormat}
+                </p>
+              )}
+            </TabsContent>
+          </Tabs>
+
+          <div className="flex items-center gap-3">
+            <Button variant="outline" onClick={validate}>
+              Validate
+            </Button>
+            {validationResult && (
+              <span
+                className={cn(
+                  'text-sm',
+                  validationResult.ok ? 'text-green-600' : 'text-red-600'
+                )}
+              >
+                {validationResult.ok
+                  ? `${validationResult.title ?? 'Spec'} v${validationResult.version ?? '?'} — ${validationResult.operations} operations, base ${validationResult.baseUrl || '—'}`
+                  : `Invalid: ${validationResult.error}`}
+              </span>
+            )}
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose} disabled={submitting}>
+            Cancel
+          </Button>
+          <Button onClick={submit} disabled={submitting}>
+            {submitting ? 'Importing…' : 'Import'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/kelta-ui/app/src/pages/ApiSpecsPage/index.ts
+++ b/kelta-ui/app/src/pages/ApiSpecsPage/index.ts
@@ -1,0 +1,4 @@
+export { ApiSpecsPage } from './ApiSpecsPage'
+export type { ApiSpecsPageProps } from './ApiSpecsPage'
+export { ApiSpecDetailPage } from './ApiSpecDetailPage'
+export type { ApiSpecDetailPageProps } from './ApiSpecDetailPage'

--- a/kelta-ui/app/src/pages/SetupHomePage/SetupHomePage.tsx
+++ b/kelta-ui/app/src/pages/SetupHomePage/SetupHomePage.tsx
@@ -189,6 +189,12 @@ const CATEGORIES: SetupCategory[] = [
         permission: 'VIEW_CREDENTIALS',
       },
       {
+        name: 'API Specs',
+        path: '/api-specs',
+        description: 'OpenAPI spec library used by the flow builder',
+        permission: 'VIEW_API_SPECS',
+      },
+      {
         name: 'Webhooks',
         path: '/webhooks',
         description: 'Configure outbound webhooks',

--- a/kelta-ui/app/src/pages/index.ts
+++ b/kelta-ui/app/src/pages/index.ts
@@ -209,6 +209,10 @@ export type { ConnectedAppsPageProps } from './ConnectedAppsPage'
 export { CredentialsPage } from './CredentialsPage'
 export type { CredentialsPageProps } from './CredentialsPage'
 
+// ApiSpecsPage - OpenAPI spec library (PR 3)
+export { ApiSpecsPage, ApiSpecDetailPage } from './ApiSpecsPage'
+export type { ApiSpecsPageProps, ApiSpecDetailPageProps } from './ApiSpecsPage'
+
 // ApiTokensPage - Personal access token management page
 export { ApiTokensPage } from './ApiTokensPage'
 export type { ApiTokensPageProps } from './ApiTokensPage'

--- a/kelta-web/packages/sdk/src/admin/AdminClient.ts
+++ b/kelta-web/packages/sdk/src/admin/AdminClient.ts
@@ -1,9 +1,15 @@
 import type { AxiosInstance } from 'axios';
 import type {
   CollectionDefinition,
+  ApiOperationDetail,
+  ApiOperationSummary,
+  ApiSpecSummary,
+  ApiSpecValidateResult,
   CredentialTemplateDescriptor,
   CredentialTestResultPayload,
   CredentialTypeDescriptor,
+  ImportApiSpecRequest,
+  ImportApiSpecResponse,
   FieldDefinition,
   Role,
   Policy,
@@ -1895,6 +1901,67 @@ export class AdminClient {
         redirectUri,
       });
       return response.data as { ok: boolean; expiresAt?: string; scope?: string };
+    },
+  };
+
+  // ---------------------------------------------------------------------------
+  // OpenAPI Spec Library (PR 3)
+  // ---------------------------------------------------------------------------
+
+  readonly apiSpecs = {
+    list: async (): Promise<ApiSpecSummary[]> => {
+      const response = await this.axios.get('/api/api-specs/library');
+      return (response.data as { data: ApiSpecSummary[] }).data ?? [];
+    },
+
+    get: async (id: string): Promise<ApiSpecSummary> => {
+      const response = await this.axios.get(`/api/api-specs/${id}/details`);
+      return response.data as ApiSpecSummary;
+    },
+
+    raw: async (id: string): Promise<string> => {
+      const response = await this.axios.get(`/api/api-specs/${id}/raw`, {
+        responseType: 'text',
+        transformResponse: (v: unknown) => (typeof v === 'string' ? v : JSON.stringify(v)),
+      });
+      return String(response.data ?? '');
+    },
+
+    importSpec: async (request: ImportApiSpecRequest): Promise<ImportApiSpecResponse> => {
+      const response = await this.axios.post('/api/api-specs/import', request);
+      return response.data as ImportApiSpecResponse;
+    },
+
+    validate: async (request: {
+      raw?: string;
+      sourceUrl?: string;
+    }): Promise<ApiSpecValidateResult> => {
+      const response = await this.axios.post('/api/api-specs/validate', request);
+      return response.data as ApiSpecValidateResult;
+    },
+
+    delete: async (id: string): Promise<void> => {
+      await this.axios.delete(`/api/api-specs/${id}`);
+    },
+
+    listOperations: async (specId: string): Promise<ApiOperationSummary[]> => {
+      const response = await this.axios.get(`/api/api-specs/${specId}/operations`);
+      return (response.data as { data: ApiOperationSummary[] }).data ?? [];
+    },
+
+    getOperation: async (specId: string, opId: string): Promise<ApiOperationDetail> => {
+      const response = await this.axios.get(`/api/api-specs/${specId}/operations/${opId}`);
+      return response.data as ApiOperationDetail;
+    },
+
+    searchOperations: async (params: {
+      q?: string;
+      method?: string;
+      specId?: string;
+      limit?: number;
+    }): Promise<ApiOperationSummary[]> => {
+      const response = await this.axios.get('/api/api-operations/search', { params });
+      return (response.data as { data: ApiOperationSummary[] }).data ?? [];
     },
   };
 

--- a/kelta-web/packages/sdk/src/admin/types.ts
+++ b/kelta-web/packages/sdk/src/admin/types.ts
@@ -1961,3 +1961,68 @@ export interface CredentialRecord {
   createdAt?: string;
   updatedAt?: string;
 }
+
+// ----------------------------------------------------------------------------
+// OpenAPI Spec Library (PR 3)
+// ----------------------------------------------------------------------------
+
+export interface ApiSpecSummary {
+  id: string;
+  name: string;
+  description?: string | null;
+  specVersion: string;
+  apiTitle?: string | null;
+  apiVersion?: string | null;
+  baseUrl?: string | null;
+  servers?: unknown;
+  securitySchemes?: unknown;
+  sourceType: 'INLINE_JSON' | 'INLINE_YAML' | 'URL';
+  sourceUrl?: string | null;
+  revision: number;
+  active: boolean;
+  lastImportedAt?: string | null;
+}
+
+export interface ApiOperationSummary {
+  id: string;
+  specId: string;
+  operationId?: string | null;
+  syntheticOpId: string;
+  httpMethod: string;
+  pathTemplate: string;
+  summary?: string | null;
+  tags?: unknown;
+  deprecated: boolean;
+}
+
+export interface ApiOperationDetail extends ApiOperationSummary {
+  description?: string | null;
+  parametersSchema?: unknown;
+  requestBodySchema?: unknown;
+  responseSchemas?: unknown;
+  securityRequired?: unknown;
+}
+
+export interface ImportApiSpecRequest {
+  name: string;
+  description?: string;
+  sourceType: 'INLINE_JSON' | 'INLINE_YAML' | 'URL';
+  sourceUrl?: string;
+  raw?: string;
+  rawFormat?: 'json' | 'yaml';
+}
+
+export interface ImportApiSpecResponse {
+  spec: ApiSpecSummary;
+  diff: { added: number; changed: number; removed: number };
+}
+
+export interface ApiSpecValidateResult {
+  ok: boolean;
+  title?: string;
+  version?: string;
+  specVersion?: string;
+  operations?: number;
+  baseUrl?: string;
+  error?: string;
+}

--- a/kelta-web/packages/sdk/src/index.ts
+++ b/kelta-web/packages/sdk/src/index.ts
@@ -140,6 +140,12 @@ export type {
   CredentialTypeDescriptor,
   CredentialTemplateDescriptor,
   CredentialTestResultPayload,
+  ApiSpecSummary,
+  ApiOperationSummary,
+  ApiOperationDetail,
+  ImportApiSpecRequest,
+  ImportApiSpecResponse,
+  ApiSpecValidateResult,
 } from './admin/types';
 
 // Authentication

--- a/kelta-worker/src/main/java/io/kelta/worker/config/FlowConfig.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/config/FlowConfig.java
@@ -22,8 +22,10 @@ import io.kelta.worker.listener.FieldConfigEventPublisher;
 import io.kelta.worker.listener.ApprovalProcessConfigHook;
 import io.kelta.worker.listener.ApprovalRecordLockHook;
 import io.kelta.worker.listener.CerbosPolicySyncHook;
+import io.kelta.worker.listener.ApiSpecConfigHook;
 import io.kelta.worker.listener.CredentialEncryptionHook;
 import io.kelta.worker.listener.CredentialEventPublisher;
+import io.kelta.runtime.module.integration.api.OpenApiSpecParser;
 import io.kelta.worker.listener.RecordTypeEnforcementHook;
 import io.kelta.worker.listener.ValidationRuleRefreshHook;
 import io.kelta.crypto.EncryptionService;
@@ -285,6 +287,24 @@ public class FlowConfig {
             BeforeSaveHookRegistry hookRegistry,
             PlatformEventPublisher eventPublisher) {
         CredentialEventPublisher hook = new CredentialEventPublisher(eventPublisher);
+        hookRegistry.register(hook);
+        return hook;
+    }
+
+    // ---------------------------------------------------------------------------
+    // OpenAPI spec library — parser bean + NATS broadcast on spec changes
+    // ---------------------------------------------------------------------------
+
+    @Bean
+    public OpenApiSpecParser openApiSpecParser(ObjectMapper objectMapper) {
+        return new OpenApiSpecParser(objectMapper);
+    }
+
+    @Bean
+    public ApiSpecConfigHook apiSpecConfigHook(
+            BeforeSaveHookRegistry hookRegistry,
+            PlatformEventPublisher eventPublisher) {
+        ApiSpecConfigHook hook = new ApiSpecConfigHook(eventPublisher);
         hookRegistry.register(hook);
         return hook;
     }

--- a/kelta-worker/src/main/java/io/kelta/worker/controller/ApiSpecController.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/controller/ApiSpecController.java
@@ -1,0 +1,271 @@
+package io.kelta.worker.controller;
+
+import io.kelta.runtime.context.TenantContext;
+import io.kelta.runtime.module.integration.api.ApiOperation;
+import io.kelta.runtime.module.integration.api.ApiSpec;
+import io.kelta.runtime.module.integration.api.OpenApiParseException;
+import io.kelta.runtime.module.integration.api.OpenApiSpecParser;
+import io.kelta.runtime.module.integration.api.ParsedSpec;
+import io.kelta.worker.repository.ApiOperationRepository;
+import io.kelta.worker.service.api.ApiSpecService;
+import io.kelta.worker.service.api.ApiSpecService.ImportRequest;
+import io.kelta.worker.service.api.ApiSpecService.ImportResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * REST endpoints for the OpenAPI spec library.
+ *
+ * <p>CRUD on the {@code api-specs} system collection routes through
+ * {@code DynamicCollectionRouter} and produces JSON:API responses; this
+ * controller adds operation-level reads, search, raw-text fetch, validate-only,
+ * and the import (POST/PUT) entry points where the worker invokes the parser.
+ */
+@RestController
+@RequestMapping("/api")
+public class ApiSpecController {
+
+    private static final Logger log = LoggerFactory.getLogger(ApiSpecController.class);
+
+    private final ApiSpecService specService;
+    private final ApiOperationRepository operationRepository;
+    private final OpenApiSpecParser parser;
+
+    public ApiSpecController(ApiSpecService specService,
+                              ApiOperationRepository operationRepository,
+                              OpenApiSpecParser parser) {
+        this.specService = specService;
+        this.operationRepository = operationRepository;
+        this.parser = parser;
+    }
+
+    // ---------------------------------------------------------------------
+    // Spec listing + retrieval (parallel to the JSON:API CRUD path; these
+    // are convenience endpoints the UI uses when it wants the parsed shape
+    // rather than the system-collection wire format)
+    // ---------------------------------------------------------------------
+
+    @GetMapping("/api-specs/library")
+    public ResponseEntity<?> list() {
+        String tenantId = TenantContext.get();
+        if (tenantId == null) {
+            return ResponseEntity.badRequest().body(Map.of("error", "No tenant context"));
+        }
+        List<Map<String, Object>> specs = specService.listActive(tenantId).stream()
+            .map(ApiSpecController::summarize).toList();
+        return ResponseEntity.ok(Map.of("data", specs));
+    }
+
+    @GetMapping("/api-specs/{id}/details")
+    public ResponseEntity<?> get(@PathVariable String id) {
+        String tenantId = TenantContext.get();
+        if (tenantId == null) {
+            return ResponseEntity.badRequest().body(Map.of("error", "No tenant context"));
+        }
+        return specService.findById(id, tenantId)
+            .map(ApiSpecController::summarize)
+            .<ResponseEntity<?>>map(ResponseEntity::ok)
+            .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @GetMapping(value = "/api-specs/{id}/raw", produces = MediaType.TEXT_PLAIN_VALUE)
+    public ResponseEntity<?> raw(@PathVariable String id) {
+        String tenantId = TenantContext.get();
+        if (tenantId == null) {
+            return ResponseEntity.badRequest().body("No tenant context");
+        }
+        Optional<ApiSpec> spec = specService.findById(id, tenantId);
+        return spec.<ResponseEntity<?>>map(s -> ResponseEntity.ok(s.rawSpec()))
+            .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @DeleteMapping("/api-specs/{id}")
+    public ResponseEntity<?> delete(@PathVariable String id) {
+        String tenantId = TenantContext.get();
+        if (tenantId == null) {
+            return ResponseEntity.badRequest().body(Map.of("error", "No tenant context"));
+        }
+        specService.softDelete(id, tenantId, /*userId*/ null);
+        return ResponseEntity.noContent().build();
+    }
+
+    // ---------------------------------------------------------------------
+    // Import / re-import
+    // ---------------------------------------------------------------------
+
+    @PostMapping("/api-specs/import")
+    public ResponseEntity<?> importSpec(@RequestBody ImportRequest body) {
+        String tenantId = TenantContext.get();
+        if (tenantId == null) {
+            return ResponseEntity.badRequest().body(Map.of("error", "No tenant context"));
+        }
+        try {
+            ImportResult result = specService.importSpec(body, tenantId, /*userId*/ null);
+            return ResponseEntity.status(HttpStatus.CREATED).body(toMap(result));
+        } catch (OpenApiParseException e) {
+            return ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY)
+                .body(Map.of("error", "Failed to parse spec", "message", e.getMessage()));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest()
+                .body(Map.of("error", e.getMessage()));
+        } catch (Exception e) {
+            log.error("Spec import failed: {}", e.getMessage(), e);
+            return ResponseEntity.internalServerError()
+                .body(Map.of("error", "Spec import failed", "message", e.getMessage()));
+        }
+    }
+
+    @PostMapping("/api-specs/validate")
+    public ResponseEntity<?> validate(@RequestBody Map<String, String> body) {
+        String raw = body.get("raw");
+        String url = body.get("sourceUrl");
+        try {
+            String content = raw != null && !raw.isBlank()
+                ? raw
+                : fetch(url);
+            ParsedSpec parsed = parser.parse(content);
+            return ResponseEntity.ok(Map.of(
+                "ok", true,
+                "title", parsed.apiTitle() == null ? "" : parsed.apiTitle(),
+                "version", parsed.apiVersion() == null ? "" : parsed.apiVersion(),
+                "specVersion", parsed.specVersion(),
+                "operations", parsed.operations().size(),
+                "baseUrl", parsed.baseUrl() == null ? "" : parsed.baseUrl()));
+        } catch (OpenApiParseException e) {
+            return ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY)
+                .body(Map.of("ok", false, "error", e.getMessage()));
+        } catch (Exception e) {
+            return ResponseEntity.badRequest()
+                .body(Map.of("ok", false, "error", e.getMessage()));
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // Operations
+    // ---------------------------------------------------------------------
+
+    @GetMapping("/api-specs/{id}/operations")
+    public ResponseEntity<?> listOperations(@PathVariable String id) {
+        String tenantId = TenantContext.get();
+        if (tenantId == null) {
+            return ResponseEntity.badRequest().body(Map.of("error", "No tenant context"));
+        }
+        List<Map<String, Object>> ops = operationRepository.listBySpec(tenantId, id).stream()
+            .map(ApiSpecController::summarizeOp).toList();
+        return ResponseEntity.ok(Map.of("data", ops));
+    }
+
+    @GetMapping("/api-specs/{specId}/operations/{opId}")
+    public ResponseEntity<?> getOperation(@PathVariable String specId,
+                                           @PathVariable String opId) {
+        String tenantId = TenantContext.get();
+        if (tenantId == null) {
+            return ResponseEntity.badRequest().body(Map.of("error", "No tenant context"));
+        }
+        return operationRepository.findOperation(tenantId, specId, opId)
+            .<ResponseEntity<?>>map(op -> ResponseEntity.ok(detailOp(op)))
+            .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @GetMapping("/api-operations/search")
+    public ResponseEntity<?> searchOperations(
+            @RequestParam(value = "q", required = false) String q,
+            @RequestParam(value = "method", required = false) String method,
+            @RequestParam(value = "specId", required = false) String specId,
+            @RequestParam(value = "limit", defaultValue = "50") int limit) {
+        String tenantId = TenantContext.get();
+        if (tenantId == null) {
+            return ResponseEntity.badRequest().body(Map.of("error", "No tenant context"));
+        }
+        List<Map<String, Object>> ops = operationRepository
+            .search(tenantId, q, method, specId, limit).stream()
+            .map(ApiSpecController::summarizeOp).toList();
+        return ResponseEntity.ok(Map.of("data", ops));
+    }
+
+    // ---------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------
+
+    private static Map<String, Object> summarize(ApiSpec spec) {
+        Map<String, Object> out = new LinkedHashMap<>();
+        out.put("id", spec.id());
+        out.put("name", spec.name());
+        out.put("description", spec.description());
+        out.put("specVersion", spec.specVersion());
+        out.put("apiTitle", spec.apiTitle());
+        out.put("apiVersion", spec.apiVersion());
+        out.put("baseUrl", spec.baseUrl());
+        out.put("servers", spec.servers());
+        out.put("securitySchemes", spec.securitySchemes());
+        out.put("sourceType", spec.sourceType());
+        out.put("sourceUrl", spec.sourceUrl());
+        out.put("revision", spec.revision());
+        out.put("active", spec.active());
+        out.put("lastImportedAt", spec.lastImportedAt() == null
+            ? null : spec.lastImportedAt().toString());
+        return out;
+    }
+
+    private static Map<String, Object> summarizeOp(ApiOperation op) {
+        Map<String, Object> out = new LinkedHashMap<>();
+        out.put("id", op.id());
+        out.put("specId", op.specId());
+        out.put("operationId", op.operationId());
+        out.put("syntheticOpId", op.syntheticOpId());
+        out.put("httpMethod", op.httpMethod());
+        out.put("pathTemplate", op.pathTemplate());
+        out.put("summary", op.summary());
+        out.put("tags", op.tags());
+        out.put("deprecated", op.deprecated());
+        return out;
+    }
+
+    private static Map<String, Object> detailOp(ApiOperation op) {
+        Map<String, Object> out = summarizeOp(op);
+        out.put("description", op.description());
+        out.put("parametersSchema", op.parametersSchema());
+        out.put("requestBodySchema", op.requestBodySchema());
+        out.put("responseSchemas", op.responseSchemas());
+        out.put("securityRequired", op.securityRequired());
+        return out;
+    }
+
+    private static Map<String, Object> toMap(ImportResult result) {
+        Map<String, Object> out = new LinkedHashMap<>();
+        out.put("spec", summarize(result.spec()));
+        out.put("diff", Map.of(
+            "added", result.diff().added(),
+            "changed", result.diff().changed(),
+            "removed", result.diff().removed()));
+        return out;
+    }
+
+    private static String fetch(String url) throws Exception {
+        if (url == null || url.isBlank()) {
+            throw new IllegalArgumentException("Provide either 'raw' or 'sourceUrl'");
+        }
+        java.net.http.HttpClient client = java.net.http.HttpClient.newBuilder()
+            .connectTimeout(java.time.Duration.ofSeconds(10)).build();
+        java.net.http.HttpResponse<String> res = client.send(
+            java.net.http.HttpRequest.newBuilder()
+                .uri(java.net.URI.create(url))
+                .timeout(java.time.Duration.ofSeconds(10))
+                .header("Accept", "application/json, application/yaml, text/yaml")
+                .GET().build(),
+            java.net.http.HttpResponse.BodyHandlers.ofString());
+        if (res.statusCode() / 100 != 2) {
+            throw new IllegalStateException("HTTP " + res.statusCode());
+        }
+        return res.body();
+    }
+}

--- a/kelta-worker/src/main/java/io/kelta/worker/listener/ApiSpecConfigHook.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/listener/ApiSpecConfigHook.java
@@ -1,0 +1,72 @@
+package io.kelta.worker.listener;
+
+import io.kelta.runtime.event.ChangeType;
+import io.kelta.runtime.event.EventFactory;
+import io.kelta.runtime.event.PlatformEvent;
+import io.kelta.runtime.event.PlatformEventPublisher;
+import io.kelta.runtime.workflow.BeforeSaveHook;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Broadcasts {@code kelta.config.api-spec.changed.<id>} after spec
+ * create/update/delete so all worker pods can refresh local caches if they
+ * keep any (currently the {@link io.kelta.worker.service.api.JdbcApiSpecStore}
+ * is stateless, but PR 4's CALL_API handler may add a parsed-spec cache).
+ */
+public class ApiSpecConfigHook implements BeforeSaveHook {
+
+    private static final Logger log = LoggerFactory.getLogger(ApiSpecConfigHook.class);
+    static final String SUBJECT_PREFIX = "kelta.config.api-spec.changed.";
+    private static final String EVENT_TYPE = "kelta.config.api-spec.changed";
+
+    private final PlatformEventPublisher eventPublisher;
+
+    public ApiSpecConfigHook(PlatformEventPublisher eventPublisher) {
+        this.eventPublisher = eventPublisher;
+    }
+
+    @Override public String getCollectionName() { return "api-specs"; }
+    @Override public int getOrder() { return 100; }
+
+    @Override
+    public void afterCreate(Map<String, Object> record, String tenantId) {
+        publish(record, ChangeType.CREATED, tenantId);
+    }
+
+    @Override
+    public void afterUpdate(String id, Map<String, Object> record,
+                             Map<String, Object> previous, String tenantId) {
+        publish(record, ChangeType.UPDATED, tenantId);
+    }
+
+    @Override
+    public void afterDelete(String id, String tenantId) {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("id", id);
+        payload.put("changeType", ChangeType.DELETED.name());
+        send(payload, id, tenantId);
+    }
+
+    private void publish(Map<String, Object> record, ChangeType changeType, String tenantId) {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("id", record.get("id"));
+        payload.put("name", record.get("name"));
+        payload.put("changeType", changeType.name());
+        Object id = record.get("id");
+        if (id == null) {
+            log.warn("Skipping api-spec changed event: record missing id");
+            return;
+        }
+        send(payload, id.toString(), tenantId);
+    }
+
+    private void send(Map<String, Object> payload, String id, String tenantId) {
+        PlatformEvent<Map<String, Object>> event = EventFactory.createEvent(EVENT_TYPE, payload);
+        event.setTenantId(tenantId);
+        eventPublisher.publish(SUBJECT_PREFIX + id, event);
+    }
+}

--- a/kelta-worker/src/main/java/io/kelta/worker/listener/TenantProvisioningHook.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/listener/TenantProvisioningHook.java
@@ -36,7 +36,8 @@ public class TenantProvisioningHook implements BeforeSaveHook {
             "MANAGE_SHARING", "MANAGE_WORKFLOWS", "MANAGE_REPORTS", "MANAGE_EMAIL_TEMPLATES",
             "MANAGE_CONNECTED_APPS", "MANAGE_DATA", "API_ACCESS", "VIEW_ALL_DATA",
             "MODIFY_ALL_DATA", "MANAGE_APPROVALS", "MANAGE_LISTVIEWS", "MANAGE_TENANTS",
-            "MANAGE_CREDENTIALS", "VIEW_CREDENTIALS"
+            "MANAGE_CREDENTIALS", "VIEW_CREDENTIALS",
+            "MANAGE_API_SPECS", "VIEW_API_SPECS"
     );
 
     private final JdbcTemplate jdbcTemplate;
@@ -104,10 +105,11 @@ public class TenantProvisioningHook implements BeforeSaveHook {
                                 "MANAGE_SHARING", "MANAGE_WORKFLOWS", "MANAGE_REPORTS", "MANAGE_EMAIL_TEMPLATES",
                                 "MANAGE_CONNECTED_APPS", "MANAGE_DATA", "API_ACCESS", "VIEW_ALL_DATA",
                                 "MODIFY_ALL_DATA", "MANAGE_APPROVALS", "MANAGE_LISTVIEWS",
-                                "MANAGE_CREDENTIALS", "VIEW_CREDENTIALS")),
+                                "MANAGE_CREDENTIALS", "VIEW_CREDENTIALS",
+                                "MANAGE_API_SPECS", "VIEW_API_SPECS")),
                 new ProfileDef("Standard User",
                         "Read, create, and edit records in all collections",
-                        Set.of("API_ACCESS", "MANAGE_LISTVIEWS", "VIEW_CREDENTIALS")),
+                        Set.of("API_ACCESS", "MANAGE_LISTVIEWS", "VIEW_CREDENTIALS", "VIEW_API_SPECS")),
                 new ProfileDef("Read Only",
                         "View all records and reports, no create/edit/delete capability",
                         Set.of("VIEW_ALL_DATA")),

--- a/kelta-worker/src/main/java/io/kelta/worker/repository/ApiOperationRepository.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/repository/ApiOperationRepository.java
@@ -1,0 +1,227 @@
+package io.kelta.worker.repository;
+
+import io.kelta.runtime.module.integration.api.ApiOperation;
+import io.kelta.runtime.module.integration.api.ParsedSpec;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Repository;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * JDBC repository for the {@code api_operation} table. Each {@link ApiOperation}
+ * is a row keyed by {@code (spec_id, synthetic_op_id)}. Re-imports use
+ * {@link #syncOperations} which adds new operations, updates changed ones,
+ * and soft-deletes ones that disappeared (sets {@code deprecated=TRUE}) so
+ * existing flows that reference them keep working until the user updates
+ * them.
+ */
+@Repository
+public class ApiOperationRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+    private final ObjectMapper objectMapper;
+
+    public ApiOperationRepository(JdbcTemplate jdbcTemplate, ObjectMapper objectMapper) {
+        this.jdbcTemplate = jdbcTemplate;
+        this.objectMapper = objectMapper;
+    }
+
+    public List<ApiOperation> listBySpec(String tenantId, String specId) {
+        return jdbcTemplate.query(
+            """
+            SELECT id, tenant_id, spec_id, operation_id, synthetic_op_id, http_method,
+                   path_template, summary, description, tags, parameters_schema,
+                   request_body_schema, response_schemas, security_required, deprecated
+            FROM api_operation
+            WHERE tenant_id = ? AND spec_id = ?
+            ORDER BY tags NULLS LAST, path_template, http_method
+            """,
+            operationRowMapper(), tenantId, specId);
+    }
+
+    public Optional<ApiOperation> findOperation(String tenantId, String specId,
+                                                 String syntheticOpId) {
+        try {
+            ApiOperation op = jdbcTemplate.queryForObject(
+                """
+                SELECT id, tenant_id, spec_id, operation_id, synthetic_op_id, http_method,
+                       path_template, summary, description, tags, parameters_schema,
+                       request_body_schema, response_schemas, security_required, deprecated
+                FROM api_operation
+                WHERE tenant_id = ? AND spec_id = ? AND synthetic_op_id = ?
+                """,
+                operationRowMapper(), tenantId, specId, syntheticOpId);
+            return Optional.ofNullable(op);
+        } catch (EmptyResultDataAccessException e) {
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Searches operations for the picker UI. Filters are AND-ed; pass
+     * {@code null} or empty string to skip a filter.
+     */
+    public List<ApiOperation> search(String tenantId, String query, String method,
+                                      String specId, int limit) {
+        StringBuilder sql = new StringBuilder("""
+            SELECT id, tenant_id, spec_id, operation_id, synthetic_op_id, http_method,
+                   path_template, summary, description, tags, parameters_schema,
+                   request_body_schema, response_schemas, security_required, deprecated
+            FROM api_operation
+            WHERE tenant_id = ?
+            """);
+        java.util.List<Object> args = new java.util.ArrayList<>();
+        args.add(tenantId);
+
+        if (query != null && !query.isBlank()) {
+            sql.append(" AND search_text ILIKE ? ");
+            args.add("%" + query + "%");
+        }
+        if (method != null && !method.isBlank()) {
+            sql.append(" AND http_method = ? ");
+            args.add(method.toUpperCase());
+        }
+        if (specId != null && !specId.isBlank()) {
+            sql.append(" AND spec_id = ? ");
+            args.add(specId);
+        }
+        sql.append(" ORDER BY path_template, http_method LIMIT ? ");
+        args.add(Math.max(1, Math.min(limit, 200)));
+
+        return jdbcTemplate.query(sql.toString(), operationRowMapper(), args.toArray());
+    }
+
+    /**
+     * Re-points the operation set for a spec to {@code parsedOps}:
+     * <ul>
+     *   <li>New synthetic ops → INSERT</li>
+     *   <li>Existing synthetic ops → UPDATE in place</li>
+     *   <li>Existing synthetic ops not in {@code parsedOps} → mark
+     *       {@code deprecated=TRUE} (NOT hard-deleted, since flow definitions
+     *       reference them by id)</li>
+     * </ul>
+     *
+     * @return diff summary: counts of added / changed / removed (deprecated)
+     */
+    public OperationSyncResult syncOperations(String tenantId, String specId,
+                                               List<ParsedSpec.ParsedOperation> parsedOps) {
+        Map<String, ApiOperation> existing = new LinkedHashMap<>();
+        for (ApiOperation op : listBySpec(tenantId, specId)) {
+            existing.put(op.syntheticOpId(), op);
+        }
+
+        Set<String> seen = new HashSet<>();
+        int added = 0;
+        int changed = 0;
+
+        for (ParsedSpec.ParsedOperation parsed : parsedOps) {
+            seen.add(parsed.syntheticOpId());
+            ApiOperation prior = existing.get(parsed.syntheticOpId());
+            if (prior == null) {
+                jdbcTemplate.update(
+                    """
+                    INSERT INTO api_operation (
+                        id, tenant_id, spec_id, operation_id, synthetic_op_id, http_method,
+                        path_template, summary, description, tags, parameters_schema,
+                        request_body_schema, response_schemas, security_required,
+                        deprecated, search_text)
+                    VALUES (?, ?, ?, ?, ?, ?,
+                            ?, ?, ?, ?::jsonb, ?::jsonb,
+                            ?::jsonb, ?::jsonb, ?::jsonb,
+                            ?, ?)
+                    """,
+                    UUID.randomUUID().toString(), tenantId, specId,
+                    parsed.operationId(), parsed.syntheticOpId(), parsed.httpMethod(),
+                    parsed.pathTemplate(), parsed.summary(), parsed.description(),
+                    writeJson(parsed.tags()), writeJson(parsed.parametersSchema()),
+                    writeJson(parsed.requestBodySchema()), writeJson(parsed.responseSchemas()),
+                    writeJson(parsed.securityRequired()),
+                    parsed.deprecated(), parsed.searchText());
+                added++;
+            } else {
+                jdbcTemplate.update(
+                    """
+                    UPDATE api_operation
+                    SET    operation_id = ?, http_method = ?, path_template = ?,
+                           summary = ?, description = ?, tags = ?::jsonb,
+                           parameters_schema = ?::jsonb, request_body_schema = ?::jsonb,
+                           response_schemas = ?::jsonb, security_required = ?::jsonb,
+                           deprecated = ?, search_text = ?
+                    WHERE  id = ?
+                    """,
+                    parsed.operationId(), parsed.httpMethod(), parsed.pathTemplate(),
+                    parsed.summary(), parsed.description(),
+                    writeJson(parsed.tags()), writeJson(parsed.parametersSchema()),
+                    writeJson(parsed.requestBodySchema()), writeJson(parsed.responseSchemas()),
+                    writeJson(parsed.securityRequired()),
+                    parsed.deprecated(), parsed.searchText(),
+                    prior.id());
+                changed++;
+            }
+        }
+
+        int removed = 0;
+        for (Map.Entry<String, ApiOperation> entry : existing.entrySet()) {
+            if (!seen.contains(entry.getKey()) && !entry.getValue().deprecated()) {
+                jdbcTemplate.update(
+                    "UPDATE api_operation SET deprecated = TRUE WHERE id = ?",
+                    entry.getValue().id());
+                removed++;
+            }
+        }
+
+        return new OperationSyncResult(added, changed, removed);
+    }
+
+    public record OperationSyncResult(int added, int changed, int removed) {
+    }
+
+    // -----------------------------------------------------------------------
+
+    private RowMapper<ApiOperation> operationRowMapper() {
+        return (rs, rowNum) -> new ApiOperation(
+            rs.getString("id"),
+            rs.getString("tenant_id"),
+            rs.getString("spec_id"),
+            rs.getString("operation_id"),
+            rs.getString("synthetic_op_id"),
+            rs.getString("http_method"),
+            rs.getString("path_template"),
+            rs.getString("summary"),
+            rs.getString("description"),
+            readJson(rs.getString("tags")),
+            readJson(rs.getString("parameters_schema")),
+            readJson(rs.getString("request_body_schema")),
+            readJson(rs.getString("response_schemas")),
+            readJson(rs.getString("security_required")),
+            rs.getBoolean("deprecated"));
+    }
+
+    private String writeJson(JsonNode node) {
+        if (node == null) return null;
+        try {
+            return objectMapper.writeValueAsString(node);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private JsonNode readJson(String json) {
+        if (json == null || json.isBlank()) return null;
+        try {
+            return objectMapper.readTree(json);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}

--- a/kelta-worker/src/main/java/io/kelta/worker/repository/ApiSpecRepository.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/repository/ApiSpecRepository.java
@@ -1,0 +1,185 @@
+package io.kelta.worker.repository;
+
+import io.kelta.runtime.module.integration.api.ApiSpec;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Repository;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * JDBC repository for the {@code api_spec} table. Reads route through
+ * {@code TenantContext.callWithTenant(...)} to engage the V127 RLS policy.
+ */
+@Repository
+public class ApiSpecRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+    private final ObjectMapper objectMapper;
+
+    public ApiSpecRepository(JdbcTemplate jdbcTemplate, ObjectMapper objectMapper) {
+        this.jdbcTemplate = jdbcTemplate;
+        this.objectMapper = objectMapper;
+    }
+
+    public List<ApiSpec> listActive(String tenantId) {
+        return jdbcTemplate.query(
+            """
+            SELECT id, tenant_id, name, description, spec_version, api_title, api_version,
+                   base_url, servers, security_schemes, source_type, source_url,
+                   raw_spec, raw_format, parsed_spec, spec_hash, revision, is_active,
+                   last_imported_at
+            FROM api_spec
+            WHERE tenant_id = ? AND is_active = TRUE
+            ORDER BY api_title NULLS LAST, name
+            """,
+            specRowMapper(), tenantId);
+    }
+
+    public Optional<ApiSpec> findById(String id, String tenantId) {
+        try {
+            ApiSpec spec = jdbcTemplate.queryForObject(
+                """
+                SELECT id, tenant_id, name, description, spec_version, api_title, api_version,
+                       base_url, servers, security_schemes, source_type, source_url,
+                       raw_spec, raw_format, parsed_spec, spec_hash, revision, is_active,
+                       last_imported_at
+                FROM api_spec
+                WHERE id = ? AND tenant_id = ?
+                """,
+                specRowMapper(), id, tenantId);
+            return Optional.ofNullable(spec);
+        } catch (EmptyResultDataAccessException e) {
+            return Optional.empty();
+        }
+    }
+
+    public Optional<ApiSpec> findByName(String name, String tenantId) {
+        List<ApiSpec> rows = jdbcTemplate.query(
+            """
+            SELECT id, tenant_id, name, description, spec_version, api_title, api_version,
+                   base_url, servers, security_schemes, source_type, source_url,
+                   raw_spec, raw_format, parsed_spec, spec_hash, revision, is_active,
+                   last_imported_at
+            FROM api_spec
+            WHERE name = ? AND tenant_id = ?
+            """,
+            specRowMapper(), name, tenantId);
+        return rows.isEmpty() ? Optional.empty() : Optional.of(rows.get(0));
+    }
+
+    public void insert(ApiSpec spec, String createdBy) {
+        Timestamp now = Timestamp.from(Instant.now());
+        jdbcTemplate.update(
+            """
+            INSERT INTO api_spec (
+                id, tenant_id, name, description, spec_version, api_title, api_version,
+                base_url, servers, security_schemes, source_type, source_url,
+                raw_spec, raw_format, parsed_spec, spec_hash, revision, is_active,
+                last_imported_at, created_by, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?,
+                    ?, ?::jsonb, ?::jsonb, ?, ?,
+                    ?, ?, ?::jsonb, ?, ?, ?,
+                    ?, ?, ?, ?)
+            """,
+            spec.id(), spec.tenantId(), spec.name(), spec.description(),
+            spec.specVersion(), spec.apiTitle(), spec.apiVersion(),
+            spec.baseUrl(), writeJson(spec.servers()), writeJson(spec.securitySchemes()),
+            spec.sourceType(), spec.sourceUrl(),
+            spec.rawSpec(), spec.rawFormat(), writeJson(spec.parsedSpec()),
+            spec.specHash(), spec.revision(), spec.active(),
+            Timestamp.from(spec.lastImportedAt()), createdBy, now, now);
+    }
+
+    public void updateForReimport(ApiSpec spec, String updatedBy) {
+        jdbcTemplate.update(
+            """
+            UPDATE api_spec
+            SET    description = ?,
+                   spec_version = ?,
+                   api_title = ?,
+                   api_version = ?,
+                   base_url = ?,
+                   servers = ?::jsonb,
+                   security_schemes = ?::jsonb,
+                   source_type = ?,
+                   source_url = ?,
+                   raw_spec = ?,
+                   raw_format = ?,
+                   parsed_spec = ?::jsonb,
+                   spec_hash = ?,
+                   revision = ?,
+                   is_active = TRUE,
+                   last_imported_at = ?,
+                   updated_by = ?,
+                   updated_at = ?
+            WHERE  id = ? AND tenant_id = ?
+            """,
+            spec.description(), spec.specVersion(), spec.apiTitle(), spec.apiVersion(),
+            spec.baseUrl(), writeJson(spec.servers()), writeJson(spec.securitySchemes()),
+            spec.sourceType(), spec.sourceUrl(),
+            spec.rawSpec(), spec.rawFormat(), writeJson(spec.parsedSpec()),
+            spec.specHash(), spec.revision(),
+            Timestamp.from(spec.lastImportedAt()), updatedBy, Timestamp.from(Instant.now()),
+            spec.id(), spec.tenantId());
+    }
+
+    public void softDelete(String id, String tenantId, String updatedBy) {
+        jdbcTemplate.update(
+            """
+            UPDATE api_spec
+            SET    is_active = FALSE, updated_by = ?, updated_at = ?
+            WHERE  id = ? AND tenant_id = ?
+            """,
+            updatedBy, Timestamp.from(Instant.now()), id, tenantId);
+    }
+
+    // -----------------------------------------------------------------------
+
+    private RowMapper<ApiSpec> specRowMapper() {
+        return (rs, rowNum) -> new ApiSpec(
+            rs.getString("id"),
+            rs.getString("tenant_id"),
+            rs.getString("name"),
+            rs.getString("description"),
+            rs.getString("spec_version"),
+            rs.getString("api_title"),
+            rs.getString("api_version"),
+            rs.getString("base_url"),
+            readJson(rs.getString("servers")),
+            readJson(rs.getString("security_schemes")),
+            rs.getString("source_type"),
+            rs.getString("source_url"),
+            rs.getString("raw_spec"),
+            rs.getString("raw_format"),
+            readJson(rs.getString("parsed_spec")),
+            rs.getString("spec_hash"),
+            rs.getInt("revision"),
+            rs.getBoolean("is_active"),
+            rs.getTimestamp("last_imported_at").toInstant());
+    }
+
+    private String writeJson(JsonNode node) {
+        if (node == null) return null;
+        try {
+            return objectMapper.writeValueAsString(node);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private JsonNode readJson(String json) {
+        if (json == null || json.isBlank()) return null;
+        try {
+            return objectMapper.readTree(json);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}

--- a/kelta-worker/src/main/java/io/kelta/worker/service/api/ApiSpecService.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/service/api/ApiSpecService.java
@@ -1,0 +1,206 @@
+package io.kelta.worker.service.api;
+
+import io.kelta.runtime.context.TenantContext;
+import io.kelta.runtime.module.integration.api.ApiSpec;
+import io.kelta.runtime.module.integration.api.OpenApiParseException;
+import io.kelta.runtime.module.integration.api.OpenApiSpecParser;
+import io.kelta.runtime.module.integration.api.ParsedSpec;
+import io.kelta.worker.repository.ApiOperationRepository;
+import io.kelta.worker.repository.ApiOperationRepository.OperationSyncResult;
+import io.kelta.worker.repository.ApiSpecRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import tools.jackson.databind.ObjectMapper;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Orchestrates the import lifecycle for an OpenAPI spec:
+ * <ol>
+ *   <li>Fetch the document (URL) or accept inline JSON / YAML</li>
+ *   <li>Parse + validate via {@link OpenApiSpecParser}</li>
+ *   <li>Insert (first-time) or update (re-import) the {@code api_spec} row,
+ *       bumping {@code revision} and the spec hash</li>
+ *   <li>Sync the operation index — adds new, updates changed, deprecates
+ *       removed</li>
+ * </ol>
+ *
+ * Storage is wrapped in {@code TenantContext.callWithTenant(...)} so the V127
+ * RLS policies engage on every read and write.
+ */
+@Service
+public class ApiSpecService {
+
+    private static final Logger log = LoggerFactory.getLogger(ApiSpecService.class);
+    private static final Duration FETCH_TIMEOUT = Duration.ofSeconds(15);
+
+    private final OpenApiSpecParser parser;
+    private final ApiSpecRepository specRepository;
+    private final ApiOperationRepository operationRepository;
+    @SuppressWarnings("unused")
+    private final ObjectMapper objectMapper;
+
+    public ApiSpecService(OpenApiSpecParser parser,
+                          ApiSpecRepository specRepository,
+                          ApiOperationRepository operationRepository,
+                          ObjectMapper objectMapper) {
+        this.parser = parser;
+        this.specRepository = specRepository;
+        this.operationRepository = operationRepository;
+        this.objectMapper = objectMapper;
+    }
+
+    /**
+     * Imports a new spec or re-imports an existing one (matched by name within
+     * the tenant). Returns the resulting record.
+     */
+    public ImportResult importSpec(ImportRequest req, String tenantId, String userId) {
+        if (req.name() == null || req.name().isBlank()) {
+            throw new IllegalArgumentException("name is required");
+        }
+        String raw = resolveRaw(req);
+        String format = detectFormat(raw, req.rawFormat());
+
+        ParsedSpec parsed;
+        try {
+            parsed = parser.parse(raw);
+        } catch (OpenApiParseException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new OpenApiParseException("Failed to parse spec: " + e.getMessage(), e);
+        }
+
+        String hash = parser.hash(raw);
+
+        return TenantContext.callWithTenant(tenantId, () -> {
+            Optional<ApiSpec> existing = specRepository.findByName(req.name(), tenantId);
+            ApiSpec saved;
+            OperationSyncResult diff;
+            if (existing.isPresent()) {
+                ApiSpec prior = existing.get();
+                if (prior.specHash().equals(hash)) {
+                    log.debug("Spec '{}' unchanged (hash match); skipping", req.name());
+                    diff = new OperationSyncResult(0, 0, 0);
+                    saved = prior;
+                } else {
+                    ApiSpec next = new ApiSpec(
+                        prior.id(), tenantId, prior.name(),
+                        req.description() != null ? req.description() : prior.description(),
+                        parsed.specVersion(), parsed.apiTitle(), parsed.apiVersion(),
+                        parsed.baseUrl(), parsed.servers(), parsed.securitySchemes(),
+                        req.sourceType(), req.sourceUrl(),
+                        raw, format, parsed.parsedSpec(),
+                        hash, prior.revision() + 1, true, Instant.now());
+                    specRepository.updateForReimport(next, userId);
+                    diff = operationRepository.syncOperations(tenantId, prior.id(),
+                        parsed.operations());
+                    saved = next;
+                    log.info("Re-imported spec '{}' (rev {}): +{} ~{} -{}",
+                        prior.name(), next.revision(), diff.added(), diff.changed(),
+                        diff.removed());
+                }
+            } else {
+                ApiSpec next = new ApiSpec(
+                    UUID.randomUUID().toString(), tenantId, req.name(), req.description(),
+                    parsed.specVersion(), parsed.apiTitle(), parsed.apiVersion(),
+                    parsed.baseUrl(), parsed.servers(), parsed.securitySchemes(),
+                    req.sourceType(), req.sourceUrl(),
+                    raw, format, parsed.parsedSpec(),
+                    hash, 1, true, Instant.now());
+                specRepository.insert(next, userId);
+                diff = operationRepository.syncOperations(tenantId, next.id(),
+                    parsed.operations());
+                saved = next;
+                log.info("Imported new spec '{}' with {} operations",
+                    next.name(), parsed.operations().size());
+            }
+            return new ImportResult(saved, diff);
+        });
+    }
+
+    public List<ApiSpec> listActive(String tenantId) {
+        return TenantContext.callWithTenant(tenantId, () -> specRepository.listActive(tenantId));
+    }
+
+    public Optional<ApiSpec> findById(String id, String tenantId) {
+        return TenantContext.callWithTenant(tenantId, () -> specRepository.findById(id, tenantId));
+    }
+
+    public void softDelete(String id, String tenantId, String userId) {
+        TenantContext.runWithTenant(tenantId, () -> specRepository.softDelete(id, tenantId, userId));
+    }
+
+    // -----------------------------------------------------------------------
+
+    private String resolveRaw(ImportRequest req) {
+        if ("URL".equalsIgnoreCase(req.sourceType())) {
+            if (req.sourceUrl() == null || req.sourceUrl().isBlank()) {
+                throw new IllegalArgumentException(
+                    "sourceUrl is required when sourceType=URL");
+            }
+            try {
+                HttpClient client = HttpClient.newBuilder().connectTimeout(FETCH_TIMEOUT).build();
+                HttpResponse<String> res = client.send(
+                    HttpRequest.newBuilder()
+                        .uri(URI.create(req.sourceUrl()))
+                        .timeout(FETCH_TIMEOUT)
+                        .header("Accept", "application/json, application/yaml, text/yaml")
+                        .GET().build(),
+                    HttpResponse.BodyHandlers.ofString());
+                if (res.statusCode() / 100 != 2) {
+                    throw new OpenApiParseException(
+                        "Failed to fetch spec: HTTP " + res.statusCode());
+                }
+                return res.body();
+            } catch (OpenApiParseException e) {
+                throw e;
+            } catch (Exception e) {
+                throw new OpenApiParseException(
+                    "Failed to fetch spec from " + req.sourceUrl() + ": " + e.getMessage(), e);
+            }
+        }
+        if (req.raw() == null || req.raw().isBlank()) {
+            throw new IllegalArgumentException(
+                "raw spec body is required when sourceType is INLINE_JSON or INLINE_YAML");
+        }
+        return req.raw();
+    }
+
+    private String detectFormat(String raw, String hint) {
+        if (hint != null && !hint.isBlank()) return hint.toLowerCase();
+        String trimmed = raw.stripLeading();
+        if (trimmed.startsWith("{")) return "json";
+        return "yaml";
+    }
+
+    // -----------------------------------------------------------------------
+    // DTOs
+    // -----------------------------------------------------------------------
+
+    /**
+     * Body shape expected by the import / re-import endpoints. Exactly one of
+     * {@code raw} or {@code sourceUrl} should be supplied (matching
+     * {@code sourceType}).
+     */
+    public record ImportRequest(
+        String name,
+        String description,
+        String sourceType,
+        String sourceUrl,
+        String raw,
+        String rawFormat
+    ) {
+    }
+
+    public record ImportResult(ApiSpec spec, OperationSyncResult diff) {
+    }
+}

--- a/kelta-worker/src/main/java/io/kelta/worker/service/api/JdbcApiSpecStore.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/service/api/JdbcApiSpecStore.java
@@ -1,0 +1,44 @@
+package io.kelta.worker.service.api;
+
+import io.kelta.runtime.context.TenantContext;
+import io.kelta.runtime.module.integration.api.ApiOperation;
+import io.kelta.runtime.module.integration.api.ApiSpec;
+import io.kelta.runtime.module.integration.spi.ApiSpecStore;
+import io.kelta.worker.repository.ApiOperationRepository;
+import io.kelta.worker.repository.ApiSpecRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+/**
+ * Worker-side implementation of {@link ApiSpecStore}. The
+ * {@code IntegrationModule} (PR 4 onwards) consumes this through the
+ * {@code ModuleContext} extension API so the {@code CALL_API} handler can
+ * resolve {@code (specId, operationId)} into the bits it needs to execute a
+ * request.
+ */
+@Service
+public class JdbcApiSpecStore implements ApiSpecStore {
+
+    private final ApiSpecRepository specRepository;
+    private final ApiOperationRepository operationRepository;
+
+    public JdbcApiSpecStore(ApiSpecRepository specRepository,
+                             ApiOperationRepository operationRepository) {
+        this.specRepository = specRepository;
+        this.operationRepository = operationRepository;
+    }
+
+    @Override
+    public Optional<ApiSpec> findSpec(String tenantId, String specId) {
+        return TenantContext.callWithTenant(tenantId,
+            () -> specRepository.findById(specId, tenantId));
+    }
+
+    @Override
+    public Optional<ApiOperation> findOperation(String tenantId, String specId,
+                                                 String syntheticOpId) {
+        return TenantContext.callWithTenant(tenantId,
+            () -> operationRepository.findOperation(tenantId, specId, syntheticOpId));
+    }
+}

--- a/kelta-worker/src/main/resources/db/migration/V127__add_api_spec_library.sql
+++ b/kelta-worker/src/main/resources/db/migration/V127__add_api_spec_library.sql
@@ -1,0 +1,147 @@
+-- V127: OpenAPI Spec Library
+-- Tenants upload OpenAPI 3.x specs (JSON or YAML) and the worker parses them
+-- into a normalized operations index that the flow builder picker can search
+-- across. The new CALL_API step (PR 4) executes operations chosen from this
+-- catalog.
+
+-- Required for trigram search across operation summaries / paths / tags.
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+CREATE TABLE api_spec (
+    id                VARCHAR(36)              PRIMARY KEY,
+    tenant_id         VARCHAR(36)              NOT NULL REFERENCES tenant(id),
+    name              VARCHAR(200)             NOT NULL,
+    description       VARCHAR(1000),
+    spec_version      VARCHAR(20)              NOT NULL,
+    api_title         VARCHAR(500),
+    api_version       VARCHAR(50),
+    base_url          VARCHAR(1000),
+    servers           JSONB,
+    security_schemes  JSONB,
+    source_type       VARCHAR(20)              NOT NULL,
+    source_url        VARCHAR(2000),
+    raw_spec          TEXT                     NOT NULL,
+    raw_format        VARCHAR(10)              NOT NULL,
+    parsed_spec       JSONB                    NOT NULL,
+    spec_hash         VARCHAR(64)              NOT NULL,
+    revision          INTEGER                  NOT NULL DEFAULT 1,
+    is_active         BOOLEAN                  NOT NULL DEFAULT TRUE,
+    last_imported_at  TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    created_by        VARCHAR(36),
+    created_at        TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_by        VARCHAR(36),
+    updated_at        TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    CONSTRAINT uq_api_spec_tenant_name UNIQUE (tenant_id, name)
+);
+
+CREATE INDEX idx_api_spec_tenant      ON api_spec(tenant_id) WHERE is_active = TRUE;
+CREATE INDEX idx_api_spec_tenant_all  ON api_spec(tenant_id);
+
+COMMENT ON COLUMN api_spec.spec_version IS 'OpenAPI version (e.g. 3.0.3, 3.1.0)';
+COMMENT ON COLUMN api_spec.source_type  IS 'INLINE_JSON | INLINE_YAML | URL';
+COMMENT ON COLUMN api_spec.raw_format   IS 'json | yaml';
+COMMENT ON COLUMN api_spec.spec_hash    IS 'sha-256 of raw_spec — used to detect re-imports';
+
+CREATE TABLE api_operation (
+    id                  VARCHAR(36)              PRIMARY KEY,
+    tenant_id           VARCHAR(36)              NOT NULL,
+    spec_id             VARCHAR(36)              NOT NULL
+                            REFERENCES api_spec(id) ON DELETE CASCADE,
+    operation_id        VARCHAR(200),
+    synthetic_op_id     VARCHAR(200)             NOT NULL,
+    http_method         VARCHAR(10)              NOT NULL,
+    path_template       VARCHAR(1000)            NOT NULL,
+    summary             VARCHAR(500),
+    description         TEXT,
+    tags                JSONB,
+    parameters_schema   JSONB,
+    request_body_schema JSONB,
+    response_schemas    JSONB,
+    security_required   JSONB,
+    deprecated          BOOLEAN                  NOT NULL DEFAULT FALSE,
+    search_text         TEXT,
+    created_at          TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    CONSTRAINT uq_api_operation_spec_op UNIQUE (spec_id, synthetic_op_id)
+);
+
+CREATE INDEX idx_api_operation_tenant_method
+    ON api_operation(tenant_id, http_method);
+CREATE INDEX idx_api_operation_search
+    ON api_operation USING gin (search_text gin_trgm_ops);
+CREATE INDEX idx_api_operation_tags
+    ON api_operation USING gin (tags jsonb_path_ops);
+CREATE INDEX idx_api_operation_spec
+    ON api_operation(spec_id);
+
+COMMENT ON COLUMN api_operation.synthetic_op_id IS
+    'Always present; synthesized as <METHOD>_<sanitized_path> when the spec omits operationId';
+COMMENT ON COLUMN api_operation.search_text IS
+    'Concatenation of method + path + summary + tags for trigram search';
+
+-- Row-Level Security — mirror V77 / V126 pattern.
+ALTER TABLE api_spec        ENABLE ROW LEVEL SECURITY;
+ALTER TABLE api_spec        FORCE  ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS tenant_isolation ON api_spec;
+DROP POLICY IF EXISTS admin_bypass     ON api_spec;
+CREATE POLICY tenant_isolation ON api_spec
+    USING (tenant_id = current_setting('app.current_tenant_id', true));
+CREATE POLICY admin_bypass ON api_spec
+    USING (current_setting('app.current_tenant_id', true) = '');
+
+ALTER TABLE api_operation   ENABLE ROW LEVEL SECURITY;
+ALTER TABLE api_operation   FORCE  ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS tenant_isolation ON api_operation;
+DROP POLICY IF EXISTS admin_bypass     ON api_operation;
+CREATE POLICY tenant_isolation ON api_operation
+    USING (tenant_id = current_setting('app.current_tenant_id', true));
+CREATE POLICY admin_bypass ON api_operation
+    USING (current_setting('app.current_tenant_id', true) = '');
+
+-- Permissions — same V126 pattern (NOT EXISTS guard, tenant_id required).
+DO $$
+DECLARE
+    p RECORD;
+BEGIN
+    FOR p IN
+        SELECT id, tenant_id
+        FROM profile
+        WHERE name = 'System Administrator' AND is_system = TRUE
+    LOOP
+        IF NOT EXISTS (
+            SELECT 1 FROM profile_system_permission
+            WHERE profile_id = p.id AND permission_name = 'MANAGE_API_SPECS'
+        ) THEN
+            INSERT INTO profile_system_permission
+                (id, tenant_id, profile_id, permission_name, granted)
+            VALUES (gen_random_uuid()::text, p.tenant_id, p.id,
+                    'MANAGE_API_SPECS', TRUE);
+        END IF;
+        IF NOT EXISTS (
+            SELECT 1 FROM profile_system_permission
+            WHERE profile_id = p.id AND permission_name = 'VIEW_API_SPECS'
+        ) THEN
+            INSERT INTO profile_system_permission
+                (id, tenant_id, profile_id, permission_name, granted)
+            VALUES (gen_random_uuid()::text, p.tenant_id, p.id,
+                    'VIEW_API_SPECS', TRUE);
+        END IF;
+    END LOOP;
+
+    -- Standard users can browse specs (so they can pick one in a flow) but
+    -- cannot upload or delete them.
+    FOR p IN
+        SELECT id, tenant_id
+        FROM profile
+        WHERE name = 'Standard User' AND is_system = TRUE
+    LOOP
+        IF NOT EXISTS (
+            SELECT 1 FROM profile_system_permission
+            WHERE profile_id = p.id AND permission_name = 'VIEW_API_SPECS'
+        ) THEN
+            INSERT INTO profile_system_permission
+                (id, tenant_id, profile_id, permission_name, granted)
+            VALUES (gen_random_uuid()::text, p.tenant_id, p.id,
+                    'VIEW_API_SPECS', TRUE);
+        END IF;
+    END LOOP;
+END $$;

--- a/kelta-worker/src/test/java/io/kelta/worker/listener/TenantProvisioningHookTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/listener/TenantProvisioningHookTest.java
@@ -88,8 +88,8 @@ class TenantProvisioningHookTest {
                     contains("INSERT INTO profile"),
                     anyString(), eq(TENANT_ID), anyString(), anyString());
 
-            // 7 profiles × 18 permissions = 126 permission records
-            verify(jdbcTemplate, times(126)).update(
+            // 7 profiles × 20 permissions = 140 permission records
+            verify(jdbcTemplate, times(140)).update(
                     contains("INSERT INTO profile_system_permission"),
                     anyString(), anyString(), anyString(), anyString(), anyBoolean());
         }


### PR DESCRIPTION
## Summary

Tenants can import OpenAPI 3.x specs (URL fetch, paste, or file drop) and browse the operations they expose. PR 4's `CALL_API` flow step will pick operations from this catalog at runtime via the new `ApiSpecStore` SPI.

## Changes

### Backend
- **V127 migration**: `api_spec` + `api_operation` tables, RLS, `pg_trgm`-backed search index across operation method/path/summary/tags. Seeds new `MANAGE_API_SPECS` / `VIEW_API_SPECS` permissions on existing System Administrator and Standard User profiles using the V112-style `NOT EXISTS`-with-tenant_id pattern.
- **runtime-module-integration**:
  - `swagger-parser-v3` dependency
  - `OpenApiSpecParser` — resolves `$ref`s fully, synthesizes `operationId` when missing, builds search_text
  - `ApiSpec` / `ApiOperation` / `ParsedSpec` records
  - `ApiSpecStore` SPI for handlers (PR 4 consumer)
- **kelta-worker**:
  - `ApiSpecRepository` + `ApiOperationRepository` (JDBC)
  - `ApiSpecService` — URL fetch + parse + diff + upsert; soft-deletes removed operations rather than hard-deleting (existing flow definitions stay safe)
  - `JdbcApiSpecStore` (worker-side SPI impl)
  - `ApiSpecConfigHook` broadcasts `kelta.config.api-spec.changed.<id>`
  - `ApiSpecController` with import / validate / list / details / raw / operations / search endpoints
- `TenantProvisioningHook` grants the new permissions on tenant creation; `ALL_PERMISSIONS` now 20 entries (test count adjusted to 7 × 20 = 140).

### Frontend
- `@kelta/sdk` admin client: `keltaClient.admin.apiSpecs.{list,get,raw,importSpec,validate,delete,listOperations,getOperation,searchOperations}` + types.
- `ApiSpecsPage` — list view + import dialog with URL / Paste / Drop tabs and validate-before-save.
- `ApiSpecDetailPage` — overview, grouped operations browser with method-colored rows, per-operation schema view, raw-text tab.
- Reusable primitives for PR 4:
  - `<FileDropzone>` (native drag/drop, no extra dep)
  - `<SpecPicker>` (combobox)
  - `<OperationPicker>` (searchable list with method colors)
- Routes `/api-specs` + `/api-specs/:specId` in `App.tsx`; Setup hub entry under Integration; both gated on `VIEW_API_SPECS`.

## Tests
- 8 unit tests for `OpenApiSpecParser` (happy path, `$ref` resolution, synthetic op IDs, hash stability, format detection, search text, error path).
- All 30 existing credential tests still pass alongside.

## Test plan
- [ ] CI: build + tests + integration tests green
- [ ] Smoke: import [Swagger Petstore](https://petstore3.swagger.io/api/v3/openapi.json) by URL, confirm 13 operations indexed
- [ ] Smoke: re-import unchanged spec → no diff; re-import modified spec → operations diff reflected; verify removed operations soft-deprecated, not hard-deleted
- [ ] Smoke: drop a YAML spec via the file dropzone, browse operations, view schemas
- [ ] Smoke: search in the OperationPicker; method/spec filters work

🤖 Generated with [Claude Code](https://claude.com/claude-code)