### PR TITLE
fix(ui): replace ScrollArea with native overflow-auto in ExecutionLogModal

### DIFF
--- a/kelta-ui/app/src/components/ExecutionLogModal/ExecutionLogModal.tsx
+++ b/kelta-ui/app/src/components/ExecutionLogModal/ExecutionLogModal.tsx
@@ -2,13 +2,13 @@
  * ExecutionLogModal Component
  *
  * A modal dialog for displaying execution logs in a tabular format.
- * Built on shadcn Dialog + ScrollArea with Tailwind CSS styling.
+ * Built on shadcn Dialog with Tailwind CSS styling.
  *
  * Features:
  * - Modal overlay with centered dialog
  * - Table display with configurable columns
  * - Loading, error, and empty states
- * - Scrollable content area via ScrollArea
+ * - Native overflow-auto scroll (both axes) for tables wider than the modal
  * - Accessible with ARIA dialog role
  */
 
@@ -21,7 +21,6 @@ import {
   DialogTitle,
   DialogDescription,
 } from '@/components/ui/dialog'
-import { ScrollArea } from '@/components/ui/scroll-area'
 
 export interface LogColumn<T> {
   key: string
@@ -53,7 +52,7 @@ export function ExecutionLogModal<T extends Record<string, unknown>>({
   return (
     <Dialog open={true} onOpenChange={(open) => !open && onClose()}>
       <DialogContent
-        className="sm:max-w-[900px] max-h-[80vh] flex flex-col p-0"
+        className="sm:max-w-[1100px] max-h-[80vh] flex flex-col p-0"
         data-testid="execution-log-modal"
       >
         {/* Header */}
@@ -73,8 +72,11 @@ export function ExecutionLogModal<T extends Record<string, unknown>>({
           {!subtitle && <DialogDescription className="sr-only">{title}</DialogDescription>}
         </DialogHeader>
 
-        {/* Body */}
-        <ScrollArea className="flex-1 px-6 py-5">
+        {/* Body — native overflow-auto handles both vertical and horizontal scroll;
+            the table cells are nowrap so the parent must clip + scroll, not radix
+            ScrollArea (which doesn't expose horizontal scroll by default and breaks
+            sizing when content exceeds the viewport in either dimension). */}
+        <div className="flex-1 min-h-0 overflow-auto px-6 py-5">
           {isLoading ? (
             <div className="flex items-center justify-center p-8">
               <LoadingSpinner size="medium" label="Loading logs..." />
@@ -86,49 +88,44 @@ export function ExecutionLogModal<T extends Record<string, unknown>>({
               <p className="text-sm text-muted-foreground">{emptyMessage}</p>
             </div>
           ) : (
-            <div className="overflow-x-auto">
-              <table
-                className="w-full border-collapse text-[0.8125rem]"
-                role="grid"
-                aria-label={title}
-              >
-                <thead>
-                  <tr>
+            <table
+              className="w-full border-collapse text-[0.8125rem]"
+              role="grid"
+              aria-label={title}
+            >
+              <thead>
+                <tr>
+                  {columns.map((col) => (
+                    <th
+                      key={col.key}
+                      className="px-3 py-2 text-left text-xs font-semibold uppercase text-muted-foreground border-b whitespace-nowrap sticky top-0 bg-background"
+                    >
+                      {col.header}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {data.map((row, rowIndex) => (
+                  <tr
+                    key={((row as Record<string, unknown>).id as string) ?? rowIndex}
+                    className="hover:bg-muted/50 transition-colors"
+                  >
                     {columns.map((col) => (
-                      <th
-                        key={col.key}
-                        className="px-3 py-2 text-left text-xs font-semibold uppercase text-muted-foreground border-b whitespace-nowrap sticky top-0 bg-background"
-                      >
-                        {col.header}
-                      </th>
+                      <td key={col.key} className="px-3 py-2 text-left border-b whitespace-nowrap">
+                        {col.render
+                          ? col.render(row[col.key], row)
+                          : row[col.key] != null
+                            ? String(row[col.key])
+                            : '-'}
+                      </td>
                     ))}
                   </tr>
-                </thead>
-                <tbody>
-                  {data.map((row, rowIndex) => (
-                    <tr
-                      key={((row as Record<string, unknown>).id as string) ?? rowIndex}
-                      className="hover:bg-muted/50 transition-colors"
-                    >
-                      {columns.map((col) => (
-                        <td
-                          key={col.key}
-                          className="px-3 py-2 text-left border-b whitespace-nowrap"
-                        >
-                          {col.render
-                            ? col.render(row[col.key], row)
-                            : row[col.key] != null
-                              ? String(row[col.key])
-                              : '-'}
-                        </td>
-                      ))}
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
+                ))}
+              </tbody>
+            </table>
           )}
-        </ScrollArea>
+        </div>
       </DialogContent>
     </Dialog>
   )


### PR DESCRIPTION
## Summary

The ExecutionLogModal stopped scrolling and table content spilled outside the dialog edge when many columns combined with long error messages. Two related issues:

1. **shadcn `ScrollArea`** (radix-based) only renders a vertical scrollbar and its viewport sizing breaks down when content overflows either axis — content pushes past the modal edge instead of clipping/scrolling.
2. **`flex-1` without `min-h-0`** prevents the body from shrinking below content height inside a column flex parent, so vertical scroll silently fails when rows overflow.

Replace the `ScrollArea` + redundant `overflow-x-auto` wrapper with a single native `overflow-auto` div + `min-h-0`. Bump `max-w` 900 → 1100 so common column counts fit without horizontal scroll on standard displays.

## Affected pages
The component is shared across:
- [FlowsPage](kelta-ui/app/src/pages/FlowsPage/FlowsPage.tsx) — flow execution history modal (the one in the user's screenshot)
- [FlowDesignerPage](kelta-ui/app/src/pages/FlowDesignerPage)
- [ApprovalProcessesPage](kelta-ui/app/src/pages/ApprovalProcessesPage/ApprovalProcessesPage.tsx)
- [ScheduledJobsPage](kelta-ui/app/src/pages/ScheduledJobsPage/ScheduledJobsPage.tsx)
- [ScriptsPage](kelta-ui/app/src/pages/ScriptsPage/ScriptsPage.tsx)

All five benefit from the fix.

## Out of scope
- The Execution History "Trigger Record" column rendering "-" for every row is a **separate backend bug** — `FlowEngine.startExecution` hardcodes `null` for the `triggerRecordId` parameter on `JdbcFlowStore.createExecution`, so the DB column is always NULL. Spawned as a follow-up task.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `prettier --check` clean
- [x] `eslint` clean for the touched file
- [x] `vitest run src/utils/jsonapi.test.ts` — 30/30 pass (no regression to consuming pages' parsing)
- [ ] Manual after deploy: open the Execution History modal from the flows list page; confirm vertical scroll works on tables with >15 rows and the modal doesn't visually overflow when error messages are long.

🤖 Generated with [Claude Code](https://claude.com/claude-code)