### PR TITLE
feat(payload-mapper): visual mapper UI + email handler integration (PR 5/5)

### DIFF
--- a/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/model/system/SystemCollectionDefinitions.java
+++ b/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/model/system/SystemCollectionDefinitions.java
@@ -514,6 +514,10 @@ public final class SystemCollectionDefinitions {
                 .withColumnName("related_collection_id"))
             .addField(FieldDefinition.string("folder"))
             .addField(FieldDefinition.bool("isActive").withColumnName("is_active"))
+            // PR 5 — payload mapper integration
+            .addField(FieldDefinition.json("variablesSchema").withColumnName("variables_schema"))
+            .addField(FieldDefinition.lookup("smtpCredentialId", "credentials", "SMTP Credential")
+                .withColumnName("smtp_credential_id"))
             .build();
     }
 

--- a/kelta-platform/runtime/runtime-module-integration/src/main/java/io/kelta/runtime/module/integration/IntegrationModule.java
+++ b/kelta-platform/runtime/runtime-module-integration/src/main/java/io/kelta/runtime/module/integration/IntegrationModule.java
@@ -90,11 +90,19 @@ public class IntegrationModule implements KeltaModule {
         }
         handlers.add(new DelayActionHandler(objectMapper, pendingActionStore));
 
+        // PayloadMapperService is shared by EmailAlert (PR 5) and CALL_API
+        // (PR 4) so build it once up front.
+        StateDataResolver dataResolver = context.getExtension(StateDataResolver.class);
+        if (dataResolver == null) {
+            dataResolver = new StateDataResolver(objectMapper);
+        }
+        PayloadMapperService payloadMapper = new PayloadMapperService(dataResolver);
+
         EmailService emailService = context.getExtension(EmailService.class);
         if (emailService == null) {
             emailService = new LoggingEmailService();
         }
-        handlers.add(new EmailAlertActionHandler(objectMapper, emailService));
+        handlers.add(new EmailAlertActionHandler(objectMapper, emailService, payloadMapper));
 
         ScriptExecutor scriptExecutor = context.getExtension(ScriptExecutor.class);
         if (scriptExecutor == null) {
@@ -106,11 +114,6 @@ public class IntegrationModule implements KeltaModule {
         // from the worker via ModuleContext extensions; missing extensions
         // produce typed runtime errors instead of failing module startup so
         // legacy installations stay bootable.
-        StateDataResolver dataResolver = context.getExtension(StateDataResolver.class);
-        if (dataResolver == null) {
-            dataResolver = new StateDataResolver(objectMapper);
-        }
-        PayloadMapperService payloadMapper = new PayloadMapperService(dataResolver);
         ApiSpecStore apiSpecStore = context.getExtension(ApiSpecStore.class);
         CredentialResolverPort credentialResolver =
             context.getExtension(CredentialResolverPort.class);

--- a/kelta-platform/runtime/runtime-module-integration/src/main/java/io/kelta/runtime/module/integration/handlers/EmailAlertActionHandler.java
+++ b/kelta-platform/runtime/runtime-module-integration/src/main/java/io/kelta/runtime/module/integration/handlers/EmailAlertActionHandler.java
@@ -1,5 +1,7 @@
 package io.kelta.runtime.module.integration.handlers;
 
+import io.kelta.runtime.module.integration.mapping.PayloadMapperException;
+import io.kelta.runtime.module.integration.mapping.PayloadMapperService;
 import io.kelta.runtime.module.integration.spi.EmailService;
 import io.kelta.runtime.workflow.ActionContext;
 import io.kelta.runtime.workflow.ActionHandler;
@@ -9,6 +11,7 @@ import tools.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
@@ -38,10 +41,17 @@ public class EmailAlertActionHandler implements ActionHandler {
 
     private final ObjectMapper objectMapper;
     private final EmailService emailService;
+    private final PayloadMapperService payloadMapper;
 
     public EmailAlertActionHandler(ObjectMapper objectMapper, EmailService emailService) {
+        this(objectMapper, emailService, null);
+    }
+
+    public EmailAlertActionHandler(ObjectMapper objectMapper, EmailService emailService,
+                                    PayloadMapperService payloadMapper) {
         this.objectMapper = objectMapper;
         this.emailService = emailService;
+        this.payloadMapper = payloadMapper;
     }
 
     @Override
@@ -84,6 +94,24 @@ public class EmailAlertActionHandler implements ActionHandler {
                 return ActionResult.failure("Email 'subject' is required");
             }
 
+            // PR 5: pass subject + body through the payload mapper so users
+            // can write ${$.path} placeholders or =jsonata expressions in
+            // either field. Falls back to the unresolved string when the
+            // mapper isn't wired (legacy installs).
+            if (payloadMapper != null) {
+                Map<String, Object> stateData = mappingState(context);
+                try {
+                    Object subjectMapped = payloadMapper.map(subject, stateData);
+                    if (subjectMapped instanceof String s) subject = s;
+                    if (body != null) {
+                        Object bodyMapped = payloadMapper.map(body, stateData);
+                        if (bodyMapped instanceof String s) body = s;
+                    }
+                } catch (PayloadMapperException e) {
+                    return ActionResult.failure("Mapper.Failure: " + e.getMessage());
+                }
+            }
+
             String emailLogId = emailService.queueEmail(
                 context.tenantId(), to, subject, body != null ? body : "",
                 "WORKFLOW", context.workflowRuleId()
@@ -102,6 +130,12 @@ public class EmailAlertActionHandler implements ActionHandler {
             log.error("Failed to execute email alert action: {}", e.getMessage(), e);
             return ActionResult.failure(e);
         }
+    }
+
+    private Map<String, Object> mappingState(ActionContext context) {
+        Map<String, Object> base = context.resolvedData() != null
+            ? context.resolvedData() : context.data();
+        return base != null ? base : new HashMap<>();
     }
 
     @Override

--- a/kelta-platform/runtime/runtime-module-integration/src/test/java/io/kelta/runtime/module/integration/handlers/EmailAlertActionHandlerMappingTest.java
+++ b/kelta-platform/runtime/runtime-module-integration/src/test/java/io/kelta/runtime/module/integration/handlers/EmailAlertActionHandlerMappingTest.java
@@ -1,0 +1,116 @@
+package io.kelta.runtime.module.integration.handlers;
+
+import io.kelta.runtime.flow.StateDataResolver;
+import io.kelta.runtime.module.integration.mapping.PayloadMapperService;
+import io.kelta.runtime.module.integration.spi.EmailService;
+import io.kelta.runtime.workflow.ActionContext;
+import io.kelta.runtime.workflow.ActionResult;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import tools.jackson.databind.ObjectMapper;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@DisplayName("EmailAlertActionHandler · payload mapper integration (PR 5)")
+class EmailAlertActionHandlerMappingTest {
+
+    private ObjectMapper objectMapper;
+    private EmailService emailService;
+    private EmailAlertActionHandler handler;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+        emailService = mock(EmailService.class);
+        when(emailService.queueEmail(anyString(), anyString(), anyString(), anyString(),
+            anyString(), any())).thenReturn("email-log-1");
+        when(emailService.getTemplate(anyString())).thenReturn(Optional.empty());
+
+        PayloadMapperService mapper = new PayloadMapperService(new StateDataResolver(objectMapper));
+        handler = new EmailAlertActionHandler(objectMapper, emailService, mapper);
+    }
+
+    @Test
+    @DisplayName("Resolves ${$.path} placeholders in subject + body before sending")
+    void resolvesDollarPath() throws Exception {
+        Map<String, Object> config = Map.of(
+            "to", "manager@example.com",
+            "subject", "Order ${$.record.data.orderNumber} approved",
+            "body", "Hi ${$.record.data.customer.name}, your order is approved.");
+
+        ActionContext ctx = ActionContext.builder()
+            .tenantId("t-1")
+            .actionConfigJson(objectMapper.writeValueAsString(config))
+            .resolvedData(Map.of(
+                "record", Map.of("data", Map.of(
+                    "orderNumber", "O-100",
+                    "customer", Map.of("name", "Alex")))))
+            .build();
+
+        ActionResult result = handler.execute(ctx);
+
+        assertTrue(result.successful(), result.errorMessage());
+        ArgumentCaptor<String> subjectCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> bodyCaptor = ArgumentCaptor.forClass(String.class);
+        verify(emailService).queueEmail(eq("t-1"), eq("manager@example.com"),
+            subjectCaptor.capture(), bodyCaptor.capture(), eq("WORKFLOW"), any());
+        assertEquals("Order O-100 approved", subjectCaptor.getValue());
+        assertEquals("Hi Alex, your order is approved.", bodyCaptor.getValue());
+    }
+
+    @Test
+    @DisplayName("Evaluates =jsonata expressions in subject")
+    void evaluatesJsonata() throws Exception {
+        Map<String, Object> config = Map.of(
+            "to", "team@example.com",
+            "subject", "=$uppercase(record.data.tag) & ' alert'",
+            "body", "n/a");
+
+        ActionContext ctx = ActionContext.builder()
+            .tenantId("t-1")
+            .actionConfigJson(objectMapper.writeValueAsString(config))
+            .resolvedData(Map.of("record", Map.of("data", Map.of("tag", "p1"))))
+            .build();
+
+        ActionResult result = handler.execute(ctx);
+
+        assertTrue(result.successful(), result.errorMessage());
+        ArgumentCaptor<String> subjectCaptor = ArgumentCaptor.forClass(String.class);
+        verify(emailService).queueEmail(eq("t-1"), anyString(), subjectCaptor.capture(),
+            anyString(), eq("WORKFLOW"), any());
+        assertEquals("P1 alert", subjectCaptor.getValue());
+    }
+
+    @Test
+    @DisplayName("Surfaces mapper failures as Mapper.Failure instead of crashing")
+    void mapperFailureSurfaces() throws Exception {
+        Map<String, Object> config = Map.of(
+            "to", "team@example.com",
+            "subject", "=this is not valid jsonata $$$",
+            "body", "x");
+
+        ActionContext ctx = ActionContext.builder()
+            .tenantId("t-1")
+            .actionConfigJson(objectMapper.writeValueAsString(config))
+            .resolvedData(Map.of())
+            .build();
+
+        ActionResult result = handler.execute(ctx);
+
+        assertTrue(!result.successful());
+        assertTrue(result.errorMessage().startsWith("Mapper.Failure"),
+            "got: " + result.errorMessage());
+    }
+}

--- a/kelta-ui/app/src/components/PayloadMapper/PayloadMapper.tsx
+++ b/kelta-ui/app/src/components/PayloadMapper/PayloadMapper.tsx
@@ -1,0 +1,427 @@
+import React, { useEffect, useMemo, useState } from 'react'
+import { Code2, Eye, FormInput } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { Card, CardContent } from '@/components/ui/card'
+import { FieldLabel } from '@/components/kelta'
+import { VariablePicker } from '@/components/VariablePicker/VariablePicker'
+import { cn } from '@/lib/utils'
+import {
+  type BindingKind,
+  type MappingMap,
+  type SourceVariable,
+  type TargetBinding,
+  type TargetField,
+} from './types'
+import { deserializeMapping, serializeBindings } from './mappingSerializer'
+
+export interface PayloadMapperProps {
+  /** Schema describing the fields the consumer wants the mapper to fill. */
+  targetSchema: TargetField[]
+  /** Available variables from flow state — drives the variable picker tree. */
+  sourceVariables: SourceVariable[]
+  /** Current value (the JSON template shape the worker expects). */
+  value: Record<string, unknown> | null | undefined
+  /** Called with the new template when bindings change. */
+  onChange: (next: Record<string, unknown>) => void
+  /** Optional: render a header (e.g., the page/sheet title) above the editor. */
+  header?: React.ReactNode
+  /** Optional: render a footer (e.g., Save / Cancel buttons) below. */
+  footer?: React.ReactNode
+}
+
+type View = 'visual' | 'code' | 'preview'
+
+/**
+ * Reusable visual mapper. Each row in the target schema gets a binding
+ * (constant / variable / expression) that the consumer can edit inline.
+ * The component serializes to the JSON template shape consumed by the
+ * platform's PayloadMapperService, so consumers can persist whatever
+ * {@link PayloadMapperProps#onChange} returns directly.
+ */
+export function PayloadMapper({
+  targetSchema,
+  sourceVariables,
+  value,
+  onChange,
+  header,
+  footer,
+}: PayloadMapperProps): React.ReactElement {
+  const targetPaths = useMemo(() => targetSchema.map((t) => t.path), [targetSchema])
+  const [bindings, setBindings] = useState<MappingMap>(() =>
+    deserializeMapping(value ?? {}, targetPaths)
+  )
+
+  // When the consumer hands us a new value (e.g., loaded from the server),
+  // reset our local bindings.
+  useEffect(() => {
+    setBindings(deserializeMapping(value ?? {}, targetPaths))
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [JSON.stringify(value), JSON.stringify(targetPaths)])
+
+  const updateBinding = (path: string, next: TargetBinding) => {
+    setBindings((prev) => {
+      const updated = { ...prev, [path]: next }
+      onChange(serializeBindings(updated))
+      return updated
+    })
+  }
+
+  const [view, setView] = useState<View>('visual')
+
+  return (
+    <div className="space-y-4">
+      {header}
+
+      <div className="flex items-center gap-2">
+        <ViewTab active={view === 'visual'} onClick={() => setView('visual')} icon={<FormInput className="h-3.5 w-3.5" />}>
+          Visual
+        </ViewTab>
+        <ViewTab active={view === 'code'} onClick={() => setView('code')} icon={<Code2 className="h-3.5 w-3.5" />}>
+          Code
+        </ViewTab>
+        <ViewTab active={view === 'preview'} onClick={() => setView('preview')} icon={<Eye className="h-3.5 w-3.5" />}>
+          Preview
+        </ViewTab>
+      </div>
+
+      {view === 'visual' && (
+        <div className="space-y-2">
+          {targetSchema.map((field) => (
+            <BindingRow
+              key={field.path}
+              field={field}
+              binding={bindings[field.path] ?? { kind: 'unset', value: '' }}
+              variables={sourceVariables}
+              onChange={(next) => updateBinding(field.path, next)}
+            />
+          ))}
+        </div>
+      )}
+
+      {view === 'code' && (
+        <CodeView
+          template={serializeBindings(bindings)}
+          onChange={(parsed) => {
+            setBindings(deserializeMapping(parsed, targetPaths))
+            onChange(parsed)
+          }}
+        />
+      )}
+
+      {view === 'preview' && (
+        <PreviewView template={serializeBindings(bindings)} variables={sourceVariables} />
+      )}
+
+      {footer}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Visual view — one row per target field
+// ---------------------------------------------------------------------------
+
+interface BindingRowProps {
+  field: TargetField
+  binding: TargetBinding
+  variables: SourceVariable[]
+  onChange: (next: TargetBinding) => void
+}
+
+function BindingRow({ field, binding, variables, onChange }: BindingRowProps) {
+  const setKind = (kind: BindingKind) => {
+    onChange({ kind, value: binding.value })
+  }
+
+  return (
+    <Card className="bg-background">
+      <CardContent className="p-3 space-y-2">
+        <div className="flex items-baseline justify-between gap-2">
+          <div className="min-w-0">
+            <FieldLabel>
+              {field.label}
+              {field.required ? <span className="text-red-500"> *</span> : null}
+            </FieldLabel>
+            <p className="text-xs text-muted-foreground font-mono truncate">
+              {field.path}
+              {field.type ? ` · ${field.type}` : ''}
+            </p>
+            {field.description && (
+              <p className="text-xs text-muted-foreground">{field.description}</p>
+            )}
+          </div>
+          <Select value={binding.kind} onValueChange={(v) => setKind(v as BindingKind)}>
+            <SelectTrigger className="h-7 w-32 text-xs">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="unset">Unset</SelectItem>
+              <SelectItem value="constant">Constant</SelectItem>
+              <SelectItem value="variable">Variable</SelectItem>
+              <SelectItem value="expression">Expression</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+        <BindingEditor binding={binding} onChange={onChange} variables={variables} />
+      </CardContent>
+    </Card>
+  )
+}
+
+interface BindingEditorProps {
+  binding: TargetBinding
+  variables: SourceVariable[]
+  onChange: (next: TargetBinding) => void
+}
+
+function BindingEditor({ binding, variables, onChange }: BindingEditorProps) {
+  if (binding.kind === 'unset') {
+    return (
+      <p className="text-xs text-muted-foreground italic">
+        No value bound — the field will be omitted from the payload.
+      </p>
+    )
+  }
+
+  if (binding.kind === 'constant') {
+    return (
+      <Input
+        value={binding.value}
+        onChange={(e) => onChange({ ...binding, value: e.target.value })}
+        placeholder="Literal value"
+        className="font-mono text-xs"
+      />
+    )
+  }
+
+  if (binding.kind === 'variable') {
+    return (
+      <div className="flex items-center gap-2">
+        <Input
+          value={binding.value}
+          onChange={(e) => onChange({ ...binding, value: e.target.value })}
+          placeholder="$.input.fieldName"
+          className="font-mono text-xs flex-1"
+        />
+        <VariablePicker
+          variables={variables}
+          raw
+          onPick={(token) => onChange({ ...binding, value: token })}
+        />
+      </div>
+    )
+  }
+
+  // expression
+  return (
+    <Textarea
+      rows={3}
+      value={binding.value}
+      onChange={(e) => onChange({ ...binding, value: e.target.value })}
+      placeholder="$sum(items.price)"
+      className="font-mono text-xs"
+    />
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Code view — raw JSON editor
+// ---------------------------------------------------------------------------
+
+function CodeView({
+  template,
+  onChange,
+}: {
+  template: Record<string, unknown>
+  onChange: (parsed: Record<string, unknown>) => void
+}) {
+  const [text, setText] = useState(() => JSON.stringify(template, null, 2))
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    setText(JSON.stringify(template, null, 2))
+  }, [JSON.stringify(template)])
+
+  return (
+    <div className="space-y-2">
+      <Textarea
+        rows={14}
+        value={text}
+        onChange={(e) => {
+          setText(e.target.value)
+          try {
+            const parsed = JSON.parse(e.target.value)
+            if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+              setError(null)
+              onChange(parsed as Record<string, unknown>)
+            } else {
+              setError('Mapping must be a JSON object at the top level')
+            }
+          } catch (err) {
+            setError(err instanceof Error ? err.message : 'Invalid JSON')
+          }
+        }}
+        className="font-mono text-xs"
+      />
+      {error && <p className="text-xs text-red-600">{error}</p>}
+      <p className="text-xs text-muted-foreground">
+        Strings starting with <code>=</code> are evaluated as JSONata; everything else flows
+        through <code>${'${$.path}'}</code> substitution.
+      </p>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Preview view — best-effort client-side resolution against synthetic data
+// ---------------------------------------------------------------------------
+
+function PreviewView({
+  template,
+  variables,
+}: {
+  template: Record<string, unknown>
+  variables: SourceVariable[]
+}) {
+  const sample = useMemo(() => buildSampleState(variables), [variables])
+  const [stateJson, setStateJson] = useState(() => JSON.stringify(sample, null, 2))
+  const resolved = useMemo(() => {
+    try {
+      const state = JSON.parse(stateJson)
+      return resolveTemplate(template, state)
+    } catch {
+      return null
+    }
+  }, [stateJson, template])
+
+  return (
+    <div className="grid gap-3 md:grid-cols-2">
+      <div className="space-y-1">
+        <FieldLabel>Sample state</FieldLabel>
+        <Textarea
+          rows={14}
+          value={stateJson}
+          onChange={(e) => setStateJson(e.target.value)}
+          className="font-mono text-xs"
+        />
+      </div>
+      <div className="space-y-1">
+        <FieldLabel>Resolved payload</FieldLabel>
+        <pre className="rounded-md border bg-muted/30 p-3 text-xs font-mono whitespace-pre-wrap">
+          {resolved ? JSON.stringify(resolved, null, 2) : '— invalid sample state —'}
+        </pre>
+        <p className="text-xs text-muted-foreground">
+          Preview resolves <code>${'${$.path}'}</code> tokens client-side. JSONata expressions
+          are not evaluated here — they're only run by the worker.
+        </p>
+      </div>
+    </div>
+  )
+}
+
+function buildSampleState(variables: SourceVariable[]): Record<string, unknown> {
+  const out: Record<string, unknown> = {}
+  for (const v of variables) {
+    setSamplePath(out, v.path, sampleValueFor(v))
+  }
+  return out
+}
+
+function sampleValueFor(v: SourceVariable): unknown {
+  if (v.type === 'number' || v.type === 'integer') return 42
+  if (v.type === 'boolean') return true
+  if (v.type === 'array') return ['…']
+  if (v.type === 'object') return {}
+  return v.label ?? `<${v.path}>`
+}
+
+function setSamplePath(target: Record<string, unknown>, path: string, value: unknown) {
+  const segments = path.replace(/^\$\.?/, '').split('.').filter(Boolean)
+  if (segments.length === 0) return
+  let cursor: Record<string, unknown> = target
+  for (let i = 0; i < segments.length - 1; i++) {
+    const seg = segments[i]
+    if (typeof cursor[seg] !== 'object' || cursor[seg] === null) {
+      cursor[seg] = {}
+    }
+    cursor = cursor[seg] as Record<string, unknown>
+  }
+  cursor[segments[segments.length - 1]] = value
+}
+
+function resolveTemplate(template: unknown, state: Record<string, unknown>): unknown {
+  if (template === null || template === undefined) return template
+  if (typeof template === 'string') return resolveString(template, state)
+  if (Array.isArray(template)) return template.map((item) => resolveTemplate(item, state))
+  if (typeof template === 'object') {
+    const out: Record<string, unknown> = {}
+    for (const [k, v] of Object.entries(template)) {
+      out[k] = resolveTemplate(v, state)
+    }
+    return out
+  }
+  return template
+}
+
+const TOKEN = /\$\{\$\.([^}]+)\}/g
+
+function resolveString(template: string, state: Record<string, unknown>): unknown {
+  // Whole-string token returns the raw value (preserves type)
+  const wholeMatch = template.match(/^\$\{\$\.([^}]+)\}$/)
+  if (wholeMatch) {
+    return readPath(state, wholeMatch[1])
+  }
+  // Otherwise interpolate inline
+  return template.replace(TOKEN, (_match, path: string) => {
+    const value = readPath(state, path)
+    return value === undefined ? '' : String(value)
+  })
+}
+
+function readPath(state: Record<string, unknown>, path: string): unknown {
+  const segments = path.split('.')
+  let cursor: unknown = state
+  for (const seg of segments) {
+    if (cursor == null || typeof cursor !== 'object') return undefined
+    cursor = (cursor as Record<string, unknown>)[seg]
+  }
+  return cursor
+}
+
+// ---------------------------------------------------------------------------
+// Tab pill
+// ---------------------------------------------------------------------------
+
+function ViewTab({
+  active,
+  onClick,
+  icon,
+  children,
+}: {
+  active: boolean
+  onClick: () => void
+  icon: React.ReactNode
+  children: React.ReactNode
+}) {
+  return (
+    <Button
+      type="button"
+      variant={active ? 'default' : 'outline'}
+      size="sm"
+      onClick={onClick}
+      className={cn('gap-1.5')}
+    >
+      {icon}
+      {children}
+    </Button>
+  )
+}

--- a/kelta-ui/app/src/components/PayloadMapper/__tests__/mappingSerializer.test.ts
+++ b/kelta-ui/app/src/components/PayloadMapper/__tests__/mappingSerializer.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest'
+import { deserializeMapping, serializeBindings } from '../mappingSerializer'
+import type { MappingMap } from '../types'
+
+describe('PayloadMapper · mappingSerializer', () => {
+  const TARGETS = ['subject', 'body', 'meta.priority']
+
+  it('serializes constants verbatim', () => {
+    const bindings: MappingMap = {
+      subject: { kind: 'constant', value: 'Order approved' },
+      body: { kind: 'unset', value: '' },
+      'meta.priority': { kind: 'unset', value: '' },
+    }
+
+    expect(serializeBindings(bindings)).toEqual({
+      subject: 'Order approved',
+    })
+  })
+
+  it('wraps variable bindings in ${} tokens', () => {
+    const bindings: MappingMap = {
+      subject: { kind: 'variable', value: '$.record.data.name' },
+      body: { kind: 'unset', value: '' },
+      'meta.priority': { kind: 'unset', value: '' },
+    }
+
+    expect(serializeBindings(bindings)).toEqual({
+      subject: '${$.record.data.name}',
+    })
+  })
+
+  it('prefixes expression bindings with =', () => {
+    const bindings: MappingMap = {
+      subject: { kind: 'expression', value: '$uppercase(record.name)' },
+      body: { kind: 'unset', value: '' },
+      'meta.priority': { kind: 'unset', value: '' },
+    }
+
+    expect(serializeBindings(bindings)).toEqual({
+      subject: '=$uppercase(record.name)',
+    })
+  })
+
+  it('reifies dotted target paths into nested objects', () => {
+    const bindings: MappingMap = {
+      subject: { kind: 'unset', value: '' },
+      body: { kind: 'unset', value: '' },
+      'meta.priority': { kind: 'constant', value: 'high' },
+    }
+
+    expect(serializeBindings(bindings)).toEqual({
+      meta: { priority: 'high' },
+    })
+  })
+
+  it('round-trips bindings through serialize → deserialize', () => {
+    const bindings: MappingMap = {
+      subject: { kind: 'variable', value: '$.record.data.name' },
+      body: { kind: 'expression', value: '$sum(items.price)' },
+      'meta.priority': { kind: 'constant', value: 'high' },
+    }
+
+    const wire = serializeBindings(bindings)
+    const decoded = deserializeMapping(wire, TARGETS)
+
+    expect(decoded.subject).toEqual({ kind: 'variable', value: '$.record.data.name' })
+    expect(decoded.body).toEqual({ kind: 'expression', value: '$sum(items.price)' })
+    expect(decoded['meta.priority']).toEqual({ kind: 'constant', value: 'high' })
+  })
+
+  it('treats targets missing from the wire shape as unset', () => {
+    const decoded = deserializeMapping({ subject: 'Hi' }, TARGETS)
+    expect(decoded.subject).toEqual({ kind: 'constant', value: 'Hi' })
+    expect(decoded.body).toEqual({ kind: 'unset', value: '' })
+    expect(decoded['meta.priority']).toEqual({ kind: 'unset', value: '' })
+  })
+
+  it('does not double-wrap pre-tokenized variables', () => {
+    const bindings: MappingMap = {
+      subject: { kind: 'variable', value: '${$.x}' },
+      body: { kind: 'unset', value: '' },
+      'meta.priority': { kind: 'unset', value: '' },
+    }
+    expect(serializeBindings(bindings)).toEqual({ subject: '${$.x}' })
+  })
+})

--- a/kelta-ui/app/src/components/PayloadMapper/index.ts
+++ b/kelta-ui/app/src/components/PayloadMapper/index.ts
@@ -1,0 +1,11 @@
+export { PayloadMapper } from './PayloadMapper'
+export type { PayloadMapperProps } from './PayloadMapper'
+export type {
+  TargetField,
+  SourceVariable,
+  TargetBinding,
+  BindingKind,
+  MappingMap,
+  SerializedMapping,
+} from './types'
+export { serializeBindings, deserializeMapping } from './mappingSerializer'

--- a/kelta-ui/app/src/components/PayloadMapper/mappingSerializer.ts
+++ b/kelta-ui/app/src/components/PayloadMapper/mappingSerializer.ts
@@ -1,0 +1,89 @@
+import type { MappingMap, SerializedMapping, TargetBinding } from './types'
+
+/**
+ * Round-trip helpers between the visual editor and the JSON form the worker
+ * payload mapper expects. The wire shape follows the platform mapper rules:
+ *
+ *   { foo: "constant value" }                       — bare string literal
+ *   { foo: "${$.path}" }                            — placeholder substitution
+ *   { foo: "=jsonata expression" }                  — JSONata expression
+ *
+ * Nested target paths (e.g. "user.email") are reified back into nested objects
+ * so {@code mapToObject} on the worker side gets the shape it expects.
+ */
+
+export function serializeBindings(bindings: MappingMap): SerializedMapping {
+  const out: SerializedMapping = {}
+  for (const [path, binding] of Object.entries(bindings)) {
+    if (binding.kind === 'unset' || binding.value === '') continue
+    setNested(out, path, encodeBinding(binding))
+  }
+  return out
+}
+
+export function deserializeMapping(
+  template: unknown,
+  knownTargets: string[]
+): MappingMap {
+  const result: MappingMap = {}
+  for (const target of knownTargets) {
+    const value = readNested(template, target)
+    if (value === undefined) {
+      result[target] = { kind: 'unset', value: '' }
+    } else if (typeof value === 'string') {
+      result[target] = decodeBindingFromString(value)
+    } else {
+      // Object/array values get serialized to JSON and treated as constants.
+      result[target] = { kind: 'constant', value: JSON.stringify(value) }
+    }
+  }
+  return result
+}
+
+function encodeBinding(binding: TargetBinding): unknown {
+  switch (binding.kind) {
+    case 'variable':
+      // Allow either bare path or already-tokenized form.
+      return binding.value.startsWith('${') ? binding.value : `\${${binding.value}}`
+    case 'expression':
+      return binding.value.startsWith('=') ? binding.value : `=${binding.value}`
+    case 'constant':
+      return binding.value
+    default:
+      return undefined
+  }
+}
+
+function decodeBindingFromString(value: string): TargetBinding {
+  if (value.startsWith('${') && value.endsWith('}')) {
+    return { kind: 'variable', value: value.slice(2, -1) }
+  }
+  if (value.startsWith('=')) {
+    return { kind: 'expression', value: value.slice(1) }
+  }
+  return { kind: 'constant', value }
+}
+
+function setNested(target: Record<string, unknown>, path: string, value: unknown) {
+  const segments = path.split('.')
+  let cursor: Record<string, unknown> = target
+  for (let i = 0; i < segments.length - 1; i++) {
+    const seg = segments[i]
+    if (typeof cursor[seg] !== 'object' || cursor[seg] === null) {
+      cursor[seg] = {}
+    }
+    cursor = cursor[seg] as Record<string, unknown>
+  }
+  cursor[segments[segments.length - 1]] = value
+}
+
+function readNested(template: unknown, path: string): unknown {
+  if (template == null || typeof template !== 'object') return undefined
+  const segments = path.split('.')
+  let cursor: unknown = template
+  for (const seg of segments) {
+    if (cursor == null || typeof cursor !== 'object') return undefined
+    cursor = (cursor as Record<string, unknown>)[seg]
+  }
+  return cursor
+}

--- a/kelta-ui/app/src/components/PayloadMapper/types.ts
+++ b/kelta-ui/app/src/components/PayloadMapper/types.ts
@@ -1,0 +1,35 @@
+/** A field on the target payload schema (an output the consumer wants filled). */
+export interface TargetField {
+  /** Dot-path within the payload, e.g. "subject" or "user.email" */
+  path: string
+  /** Human-readable label shown next to the row */
+  label: string
+  /** Optional one-line description rendered below the label */
+  description?: string
+  /** JSON Schema-ish hint: "string" | "number" | "boolean" | "object" | "array" */
+  type?: string
+  /** Whether this field is required to produce a valid payload */
+  required?: boolean
+}
+
+/** A flat-path source variable available from the surrounding flow state. */
+export interface SourceVariable {
+  path: string
+  label?: string
+  type?: string
+}
+
+/** Per-target binding kind — drives the editor row's UI. */
+export type BindingKind = 'unset' | 'constant' | 'variable' | 'expression'
+
+export interface TargetBinding {
+  kind: BindingKind
+  /** Constant string (kind=constant), variable token (kind=variable), or JSONata expression (kind=expression). */
+  value: string
+}
+
+/** The serialized template form — round-trips through the backend mapper. */
+export type SerializedMapping = Record<string, unknown>
+
+/** Working state on the UI side: target path → binding. */
+export type MappingMap = Record<string, TargetBinding>

--- a/kelta-ui/app/src/components/VariablePicker/VariablePicker.tsx
+++ b/kelta-ui/app/src/components/VariablePicker/VariablePicker.tsx
@@ -1,0 +1,126 @@
+import React, { useMemo, useState } from 'react'
+import { ChevronRight, Variable } from 'lucide-react'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { cn } from '@/lib/utils'
+
+export interface VariableNode {
+  /** JSONPath-style path users will see, e.g. "$.record.data.name" */
+  path: string
+  /** Human-readable label shown next to the path */
+  label?: string
+  /** Optional type hint shown as a small chip (string, number, ...) */
+  type?: string
+}
+
+export interface VariablePickerProps {
+  /** Available variables (flat list of paths). Group by the first segment for display. */
+  variables: VariableNode[]
+  /** Called with the inserted token when the user picks a variable. */
+  onPick: (token: string) => void
+  /** Override the trigger button content / icon. */
+  trigger?: React.ReactNode
+  /** When true, the picker emits raw paths instead of `${...}` tokens. */
+  raw?: boolean
+}
+
+/**
+ * Popover that lists every available {@code ${$.path}} accessible from the
+ * current flow state. Used by the payload mapper, JSON body editors, and any
+ * other surface that wants quick variable insertion.
+ */
+export function VariablePicker({ variables, onPick, trigger, raw }: VariablePickerProps): React.ReactElement {
+  const [open, setOpen] = useState(false)
+  const [filter, setFilter] = useState('')
+
+  const filtered = useMemo(() => {
+    if (!filter) return variables
+    const q = filter.toLowerCase()
+    return variables.filter(
+      (v) =>
+        v.path.toLowerCase().includes(q) ||
+        (v.label?.toLowerCase().includes(q) ?? false)
+    )
+  }, [variables, filter])
+
+  const grouped = useMemo(() => groupByRoot(filtered), [filtered])
+
+  const handlePick = (path: string) => {
+    onPick(raw ? path : `\${${path}}`)
+    setOpen(false)
+    setFilter('')
+  }
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        {trigger ?? (
+          <Button size="sm" variant="outline" type="button" title="Insert variable">
+            <Variable className="h-3.5 w-3.5" />
+          </Button>
+        )}
+      </PopoverTrigger>
+      <PopoverContent className="w-[320px] p-2" align="end">
+        <div className="space-y-2">
+          <Input
+            value={filter}
+            onChange={(e) => setFilter(e.target.value)}
+            placeholder="Search variables…"
+            autoFocus
+            className="h-8 text-xs"
+          />
+          <div className="max-h-72 overflow-y-auto space-y-3">
+            {Object.entries(grouped).map(([root, items]) => (
+              <div key={root}>
+                <p className="px-1 text-[10px] uppercase tracking-wider text-muted-foreground">
+                  {root}
+                </p>
+                <ul className="mt-1 rounded-md border divide-y">
+                  {items.map((v) => (
+                    <li key={v.path}>
+                      <button
+                        type="button"
+                        onClick={() => handlePick(v.path)}
+                        className={cn(
+                          'flex w-full items-center gap-2 px-2 py-1.5 text-left text-xs',
+                          'hover:bg-muted/60'
+                        )}
+                      >
+                        <span className="font-mono">{v.path}</span>
+                        {v.type && (
+                          <span className="ml-auto text-[10px] text-muted-foreground">
+                            {v.type}
+                          </span>
+                        )}
+                        {v.label && (
+                          <span className="text-muted-foreground">— {v.label}</span>
+                        )}
+                        <ChevronRight className="h-3 w-3 opacity-40" />
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+            {filtered.length === 0 && (
+              <p className="px-2 py-3 text-xs text-muted-foreground">
+                No variables match.
+              </p>
+            )}
+          </div>
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}
+
+function groupByRoot(variables: VariableNode[]): Record<string, VariableNode[]> {
+  const groups: Record<string, VariableNode[]> = {}
+  for (const v of variables) {
+    const root = v.path.split('.').slice(0, 2).join('.')
+    if (!groups[root]) groups[root] = []
+    groups[root].push(v)
+  }
+  return groups
+}

--- a/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/EmailAlertParams.tsx
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/EmailAlertParams.tsx
@@ -1,12 +1,51 @@
-import React from 'react'
+import { useState } from 'react'
 import { Input } from '@/components/ui/input'
 import { FieldLabel } from '@/components/kelta'
 import { Textarea } from '@/components/ui/textarea'
+import { Button } from '@/components/ui/button'
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet'
+import { Wand2 } from 'lucide-react'
+import { PayloadMapper } from '@/components/PayloadMapper'
+import type {
+  SourceVariable,
+  TargetField,
+} from '@/components/PayloadMapper'
 
 interface EmailAlertParamsProps {
   parameters?: Record<string, unknown>
   onUpdate: (params: Record<string, unknown>) => void
 }
+
+const EMAIL_TARGETS: TargetField[] = [
+  {
+    path: 'subject',
+    label: 'Subject',
+    type: 'string',
+    required: true,
+    description: 'Use ${$.path} placeholders or =jsonata expressions for dynamic content.',
+  },
+  {
+    path: 'body',
+    label: 'Body',
+    type: 'string',
+    required: false,
+    description: 'HTML or plain text. Strings starting with = are evaluated as JSONata.',
+  },
+]
+
+const DEFAULT_VARIABLES: SourceVariable[] = [
+  { path: '$.record.data', label: 'Triggering record', type: 'object' },
+  { path: '$.record.id', label: 'Triggering record id', type: 'string' },
+  { path: '$.context.user.email', label: 'Acting user', type: 'string' },
+  { path: '$.context.tenant.slug', label: 'Tenant slug', type: 'string' },
+  { path: '$.context.now', label: 'Current timestamp', type: 'string' },
+]
 
 export function EmailAlertParams({ parameters, onUpdate }: EmailAlertParamsProps) {
   const params = parameters || {}
@@ -14,9 +53,21 @@ export function EmailAlertParams({ parameters, onUpdate }: EmailAlertParamsProps
   const subject = (params.subject as string) || ''
   const body = (params.body as string) || ''
   const templateId = (params.templateId as string) || ''
+  const [builderOpen, setBuilderOpen] = useState(false)
 
   const update = (field: string, value: unknown) => {
     onUpdate({ ...params, [field]: value })
+  }
+
+  // The mapper round-trips through a small template object whose keys match
+  // the target schema. We treat subject + body as the only mapped fields here.
+  const mapperValue = { subject, body }
+  const onMapperChange = (next: Record<string, unknown>) => {
+    onUpdate({
+      ...params,
+      subject: typeof next.subject === 'string' ? next.subject : params.subject,
+      body: typeof next.body === 'string' ? next.body : params.body,
+    })
   }
 
   return (
@@ -36,7 +87,19 @@ export function EmailAlertParams({ parameters, onUpdate }: EmailAlertParamsProps
       </div>
 
       <div>
-        <FieldLabel className="text-[10px]">Subject</FieldLabel>
+        <div className="flex items-center justify-between">
+          <FieldLabel className="text-[10px]">Subject</FieldLabel>
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            className="h-6 px-2 text-[10px]"
+            onClick={() => setBuilderOpen(true)}
+          >
+            <Wand2 className="mr-1 h-3 w-3" />
+            Body builder
+          </Button>
+        </div>
         <Input
           value={subject}
           onChange={(e) => update('subject', e.target.value)}
@@ -65,6 +128,32 @@ export function EmailAlertParams({ parameters, onUpdate }: EmailAlertParamsProps
           placeholder="template-uuid"
         />
       </div>
+
+      <Sheet open={builderOpen} onOpenChange={setBuilderOpen}>
+        <SheetContent side="right" className="w-full sm:max-w-2xl overflow-y-auto">
+          <SheetHeader>
+            <SheetTitle>Email body builder</SheetTitle>
+            <SheetDescription>
+              Map flow state variables into the email subject and body. Strings
+              starting with <code>=</code> are evaluated as JSONata at send time;
+              everything else flows through <code>${'${$.path}'}</code> substitution.
+            </SheetDescription>
+          </SheetHeader>
+          <div className="mt-4">
+            <PayloadMapper
+              targetSchema={EMAIL_TARGETS}
+              sourceVariables={DEFAULT_VARIABLES}
+              value={mapperValue}
+              onChange={onMapperChange}
+              footer={
+                <div className="mt-4 flex justify-end">
+                  <Button onClick={() => setBuilderOpen(false)}>Done</Button>
+                </div>
+              }
+            />
+          </div>
+        </SheetContent>
+      </Sheet>
     </div>
   )
 }

--- a/kelta-worker/src/main/resources/db/migration/V129__add_email_template_variables_and_credential.sql
+++ b/kelta-worker/src/main/resources/db/migration/V129__add_email_template_variables_and_credential.sql
@@ -1,0 +1,32 @@
+-- V129: Email template enrichment for the payload mapper UI (PR 5)
+-- - variables_schema declares the named inputs the template expects, so the
+--   PayloadMapper UI can render the right target schema.
+-- - smtp_credential_id lets a template route through a per-template SMTP
+--   credential (e.g., a transactional service like SendGrid) via the PR 1
+--   credential vault, instead of the platform-default SMTP.
+
+ALTER TABLE email_template
+    ADD COLUMN IF NOT EXISTS variables_schema JSONB,
+    ADD COLUMN IF NOT EXISTS smtp_credential_id VARCHAR(36);
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.table_constraints
+        WHERE table_name = 'email_template'
+          AND constraint_name = 'fk_email_template_smtp_credential'
+    ) THEN
+        ALTER TABLE email_template
+            ADD CONSTRAINT fk_email_template_smtp_credential
+            FOREIGN KEY (smtp_credential_id) REFERENCES credential(id)
+            ON DELETE SET NULL;
+    END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_email_template_smtp_credential
+    ON email_template(smtp_credential_id) WHERE smtp_credential_id IS NOT NULL;
+
+COMMENT ON COLUMN email_template.variables_schema IS
+    'JSON schema describing the inputs the template expects (drives the PayloadMapper target panel)';
+COMMENT ON COLUMN email_template.smtp_credential_id IS
+    'Optional: route this template through a specific SMTP credential from the vault (PR 1)';


### PR DESCRIPTION
## Summary

Stacked on [#769](https://github.com/cklinker/emf/pull/769) (PR 4 — CALL_API + payload mapper service). Once PR 4 merges, this rebases onto `main`.

**Closes out the 5-PR series.** Brings the structural payload mapper from PR 4 to the UI and wires it into the email handler so flow authors can compose subject + body strings the same way they compose API request bodies — `${$.path}` placeholders, `=jsonata` expressions, and a visual editor.

## Changes

### Backend
- **V129 migration**: `email_template` gains `variables_schema` (JSONB, drives the mapper's target panel) and `smtp_credential_id` (FK to `credential`, `ON DELETE SET NULL`) so a template can route through a per-template SMTP credential from the PR 1 vault.
- `email-templates` system collection exposes the new fields.
- **`EmailAlertActionHandler`**:
  - New constructor accepts an optional `PayloadMapperService`.
  - Subject and body strings are run through the mapper before queueing — `${$.path}` placeholders interpolate, `=expr` strings evaluate as JSONata, `PayloadMapperException` surfaces as a `Mapper.Failure` error code (catchable).
  - Legacy installs without the mapper still work — the parameter is nullable.
- **`IntegrationModule`** builds one shared `PayloadMapperService` up front and passes it to both `EmailAlertActionHandler` (PR 5) and `CallApiActionHandler` (PR 4) so both handlers share the same semantics.

### Frontend
- **`<VariablePicker>`** — popover with a tree of available `${$.path}` variables grouped by root segment, with search. Reusable for any text-with-variables surface.
- **`<PayloadMapper>`** — three views:
  - Visual: one row per target field, binding kind selector (Constant / Variable / Expression / Unset), inline editor per kind.
  - Code: raw JSON editor with live JSON validation; round-trips through `deserializeMapping → serializeBindings`.
  - Preview: client-side resolution of `${$.path}` tokens against a synthetic state built from the source-variable schema.
- Self-contained: consumers pass `targetSchema`, `sourceVariables`, `value`, `onChange`. Drop-in for any handler that needs structured mapping.
- `mappingSerializer.ts`: bidirectional encoder/decoder between visual bindings and the JSON template wire shape (nested target paths via dot syntax).
- `EmailAlertParams` gets a "Body builder" button next to Subject that opens a shadcn `<Sheet>` hosting the mapper for subject + body.

## Tests
- `EmailAlertActionHandlerMappingTest` (3): `${$.path}` substitution, `=jsonata` evaluation, `Mapper.Failure` surfacing.
- `mappingSerializer.test.ts` (7, vitest): constant / variable / expression serialization, dotted-path nesting, round-trip, missing-target handling, no-double-wrap.
- 27/27 integration module Java tests pass alongside 30 credential tests + 8 spec parser tests + 16 PR-4 tests.

## Deferred to follow-ups
- `PassStateExecutor` mapper integration (lives in runtime-core which doesn't have JSONata; small standalone PR).
- Per-message SMTP credential override via `TenantEmailSettings` (column added in V129; routing wiring is a separate small change).
- Dedicated `EmailTemplatesPage` editor surfacing the new fields — current page surfaces them through the system-collection viewer.

## Test plan
- [ ] CI green
- [ ] Smoke: edit an Email Alert step → click "Body builder" → bind subject to `${$.record.data.orderNumber}` and body to a JSONata expression → save → run flow → received email shows resolved values
- [ ] Smoke: introduce a JSONata error → flow run fails with `Mapper.Failure: …` and a Catch policy on that name routes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)