### PR TITLE
feat(call-api): unified external-API flow step + payload mapper (PR 4/5)

### DIFF
--- a/kelta-platform/runtime/runtime-module-integration/pom.xml
+++ b/kelta-platform/runtime/runtime-module-integration/pom.xml
@@ -52,6 +52,15 @@
             <version>2.1.22</version>
         </dependency>
 
+        <!-- JSONata: structural transform language used by PayloadMapperService.
+             Layered on top of the existing ${$.path} substitution so any string
+             starting with `=` is treated as a JSONata expression. -->
+        <dependency>
+            <groupId>com.dashjoin</groupId>
+            <artifactId>jsonata</artifactId>
+            <version>0.9.8</version>
+        </dependency>
+
         <!-- GraalVM Polyglot API for JavaScript script execution -->
         <dependency>
             <groupId>org.graalvm.polyglot</groupId>

--- a/kelta-platform/runtime/runtime-module-integration/src/main/java/io/kelta/runtime/module/integration/IntegrationModule.java
+++ b/kelta-platform/runtime/runtime-module-integration/src/main/java/io/kelta/runtime/module/integration/IntegrationModule.java
@@ -1,7 +1,12 @@
 package io.kelta.runtime.module.integration;
 
+import io.kelta.runtime.flow.StateDataResolver;
 import io.kelta.runtime.module.integration.handlers.*;
+import io.kelta.runtime.module.integration.mapping.PayloadMapperService;
+import io.kelta.runtime.module.integration.spi.ApiSpecStore;
+import io.kelta.runtime.module.integration.spi.CredentialResolverPort;
 import io.kelta.runtime.module.integration.spi.EmailService;
+import io.kelta.runtime.module.integration.spi.IdempotencyStore;
 import io.kelta.runtime.module.integration.spi.PendingActionStore;
 import io.kelta.runtime.module.integration.spi.ScriptExecutor;
 import io.kelta.runtime.module.integration.spi.noop.LoggingEmailService;
@@ -96,6 +101,23 @@ public class IntegrationModule implements KeltaModule {
             scriptExecutor = new LoggingScriptExecutor();
         }
         handlers.add(new InvokeScriptActionHandler(objectMapper, scriptExecutor));
+
+        // CALL_API — generic external-API step. Pulls SPI implementations
+        // from the worker via ModuleContext extensions; missing extensions
+        // produce typed runtime errors instead of failing module startup so
+        // legacy installations stay bootable.
+        StateDataResolver dataResolver = context.getExtension(StateDataResolver.class);
+        if (dataResolver == null) {
+            dataResolver = new StateDataResolver(objectMapper);
+        }
+        PayloadMapperService payloadMapper = new PayloadMapperService(dataResolver);
+        ApiSpecStore apiSpecStore = context.getExtension(ApiSpecStore.class);
+        CredentialResolverPort credentialResolver =
+            context.getExtension(CredentialResolverPort.class);
+        IdempotencyStore idempotencyStore = context.getExtension(IdempotencyStore.class);
+        handlers.add(new CallApiActionHandler(
+            objectMapper, payloadMapper, apiSpecStore,
+            credentialResolver, idempotencyStore, restTemplate));
     }
 
     @Override

--- a/kelta-platform/runtime/runtime-module-integration/src/main/java/io/kelta/runtime/module/integration/handlers/CallApiActionHandler.java
+++ b/kelta-platform/runtime/runtime-module-integration/src/main/java/io/kelta/runtime/module/integration/handlers/CallApiActionHandler.java
@@ -1,0 +1,525 @@
+package io.kelta.runtime.module.integration.handlers;
+
+import io.kelta.runtime.credential.ResolvedCredential;
+import io.kelta.runtime.module.integration.api.ApiOperation;
+import io.kelta.runtime.module.integration.api.ApiSpec;
+import io.kelta.runtime.module.integration.mapping.PayloadMapperException;
+import io.kelta.runtime.module.integration.mapping.PayloadMapperService;
+import io.kelta.runtime.module.integration.spi.ApiSpecStore;
+import io.kelta.runtime.module.integration.spi.CredentialResolverPort;
+import io.kelta.runtime.module.integration.spi.IdempotencyStore;
+import io.kelta.runtime.module.integration.spi.IdempotencyStore.CachedResponse;
+import io.kelta.runtime.workflow.ActionContext;
+import io.kelta.runtime.workflow.ActionHandler;
+import io.kelta.runtime.workflow.ActionResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestTemplate;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.HexFormat;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Generic external-API call. Replaces {@code HTTP_CALLOUT} with a unified
+ * handler that:
+ * <ul>
+ *   <li>Knows two modes — {@code operation} (look up an OpenAPI operation
+ *       by id, derive URL/method from the spec) and {@code raw} (free-form
+ *       URL+method, behaves like the legacy HTTP_CALLOUT).</li>
+ *   <li>Resolves credentials by reference and applies the right auth
+ *       transformation per credential type, so step config never carries a
+ *       secret.</li>
+ *   <li>Maps path/query/header/body inputs through {@link PayloadMapperService}
+ *       so users can use {@code ${$.path}} placeholders or {@code =expr}
+ *       JSONata expressions interchangeably.</li>
+ *   <li>Supports an explicit idempotency key so retries against
+ *       non-idempotent upstreams don't double-execute.</li>
+ *   <li>Emits named error codes ({@code Api.HttpClientError},
+ *       {@code Api.HttpServerError}, {@code Api.Timeout},
+ *       {@code Credential.*}, {@code Mapper.Failure}) so flows can write
+ *       targeted Catch policies.</li>
+ * </ul>
+ */
+public class CallApiActionHandler implements ActionHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(CallApiActionHandler.class);
+    private static final Set<String> ALLOWED_METHODS =
+        Set.of("GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS");
+    private static final int MAX_RESPONSE_SIZE = 50_000;
+    private static final Duration DEFAULT_IDEMPOTENCY_TTL = Duration.ofHours(24);
+
+    private final ObjectMapper objectMapper;
+    private final PayloadMapperService payloadMapper;
+    private final ApiSpecStore apiSpecStore;
+    private final CredentialResolverPort credentialResolver;
+    private final IdempotencyStore idempotencyStore;
+    private RestTemplate restTemplate;
+
+    public CallApiActionHandler(ObjectMapper objectMapper,
+                                 PayloadMapperService payloadMapper,
+                                 ApiSpecStore apiSpecStore,
+                                 CredentialResolverPort credentialResolver,
+                                 IdempotencyStore idempotencyStore,
+                                 RestTemplate restTemplate) {
+        this.objectMapper = objectMapper;
+        this.payloadMapper = payloadMapper;
+        this.apiSpecStore = apiSpecStore;
+        this.credentialResolver = credentialResolver;
+        this.idempotencyStore = idempotencyStore;
+        this.restTemplate = restTemplate != null ? restTemplate : new RestTemplate();
+    }
+
+    /** Test seam. */
+    void setRestTemplate(RestTemplate restTemplate) {
+        this.restTemplate = restTemplate;
+    }
+
+    @Override
+    public String getActionTypeKey() {
+        return "CALL_API";
+    }
+
+    @Override
+    public ActionResult execute(ActionContext context) {
+        try {
+            Map<String, Object> config = objectMapper.readValue(
+                context.actionConfigJson(), new TypeReference<>() {});
+            Map<String, Object> stateData = context.resolvedData() != null
+                ? context.resolvedData() : context.data();
+            if (stateData == null) {
+                stateData = new HashMap<>();
+            }
+
+            String mode = stringOrDefault(config.get("mode"), "raw");
+            ResolvedRequest request = "operation".equalsIgnoreCase(mode)
+                ? buildFromOperation(config, stateData, context.tenantId())
+                : buildFromRaw(config, stateData);
+
+            // Apply credential auth (if a credential ref was provided)
+            String credentialRef = stringOrNull(config.get("credentialRef"));
+            if (credentialRef != null && !credentialRef.isBlank()) {
+                if (credentialResolver == null) {
+                    return ActionResult.failure(
+                        "Credential.NotConfigured: credential vault is not configured "
+                            + "in this environment");
+                }
+                ResolvedCredential cred = credentialResolver.resolve(
+                    context.tenantId(), credentialRef,
+                    "CALL_API:" + (request.url == null ? "raw" : request.url));
+                applyAuth(request, cred);
+            }
+
+            // Idempotency: compute key, look up cache, attach upstream header
+            IdempotencyConfig idempotency = readIdempotency(config, request, context);
+            if (idempotency != null && idempotencyStore != null) {
+                Optional<CachedResponse> cached =
+                    idempotencyStore.lookup(context.tenantId(), idempotency.key);
+                if (cached.isPresent()) {
+                    log.info("CALL_API idempotency hit for key {} — replaying cached {}",
+                        idempotency.key, cached.get().statusCode());
+                    return success(request, cached.get().statusCode(),
+                        cached.get().responseBody(), config, stateData);
+                }
+                request.headers.set("Idempotency-Key", idempotency.key);
+            }
+
+            log.info("CALL_API: method={} url={} mode={} workflowRule={}",
+                request.method, request.url, mode, context.workflowRuleId());
+
+            ResponseEntity<String> response;
+            try {
+                response = restTemplate.exchange(
+                    request.url,
+                    HttpMethod.valueOf(request.method),
+                    new HttpEntity<>(request.body, request.headers),
+                    String.class);
+            } catch (HttpClientErrorException e) {
+                return ActionResult.failure(
+                    "Api.HttpClientError: " + e.getStatusCode().value()
+                        + " — " + truncate(e.getResponseBodyAsString()));
+            } catch (HttpServerErrorException e) {
+                return ActionResult.failure(
+                    "Api.HttpServerError: " + e.getStatusCode().value()
+                        + " — " + truncate(e.getResponseBodyAsString()));
+            } catch (ResourceAccessException e) {
+                return ActionResult.failure("Api.Timeout: " + e.getMessage());
+            }
+
+            int status = response.getStatusCode().value();
+            String body = response.getBody();
+
+            if (idempotency != null && idempotencyStore != null && status / 100 == 2) {
+                idempotencyStore.record(context.tenantId(), idempotency.key,
+                    context.executionLogId(), context.workflowRuleId(),
+                    status, body, idempotency.ttl);
+            }
+
+            return success(request, status, body, config, stateData);
+        } catch (PayloadMapperException e) {
+            return ActionResult.failure("Mapper.Failure: " + e.getMessage());
+        } catch (CredentialFailure e) {
+            return ActionResult.failure(e.code + ": " + e.getMessage());
+        } catch (Exception e) {
+            log.error("CALL_API failed: {}", e.getMessage(), e);
+            return ActionResult.failure("Api.Unexpected: " + e.getMessage());
+        }
+    }
+
+    @Override
+    public void validate(String configJson) {
+        try {
+            Map<String, Object> config = objectMapper.readValue(
+                configJson, new TypeReference<>() {});
+            String mode = stringOrDefault(config.get("mode"), "raw");
+            if ("operation".equalsIgnoreCase(mode)) {
+                if (stringOrNull(config.get("specId")) == null
+                    || stringOrNull(config.get("operationId")) == null) {
+                    throw new IllegalArgumentException(
+                        "operation mode requires specId and operationId");
+                }
+            } else if ("raw".equalsIgnoreCase(mode)) {
+                if (stringOrNull(config.get("url")) == null) {
+                    throw new IllegalArgumentException("raw mode requires url");
+                }
+                String method = stringOrDefault(config.get("method"), "GET");
+                if (!ALLOWED_METHODS.contains(method.toUpperCase())) {
+                    throw new IllegalArgumentException("Invalid method: " + method);
+                }
+            } else {
+                throw new IllegalArgumentException(
+                    "mode must be 'operation' or 'raw'");
+            }
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Invalid CALL_API config: " + e.getMessage(), e);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Request building
+    // -----------------------------------------------------------------------
+
+    private ResolvedRequest buildFromOperation(Map<String, Object> config,
+                                                 Map<String, Object> stateData,
+                                                 String tenantId) {
+        if (apiSpecStore == null) {
+            throw new RuntimeException(
+                "Api.SpecLibraryUnavailable: spec library is not configured");
+        }
+        String specId = stringOrNull(config.get("specId"));
+        String operationId = stringOrNull(config.get("operationId"));
+        if (specId == null || operationId == null) {
+            throw new IllegalArgumentException(
+                "operation mode requires specId and operationId");
+        }
+        ApiSpec spec = apiSpecStore.findSpec(tenantId, specId)
+            .orElseThrow(() -> new RuntimeException("Api.SpecNotFound: " + specId));
+        ApiOperation operation = apiSpecStore.findOperation(tenantId, specId, operationId)
+            .orElseThrow(() -> new RuntimeException(
+                "Api.OperationNotFound: " + operationId + " in " + specId));
+
+        Map<String, Object> pathParams = mapOf(payloadMapper.map(
+            config.getOrDefault("pathParams", Map.of()), stateData));
+        Map<String, Object> queryParams = mapOf(payloadMapper.map(
+            config.getOrDefault("queryParams", Map.of()), stateData));
+        Map<String, Object> headersMap = mapOf(payloadMapper.map(
+            config.getOrDefault("headers", Map.of()), stateData));
+        Object body = payloadMapper.map(config.get("requestBody"), stateData);
+
+        String url = buildUrl(spec.baseUrl(), operation.pathTemplate(), pathParams, queryParams);
+        HttpHeaders headers = new HttpHeaders();
+        headersMap.forEach((k, v) -> headers.set(k, v == null ? "" : v.toString()));
+        if (!headers.containsHeader("Content-Type") && body != null) {
+            headers.set("Content-Type", "application/json");
+        }
+        String bodyString = serializeBody(body);
+        return new ResolvedRequest(operation.httpMethod(), url, headers, bodyString);
+    }
+
+    private ResolvedRequest buildFromRaw(Map<String, Object> config,
+                                          Map<String, Object> stateData) {
+        String url = stringOrNull(payloadMapper.map(config.get("url"), stateData));
+        if (url == null || url.isBlank()) {
+            throw new IllegalArgumentException("raw mode requires url");
+        }
+        String method = stringOrDefault(config.get("method"), "GET").toUpperCase();
+        if (!ALLOWED_METHODS.contains(method)) {
+            throw new IllegalArgumentException("Invalid method: " + method);
+        }
+
+        Map<String, Object> queryParams = mapOf(payloadMapper.map(
+            config.getOrDefault("queryParams", Map.of()), stateData));
+        Map<String, Object> headersMap = mapOf(payloadMapper.map(
+            config.getOrDefault("headers", Map.of()), stateData));
+
+        Object body = payloadMapper.map(config.get("body"), stateData);
+
+        String fullUrl = appendQuery(url, queryParams);
+        HttpHeaders headers = new HttpHeaders();
+        headersMap.forEach((k, v) -> headers.set(k, v == null ? "" : v.toString()));
+        if (!headers.containsHeader("Content-Type") && body != null) {
+            headers.set("Content-Type", "application/json");
+        }
+        return new ResolvedRequest(method, fullUrl, headers, serializeBody(body));
+    }
+
+    private String buildUrl(String baseUrl, String pathTemplate,
+                             Map<String, Object> pathParams,
+                             Map<String, Object> queryParams) {
+        if (baseUrl == null) baseUrl = "";
+        if (baseUrl.endsWith("/") && pathTemplate.startsWith("/")) {
+            baseUrl = baseUrl.substring(0, baseUrl.length() - 1);
+        }
+        String filled = pathTemplate;
+        for (Map.Entry<String, Object> entry : pathParams.entrySet()) {
+            String value = entry.getValue() == null ? "" : entry.getValue().toString();
+            filled = filled.replace("{" + entry.getKey() + "}",
+                URLEncoder.encode(value, StandardCharsets.UTF_8));
+        }
+        return appendQuery(baseUrl + filled, queryParams);
+    }
+
+    private String appendQuery(String url, Map<String, Object> queryParams) {
+        if (queryParams == null || queryParams.isEmpty()) {
+            return url;
+        }
+        StringBuilder sb = new StringBuilder(url);
+        sb.append(url.contains("?") ? '&' : '?');
+        boolean first = true;
+        for (Map.Entry<String, Object> entry : queryParams.entrySet()) {
+            if (entry.getValue() == null) continue;
+            if (!first) sb.append('&');
+            first = false;
+            sb.append(URLEncoder.encode(entry.getKey(), StandardCharsets.UTF_8))
+              .append('=')
+              .append(URLEncoder.encode(entry.getValue().toString(), StandardCharsets.UTF_8));
+        }
+        return sb.toString();
+    }
+
+    private String serializeBody(Object body) {
+        if (body == null) return null;
+        if (body instanceof String s) return s;
+        try {
+            return objectMapper.writeValueAsString(body);
+        } catch (Exception e) {
+            return body.toString();
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Auth application
+    // -----------------------------------------------------------------------
+
+    private void applyAuth(ResolvedRequest request, ResolvedCredential cred) {
+        switch (cred.type()) {
+            case "api_key" -> applyApiKey(request, cred);
+            case "bearer_token" -> {
+                Object token = cred.secret("token");
+                if (token != null) {
+                    request.headers.set("Authorization", "Bearer " + token);
+                }
+            }
+            case "basic_auth" -> {
+                Object u = cred.secret("username");
+                Object p = cred.secret("password");
+                if (u != null && p != null) {
+                    String encoded = Base64.getEncoder().encodeToString(
+                        (u + ":" + p).getBytes(StandardCharsets.UTF_8));
+                    request.headers.set("Authorization", "Basic " + encoded);
+                }
+            }
+            case "oauth2_client_credentials", "oauth2_authorization_code" -> {
+                // The resolver returns the *current* access token (refreshing
+                // automatically if it was about to expire). For OAuth flows
+                // the token is stored under "accessToken" in secretFields by
+                // the worker's resolver adapter.
+                Object accessToken = cred.secret("accessToken");
+                if (accessToken == null) {
+                    throw new CredentialFailure("Credential.NoAccessToken",
+                        "OAuth credential has no current access token");
+                }
+                request.headers.set("Authorization", "Bearer " + accessToken);
+            }
+            default -> {
+                // SMTP / custom — credential isn't useful to a plain HTTP step.
+                // Fall through silently; the user picked the wrong credential.
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void applyApiKey(ResolvedRequest request, ResolvedCredential cred) {
+        String headerName = (String) cred.metadata("headerName");
+        String location = (String) cred.metadata("location");
+        String prefix = (String) cred.metadata("prefix");
+        Object value = cred.secret("value");
+        if (value == null || headerName == null) return;
+        String composed = (prefix == null ? "" : prefix) + value;
+        if ("query".equalsIgnoreCase(location)) {
+            request.url = appendQuery(request.url, Map.of(headerName, (Object) composed));
+        } else {
+            request.headers.set(headerName, composed);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Idempotency
+    // -----------------------------------------------------------------------
+
+    private IdempotencyConfig readIdempotency(Map<String, Object> config,
+                                               ResolvedRequest request,
+                                               ActionContext context) {
+        Object raw = config.get("idempotency");
+        if (!(raw instanceof Map<?, ?> map)) {
+            // Default-on for non-idempotent methods if no explicit config.
+            return defaultIdempotency(request, context);
+        }
+        Object enabled = map.get("enabled");
+        if (Boolean.FALSE.equals(enabled)) {
+            return null;
+        }
+        String explicitKey = stringOrNull(map.get("key"));
+        long ttlSeconds = map.get("ttlSeconds") instanceof Number n
+            ? n.longValue() : DEFAULT_IDEMPOTENCY_TTL.toSeconds();
+        String key = explicitKey != null ? explicitKey
+            : computeKey(request, context);
+        return new IdempotencyConfig(key, Duration.ofSeconds(ttlSeconds));
+    }
+
+    private IdempotencyConfig defaultIdempotency(ResolvedRequest request, ActionContext context) {
+        String method = request.method == null ? "GET" : request.method.toUpperCase();
+        if ("GET".equals(method) || "HEAD".equals(method) || "OPTIONS".equals(method)) {
+            return null;
+        }
+        return new IdempotencyConfig(computeKey(request, context), DEFAULT_IDEMPOTENCY_TTL);
+    }
+
+    private static String computeKey(ResolvedRequest request, ActionContext context) {
+        String raw = request.method + " " + request.url + " "
+            + (request.body == null ? "" : request.body) + " "
+            + (context.executionLogId() == null ? "" : context.executionLogId()) + " "
+            + (context.workflowRuleId() == null ? "" : context.workflowRuleId());
+        try {
+            byte[] digest = MessageDigest.getInstance("SHA-256")
+                .digest(raw.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(digest);
+        } catch (Exception e) {
+            return Integer.toHexString(raw.hashCode());
+        }
+    }
+
+    private record IdempotencyConfig(String key, Duration ttl) {
+    }
+
+    // -----------------------------------------------------------------------
+    // Response shaping
+    // -----------------------------------------------------------------------
+
+    private ActionResult success(ResolvedRequest request, int status, String body,
+                                  Map<String, Object> config,
+                                  Map<String, Object> stateData) {
+        Map<String, Object> output = new LinkedHashMap<>();
+        output.put("statusCode", status);
+        output.put("url", request.url);
+        output.put("method", request.method);
+        if (body != null) {
+            output.put("responseBody", truncate(body));
+            try {
+                output.put("responseData", objectMapper.readValue(body, Object.class));
+            } catch (Exception ignored) {
+                // not JSON, that's fine
+            }
+        }
+
+        Object responseMappingTemplate = config.get("responseMapping");
+        if (responseMappingTemplate != null) {
+            Map<String, Object> mappingState = new LinkedHashMap<>(stateData);
+            mappingState.put("$response", output);
+            try {
+                Object mapped = payloadMapper.map(responseMappingTemplate, mappingState);
+                output.put("mapped", mapped);
+            } catch (PayloadMapperException e) {
+                log.debug("Response mapping failed: {}", e.getMessage());
+            }
+        }
+        return ActionResult.success(output);
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> mapOf(Object value) {
+        if (value == null) return Map.of();
+        if (value instanceof Map<?, ?> m) return (Map<String, Object>) m;
+        return Map.of();
+    }
+
+    private static String stringOrNull(Object o) {
+        if (o == null) return null;
+        if (o instanceof String s) return s.isBlank() ? null : s;
+        return o.toString();
+    }
+
+    private static String stringOrDefault(Object o, String fallback) {
+        String s = stringOrNull(o);
+        return s == null ? fallback : s;
+    }
+
+    private static String truncate(String body) {
+        if (body == null) return null;
+        if (body.length() <= MAX_RESPONSE_SIZE) return body;
+        return body.substring(0, MAX_RESPONSE_SIZE) + "... [truncated]";
+    }
+
+    private static class ResolvedRequest {
+        String method;
+        String url;
+        HttpHeaders headers;
+        String body;
+
+        ResolvedRequest(String method, String url, HttpHeaders headers, String body) {
+            this.method = method;
+            this.url = url;
+            this.headers = headers;
+            this.body = body;
+        }
+    }
+
+    private static class CredentialFailure extends RuntimeException {
+        final String code;
+        CredentialFailure(String code, String message) {
+            super(message);
+            this.code = code;
+        }
+    }
+
+    /** Suppress unused-warning on collections list import in IDE checks. */
+    @SuppressWarnings("unused")
+    private static List<String> _supportedTypes() {
+        return List.of("api_key", "bearer_token", "basic_auth",
+            "oauth2_client_credentials", "oauth2_authorization_code");
+    }
+}

--- a/kelta-platform/runtime/runtime-module-integration/src/main/java/io/kelta/runtime/module/integration/mapping/PayloadMapperException.java
+++ b/kelta-platform/runtime/runtime-module-integration/src/main/java/io/kelta/runtime/module/integration/mapping/PayloadMapperException.java
@@ -1,0 +1,18 @@
+package io.kelta.runtime.module.integration.mapping;
+
+/**
+ * Thrown when a payload mapping cannot be resolved — bad JSONata, type
+ * mismatch, or unexpected template shape. Surfaces in flow execution as a
+ * named error code (e.g., {@code Mapper.Failure}) so users can write Catch
+ * policies against it.
+ */
+public class PayloadMapperException extends RuntimeException {
+
+    public PayloadMapperException(String message) {
+        super(message);
+    }
+
+    public PayloadMapperException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/kelta-platform/runtime/runtime-module-integration/src/main/java/io/kelta/runtime/module/integration/mapping/PayloadMapperService.java
+++ b/kelta-platform/runtime/runtime-module-integration/src/main/java/io/kelta/runtime/module/integration/mapping/PayloadMapperService.java
@@ -1,0 +1,129 @@
+package io.kelta.runtime.module.integration.mapping;
+
+import com.dashjoin.jsonata.Jsonata;
+import io.kelta.runtime.flow.StateDataResolver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Resolves a payload template against the current flow state. Used by
+ * action handlers (PR 4's {@code CALL_API}, PR 5's email integration) to
+ * build request bodies, headers, and other structured payloads from the
+ * combination of step config and state data.
+ *
+ * <p><b>Resolution rules</b> (applied recursively to objects, arrays, and scalars):
+ * <ol>
+ *   <li>Strings starting with {@code =} are evaluated as JSONata against the
+ *       state data and the result replaces the string. Useful for
+ *       conditionals, list mapping, defaults, and formatters.</li>
+ *   <li>Objects containing exactly one key {@code "$expr"} are treated the
+ *       same — the expression's result replaces the whole object.</li>
+ *   <li>All other strings flow through {@link StateDataResolver#resolveTemplate}
+ *       so existing {@code ${$.path}} placeholders keep working.</li>
+ *   <li>Object values and array elements recurse.</li>
+ * </ol>
+ *
+ * <p>JSONata expressions are pre-compiled per call (the dashjoin runtime is
+ * already cached internally). Compilation errors surface as
+ * {@link PayloadMapperException} so handlers can fail flows cleanly.
+ */
+public class PayloadMapperService {
+
+    private static final Logger log = LoggerFactory.getLogger(PayloadMapperService.class);
+    private static final String EXPR_KEY = "$expr";
+
+    private final StateDataResolver dataResolver;
+
+    public PayloadMapperService(StateDataResolver dataResolver) {
+        this.dataResolver = dataResolver;
+    }
+
+    /**
+     * Walks {@code template} recursively and produces the resolved payload.
+     * Pass {@code stateData} as the current flow state map.
+     */
+    public Object map(Object template, Map<String, Object> stateData) {
+        if (template == null) {
+            return null;
+        }
+        if (template instanceof String s) {
+            return mapString(s, stateData);
+        }
+        if (template instanceof Map<?, ?> m) {
+            return mapMap(m, stateData);
+        }
+        if (template instanceof List<?> l) {
+            return mapList(l, stateData);
+        }
+        return template;
+    }
+
+    /**
+     * Convenience for handlers that need an {@code Object → Map<String,Object>}
+     * mapping. When {@link #map} returns a non-Map value (e.g., a JSONata
+     * expression that produced a scalar), throws {@link PayloadMapperException}.
+     */
+    @SuppressWarnings("unchecked")
+    public Map<String, Object> mapToObject(Object template, Map<String, Object> stateData) {
+        Object resolved = map(template, stateData);
+        if (resolved == null) {
+            return new LinkedHashMap<>();
+        }
+        if (resolved instanceof Map<?, ?> m) {
+            return (Map<String, Object>) m;
+        }
+        throw new PayloadMapperException(
+            "Mapping produced a " + resolved.getClass().getSimpleName()
+                + " but an object was expected");
+    }
+
+    // -----------------------------------------------------------------------
+
+    private Object mapString(String s, Map<String, Object> stateData) {
+        if (s.startsWith("=")) {
+            return evalJsonata(s.substring(1), stateData);
+        }
+        return dataResolver.resolveTemplate(s, stateData);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Object mapMap(Map<?, ?> map, Map<String, Object> stateData) {
+        // {"$expr": "..."} replaces the whole object
+        if (map.size() == 1 && map.containsKey(EXPR_KEY)) {
+            Object expr = map.get(EXPR_KEY);
+            if (expr instanceof String s) {
+                return evalJsonata(s, stateData);
+            }
+        }
+        Map<String, Object> out = new LinkedHashMap<>();
+        for (Map.Entry<?, ?> entry : map.entrySet()) {
+            String key = String.valueOf(entry.getKey());
+            out.put(key, map(entry.getValue(), stateData));
+        }
+        return out;
+    }
+
+    private Object mapList(List<?> list, Map<String, Object> stateData) {
+        List<Object> out = new ArrayList<>(list.size());
+        for (Object item : list) {
+            out.add(map(item, stateData));
+        }
+        return out;
+    }
+
+    private Object evalJsonata(String expression, Map<String, Object> stateData) {
+        try {
+            Jsonata expr = Jsonata.jsonata(expression);
+            return expr.evaluate(stateData);
+        } catch (Exception e) {
+            log.debug("JSONata expression failed: '{}': {}", expression, e.getMessage());
+            throw new PayloadMapperException(
+                "JSONata expression failed: " + e.getMessage(), e);
+        }
+    }
+}

--- a/kelta-platform/runtime/runtime-module-integration/src/main/java/io/kelta/runtime/module/integration/spi/CredentialResolverPort.java
+++ b/kelta-platform/runtime/runtime-module-integration/src/main/java/io/kelta/runtime/module/integration/spi/CredentialResolverPort.java
@@ -1,0 +1,25 @@
+package io.kelta.runtime.module.integration.spi;
+
+import io.kelta.runtime.credential.ResolvedCredential;
+
+/**
+ * Module-side bridge to the platform credential resolver. The worker adapts
+ * its {@code CredentialResolverImpl} to this interface and registers it as a
+ * {@code ModuleContext} extension so handlers (CALL_API, future mailers)
+ * never depend on worker-internal types.
+ *
+ * <p>If no implementation is available, handlers that require a credential
+ * fail with {@code Credential.NotConfigured} — the platform was not
+ * configured with the credential vault foundation (PR 1) bootstrapped.
+ */
+public interface CredentialResolverPort {
+
+    /**
+     * Returns the decrypted credential for {@code reference} (id or name)
+     * scoped to the supplied tenant. {@code purpose} is captured in the
+     * platform's audit trail.
+     *
+     * @throws RuntimeException when the credential cannot be resolved
+     */
+    ResolvedCredential resolve(String tenantId, String reference, String purpose);
+}

--- a/kelta-platform/runtime/runtime-module-integration/src/main/java/io/kelta/runtime/module/integration/spi/IdempotencyStore.java
+++ b/kelta-platform/runtime/runtime-module-integration/src/main/java/io/kelta/runtime/module/integration/spi/IdempotencyStore.java
@@ -1,0 +1,27 @@
+package io.kelta.runtime.module.integration.spi;
+
+import java.time.Duration;
+import java.util.Optional;
+
+/**
+ * Per-tenant idempotency cache for non-idempotent API calls. The
+ * {@code CALL_API} handler uses this to short-circuit duplicate executions
+ * (e.g., a flow retried after a partial failure) so we never double-charge,
+ * double-create, or otherwise duplicate side-effects on remote systems.
+ */
+public interface IdempotencyStore {
+
+    /** Looks up a cached response for {@code key}. */
+    Optional<CachedResponse> lookup(String tenantId, String key);
+
+    /** Records a response for {@code key} with the given TTL. */
+    void record(String tenantId, String key, String flowRunId, String stateName,
+                int statusCode, String responseBody, Duration ttl);
+
+    /**
+     * Cached response — what the upstream replied last time, replayed when a
+     * subsequent call presents the same {@code Idempotency-Key}.
+     */
+    record CachedResponse(int statusCode, String responseBody, String responseHash) {
+    }
+}

--- a/kelta-platform/runtime/runtime-module-integration/src/test/java/io/kelta/runtime/module/integration/handlers/CallApiActionHandlerTest.java
+++ b/kelta-platform/runtime/runtime-module-integration/src/test/java/io/kelta/runtime/module/integration/handlers/CallApiActionHandlerTest.java
@@ -1,0 +1,312 @@
+package io.kelta.runtime.module.integration.handlers;
+
+import io.kelta.runtime.credential.ResolvedCredential;
+import io.kelta.runtime.flow.StateDataResolver;
+import io.kelta.runtime.module.integration.api.ApiOperation;
+import io.kelta.runtime.module.integration.api.ApiSpec;
+import io.kelta.runtime.module.integration.mapping.PayloadMapperService;
+import io.kelta.runtime.module.integration.spi.ApiSpecStore;
+import io.kelta.runtime.module.integration.spi.CredentialResolverPort;
+import io.kelta.runtime.module.integration.spi.IdempotencyStore;
+import io.kelta.runtime.module.integration.spi.IdempotencyStore.CachedResponse;
+import io.kelta.runtime.workflow.ActionContext;
+import io.kelta.runtime.workflow.ActionResult;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+import tools.jackson.databind.ObjectMapper;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@DisplayName("CallApiActionHandler")
+class CallApiActionHandlerTest {
+
+    private CallApiActionHandler handler;
+    private ObjectMapper objectMapper;
+    private ApiSpecStore specStore;
+    private CredentialResolverPort credentialResolver;
+    private IdempotencyStore idempotencyStore;
+    private RestTemplate restTemplate;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+        PayloadMapperService mapper = new PayloadMapperService(new StateDataResolver(objectMapper));
+        specStore = mock(ApiSpecStore.class);
+        credentialResolver = mock(CredentialResolverPort.class);
+        idempotencyStore = mock(IdempotencyStore.class);
+        restTemplate = mock(RestTemplate.class);
+        handler = new CallApiActionHandler(
+            objectMapper, mapper, specStore, credentialResolver, idempotencyStore, restTemplate);
+    }
+
+    @Test
+    @DisplayName("Action type key is CALL_API")
+    void typeKey() {
+        assertEquals("CALL_API", handler.getActionTypeKey());
+    }
+
+    @Test
+    @DisplayName("Raw mode: builds URL from config + state, maps headers and body")
+    void rawModeExecutes() throws Exception {
+        when(restTemplate.exchange(
+                anyString(), eq(HttpMethod.POST), any(HttpEntity.class), eq(String.class)))
+            .thenReturn(new ResponseEntity<>("{\"id\":42}", HttpStatus.OK));
+
+        Map<String, Object> config = new LinkedHashMap<>();
+        config.put("mode", "raw");
+        config.put("url", "https://api.example.com/orders/${$.input.orderId}");
+        config.put("method", "POST");
+        config.put("headers", Map.of("X-Trace", "${$.input.traceId}"));
+        config.put("body", Map.of("status", "submitted"));
+
+        ActionContext ctx = ActionContext.builder()
+            .tenantId("t-1")
+            .actionConfigJson(objectMapper.writeValueAsString(config))
+            .resolvedData(Map.of("input", Map.of("orderId", "O-99", "traceId", "trc")))
+            .build();
+
+        ActionResult result = handler.execute(ctx);
+
+        assertTrue(result.successful(), "expected success but got: " + result.errorMessage());
+        ArgumentCaptor<String> urlCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<HttpEntity<String>> entityCaptor = ArgumentCaptor.forClass(HttpEntity.class);
+        verify(restTemplate).exchange(urlCaptor.capture(), eq(HttpMethod.POST),
+            entityCaptor.capture(), eq(String.class));
+        assertEquals("https://api.example.com/orders/O-99", urlCaptor.getValue());
+        assertEquals("trc", entityCaptor.getValue().getHeaders().getFirst("X-Trace"));
+        assertTrue(entityCaptor.getValue().getBody().contains("\"status\":\"submitted\""));
+    }
+
+    @Test
+    @DisplayName("Operation mode: loads spec + operation, fills path params, builds URL")
+    void operationModeBuildsUrl() throws Exception {
+        ApiSpec spec = spec("petstore", "https://petstore.swagger.io/v2");
+        ApiOperation operation = operation(spec.id(), "getPetById", "GET", "/pet/{petId}");
+        when(specStore.findSpec("t-1", "petstore")).thenReturn(Optional.of(spec));
+        when(specStore.findOperation("t-1", "petstore", "getPetById"))
+            .thenReturn(Optional.of(operation));
+
+        when(restTemplate.exchange(
+                anyString(), eq(HttpMethod.GET), any(HttpEntity.class), eq(String.class)))
+            .thenReturn(new ResponseEntity<>("{}", HttpStatus.OK));
+
+        Map<String, Object> config = new LinkedHashMap<>();
+        config.put("mode", "operation");
+        config.put("specId", "petstore");
+        config.put("operationId", "getPetById");
+        config.put("pathParams", Map.of("petId", "${$.queryResult.id}"));
+
+        ActionContext ctx = ActionContext.builder()
+            .tenantId("t-1")
+            .actionConfigJson(objectMapper.writeValueAsString(config))
+            .resolvedData(Map.of("queryResult", Map.of("id", "501")))
+            .build();
+
+        ActionResult result = handler.execute(ctx);
+
+        assertTrue(result.successful());
+        ArgumentCaptor<String> urlCaptor = ArgumentCaptor.forClass(String.class);
+        verify(restTemplate).exchange(urlCaptor.capture(), eq(HttpMethod.GET),
+            any(HttpEntity.class), eq(String.class));
+        assertEquals("https://petstore.swagger.io/v2/pet/501", urlCaptor.getValue());
+    }
+
+    @Test
+    @DisplayName("Applies api_key credential as a header")
+    void appliesApiKeyHeader() throws Exception {
+        when(credentialResolver.resolve(eq("t-1"), eq("salesforce"), anyString()))
+            .thenReturn(new ResolvedCredential("c-1", "salesforce", "api_key",
+                Map.of("value", "sk_test_123"),
+                Map.of("headerName", "X-API-Key", "location", "header"),
+                Instant.now()));
+        when(restTemplate.exchange(
+                anyString(), eq(HttpMethod.GET), any(HttpEntity.class), eq(String.class)))
+            .thenReturn(new ResponseEntity<>("ok", HttpStatus.OK));
+
+        Map<String, Object> config = Map.of(
+            "mode", "raw",
+            "url", "https://example.com/x",
+            "method", "GET",
+            "credentialRef", "salesforce");
+
+        ActionContext ctx = ActionContext.builder()
+            .tenantId("t-1")
+            .actionConfigJson(objectMapper.writeValueAsString(config))
+            .resolvedData(Map.of())
+            .build();
+
+        ActionResult result = handler.execute(ctx);
+
+        assertTrue(result.successful());
+        ArgumentCaptor<HttpEntity<String>> entityCaptor = ArgumentCaptor.forClass(HttpEntity.class);
+        verify(restTemplate).exchange(anyString(), eq(HttpMethod.GET),
+            entityCaptor.capture(), eq(String.class));
+        assertEquals("sk_test_123", entityCaptor.getValue().getHeaders().getFirst("X-API-Key"));
+    }
+
+    @Test
+    @DisplayName("Applies bearer_token credential as Authorization header")
+    void appliesBearer() throws Exception {
+        when(credentialResolver.resolve(eq("t-1"), eq("github"), anyString()))
+            .thenReturn(new ResolvedCredential("c-2", "github", "bearer_token",
+                Map.of("token", "ghp_token"), Map.of(), Instant.now()));
+        when(restTemplate.exchange(
+                anyString(), eq(HttpMethod.GET), any(HttpEntity.class), eq(String.class)))
+            .thenReturn(new ResponseEntity<>("[]", HttpStatus.OK));
+
+        Map<String, Object> config = Map.of(
+            "mode", "raw",
+            "url", "https://api.github.com/user",
+            "credentialRef", "github");
+
+        ActionContext ctx = ActionContext.builder()
+            .tenantId("t-1")
+            .actionConfigJson(objectMapper.writeValueAsString(config))
+            .resolvedData(Map.of())
+            .build();
+
+        ActionResult result = handler.execute(ctx);
+
+        assertTrue(result.successful());
+        ArgumentCaptor<HttpEntity<String>> captor = ArgumentCaptor.forClass(HttpEntity.class);
+        verify(restTemplate).exchange(anyString(), eq(HttpMethod.GET), captor.capture(),
+            eq(String.class));
+        assertEquals("Bearer ghp_token",
+            captor.getValue().getHeaders().getFirst("Authorization"));
+    }
+
+    @Test
+    @DisplayName("Idempotency hit replays cached response without calling upstream")
+    void idempotencyHitReplays() throws Exception {
+        when(idempotencyStore.lookup(eq("t-1"), anyString()))
+            .thenReturn(Optional.of(new CachedResponse(201, "{\"cached\":true}", "hash")));
+
+        Map<String, Object> config = Map.of(
+            "mode", "raw",
+            "url", "https://api.example.com/orders",
+            "method", "POST",
+            "body", Map.of("x", 1),
+            "idempotency", Map.of("enabled", true, "key", "fixed-key-1"));
+
+        ActionContext ctx = ActionContext.builder()
+            .tenantId("t-1")
+            .actionConfigJson(objectMapper.writeValueAsString(config))
+            .resolvedData(Map.of())
+            .build();
+
+        ActionResult result = handler.execute(ctx);
+
+        assertTrue(result.successful());
+        verify(restTemplate, never()).exchange(anyString(), any(HttpMethod.class),
+            any(HttpEntity.class), eq(String.class));
+        assertEquals(201, result.outputData().get("statusCode"));
+    }
+
+    @Test
+    @DisplayName("Idempotency miss sends upstream with header and records response on success")
+    void idempotencyMissRecords() throws Exception {
+        when(idempotencyStore.lookup(eq("t-1"), anyString())).thenReturn(Optional.empty());
+        when(restTemplate.exchange(
+                anyString(), eq(HttpMethod.POST), any(HttpEntity.class), eq(String.class)))
+            .thenReturn(new ResponseEntity<>("{\"ok\":true}", HttpStatus.CREATED));
+
+        Map<String, Object> config = Map.of(
+            "mode", "raw",
+            "url", "https://api.example.com/orders",
+            "method", "POST",
+            "body", Map.of("x", 1),
+            "idempotency", Map.of("enabled", true, "key", "key-7", "ttlSeconds", 60));
+
+        ActionContext ctx = ActionContext.builder()
+            .tenantId("t-1")
+            .actionConfigJson(objectMapper.writeValueAsString(config))
+            .resolvedData(Map.of())
+            .build();
+
+        handler.execute(ctx);
+
+        ArgumentCaptor<HttpEntity<String>> entity = ArgumentCaptor.forClass(HttpEntity.class);
+        verify(restTemplate).exchange(anyString(), eq(HttpMethod.POST), entity.capture(),
+            eq(String.class));
+        assertEquals("key-7", entity.getValue().getHeaders().getFirst("Idempotency-Key"));
+        verify(idempotencyStore).record(eq("t-1"), eq("key-7"), any(), any(),
+            eq(201), eq("{\"ok\":true}"), eq(Duration.ofSeconds(60)));
+    }
+
+    @Test
+    @DisplayName("4xx maps to Api.HttpClientError")
+    void httpClientErrorMaps() throws Exception {
+        when(restTemplate.exchange(
+                anyString(), any(HttpMethod.class), any(HttpEntity.class), eq(String.class)))
+            .thenThrow(HttpClientErrorException.create(
+                HttpStatus.NOT_FOUND, "Not Found", null, null, null));
+
+        Map<String, Object> config = Map.of("mode", "raw", "url", "https://example.com/x");
+        ActionContext ctx = ActionContext.builder()
+            .tenantId("t-1")
+            .actionConfigJson(objectMapper.writeValueAsString(config))
+            .resolvedData(Map.of())
+            .build();
+
+        ActionResult result = handler.execute(ctx);
+
+        assertFalse(result.successful());
+        assertTrue(result.errorMessage().startsWith("Api.HttpClientError:"),
+            "got: " + result.errorMessage());
+    }
+
+    @Test
+    @DisplayName("validate() rejects raw mode without url and operation mode without specId")
+    void validateRejectsBadConfig() throws Exception {
+        // raw mode without url
+        String config1 = objectMapper.writeValueAsString(Map.of("mode", "raw"));
+        assertThrows(IllegalArgumentException.class, () -> handler.validate(config1));
+
+        // operation mode without specId
+        String config2 = objectMapper.writeValueAsString(
+            Map.of("mode", "operation", "operationId", "x"));
+        assertThrows(IllegalArgumentException.class, () -> handler.validate(config2));
+
+        // good raw
+        String good = objectMapper.writeValueAsString(
+            Map.of("mode", "raw", "url", "https://example.com"));
+        assertDoesNotThrow(() -> handler.validate(good));
+    }
+
+    // -----------------------------------------------------------------------
+
+    private static ApiSpec spec(String name, String baseUrl) {
+        return new ApiSpec(
+            name, "t-1", name, null, "3.0.3", name, "1.0", baseUrl,
+            null, null, "URL", null, "{}", "json", null,
+            "deadbeef", 1, true, Instant.now());
+    }
+
+    private static ApiOperation operation(String specId, String opId, String method, String path) {
+        return new ApiOperation(
+            opId, "t-1", specId, opId, opId, method, path,
+            "summary", null, null, null, null, null, null, false);
+    }
+
+    @SuppressWarnings("unused")
+    private static List<String> _refs() {
+        return List.of("ApiSpec");   // keep imports stable
+    }
+}

--- a/kelta-platform/runtime/runtime-module-integration/src/test/java/io/kelta/runtime/module/integration/mapping/PayloadMapperServiceTest.java
+++ b/kelta-platform/runtime/runtime-module-integration/src/test/java/io/kelta/runtime/module/integration/mapping/PayloadMapperServiceTest.java
@@ -1,0 +1,110 @@
+package io.kelta.runtime.module.integration.mapping;
+
+import io.kelta.runtime.flow.StateDataResolver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("PayloadMapperService")
+class PayloadMapperServiceTest {
+
+    private PayloadMapperService mapper;
+
+    @BeforeEach
+    void setUp() {
+        mapper = new PayloadMapperService(new StateDataResolver(new ObjectMapper()));
+    }
+
+    @Test
+    @DisplayName("Substitutes ${$.path} placeholders unchanged from the existing engine")
+    void preservesDollarPathSyntax() {
+        Map<String, Object> state = Map.of(
+            "record", Map.of("data", Map.of("orderId", "O-100")));
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> resolved = (Map<String, Object>) mapper.map(
+            Map.of("orderId", "${$.record.data.orderId}"), state);
+
+        assertEquals("O-100", resolved.get("orderId"));
+    }
+
+    @Test
+    @DisplayName("Evaluates strings starting with = as JSONata expressions")
+    void evaluatesEqualsExpression() {
+        Map<String, Object> state = Map.of(
+            "order", Map.of(
+                "items", List.of(
+                    Map.of("name", "Widget", "price", 10),
+                    Map.of("name", "Gadget", "price", 5))));
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> resolved = (Map<String, Object>) mapper.map(
+            Map.of("total", "=$sum(order.items.price)"), state);
+
+        // jsonata returns Number; assertion is permissive on int vs long.
+        assertEquals(15, ((Number) resolved.get("total")).intValue());
+    }
+
+    @Test
+    @DisplayName("Treats { $expr: ... } objects as full-document expressions")
+    void evaluatesDollarExprObject() {
+        Map<String, Object> state = Map.of("name", "Buddy", "status", "available");
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> result = (Map<String, Object>) mapper.map(
+            Map.of("$expr", "{ \"upper\": $uppercase(name), \"isAvailable\": status = 'available' }"),
+            state);
+
+        assertEquals("BUDDY", result.get("upper"));
+        assertEquals(true, result.get("isAvailable"));
+    }
+
+    @Test
+    @DisplayName("Recurses into nested objects and arrays")
+    void recurses() {
+        Map<String, Object> state = Map.of("user", Map.of("name", "Alex"));
+
+        Map<String, Object> template = new LinkedHashMap<>();
+        template.put("greeting", "Hello ${$.user.name}");
+        template.put("tags", List.of("a", "${$.user.name}"));
+        template.put("nested", Map.of("who", "${$.user.name}"));
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> out = (Map<String, Object>) mapper.map(template, state);
+
+        assertEquals("Hello Alex", out.get("greeting"));
+        @SuppressWarnings("unchecked")
+        List<String> tags = (List<String>) out.get("tags");
+        assertEquals(List.of("a", "Alex"), tags);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> nested = (Map<String, Object>) out.get("nested");
+        assertEquals("Alex", nested.get("who"));
+    }
+
+    @Test
+    @DisplayName("Surfaces JSONata errors as PayloadMapperException")
+    void mapperException() {
+        assertThrows(PayloadMapperException.class, () ->
+            mapper.map(Map.of("x", "=this is not valid jsonata at all $$"), Map.of()));
+    }
+
+    @Test
+    @DisplayName("Returns null when template is null")
+    void nullTemplate() {
+        assertNull(mapper.map(null, Map.of()));
+    }
+
+    @Test
+    @DisplayName("mapToObject throws when expression yields a scalar")
+    void mapToObjectRejectsScalar() {
+        assertThrows(PayloadMapperException.class, () ->
+            mapper.mapToObject("=42", Map.of()));
+    }
+}

--- a/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/CallApiParams.tsx
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/CallApiParams.tsx
@@ -1,0 +1,364 @@
+import React, { useState } from 'react'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+import { Button } from '@/components/ui/button'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { Card, CardContent } from '@/components/ui/card'
+import { FieldLabel } from '@/components/kelta'
+import { Plus, Trash2 } from 'lucide-react'
+import { CredentialPicker } from '@/components/credentials/CredentialPicker'
+import { SpecPicker } from '@/components/apiSpec/SpecPicker'
+import { OperationPicker } from '@/components/apiSpec/OperationPicker'
+import { cn } from '@/lib/utils'
+
+interface CallApiParamsProps {
+  parameters?: Record<string, unknown>
+  onUpdate: (params: Record<string, unknown>) => void
+}
+
+type Mode = 'operation' | 'raw'
+
+interface KeyValue {
+  key: string
+  value: string
+}
+
+function toEntries(map: unknown): KeyValue[] {
+  if (!map || typeof map !== 'object') return []
+  return Object.entries(map as Record<string, unknown>).map(([key, value]) => ({
+    key,
+    value: typeof value === 'string' ? value : JSON.stringify(value),
+  }))
+}
+
+function fromEntries(entries: KeyValue[]): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (const e of entries) {
+    if (e.key.trim()) out[e.key] = e.value
+  }
+  return out
+}
+
+const HTTP_METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS']
+
+/**
+ * Properties editor for the CALL_API flow step. Two modes:
+ * - operation: pick an OpenAPI spec + operation, fill path/query/headers/body
+ * - raw: free-form URL + method (Postman-style), with credential and idempotency
+ */
+export function CallApiParams({ parameters, onUpdate }: CallApiParamsProps) {
+  const params = parameters ?? {}
+  const mode = ((params.mode as string) ?? 'raw') as Mode
+
+  const update = (next: Record<string, unknown>) => onUpdate({ ...params, ...next })
+
+  const [headerEntries, setHeaderEntries] = useState<KeyValue[]>(() =>
+    toEntries(params.headers)
+  )
+  const [pathParamEntries, setPathParamEntries] = useState<KeyValue[]>(() =>
+    toEntries(params.pathParams)
+  )
+  const [queryEntries, setQueryEntries] = useState<KeyValue[]>(() =>
+    toEntries(params.queryParams)
+  )
+
+  const updateHeaders = (entries: KeyValue[]) => {
+    setHeaderEntries(entries)
+    update({ headers: fromEntries(entries) })
+  }
+  const updatePathParams = (entries: KeyValue[]) => {
+    setPathParamEntries(entries)
+    update({ pathParams: fromEntries(entries) })
+  }
+  const updateQueryParams = (entries: KeyValue[]) => {
+    setQueryEntries(entries)
+    update({ queryParams: fromEntries(entries) })
+  }
+
+  const credentialId = (params.credentialRef as string) ?? ''
+  const specId = (params.specId as string) ?? ''
+  const operationId = (params.operationId as string) ?? ''
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-1">
+        <FieldLabel>Mode</FieldLabel>
+        <div
+          role="tablist"
+          className="grid grid-cols-2 rounded-md border p-1 text-sm bg-muted/30"
+        >
+          <ModeTab
+            active={mode === 'operation'}
+            onClick={() => update({ mode: 'operation' })}
+          >
+            From OpenAPI spec
+          </ModeTab>
+          <ModeTab
+            active={mode === 'raw'}
+            onClick={() => update({ mode: 'raw' })}
+          >
+            Ad-hoc (Postman)
+          </ModeTab>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          {mode === 'operation'
+            ? 'Pick an imported spec and operation; URL + method are derived from the spec.'
+            : 'Free-form URL + method. Use ${$.path} placeholders or =jsonata expressions in any field.'}
+        </p>
+      </div>
+
+      {mode === 'operation' ? (
+        <Card className="bg-muted/20">
+          <CardContent className="space-y-3 p-3">
+            <SpecPicker
+              value={specId}
+              onChange={(id) => update({ specId: id, operationId: '' })}
+            />
+            {specId && (
+              <OperationPicker
+                specId={specId}
+                value={operationId}
+                onChange={(id) => update({ operationId: id })}
+              />
+            )}
+          </CardContent>
+        </Card>
+      ) : (
+        <Card className="bg-muted/20">
+          <CardContent className="space-y-3 p-3">
+            <div className="flex gap-2">
+              <div className="space-y-1 w-32">
+                <FieldLabel>Method</FieldLabel>
+                <Select
+                  value={(params.method as string) ?? 'GET'}
+                  onValueChange={(v) => update({ method: v })}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {HTTP_METHODS.map((m) => (
+                      <SelectItem key={m} value={m}>
+                        {m}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-1 flex-1">
+                <FieldLabel>URL</FieldLabel>
+                <Input
+                  value={(params.url as string) ?? ''}
+                  onChange={(e) => update({ url: e.target.value })}
+                  placeholder="https://api.example.com/things/${$.input.id}"
+                  className="font-mono text-xs"
+                />
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      <CredentialPicker
+        value={credentialId}
+        onChange={(id) => update({ credentialRef: id })}
+      />
+
+      {mode === 'operation' && (
+        <KeyValueList
+          label="Path parameters"
+          entries={pathParamEntries}
+          onChange={updatePathParams}
+          placeholderKey="petId"
+          placeholderValue="${$.input.id}"
+        />
+      )}
+
+      <KeyValueList
+        label="Query parameters"
+        entries={queryEntries}
+        onChange={updateQueryParams}
+        placeholderKey="status"
+        placeholderValue="active"
+      />
+
+      <KeyValueList
+        label="Headers"
+        entries={headerEntries}
+        onChange={updateHeaders}
+        placeholderKey="X-Trace"
+        placeholderValue="${$.executionId}"
+      />
+
+      <div className="space-y-1">
+        <FieldLabel>{mode === 'operation' ? 'Request body' : 'Body'}</FieldLabel>
+        <Textarea
+          rows={6}
+          value={
+            typeof params[mode === 'operation' ? 'requestBody' : 'body'] === 'string'
+              ? (params[mode === 'operation' ? 'requestBody' : 'body'] as string)
+              : params[mode === 'operation' ? 'requestBody' : 'body']
+                ? JSON.stringify(params[mode === 'operation' ? 'requestBody' : 'body'], null, 2)
+                : ''
+          }
+          onChange={(e) => {
+            const trimmed = e.target.value.trim()
+            let parsed: unknown = e.target.value
+            if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
+              try {
+                parsed = JSON.parse(trimmed)
+              } catch {
+                parsed = e.target.value
+              }
+            }
+            update({ [mode === 'operation' ? 'requestBody' : 'body']: parsed })
+          }}
+          className="font-mono text-xs"
+          placeholder={'{ "name": "${$.record.data.name}" }'}
+        />
+        <p className="text-xs text-muted-foreground">
+          Strings starting with <code className="font-mono">=</code> are evaluated as
+          JSONata; everything else flows through <code className="font-mono">${'${$.path}'}</code>{' '}
+          substitution.
+        </p>
+      </div>
+
+      <div className="space-y-1">
+        <FieldLabel>Response variable</FieldLabel>
+        <Input
+          value={(params.responseVariable as string) ?? ''}
+          onChange={(e) => update({ responseVariable: e.target.value })}
+          placeholder="apiResult"
+        />
+        <p className="text-xs text-muted-foreground">
+          Optional. Persists the response under this name on the flow state.
+        </p>
+      </div>
+
+      <details className="rounded-md border bg-muted/10">
+        <summary className="cursor-pointer px-3 py-2 text-sm font-medium">
+          Advanced — idempotency &amp; retry
+        </summary>
+        <div className="space-y-3 p-3">
+          <div className="space-y-1">
+            <FieldLabel>Idempotency key (optional)</FieldLabel>
+            <Input
+              value={
+                ((params.idempotency as Record<string, unknown> | undefined)?.key as string) ?? ''
+              }
+              onChange={(e) =>
+                update({
+                  idempotency: {
+                    ...(params.idempotency as object | undefined),
+                    enabled: true,
+                    key: e.target.value,
+                  },
+                })
+              }
+              placeholder="${$.input.orderId}"
+              className="font-mono text-xs"
+            />
+            <p className="text-xs text-muted-foreground">
+              When set, the platform sends an Idempotency-Key header upstream and replays
+              cached responses on retry.
+            </p>
+          </div>
+        </div>
+      </details>
+    </div>
+  )
+}
+
+function ModeTab({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean
+  onClick: () => void
+  children: React.ReactNode
+}) {
+  return (
+    <button
+      role="tab"
+      aria-selected={active}
+      onClick={onClick}
+      className={cn(
+        'rounded px-3 py-1.5 transition-colors',
+        active ? 'bg-background shadow-sm font-medium' : 'text-muted-foreground'
+      )}
+    >
+      {children}
+    </button>
+  )
+}
+
+interface KeyValueListProps {
+  label: string
+  entries: KeyValue[]
+  onChange: (entries: KeyValue[]) => void
+  placeholderKey: string
+  placeholderValue: string
+}
+
+function KeyValueList({
+  label,
+  entries,
+  onChange,
+  placeholderKey,
+  placeholderValue,
+}: KeyValueListProps) {
+  return (
+    <div className="space-y-1">
+      <FieldLabel>{label}</FieldLabel>
+      <div className="space-y-1">
+        {entries.map((entry, i) => (
+          <div key={i} className="flex gap-2">
+            <Input
+              className="flex-1 font-mono text-xs"
+              value={entry.key}
+              onChange={(e) => {
+                const next = [...entries]
+                next[i] = { ...entry, key: e.target.value }
+                onChange(next)
+              }}
+              placeholder={placeholderKey}
+            />
+            <Input
+              className="flex-1 font-mono text-xs"
+              value={entry.value}
+              onChange={(e) => {
+                const next = [...entries]
+                next[i] = { ...entry, value: e.target.value }
+                onChange(next)
+              }}
+              placeholder={placeholderValue}
+            />
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => onChange(entries.filter((_, idx) => idx !== i))}
+              title="Remove"
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+            </Button>
+          </div>
+        ))}
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={() => onChange([...entries, { key: '', value: '' }])}
+        >
+          <Plus className="mr-1 h-3.5 w-3.5" />
+          Add
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/TaskProperties.tsx
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/TaskProperties.tsx
@@ -13,6 +13,7 @@ import { DeleteRecordParams } from './DeleteRecordParams'
 import { FieldUpdateParams } from './FieldUpdateParams'
 import { LogMessageParams } from './LogMessageParams'
 import { HttpCalloutParams } from './HttpCalloutParams'
+import { CallApiParams } from './CallApiParams'
 import { SendNotificationParams } from './SendNotificationParams'
 import { EmailAlertParams } from './EmailAlertParams'
 import { TriggerFlowParams } from './TriggerFlowParams'
@@ -92,6 +93,12 @@ export function TaskProperties({ nodeId, data, allNodeIds, onUpdate }: TaskPrope
       )}
       {resource === 'HTTP_CALLOUT' && (
         <HttpCalloutParams
+          parameters={data.parameters as Record<string, unknown> | undefined}
+          onUpdate={(params) => onUpdate({ parameters: params })}
+        />
+      )}
+      {resource === 'CALL_API' && (
+        <CallApiParams
           parameters={data.parameters as Record<string, unknown> | undefined}
           onUpdate={(params) => onUpdate({ parameters: params })}
         />

--- a/kelta-ui/app/src/pages/FlowDesignerPage/types.ts
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/types.ts
@@ -318,6 +318,7 @@ export const RESOURCE_GROUPS: ResourceGroup[] = [
   {
     label: 'Integration',
     options: [
+      { value: 'CALL_API', label: 'Call API' },
       { value: 'HTTP_CALLOUT', label: 'HTTP Callout' },
       { value: 'PUBLISH_EVENT', label: 'Publish Event' },
       { value: 'INVOKE_SCRIPT', label: 'Invoke Script' },

--- a/kelta-worker/src/main/java/io/kelta/worker/config/FlowConfig.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/config/FlowConfig.java
@@ -183,7 +183,13 @@ public class FlowConfig {
                                           FlowEngine flowEngine,
                                           RollupSummaryService rollupSummaryService,
                                           @Autowired(required = false) EmailService emailService,
-                                          @Autowired(required = false) ScriptExecutor scriptExecutor) {
+                                          @Autowired(required = false) ScriptExecutor scriptExecutor,
+                                          @Autowired(required = false)
+                                              io.kelta.runtime.module.integration.spi.ApiSpecStore apiSpecStore,
+                                          @Autowired(required = false)
+                                              io.kelta.runtime.module.integration.spi.CredentialResolverPort credentialResolverPort,
+                                          @Autowired(required = false)
+                                              io.kelta.runtime.module.integration.spi.IdempotencyStore idempotencyStore) {
         ModuleRegistry registry = new ModuleRegistry(actionHandlerRegistry, beforeSaveHookRegistry);
 
         if (discoveredModules != null && !discoveredModules.isEmpty()) {
@@ -199,6 +205,23 @@ public class FlowConfig {
             if (scriptExecutor != null) {
                 extensions.put(ScriptExecutor.class, scriptExecutor);
                 log.info("ScriptExecutor wired into module context — flow scripts will use GraalVM execution");
+            }
+
+            // PR 4: wire CALL_API SPI implementations so the integration
+            // module can resolve specs, credentials, and idempotency state.
+            if (apiSpecStore != null) {
+                extensions.put(io.kelta.runtime.module.integration.spi.ApiSpecStore.class, apiSpecStore);
+                log.info("ApiSpecStore wired into module context — CALL_API operation mode active");
+            }
+            if (credentialResolverPort != null) {
+                extensions.put(io.kelta.runtime.module.integration.spi.CredentialResolverPort.class,
+                    credentialResolverPort);
+                log.info("CredentialResolverPort wired into module context — CALL_API can attach credentials");
+            }
+            if (idempotencyStore != null) {
+                extensions.put(io.kelta.runtime.module.integration.spi.IdempotencyStore.class,
+                    idempotencyStore);
+                log.info("IdempotencyStore wired into module context — CALL_API will dedupe non-idempotent calls");
             }
 
             ModuleContext context = new ModuleContext(

--- a/kelta-worker/src/main/java/io/kelta/worker/service/api/JdbcIdempotencyStore.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/service/api/JdbcIdempotencyStore.java
@@ -1,0 +1,98 @@
+package io.kelta.worker.service.api;
+
+import io.kelta.runtime.context.TenantContext;
+import io.kelta.runtime.module.integration.spi.IdempotencyStore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+
+import java.security.MessageDigest;
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HexFormat;
+import java.util.Optional;
+
+/**
+ * JDBC implementation of {@link IdempotencyStore}. Lookups and writes both
+ * happen inside a {@code TenantContext.callWithTenant(...)} so the V128 RLS
+ * policy filters by tenant_id.
+ */
+@Service
+public class JdbcIdempotencyStore implements IdempotencyStore {
+
+    private static final Logger log = LoggerFactory.getLogger(JdbcIdempotencyStore.class);
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public JdbcIdempotencyStore(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    @Override
+    public Optional<CachedResponse> lookup(String tenantId, String key) {
+        return TenantContext.callWithTenant(tenantId, () -> {
+            try {
+                CachedResponse row = jdbcTemplate.queryForObject(
+                    """
+                    SELECT status_code, response_body, response_hash
+                    FROM   api_call_idempotency
+                    WHERE  tenant_id = ? AND idempotency_key = ?
+                       AND expires_at > NOW()
+                    """,
+                    (rs, n) -> new CachedResponse(
+                        rs.getInt("status_code"),
+                        rs.getString("response_body"),
+                        rs.getString("response_hash")),
+                    tenantId, key);
+                return Optional.ofNullable(row);
+            } catch (EmptyResultDataAccessException e) {
+                return Optional.empty();
+            }
+        });
+    }
+
+    @Override
+    public void record(String tenantId, String key, String flowRunId, String stateName,
+                        int statusCode, String responseBody, Duration ttl) {
+        TenantContext.runWithTenant(tenantId, () -> {
+            String hash = sha256(responseBody);
+            Timestamp now = Timestamp.from(Instant.now());
+            Timestamp expires = Timestamp.from(Instant.now().plus(ttl));
+            try {
+                jdbcTemplate.update(
+                    """
+                    INSERT INTO api_call_idempotency (
+                        tenant_id, idempotency_key, flow_run_id, state_name,
+                        status_code, response_body, response_hash, created_at, expires_at)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    ON CONFLICT (tenant_id, idempotency_key)
+                    DO UPDATE SET status_code = EXCLUDED.status_code,
+                                  response_body = EXCLUDED.response_body,
+                                  response_hash = EXCLUDED.response_hash,
+                                  flow_run_id = EXCLUDED.flow_run_id,
+                                  state_name = EXCLUDED.state_name,
+                                  created_at = EXCLUDED.created_at,
+                                  expires_at = EXCLUDED.expires_at
+                    """,
+                    tenantId, key, flowRunId, stateName,
+                    statusCode, responseBody, hash, now, expires);
+            } catch (Exception e) {
+                log.warn("Failed to record idempotency entry for {}: {}", key, e.getMessage());
+            }
+        });
+    }
+
+    private static String sha256(String value) {
+        if (value == null) return null;
+        try {
+            byte[] digest = MessageDigest.getInstance("SHA-256")
+                .digest(value.getBytes());
+            return HexFormat.of().formatHex(digest);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}

--- a/kelta-worker/src/main/java/io/kelta/worker/service/credential/CredentialResolverPortAdapter.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/service/credential/CredentialResolverPortAdapter.java
@@ -1,0 +1,87 @@
+package io.kelta.worker.service.credential;
+
+import io.kelta.crypto.EncryptionService;
+import io.kelta.runtime.credential.ResolvedCredential;
+import io.kelta.runtime.module.integration.spi.CredentialResolverPort;
+import io.kelta.worker.repository.CredentialOAuthTokenRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Adapts the worker's {@link CredentialResolver} to the platform-side
+ * {@link CredentialResolverPort} SPI consumed by integration handlers
+ * (CALL_API and friends in PR 4+). Also splices the current OAuth access
+ * token onto the credential's secrets for OAuth types so handlers can write
+ * a single uniform applyAuth path.
+ */
+@Service
+public class CredentialResolverPortAdapter implements CredentialResolverPort {
+
+    private static final Logger log = LoggerFactory.getLogger(CredentialResolverPortAdapter.class);
+
+    private final CredentialResolver resolver;
+    private final CredentialOAuthTokenRepository tokenRepository;
+    private final EncryptionService encryptionService;
+
+    public CredentialResolverPortAdapter(CredentialResolver resolver,
+                                          CredentialOAuthTokenRepository tokenRepository,
+                                          EncryptionService encryptionService) {
+        this.resolver = resolver;
+        this.tokenRepository = tokenRepository;
+        this.encryptionService = encryptionService;
+    }
+
+    @Override
+    public ResolvedCredential resolve(String tenantId, String reference, String purpose) {
+        ResolvedCredential base = resolver.resolve(
+            tenantId, reference, ResolutionContext.forUser(null, purpose));
+
+        if (!isOAuthType(base.type())) {
+            return base;
+        }
+
+        // Layer the (decrypted) access token onto secretFields for the handler.
+        Optional<Map<String, Object>> tokenRow =
+            tokenRepository.findByCredentialId(base.id(), tenantId);
+        if (tokenRow.isEmpty()) {
+            return base;
+        }
+        Map<String, Object> row = tokenRow.get();
+        String accessTokenEnc = (String) row.get("access_token_enc");
+        if (accessTokenEnc == null || accessTokenEnc.isBlank()) {
+            return base;
+        }
+
+        Map<String, Object> secrets = new LinkedHashMap<>(base.secretFields());
+        try {
+            secrets.put("accessToken", encryptionService.decrypt(accessTokenEnc));
+        } catch (Exception e) {
+            log.warn("Failed to decrypt OAuth access token for credential {}: {}",
+                base.id(), e.getMessage());
+            return base;
+        }
+        // Also expose token_type / expires_at so downstream code can decide
+        // whether to refresh proactively.
+        if (row.get("token_type") != null) {
+            secrets.put("tokenType", row.get("token_type"));
+        }
+        if (row.get("expires_at") != null) {
+            secrets.put("expiresAt", row.get("expires_at").toString());
+        }
+
+        return new ResolvedCredential(
+            base.id(), base.name(), base.type(),
+            secrets, base.metadataFields(), Instant.now());
+    }
+
+    private static boolean isOAuthType(String type) {
+        return "oauth2_client_credentials".equals(type)
+            || "oauth2_authorization_code".equals(type);
+    }
+}

--- a/kelta-worker/src/main/resources/db/migration/V128__add_api_call_idempotency.sql
+++ b/kelta-worker/src/main/resources/db/migration/V128__add_api_call_idempotency.sql
@@ -1,0 +1,33 @@
+-- V128: Idempotency cache for the CALL_API flow step (PR 4)
+-- Records the last successful response per (tenant, idempotency_key) so
+-- retried flow runs against non-idempotent upstreams (POST/PUT/PATCH) replay
+-- the cached response instead of double-executing on the remote system.
+
+CREATE TABLE api_call_idempotency (
+    tenant_id        VARCHAR(36)              NOT NULL,
+    idempotency_key  VARCHAR(200)             NOT NULL,
+    flow_run_id      VARCHAR(36),
+    state_name       VARCHAR(200),
+    status_code      INTEGER,
+    response_body    TEXT,
+    response_hash    VARCHAR(64),
+    created_at       TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    expires_at       TIMESTAMP WITH TIME ZONE NOT NULL,
+    PRIMARY KEY (tenant_id, idempotency_key)
+);
+
+CREATE INDEX idx_api_call_idempotency_expires
+    ON api_call_idempotency(expires_at);
+
+COMMENT ON TABLE api_call_idempotency IS
+    'Cached responses for non-idempotent CALL_API steps; replayed on retry within TTL';
+
+-- RLS — same pattern as V126/V127.
+ALTER TABLE api_call_idempotency ENABLE ROW LEVEL SECURITY;
+ALTER TABLE api_call_idempotency FORCE  ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS tenant_isolation ON api_call_idempotency;
+DROP POLICY IF EXISTS admin_bypass     ON api_call_idempotency;
+CREATE POLICY tenant_isolation ON api_call_idempotency
+    USING (tenant_id = current_setting('app.current_tenant_id', true));
+CREATE POLICY admin_bypass ON api_call_idempotency
+    USING (current_setting('app.current_tenant_id', true) = '');


### PR DESCRIPTION
## Summary

Stacked on [#768](https://github.com/cklinker/emf/pull/768) (PR 3 — OpenAPI spec library). Once PR 3 merges, this rebases onto `main`.

Adds `CALL_API` — a generic external-API action handler that consumes the PR 1 credential vault and the PR 3 OpenAPI spec library at runtime, plus a structural payload mapper that handlers across the platform can use to build typed request bodies from flow state.

## Changes

### Backend
- **JSONata dependency** + `PayloadMapperService` — recursive walker layered on top of the existing `${$.path}` substitution. Strings starting with `=` are evaluated as JSONata; `{ "$expr": "..." }` objects evaluate the whole node.
- **`CallApiActionHandler`** — two modes:
  - **operation**: load spec + operation via `ApiSpecStore`; URL built from the spec's baseUrl + interpolated path template.
  - **raw**: free-form URL+method (Postman-style), behaves like the legacy HTTP_CALLOUT.
  - Common path: payload mapper applied to path/query/headers/body, credential resolved + applied (api_key → header or query; bearer/oauth → `Authorization: Bearer`; basic_auth → `Authorization: Basic`), optional idempotency cache, named error codes (`Api.HttpClientError`, `Api.HttpServerError`, `Api.Timeout`) for targeted Catch policies.
- **SPIs**: `CredentialResolverPort` + `IdempotencyStore`. IntegrationModule reads them from `ModuleContext` extensions; missing extensions surface as typed runtime errors so legacy installs stay bootable.
- **V128 migration**: `api_call_idempotency` table with composite PK `(tenant_id, idempotency_key)`, TTL, RLS.
- **`JdbcIdempotencyStore`** — `ON CONFLICT UPDATE` so retried keys overwrite cleanly.
- **`CredentialResolverPortAdapter`** — bridges the worker's `CredentialResolver` to the SPI. For OAuth credential types, splices the decrypted access token from `credential_oauth_token` onto the credential's secrets so the handler's `applyAuth` is uniform.
- **`FlowConfig`** wires the new SPI implementations into the `ModuleContext` extensions map.

### Frontend
- CALL_API in the Integration palette group.
- `CallApiParams` properties editor: mode toggle (operation/raw), `SpecPicker` + `OperationPicker` (operation mode), method+URL (raw mode), `CredentialPicker`, key/value lists for path/query/headers, JSON or template body editor, response variable, advanced idempotency section.

## Tests
- `PayloadMapperServiceTest` (7): `${$.path}` pass-through, `=expr` JSONata, `$expr` full-document, recursion, error surfacing.
- `CallApiActionHandlerTest` (9): type key, raw + operation modes, api_key + bearer auth, idempotency hit replays, miss records + sends `Idempotency-Key`, 4xx → `Api.HttpClientError`, validate rejections.
- 24/24 integration module tests + 30 credential tests + 8 spec parser tests all pass.

## Test plan
- [ ] CI green across all checks
- [ ] Smoke: import petstore, build a flow with Call API → addPet, run with sample state, verify the right URL + headers + body hit the upstream
- [ ] Smoke: attach a bearer credential, verify `Authorization: Bearer …` is sent
- [ ] Smoke: re-run the same flow with the same idempotency key → second run replays cached response
- [ ] Smoke: simulate a 404 → flow fails with `Api.HttpClientError`; a Catch policy on that name routes the flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)