### PR TITLE
fix(flow-designer): enable vertical scroll in Properties panel

### DIFF
--- a/kelta-ui/app/src/pages/FlowDesignerPage/components/PropertiesPanel.tsx
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/components/PropertiesPanel.tsx
@@ -55,7 +55,7 @@ export function PropertiesPanel({
           </button>
         )}
       </div>
-      <ScrollArea className="flex-1">
+      <ScrollArea className="min-h-0 flex-1">
         <div className="p-4">
           {selectedNode ? (
             <NodeProperties


### PR DESCRIPTION
## Summary
- Properties panel on the right of the Flow Designer wasn't scrolling, so configs with many fields (e.g. Update Record with multiple Field Updates) were unreachable.
- Added `min-h-0` to the inner `ScrollArea` so it can shrink below its intrinsic content height and the Radix viewport actually constrains.

## Root cause
The `ScrollArea` is a flex child with `flex-1`. Flex items default to `min-height: auto`, meaning they grow to fit content rather than being bounded by the parent. The Radix scroll viewport then has no bounded height to scroll within. Adding `min-h-0` is the standard fix.

[#375](https://github.com/cklinker/emf/pull/375) added `overflow-hidden` to the outer container, which clipped overflow but didn't make the inner area scrollable — this PR completes that fix.

## Test plan
- [ ] Open a flow in the designer and select a step with many properties (e.g. an Update Record task with several Field Updates)
- [ ] Verify the right Properties pane scrolls vertically and all fields are reachable
- [ ] Verify the panel still resizes correctly when collapsed/reopened

🤖 Generated with [Claude Code](https://claude.com/claude-code)