### PR TITLE
fix(flows): parse executions list as JSON:API in FlowsPage execution-history modal

### DIFF
--- a/kelta-ui/app/src/pages/FlowsPage/FlowsPage.tsx
+++ b/kelta-ui/app/src/pages/FlowsPage/FlowsPage.tsx
@@ -4,6 +4,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useI18n } from '../../context/I18nContext'
 import { useApi } from '../../context/ApiContext'
 import { getTenantSlug } from '../../context/TenantContext'
+import { unwrapCollection } from '../../utils/jsonapi'
 import {
   useToast,
   ConfirmDialog,
@@ -95,8 +96,8 @@ export function FlowsPage({ testId = 'flows-page' }: FlowsPageProps): React.Reac
     queryFn: async () => {
       const resp = await apiClient.fetch(`/api/flows/${execItemId}/flow-executions`)
       if (!resp.ok) throw new Error('Failed to load executions')
-      const json = (await resp.json()) as { executions: FlowExecutionLog[] }
-      return json.executions || []
+      const json = await resp.json()
+      return unwrapCollection<FlowExecutionLog>(json).data
     },
     enabled: !!execItemId,
   })


### PR DESCRIPTION
## Summary

Companion to [#772](https://github.com/cklinker/emf/pull/772). That PR fixed the JSON:API contract mismatch in the flow-designer `ExecutionsTab`, but missed the **second** caller of `/api/flows/{id}/flow-executions` — the Execution History modal opened from the flows list page ([FlowsPage.tsx:98-99](kelta-ui/app/src/pages/FlowsPage/FlowsPage.tsx#L98-L99)). Same bug, same fix: read `{ data: [{type, id, attributes}], meta }` via the existing [unwrapCollection](kelta-ui/app/src/utils/jsonapi.ts) helper.

User confirmed via dev tools that the API response had executions but the modal showed "No executions found for this flow." after the deploy of #772 — proving the underlying flow execution is working, the second UI caller just had the same parsing bug.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `prettier --check` clean
- [x] `eslint` clean for the touched file
- [x] `unwrapCollection` already covered by 30 vitest cases (`jsonapi.test.ts`)
- [ ] Manual after deploy: open the Execution History modal from the flows list page; confirm the two `COMPLETED` executions for `f477fe36-…` show up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)