### PR TITLE
fix(native-image): include credential schemas/templates in runtime-core

### DIFF
--- a/kelta-platform/runtime/runtime-core/src/main/resources/META-INF/native-image/io.kelta/runtime-core/resource-config.json
+++ b/kelta-platform/runtime/runtime-core/src/main/resources/META-INF/native-image/io.kelta/runtime-core/resource-config.json
@@ -1,0 +1,8 @@
+{
+  "resources": {
+    "includes": [
+      { "pattern": "credential-schemas/.*\\.json$" },
+      { "pattern": "credential-templates/.*\\.json$" }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
Fixes \`emf-ai\` crashing on startup with:
\`\`\`
Missing credential schema: /credential-schemas/api_key.input.json
\`\`\`

## Root cause
The credential vault PR ([#766](https://github.com/cklinker/emf/pull/766)) introduced \`@Component\`-annotated \`CredentialType\` beans (ApiKey, BasicAuth, BearerToken, OAuth2*, SMTP, Custom) that each load \`/credential-schemas/<key>.input.json\` at construction time via \`getResourceAsStream\`. \`CredentialTemplateRegistry\` similarly loads \`/credential-templates/<key>.json\` for provider templates.

\`KeltaRuntimeAutoConfiguration\` declares \`@ComponentScan(basePackages = "io.kelta.runtime")\`, so any Spring Boot app that depends on \`runtime-core\` picks up these beans on startup — including \`kelta-ai\`, which is built as a GraalVM native image. GraalVM strips resources that aren't explicitly registered, so \`getResourceAsStream\` returns null and bean creation fails.

## Fix
Add \`META-INF/native-image/io.kelta/runtime-core/resource-config.json\` to \`runtime-core\` declaring both resource directories. GraalVM picks this up automatically for any native-image build that depends on \`runtime-core\`, so this fixes the AI service today and prevents the same surprise for any future native-image consumer.

\`\`\`json
{
  "resources": {
    "includes": [
      { "pattern": "credential-schemas/.*\\\\.json\$" },
      { "pattern": "credential-templates/.*\\\\.json\$" }
    ]
  }
}
\`\`\`

## Test plan
- [ ] CI passes
- [ ] After merge: \`emf-ai\` deploys cleanly (no \`Missing credential schema\` error in startup logs)
- [ ] AI service responds to \`/actuator/health\` after rollout

## Follow-up consideration (not in this PR)
The AI service has no business loading credential types — they are runtime infrastructure for the worker. A cleaner architectural fix would be to make the credential types conditional (e.g., \`@ConditionalOnBean(EncryptionService.class)\`) so they only load in services that actually configure encryption. That would bloat the patch surface here, so leaving as a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)