### PR TITLE
fix(flow): bind tenant slug for NATS-triggered flow execution + parse executions list as JSON:API

### DIFF
--- a/kelta-ui/app/src/pages/FlowDesignerPage/components/ExecutionsTab.tsx
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/components/ExecutionsTab.tsx
@@ -2,6 +2,7 @@ import React, { useState, useMemo } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useApi } from '../../../context/ApiContext'
 import { useToast, LoadingSpinner } from '../../../components'
+import { unwrapCollection } from '../../../utils/jsonapi'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import {
@@ -109,8 +110,8 @@ export function ExecutionsTab({ flowId, onViewExecution }: ExecutionsTabProps) {
     queryFn: async () => {
       const resp = await apiClient.fetch(`/api/flows/${flowId}/flow-executions?limit=100`)
       if (!resp.ok) throw new Error('Failed to load executions')
-      const json = (await resp.json()) as { executions: FlowExecution[] }
-      return json.executions || []
+      const json = await resp.json()
+      return unwrapCollection<FlowExecution>(json).data
     },
     refetchInterval: 5000,
   })

--- a/kelta-worker/src/main/java/io/kelta/worker/listener/FlowEventListener.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/listener/FlowEventListener.java
@@ -6,6 +6,7 @@ import io.kelta.runtime.event.RecordChangedPayload;
 import io.kelta.runtime.flow.FlowEngine;
 import io.kelta.runtime.flow.FlowTriggerEvaluator;
 import io.kelta.runtime.flow.InitialStateBuilder;
+import io.kelta.worker.service.TenantSlugResolver;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
@@ -42,6 +43,7 @@ public class FlowEventListener {
     private final InitialStateBuilder initialStateBuilder;
     private final JdbcTemplate jdbcTemplate;
     private final ObjectMapper objectMapper;
+    private final TenantSlugResolver tenantSlugResolver;
 
     /**
      * Cache: tenantId → list of active flow trigger configs.
@@ -62,12 +64,14 @@ public class FlowEventListener {
                               FlowTriggerEvaluator triggerEvaluator,
                               InitialStateBuilder initialStateBuilder,
                               JdbcTemplate jdbcTemplate,
-                              ObjectMapper objectMapper) {
+                              ObjectMapper objectMapper,
+                              TenantSlugResolver tenantSlugResolver) {
         this.flowEngine = flowEngine;
         this.triggerEvaluator = triggerEvaluator;
         this.initialStateBuilder = initialStateBuilder;
         this.jdbcTemplate = jdbcTemplate;
         this.objectMapper = objectMapper;
+        this.tenantSlugResolver = tenantSlugResolver;
     }
 
     /**
@@ -104,7 +108,12 @@ public class FlowEventListener {
                     payload.getCollectionName(), payload.getRecordId(), payload.getChangeType());
 
             final String boundUserId = userId;
-            TenantContext.runWithTenant(tenantId, () -> {
+            String tenantSlug = tenantSlugResolver.resolveSlug(tenantId).orElse(null);
+            if (tenantSlug == null) {
+                log.warn("Could not resolve slug for tenant {} — flow execution will fall back to public schema",
+                        tenantId);
+            }
+            TenantContext.runWithTenant(tenantId, tenantSlug, () -> {
                 List<FlowTriggerConfig> configs = getActiveFlowConfigs(tenantId);
                 if (configs.isEmpty()) {
                     return;

--- a/kelta-worker/src/main/java/io/kelta/worker/service/TenantSlugResolver.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/service/TenantSlugResolver.java
@@ -1,0 +1,82 @@
+package io.kelta.worker.service;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.Optional;
+
+/**
+ * Resolves a tenant's slug from its ID, with an in-memory Caffeine cache.
+ *
+ * <p>Used by background paths (NATS event listeners, scheduled jobs) that
+ * receive only a {@code tenantId} but need to bind the slug into
+ * {@link io.kelta.runtime.context.TenantContext} so that schema-per-tenant
+ * SQL resolves to the correct schema. HTTP request paths get the slug from
+ * the request filter directly and do not need this resolver.
+ *
+ * <p>The {@code tenant} table is small and slugs are immutable for the
+ * lifetime of a tenant, so a long TTL is safe. Negative lookups are NOT
+ * cached — callers should treat unknown tenant IDs as unrecoverable.
+ *
+ * @since 1.0.0
+ */
+@Service
+public class TenantSlugResolver {
+
+    private static final Logger log = LoggerFactory.getLogger(TenantSlugResolver.class);
+
+    private static final Duration TTL = Duration.ofHours(1);
+    private static final int MAX_SIZE = 10_000;
+
+    private final JdbcTemplate jdbcTemplate;
+    private final Cache<String, String> cache;
+
+    public TenantSlugResolver(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+        this.cache = Caffeine.newBuilder()
+                .maximumSize(MAX_SIZE)
+                .expireAfterWrite(TTL)
+                .build();
+    }
+
+    /**
+     * Returns the slug for the given tenant ID, or empty if the tenant is
+     * unknown. Cached on first hit.
+     */
+    public Optional<String> resolveSlug(String tenantId) {
+        if (tenantId == null || tenantId.isBlank()) {
+            return Optional.empty();
+        }
+        String cached = cache.getIfPresent(tenantId);
+        if (cached != null) {
+            return Optional.of(cached);
+        }
+        try {
+            String slug = jdbcTemplate.queryForObject(
+                    "SELECT slug FROM tenant WHERE id = ?", String.class, tenantId);
+            if (slug != null && !slug.isBlank()) {
+                cache.put(tenantId, slug);
+                return Optional.of(slug);
+            }
+            return Optional.empty();
+        } catch (EmptyResultDataAccessException e) {
+            return Optional.empty();
+        } catch (Exception e) {
+            log.warn("Failed to resolve slug for tenant {}: {}", tenantId, e.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    /** Evicts a single tenant from the cache (used when slug changes). */
+    public void evict(String tenantId) {
+        if (tenantId != null) {
+            cache.invalidate(tenantId);
+        }
+    }
+}

--- a/kelta-worker/src/test/java/io/kelta/worker/listener/FlowEventListenerTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/listener/FlowEventListenerTest.java
@@ -7,6 +7,7 @@ import io.kelta.runtime.event.RecordChangedPayload;
 import io.kelta.runtime.flow.FlowEngine;
 import io.kelta.runtime.flow.FlowTriggerEvaluator;
 import io.kelta.runtime.flow.InitialStateBuilder;
+import io.kelta.worker.service.TenantSlugResolver;
 import tools.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -18,6 +19,7 @@ import org.springframework.jdbc.core.RowMapper;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.*;
@@ -31,6 +33,7 @@ class FlowEventListenerTest {
     private InitialStateBuilder initialStateBuilder;
     private JdbcTemplate jdbcTemplate;
     private ObjectMapper objectMapper;
+    private TenantSlugResolver tenantSlugResolver;
     private FlowEventListener listener;
 
     @BeforeEach
@@ -40,7 +43,10 @@ class FlowEventListenerTest {
         initialStateBuilder = mock(InitialStateBuilder.class);
         jdbcTemplate = mock(JdbcTemplate.class);
         objectMapper = new ObjectMapper();
-        listener = new FlowEventListener(flowEngine, triggerEvaluator, initialStateBuilder, jdbcTemplate, objectMapper);
+        tenantSlugResolver = mock(TenantSlugResolver.class);
+        when(tenantSlugResolver.resolveSlug(anyString())).thenReturn(Optional.of("acme-corp"));
+        listener = new FlowEventListener(flowEngine, triggerEvaluator, initialStateBuilder,
+                jdbcTemplate, objectMapper, tenantSlugResolver);
     }
 
     @Nested
@@ -192,6 +198,58 @@ class FlowEventListenerTest {
 
             // The trigger evaluator should still be called (with empty map from the catch block)
             verify(triggerEvaluator).matchesRecordTrigger(any(), any());
+        }
+    }
+
+    @Nested
+    @DisplayName("tenant slug binding")
+    class TenantSlugBinding {
+
+        @Test
+        @DisplayName("Should resolve and bind tenant slug so flow execution sees correct schema")
+        @SuppressWarnings("unchecked")
+        void shouldBindTenantSlugDuringFlowExecution() throws Exception {
+            String plainConfig = """
+                {"events": ["UPDATED"], "collection": "orders"}
+                """;
+
+            stubJdbcWithTriggerConfig(plainConfig);
+            when(tenantSlugResolver.resolveSlug("tenant-1")).thenReturn(Optional.of("threadline-clothing"));
+            when(triggerEvaluator.matchesRecordTrigger(any(), any())).thenReturn(true);
+            when(initialStateBuilder.buildFromRecordEvent(any(), any(), any())).thenReturn(Map.of());
+
+            // Capture the slug seen by TenantContext at the moment startExecution is invoked.
+            java.util.concurrent.atomic.AtomicReference<String> seenSlug = new java.util.concurrent.atomic.AtomicReference<>();
+            when(flowEngine.startExecution(any(), any(), any(), any(), any(), anyBoolean()))
+                    .thenAnswer(invocation -> {
+                        seenSlug.set(io.kelta.runtime.context.TenantContext.getSlug());
+                        return "exec-1";
+                    });
+
+            listener.handleRecordChanged(buildRecordChangedMessage("tenant-1", "orders", ChangeType.UPDATED));
+
+            verify(tenantSlugResolver).resolveSlug("tenant-1");
+            assertThat(seenSlug.get()).isEqualTo("threadline-clothing");
+        }
+
+        @Test
+        @DisplayName("Should still execute when slug cannot be resolved (logs warning and falls back)")
+        @SuppressWarnings("unchecked")
+        void shouldExecuteWithoutSlugWhenUnresolvable() throws Exception {
+            String plainConfig = """
+                {"events": ["UPDATED"], "collection": "orders"}
+                """;
+
+            stubJdbcWithTriggerConfig(plainConfig);
+            when(tenantSlugResolver.resolveSlug("tenant-1")).thenReturn(Optional.empty());
+            when(triggerEvaluator.matchesRecordTrigger(any(), any())).thenReturn(true);
+            when(initialStateBuilder.buildFromRecordEvent(any(), any(), any())).thenReturn(Map.of());
+            when(flowEngine.startExecution(any(), any(), any(), any(), any(), anyBoolean())).thenReturn("exec-1");
+
+            listener.handleRecordChanged(buildRecordChangedMessage("tenant-1", "orders", ChangeType.UPDATED));
+
+            // Execution still attempted — degraded behaviour, but trigger evaluation still happens
+            verify(flowEngine).startExecution(eq("tenant-1"), any(), any(), any(), any(), anyBoolean());
         }
     }
 

--- a/kelta-worker/src/test/java/io/kelta/worker/service/TenantSlugResolverTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/service/TenantSlugResolverTest.java
@@ -1,0 +1,123 @@
+package io.kelta.worker.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@DisplayName("TenantSlugResolver")
+class TenantSlugResolverTest {
+
+    private JdbcTemplate jdbcTemplate;
+    private TenantSlugResolver resolver;
+
+    @BeforeEach
+    void setUp() {
+        jdbcTemplate = mock(JdbcTemplate.class);
+        resolver = new TenantSlugResolver(jdbcTemplate);
+    }
+
+    @Test
+    @DisplayName("Should query DB and return slug for known tenant")
+    void shouldReturnSlugForKnownTenant() {
+        when(jdbcTemplate.queryForObject(anyString(), eq(String.class), eq("tenant-1")))
+                .thenReturn("threadline-clothing");
+
+        Optional<String> slug = resolver.resolveSlug("tenant-1");
+
+        assertThat(slug).contains("threadline-clothing");
+    }
+
+    @Test
+    @DisplayName("Should cache slug and not re-query DB on second call")
+    void shouldCacheSlug() {
+        when(jdbcTemplate.queryForObject(anyString(), eq(String.class), eq("tenant-1")))
+                .thenReturn("threadline-clothing");
+
+        resolver.resolveSlug("tenant-1");
+        resolver.resolveSlug("tenant-1");
+        resolver.resolveSlug("tenant-1");
+
+        verify(jdbcTemplate, times(1)).queryForObject(anyString(), eq(String.class), eq("tenant-1"));
+    }
+
+    @Test
+    @DisplayName("Should re-query after eviction")
+    void shouldReQueryAfterEviction() {
+        when(jdbcTemplate.queryForObject(anyString(), eq(String.class), eq("tenant-1")))
+                .thenReturn("threadline-clothing");
+
+        resolver.resolveSlug("tenant-1");
+        resolver.evict("tenant-1");
+        resolver.resolveSlug("tenant-1");
+
+        verify(jdbcTemplate, times(2)).queryForObject(anyString(), eq(String.class), eq("tenant-1"));
+    }
+
+    @Test
+    @DisplayName("Should return empty for unknown tenant (EmptyResultDataAccessException)")
+    void shouldReturnEmptyForUnknownTenant() {
+        when(jdbcTemplate.queryForObject(anyString(), eq(String.class), eq("missing")))
+                .thenThrow(new EmptyResultDataAccessException(1));
+
+        Optional<String> slug = resolver.resolveSlug("missing");
+
+        assertThat(slug).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Should NOT cache negative lookups — re-queries on subsequent calls")
+    void shouldNotCacheNegativeLookups() {
+        when(jdbcTemplate.queryForObject(anyString(), eq(String.class), eq("missing")))
+                .thenThrow(new EmptyResultDataAccessException(1));
+
+        resolver.resolveSlug("missing");
+        resolver.resolveSlug("missing");
+
+        verify(jdbcTemplate, times(2)).queryForObject(anyString(), eq(String.class), eq("missing"));
+    }
+
+    @Test
+    @DisplayName("Should return empty for null or blank tenant ID without hitting DB")
+    void shouldReturnEmptyForNullOrBlank() {
+        assertThat(resolver.resolveSlug(null)).isEmpty();
+        assertThat(resolver.resolveSlug("")).isEmpty();
+        assertThat(resolver.resolveSlug("   ")).isEmpty();
+
+        verify(jdbcTemplate, times(0)).queryForObject(anyString(), any(Class.class), anyString());
+    }
+
+    @Test
+    @DisplayName("Should return empty when DB returns blank slug")
+    void shouldReturnEmptyForBlankSlug() {
+        when(jdbcTemplate.queryForObject(anyString(), eq(String.class), eq("tenant-1")))
+                .thenReturn("   ");
+
+        Optional<String> slug = resolver.resolveSlug("tenant-1");
+
+        assertThat(slug).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Should swallow unexpected exceptions and return empty")
+    void shouldSwallowUnexpectedExceptions() {
+        when(jdbcTemplate.queryForObject(anyString(), eq(String.class), eq("tenant-1")))
+                .thenThrow(new RuntimeException("connection refused"));
+
+        Optional<String> slug = resolver.resolveSlug("tenant-1");
+
+        assertThat(slug).isEmpty();
+    }
+}


### PR DESCRIPTION
## Summary

Two bugs surfaced from the same user report ("I updated an order, the workflow didn't run"):

1. **Trigger fired, execution failed silently.** [FlowEventListener.handleRecordChanged](kelta-worker/src/main/java/io/kelta/worker/listener/FlowEventListener.java) bound only `tenantId` into `TenantContext` (single-arg `runWithTenant`). The slug stayed `null`, so the `TenantPropagatingExecutors` snapshot captured `slug=null`, propagated `null` to the flow execution thread, and [PhysicalTableStorageAdapter.getTableRef:572](kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/storage/PhysicalTableStorageAdapter.java:572) fell back to the `public` schema. Tenant-collection queries (e.g. `SELECT * FROM orders ...`) hit `relation "orders" does not exist`. DB confirmed 4 `FAILED` executions today with `error_message = "Failed to query collection: orders"`. HTTP paths were unaffected because the request filter binds both ID and slug.
2. **Executions list looked empty in the UI.** [ExecutionsTab.tsx](kelta-ui/app/src/pages/FlowDesignerPage/components/ExecutionsTab.tsx) read `(json as { executions: FlowExecution[] }).executions || []`, but [FlowExecutionController.listExecutions:283](kelta-worker/src/main/java/io/kelta/worker/controller/FlowExecutionController.java:283) returns standard JSON:API (`{ data: [{type, id, attributes}], meta }`). Wrong key + wrong shape ⇒ silently `[]` even when executions existed — which is why the user said "no executions".

## Changes

- **New** `TenantSlugResolver` — Caffeine-cached lookup (`tenantId → slug`), TTL 1h, max 10k entries. Negative lookups not cached.
- **FlowEventListener** — injects the resolver, binds the slug via the two-arg `runWithTenant` overload before invoking the flow engine. Logs a warning and proceeds (degraded) when the slug can't be resolved, so we don't drop events on transient DB issues.
- **ExecutionsTab** — uses the existing [unwrapCollection](kelta-ui/app/src/utils/jsonapi.ts) helper.
- **Tests** — 8 new `TenantSlugResolverTest` cases (cache, eviction, negative lookups, exception swallowing, blank guards) + 2 new cases in `FlowEventListenerTest` (slug bound during `startExecution` / degraded fallback).

## Out of scope (follow-ups noted)

- `ScheduledJobExecutorService` and `FlowWebhookController` likely have the same root issue but were not in the user's reported path. Worth a separate audit.
- The systemic `FlowEventListener.invalidateCache` gap (no `BeforeSaveHook` for the `flow` collection, no NATS broadcast on flow config changes) is real but not the cause of this incident — pods were 4h33m old and the flow was unchanged for 2 months. Worth a separate PR.

## Test plan
- [x] `mvn verify -f kelta-worker/pom.xml` — 1039/1039 pass
- [x] `mvn verify -f kelta-gateway/pom.xml` — passes
- [x] `mvn install -f kelta-platform/pom.xml -DskipTests` — passes
- [x] `kelta-web` lint / typecheck / format / `test:coverage` — 605/605 pass
- [x] `kelta-ui` `tsc --noEmit` clean; `unwrapCollection` covered by 30 vitest cases (all pass); `ExecutionsTab.tsx` lint/format clean. (Pre-existing lint error in `PayloadMapper.tsx`, format warnings in 12 unrelated files, and 25 `App.test.tsx` failures all reproduce on `main` with this branch's changes stashed — not introduced here.)
- [ ] Manual e2e after deploy: update an order in `threadline-clothing`, confirm a `COMPLETED` row appears in `flow_execution` for `flow_id = 'f477fe36-…'` (replacing the previous `FAILED` entries) and the Executions tab populates within ~5s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)