### PR TITLE
fix(credentials): make credential beans conditional on EncryptionService

### DIFF
--- a/kelta-worker/src/main/java/io/kelta/worker/config/NatsSubscriptionConfig.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/config/NatsSubscriptionConfig.java
@@ -38,7 +38,9 @@ public class NatsSubscriptionConfig {
     private final CollectionSchemaListener collectionSchemaListener;
     private final ModuleEventListener moduleEventListener;
     private final CerbosCacheInvalidationListener cerbosCacheInvalidationListener;
-    private final CredentialCacheInvalidationListener credentialCacheInvalidationListener;
+
+    @Autowired(required = false)
+    private CredentialCacheInvalidationListener credentialCacheInvalidationListener;
 
     @Autowired(required = false)
     private SupersetCollectionSyncListener supersetCollectionSyncListener;
@@ -51,15 +53,13 @@ public class NatsSubscriptionConfig {
                                    SearchIndexListener searchIndexListener,
                                    CollectionSchemaListener collectionSchemaListener,
                                    ModuleEventListener moduleEventListener,
-                                   CerbosCacheInvalidationListener cerbosCacheInvalidationListener,
-                                   CredentialCacheInvalidationListener credentialCacheInvalidationListener) {
+                                   CerbosCacheInvalidationListener cerbosCacheInvalidationListener) {
         this.subscriptionManager = subscriptionManager;
         this.flowEventListener = flowEventListener;
         this.searchIndexListener = searchIndexListener;
         this.collectionSchemaListener = collectionSchemaListener;
         this.moduleEventListener = moduleEventListener;
         this.cerbosCacheInvalidationListener = cerbosCacheInvalidationListener;
-        this.credentialCacheInvalidationListener = credentialCacheInvalidationListener;
     }
 
     @PostConstruct
@@ -87,10 +87,15 @@ public class NatsSubscriptionConfig {
                 cerbosCacheInvalidationListener::handlePolicyChanged));
 
         // Credential cache invalidation — every pod drops local cache entries
-        // when a credential row changes upstream.
-        subscriptionManager.register(EventSubscription.broadcast(
-                "worker-credential-cache", "kelta.config.credential.changed.>",
-                credentialCacheInvalidationListener::handleCredentialChanged));
+        // when a credential row changes upstream. Only present when
+        // kelta.encryption.key is configured (credential beans are conditional
+        // on EncryptionService).
+        if (credentialCacheInvalidationListener != null) {
+            subscriptionManager.register(EventSubscription.broadcast(
+                    "worker-credential-cache", "kelta.config.credential.changed.>",
+                    credentialCacheInvalidationListener::handleCredentialChanged));
+            log.info("Registered NATS subscription for credential cache invalidation");
+        }
 
         // Flow trigger cache invalidation — every pod drops the per-tenant
         // FlowEventListener cache when a flow row changes (create/update/delete).
@@ -115,7 +120,8 @@ public class NatsSubscriptionConfig {
             log.info("Registered NATS subscription for Svix webhook publisher");
         }
 
-        log.info("Registered {} worker NATS subscriptions", 7
+        log.info("Registered {} worker NATS subscriptions", 6
+                + (credentialCacheInvalidationListener != null ? 1 : 0)
                 + (supersetCollectionSyncListener != null ? 1 : 0)
                 + (svixWebhookPublisher != null ? 1 : 0));
     }

--- a/kelta-worker/src/main/java/io/kelta/worker/controller/CredentialController.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/controller/CredentialController.java
@@ -15,6 +15,7 @@ import io.kelta.worker.service.credential.CredentialTestService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -44,6 +45,7 @@ import java.util.stream.Collectors;
  */
 @RestController
 @RequestMapping("/api/credentials")
+@ConditionalOnBean(EncryptionService.class)
 public class CredentialController {
 
     private static final Logger log = LoggerFactory.getLogger(CredentialController.class);

--- a/kelta-worker/src/main/java/io/kelta/worker/listener/CredentialCacheInvalidationListener.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/listener/CredentialCacheInvalidationListener.java
@@ -1,8 +1,10 @@
 package io.kelta.worker.listener;
 
+import io.kelta.crypto.EncryptionService;
 import io.kelta.worker.service.credential.CredentialResolver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.stereotype.Component;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
@@ -13,6 +15,7 @@ import tools.jackson.databind.ObjectMapper;
  * runs this listener so cache stays consistent across the fleet.
  */
 @Component
+@ConditionalOnBean(EncryptionService.class)
 public class CredentialCacheInvalidationListener {
 
     private static final Logger log = LoggerFactory.getLogger(CredentialCacheInvalidationListener.class);

--- a/kelta-worker/src/main/java/io/kelta/worker/service/credential/CredentialResolverImpl.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/service/credential/CredentialResolverImpl.java
@@ -10,6 +10,7 @@ import io.kelta.worker.service.SetupAuditService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.stereotype.Service;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
@@ -30,6 +31,7 @@ import java.util.concurrent.ConcurrentMap;
  * {@link io.kelta.worker.listener.CredentialCacheInvalidationListener}.
  */
 @Service
+@ConditionalOnBean(EncryptionService.class)
 public class CredentialResolverImpl implements CredentialResolver {
 
     private static final Logger log = LoggerFactory.getLogger(CredentialResolverImpl.class);

--- a/kelta-worker/src/main/java/io/kelta/worker/service/credential/CredentialResolverPortAdapter.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/service/credential/CredentialResolverPortAdapter.java
@@ -6,6 +6,7 @@ import io.kelta.runtime.module.integration.spi.CredentialResolverPort;
 import io.kelta.worker.repository.CredentialOAuthTokenRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.stereotype.Service;
 
 import java.time.Instant;
@@ -21,6 +22,7 @@ import java.util.Optional;
  * a single uniform applyAuth path.
  */
 @Service
+@ConditionalOnBean(EncryptionService.class)
 public class CredentialResolverPortAdapter implements CredentialResolverPort {
 
     private static final Logger log = LoggerFactory.getLogger(CredentialResolverPortAdapter.class);

--- a/kelta-worker/src/main/java/io/kelta/worker/service/credential/CredentialTestService.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/service/credential/CredentialTestService.java
@@ -10,6 +10,7 @@ import jakarta.mail.Session;
 import jakarta.mail.Transport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.stereotype.Service;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
@@ -30,6 +31,7 @@ import java.util.Properties;
  * </ul>
  */
 @Service
+@ConditionalOnBean(EncryptionService.class)
 public class CredentialTestService {
 
     private static final Logger log = LoggerFactory.getLogger(CredentialTestService.class);

--- a/kelta-worker/src/test/java/io/kelta/worker/config/NatsSubscriptionConfigTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/config/NatsSubscriptionConfigTest.java
@@ -1,0 +1,62 @@
+package io.kelta.worker.config;
+
+import io.kelta.runtime.event.EventSubscription;
+import io.kelta.runtime.messaging.nats.NatsSubscriptionManager;
+import io.kelta.worker.listener.CerbosCacheInvalidationListener;
+import io.kelta.worker.listener.CollectionSchemaListener;
+import io.kelta.worker.listener.CredentialCacheInvalidationListener;
+import io.kelta.worker.listener.FlowEventListener;
+import io.kelta.worker.listener.SearchIndexListener;
+import io.kelta.worker.module.ModuleEventListener;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@DisplayName("NatsSubscriptionConfig")
+class NatsSubscriptionConfigTest {
+
+    private NatsSubscriptionManager subscriptionManager;
+    private NatsSubscriptionConfig config;
+
+    @BeforeEach
+    void setUp() {
+        subscriptionManager = mock(NatsSubscriptionManager.class);
+        config = new NatsSubscriptionConfig(
+                subscriptionManager,
+                mock(FlowEventListener.class),
+                mock(SearchIndexListener.class),
+                mock(CollectionSchemaListener.class),
+                mock(ModuleEventListener.class),
+                mock(CerbosCacheInvalidationListener.class));
+    }
+
+    @Test
+    @DisplayName("registerSubscriptions boots without CredentialCacheInvalidationListener (no encryption key)")
+    void registerSubscriptions_withoutCredentialListener_skipsCredentialCacheRegistration() {
+        // Optional listeners (incl. credential cache) left null — mirrors Spring wiring
+        // when kelta.encryption.key is not configured.
+        config.registerSubscriptions();
+
+        // Six always-on subscriptions: worker-flows, worker-search-index, worker-schema,
+        // worker-modules, worker-cerbos, worker-flow-cache.
+        // Credential/Superset/Svix are conditional.
+        verify(subscriptionManager, times(6)).register(any(EventSubscription.class));
+    }
+
+    @Test
+    @DisplayName("registerSubscriptions registers credential cache subscription when listener is present")
+    void registerSubscriptions_withCredentialListener_registersCredentialCache() {
+        ReflectionTestUtils.setField(config, "credentialCacheInvalidationListener",
+                mock(CredentialCacheInvalidationListener.class));
+
+        config.registerSubscriptions();
+
+        verify(subscriptionManager, times(7)).register(any(EventSubscription.class));
+    }
+}


### PR DESCRIPTION
## Summary
Production has been stuck since 16:13 UTC today because every commit landed after the credential vault PR ([#766](https://github.com/cklinker/emf/pull/766)) fails worker startup when \`kelta.encryption.key\` isn't configured. This blocks ArgoCD sync via the worker-migrate PreSync hook, which has cascaded to block 6 PRs from deploying.

## Root cause
\`EncryptionAutoConfiguration\` correctly creates the \`EncryptionService\` bean only when \`kelta.encryption.key\` is set. But five credential beans declared it as a hard constructor dependency:

- \`CredentialController\`
- \`CredentialTestService\`
- \`CredentialResolverImpl\`
- \`CredentialResolverPortAdapter\`
- \`CredentialCacheInvalidationListener\` (transitively, via \`CredentialResolver\`)

When the key isn't set, Spring fails to wire \`credentialController\`, the application context refresh aborts, and the worker can't boot.

## Fix
Add \`@ConditionalOnBean(EncryptionService.class)\` to all five beans so they're only registered when encryption is configured. The credentials feature is then opt-in via config — if the key isn't set, the beans simply don't exist.

This matches the pattern already used by \`OidcProviderSecretHook\` and \`CredentialEncryptionHook\` in this codebase.

## Why this is safe
Consumers of these beans already handle their absence:

- [\`FlowConfig.java:189-190\`](kelta-worker/src/main/java/io/kelta/worker/config/FlowConfig.java#L189-L190) wires \`CredentialResolverPort\` with \`@Autowired(required = false)\` and only adds it to the module context when non-null
- [\`IntegrationModule.java:117-123\`](kelta-platform/runtime/runtime-module-integration/src/main/java/io/kelta/runtime/module/integration/IntegrationModule.java#L117-L123) — \`CallApiActionHandler\` accepts a null \`CredentialResolverPort\` and produces a typed runtime error rather than failing module startup. Comment in code: *\"missing extensions produce typed runtime errors instead of failing module startup so legacy installations stay bootable.\"*

## Companion change
A separate PR against \`homelab-argo\` will add \`KELTA_ENCRYPTION_KEY\` to the worker deployment env so the credentials feature actually works in production. This PR ensures the worker still boots even if that key is ever missing or rotated out.

## Test plan
- [ ] CI passes (worker build + tests)
- [ ] After merge + deploy with no \`kelta.encryption.key\`: worker starts, /api/credentials returns 404 (controller not registered), CALL_API works without credentials
- [ ] After merge + deploy with \`kelta.encryption.key\` set: all credential endpoints work, CALL_API can attach credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)