### PR TITLE
fix(flow): persist trigger record id + bind tenant slug in scheduled/webhook paths

### DIFF
--- a/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/flow/FlowEngine.java
+++ b/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/flow/FlowEngine.java
@@ -84,18 +84,22 @@ public class FlowEngine {
      * Starts a flow execution asynchronously. Returns the execution ID immediately.
      * The execution runs on the engine's thread pool.
      *
-     * @param tenantId        tenant ID
-     * @param flowId          flow ID
-     * @param definitionJson  the flow definition JSON
-     * @param initialInput    the initial state data
-     * @param userId          user who initiated the execution (null for triggers)
-     * @param isTest          whether this is a test execution
+     * @param tenantId         tenant ID
+     * @param flowId           flow ID
+     * @param definitionJson   the flow definition JSON
+     * @param initialInput     the initial state data
+     * @param userId           user who initiated the execution (null for triggers)
+     * @param triggerRecordId  ID of the record that triggered this execution
+     *                         (null for manual runs, scheduled jobs, and webhooks)
+     * @param isTest           whether this is a test execution
      * @return the execution ID
      */
     public String startExecution(String tenantId, String flowId, String definitionJson,
-                                 Map<String, Object> initialInput, String userId, boolean isTest) {
+                                 Map<String, Object> initialInput, String userId,
+                                 String triggerRecordId, boolean isTest) {
         FlowDefinition definition = parser.parse(definitionJson);
-        String executionId = flowStore.createExecution(tenantId, flowId, userId, null, initialInput, isTest);
+        String executionId = flowStore.createExecution(tenantId, flowId, userId, triggerRecordId,
+                initialInput, isTest);
 
         threadPool.submit(() -> TenantContext.runWithTenant(tenantId, () -> {
             listener.onExecutionStarted(flowId);

--- a/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/flow/FlowEngineTest.java
+++ b/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/flow/FlowEngineTest.java
@@ -421,7 +421,7 @@ class FlowEngineTest {
                 }
                 """;
 
-            String executionId = engine.startExecution("t1", "f1", json, Map.of(), "u1", false);
+            String executionId = engine.startExecution("t1", "f1", json, Map.of(), "u1", null, false);
             assertNotNull(executionId);
             assertFalse(executionId.isEmpty());
         }

--- a/kelta-worker/src/main/java/io/kelta/worker/controller/FlowExecutionController.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/controller/FlowExecutionController.java
@@ -107,7 +107,7 @@ public class FlowExecutionController {
         }
 
         String resultExecutionId = flowEngine.startExecution(
-                tenantId, flowId, definitionJson, initialState, userId, isTest);
+                tenantId, flowId, definitionJson, initialState, userId, null, isTest);
 
         Map<String, Object> attrs = new LinkedHashMap<>();
         attrs.put("flowId", flowId);
@@ -264,7 +264,7 @@ public class FlowExecutionController {
 
         String newExecutionId = flowEngine.startExecution(
                 exec.tenantId(), exec.flowId(), definitionJson, initialState,
-                exec.startedBy(), exec.isTest());
+                exec.startedBy(), exec.triggerRecordId(), exec.isTest());
 
         Map<String, Object> attrs = new LinkedHashMap<>();
         attrs.put("originalExecutionId", executionId);

--- a/kelta-worker/src/main/java/io/kelta/worker/controller/FlowWebhookController.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/controller/FlowWebhookController.java
@@ -5,6 +5,8 @@ import io.kelta.jsonapi.JsonApiResponseBuilder;
 import io.kelta.runtime.flow.FlowEngine;
 import io.kelta.runtime.flow.InitialStateBuilder;
 import io.kelta.worker.repository.FlowRepository;
+import io.kelta.worker.service.TenantSlugResolver;
+import io.kelta.worker.util.TenantContextUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -14,6 +16,7 @@ import org.springframework.web.bind.annotation.*;
 
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.*;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Handles inbound webhook requests that trigger AUTOLAUNCHED flows,
@@ -37,17 +40,20 @@ public class FlowWebhookController {
     private final FlowRepository flowRepository;
     private final InitialStateBuilder initialStateBuilder;
     private final ObjectMapper objectMapper;
+    private final TenantSlugResolver tenantSlugResolver;
     private final String externalBaseUrl;
 
     public FlowWebhookController(FlowEngine flowEngine,
                                   FlowRepository flowRepository,
                                   InitialStateBuilder initialStateBuilder,
                                   ObjectMapper objectMapper,
+                                  TenantSlugResolver tenantSlugResolver,
                                   @Value("${kelta.external-base-url:http://localhost:8080}") String externalBaseUrl) {
         this.flowEngine = flowEngine;
         this.flowRepository = flowRepository;
         this.initialStateBuilder = initialStateBuilder;
         this.objectMapper = objectMapper;
+        this.tenantSlugResolver = tenantSlugResolver;
         this.externalBaseUrl = externalBaseUrl;
     }
 
@@ -109,8 +115,28 @@ public class FlowWebhookController {
                 body != null ? body : Map.of(),
                 headers, tenantId, flowId, executionId);
 
-        String resultExecutionId = flowEngine.startExecution(
-                tenantId, flowId, definitionJson, initialState, "webhook", false);
+        // Webhooks are unauthenticated and bypass the tenant filter, so the slug
+        // is not yet bound. Resolve it before invoking the engine — the engine's
+        // thread-pool propagation snapshots TenantContext at submit time, and
+        // schema-per-tenant SQL inside the flow needs the slug to resolve to the
+        // right schema.
+        String tenantSlug = tenantSlugResolver.resolveSlug(tenantId).orElse(null);
+        if (tenantSlug == null) {
+            log.warn("Could not resolve slug for tenant {} on webhook for flow {} — flow execution will fall back to public schema",
+                    tenantId, flowId);
+        }
+        AtomicReference<String> resultRef = new AtomicReference<>();
+        try {
+            TenantContextUtils.withTenant(tenantId, tenantSlug, () ->
+                    resultRef.set(flowEngine.startExecution(
+                            tenantId, flowId, definitionJson, initialState, "webhook", null, false)));
+        } catch (Exception e) {
+            log.error("Failed to start webhook-triggered flow execution: flowId={}", flowId, e);
+            return ResponseEntity.internalServerError().body(
+                    JsonApiResponseBuilder.error("500", "Internal Server Error",
+                            "Failed to start flow execution"));
+        }
+        String resultExecutionId = resultRef.get();
 
         Map<String, Object> attrs = new LinkedHashMap<>();
         attrs.put("flowId", flowId);

--- a/kelta-worker/src/main/java/io/kelta/worker/listener/FlowEventListener.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/listener/FlowEventListener.java
@@ -135,6 +135,7 @@ public class FlowEventListener {
                                     config.definitionJson(),
                                     initialState,
                                     boundUserId,
+                                    payload.getRecordId(),
                                     false);
                         }
                     } catch (Exception e) {

--- a/kelta-worker/src/main/java/io/kelta/worker/service/ScheduledJobExecutorService.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/service/ScheduledJobExecutorService.java
@@ -49,6 +49,7 @@ public class ScheduledJobExecutorService {
     private final ReportExecutionService reportExecutionService;
     private final DataExportService dataExportService;
     private final DataExportRepository dataExportRepository;
+    private final TenantSlugResolver tenantSlugResolver;
 
     public ScheduledJobExecutorService(ScheduledJobRepository repository,
                                         FlowEngine flowEngine,
@@ -57,7 +58,8 @@ public class ScheduledJobExecutorService {
                                         ScriptExecutor scriptExecutor,
                                         ReportExecutionService reportExecutionService,
                                         DataExportService dataExportService,
-                                        DataExportRepository dataExportRepository) {
+                                        DataExportRepository dataExportRepository,
+                                        TenantSlugResolver tenantSlugResolver) {
         this.repository = repository;
         this.flowEngine = flowEngine;
         this.initialStateBuilder = initialStateBuilder;
@@ -66,6 +68,7 @@ public class ScheduledJobExecutorService {
         this.reportExecutionService = reportExecutionService;
         this.dataExportService = dataExportService;
         this.dataExportRepository = dataExportRepository;
+        this.tenantSlugResolver = tenantSlugResolver;
     }
 
     /**
@@ -91,8 +94,17 @@ public class ScheduledJobExecutorService {
 
             Instant startedAt = Instant.now();
 
+            // Scheduler thread has no inherited tenant context, so resolve the
+            // slug and bind both ID and slug — every job type that touches
+            // tenant-scoped tables (FLOW + REPORT_EXPORT + DATA_EXPORT) needs
+            // schema-per-tenant resolution to work.
+            String tenantSlug = tenantSlugResolver.resolveSlug(tenantId).orElse(null);
+            if (tenantSlug == null) {
+                log.warn("Could not resolve slug for tenant {} on scheduled job {} — execution will fall back to public schema",
+                        tenantId, jobId);
+            }
             try {
-                TenantContextUtils.withTenant(tenantId, () -> {
+                TenantContextUtils.withTenant(tenantId, tenantSlug, () -> {
                     switch (jobType) {
                         case "FLOW" -> executeFlowJob(jobId, tenantId, jobReferenceId, cronExpression, timezone, startedAt);
                         case "SCRIPT" -> executeScriptJob(jobId, tenantId, jobReferenceId, cronExpression, timezone, startedAt);
@@ -165,7 +177,7 @@ public class ScheduledJobExecutorService {
 
         // Execute flow (async — returns immediately)
         String flowExecutionId = flowEngine.startExecution(
-                tenantId, flowReferenceId, definitionJson, initialState, null, false);
+                tenantId, flowReferenceId, definitionJson, initialState, null, null, false);
 
         Instant completedAt = Instant.now();
         long durationMs = completedAt.toEpochMilli() - startedAt.toEpochMilli();

--- a/kelta-worker/src/main/java/io/kelta/worker/util/TenantContextUtils.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/util/TenantContextUtils.java
@@ -37,6 +37,26 @@ public final class TenantContextUtils {
     }
 
     /**
+     * Executes {@code task} with both the tenant ID and slug bound in
+     * {@link TenantContext}. Required by code paths that issue tenant-scoped
+     * SQL — schema-per-tenant table resolution depends on the slug.
+     */
+    public static void withTenant(String tenantId, String tenantSlug, ThrowingRunnable task)
+            throws Exception {
+        AtomicReference<Exception> failure = new AtomicReference<>();
+        TenantContext.runWithTenant(tenantId, tenantSlug, () -> {
+            try {
+                task.run();
+            } catch (Exception e) {
+                failure.set(e);
+            }
+        });
+        if (failure.get() != null) {
+            throw failure.get();
+        }
+    }
+
+    /**
      * Callable variant of {@link #withTenant(String, ThrowingRunnable)}.
      */
     public static <T> T withTenant(String tenantId, Callable<T> task) throws Exception {

--- a/kelta-worker/src/test/java/io/kelta/worker/listener/FlowEventListenerTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/listener/FlowEventListenerTest.java
@@ -64,7 +64,7 @@ class FlowEventListenerTest {
             stubJdbcWithTriggerConfig(plainConfig);
             when(triggerEvaluator.matchesRecordTrigger(any(), any())).thenReturn(true);
             when(initialStateBuilder.buildFromRecordEvent(any(), any(), any())).thenReturn(Map.of());
-            when(flowEngine.startExecution(any(), any(), any(), any(), any(), anyBoolean())).thenReturn("exec-1");
+            when(flowEngine.startExecution(any(), any(), any(), any(), any(), any(), anyBoolean())).thenReturn("exec-1");
 
             listener.handleRecordChanged(buildRecordChangedMessage("tenant-1", "orders", ChangeType.CREATED));
 
@@ -89,7 +89,7 @@ class FlowEventListenerTest {
             stubJdbcWithTriggerConfig(wrappedConfig);
             when(triggerEvaluator.matchesRecordTrigger(any(), any())).thenReturn(true);
             when(initialStateBuilder.buildFromRecordEvent(any(), any(), any())).thenReturn(Map.of());
-            when(flowEngine.startExecution(any(), any(), any(), any(), any(), anyBoolean())).thenReturn("exec-1");
+            when(flowEngine.startExecution(any(), any(), any(), any(), any(), any(), anyBoolean())).thenReturn("exec-1");
 
             listener.handleRecordChanged(buildRecordChangedMessage("tenant-1", "orders", ChangeType.CREATED));
 
@@ -202,6 +202,32 @@ class FlowEventListenerTest {
     }
 
     @Nested
+    @DisplayName("trigger record id propagation")
+    class TriggerRecordIdPropagation {
+
+        @Test
+        @DisplayName("Should pass the triggering record's ID to flowEngine.startExecution")
+        @SuppressWarnings("unchecked")
+        void shouldPassRecordIdAsTriggerRecordId() throws Exception {
+            String plainConfig = """
+                {"events": ["UPDATED"], "collection": "orders"}
+                """;
+
+            stubJdbcWithTriggerConfig(plainConfig);
+            when(triggerEvaluator.matchesRecordTrigger(any(), any())).thenReturn(true);
+            when(initialStateBuilder.buildFromRecordEvent(any(), any(), any())).thenReturn(Map.of());
+            when(flowEngine.startExecution(any(), any(), any(), any(), any(), any(), anyBoolean()))
+                    .thenReturn("exec-1");
+
+            // The helper builds a payload with recordId="rec-1"
+            listener.handleRecordChanged(buildRecordChangedMessage("tenant-1", "orders", ChangeType.UPDATED));
+
+            verify(flowEngine).startExecution(
+                    eq("tenant-1"), any(), any(), any(), any(), eq("rec-1"), anyBoolean());
+        }
+    }
+
+    @Nested
     @DisplayName("tenant slug binding")
     class TenantSlugBinding {
 
@@ -220,7 +246,7 @@ class FlowEventListenerTest {
 
             // Capture the slug seen by TenantContext at the moment startExecution is invoked.
             java.util.concurrent.atomic.AtomicReference<String> seenSlug = new java.util.concurrent.atomic.AtomicReference<>();
-            when(flowEngine.startExecution(any(), any(), any(), any(), any(), anyBoolean()))
+            when(flowEngine.startExecution(any(), any(), any(), any(), any(), any(), anyBoolean()))
                     .thenAnswer(invocation -> {
                         seenSlug.set(io.kelta.runtime.context.TenantContext.getSlug());
                         return "exec-1";
@@ -244,12 +270,12 @@ class FlowEventListenerTest {
             when(tenantSlugResolver.resolveSlug("tenant-1")).thenReturn(Optional.empty());
             when(triggerEvaluator.matchesRecordTrigger(any(), any())).thenReturn(true);
             when(initialStateBuilder.buildFromRecordEvent(any(), any(), any())).thenReturn(Map.of());
-            when(flowEngine.startExecution(any(), any(), any(), any(), any(), anyBoolean())).thenReturn("exec-1");
+            when(flowEngine.startExecution(any(), any(), any(), any(), any(), any(), anyBoolean())).thenReturn("exec-1");
 
             listener.handleRecordChanged(buildRecordChangedMessage("tenant-1", "orders", ChangeType.UPDATED));
 
             // Execution still attempted — degraded behaviour, but trigger evaluation still happens
-            verify(flowEngine).startExecution(eq("tenant-1"), any(), any(), any(), any(), anyBoolean());
+            verify(flowEngine).startExecution(eq("tenant-1"), any(), any(), any(), any(), any(), anyBoolean());
         }
     }
 

--- a/kelta-worker/src/test/java/io/kelta/worker/service/ScheduledJobExecutorServiceTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/service/ScheduledJobExecutorServiceTest.java
@@ -31,6 +31,7 @@ class ScheduledJobExecutorServiceTest {
     private ReportExecutionService reportExecutionService;
     private DataExportService dataExportService;
     private DataExportRepository dataExportRepository;
+    private TenantSlugResolver tenantSlugResolver;
     private ScheduledJobExecutorService executor;
 
     @BeforeEach
@@ -43,9 +44,12 @@ class ScheduledJobExecutorServiceTest {
         reportExecutionService = mock(ReportExecutionService.class);
         dataExportService = mock(DataExportService.class);
         dataExportRepository = mock(DataExportRepository.class);
+        tenantSlugResolver = mock(TenantSlugResolver.class);
+        when(tenantSlugResolver.resolveSlug(anyString())).thenReturn(Optional.of("acme-corp"));
         executor = new ScheduledJobExecutorService(
                 repository, flowEngine, initialStateBuilder, objectMapper,
-                scriptExecutor, reportExecutionService, dataExportService, dataExportRepository);
+                scriptExecutor, reportExecutionService, dataExportService, dataExportRepository,
+                tenantSlugResolver);
     }
 
     @AfterEach
@@ -67,14 +71,40 @@ class ScheduledJobExecutorServiceTest {
             when(repository.findFlowById("flow-1")).thenReturn(Optional.of(Map.of(
                     "id", "flow-1", "tenant_id", "t1", "definition", "{\"StartAt\":\"Start\"}",
                     "trigger_config", "{}", "active", true)));
-            when(flowEngine.startExecution(anyString(), anyString(), anyString(), any(), any(), anyBoolean()))
+            when(flowEngine.startExecution(anyString(), anyString(), anyString(), any(), any(), any(), anyBoolean()))
                     .thenReturn("exec-1");
 
             executor.executeAll();
 
-            verify(flowEngine).startExecution(eq("t1"), eq("flow-1"), anyString(), any(), isNull(), eq(false));
+            verify(flowEngine).startExecution(eq("t1"), eq("flow-1"), anyString(), any(), isNull(), isNull(), eq(false));
             verify(repository).updateAfterExecution(eq("job-1"), eq("SUCCESS"), any(), any());
             verify(repository).insertExecutionLog(eq("job-1"), eq("SUCCESS"), isNull(), any(), any(), anyLong());
+        }
+
+        @Test
+        @DisplayName("Should bind tenant slug so flow execution sees correct schema")
+        void shouldBindTenantSlugForFlowExecution() {
+            Map<String, Object> job = Map.of(
+                    "id", "job-1", "tenant_id", "t1", "job_type", "FLOW",
+                    "job_reference_id", "flow-1", "cron_expression", "0 0 * * * *", "timezone", "UTC");
+            when(repository.findDueJobs()).thenReturn(List.of(job));
+            when(repository.findFlowById("flow-1")).thenReturn(Optional.of(Map.of(
+                    "id", "flow-1", "tenant_id", "t1", "definition", "{\"StartAt\":\"Start\"}",
+                    "trigger_config", "{}", "active", true)));
+            when(tenantSlugResolver.resolveSlug("t1")).thenReturn(Optional.of("threadline-clothing"));
+
+            // Capture the slug visible to TenantContext at the moment startExecution is invoked.
+            java.util.concurrent.atomic.AtomicReference<String> seenSlug = new java.util.concurrent.atomic.AtomicReference<>();
+            when(flowEngine.startExecution(any(), any(), any(), any(), any(), any(), anyBoolean()))
+                    .thenAnswer(invocation -> {
+                        seenSlug.set(TenantContext.getSlug());
+                        return "exec-1";
+                    });
+
+            executor.executeAll();
+
+            verify(tenantSlugResolver).resolveSlug("t1");
+            assertThat(seenSlug.get()).isEqualTo("threadline-clothing");
         }
 
         @Test
@@ -88,7 +118,7 @@ class ScheduledJobExecutorServiceTest {
 
             executor.executeAll();
 
-            verify(flowEngine, never()).startExecution(any(), any(), any(), any(), any(), anyBoolean());
+            verify(flowEngine, never()).startExecution(any(), any(), any(), any(), any(), any(), anyBoolean());
             verify(repository).updateAfterExecution(eq("job-2"), eq("FAILED"), any(), any());
             verify(repository).insertExecutionLog(eq("job-2"), eq("FAILED"), contains("not found"), any(), any(), anyLong());
         }
@@ -105,7 +135,7 @@ class ScheduledJobExecutorServiceTest {
 
             executor.executeAll();
 
-            verify(flowEngine, never()).startExecution(any(), any(), any(), any(), any(), anyBoolean());
+            verify(flowEngine, never()).startExecution(any(), any(), any(), any(), any(), any(), anyBoolean());
             verify(repository).updateAfterExecution(eq("job-3"), eq("FAILED"), any(), any());
         }
 
@@ -122,7 +152,7 @@ class ScheduledJobExecutorServiceTest {
             when(repository.findFlowById("missing")).thenReturn(Optional.empty());
             when(repository.findFlowById("flow-ok")).thenReturn(Optional.of(Map.of(
                     "id", "flow-ok", "active", true, "definition", "{}", "trigger_config", "{}")));
-            when(flowEngine.startExecution(any(), any(), any(), any(), any(), anyBoolean())).thenReturn("exec-2");
+            when(flowEngine.startExecution(any(), any(), any(), any(), any(), any(), anyBoolean())).thenReturn("exec-2");
 
             executor.executeAll();
 
@@ -312,7 +342,7 @@ class ScheduledJobExecutorServiceTest {
             when(repository.findDueJobs()).thenReturn(List.of(flowJob, scriptJob, reportJob));
             when(repository.findFlowById("flow-1")).thenReturn(Optional.of(Map.of(
                     "id", "flow-1", "active", true, "definition", "{}", "trigger_config", "{}")));
-            when(flowEngine.startExecution(any(), any(), any(), any(), any(), anyBoolean())).thenReturn("exec-1");
+            when(flowEngine.startExecution(any(), any(), any(), any(), any(), any(), anyBoolean())).thenReturn("exec-1");
             when(repository.findScriptById("script-1")).thenReturn(Optional.of(Map.of(
                     "id", "script-1", "name", "test", "active", true,
                     "source_code", "1+1;", "language", "javascript")));
@@ -358,7 +388,7 @@ class ScheduledJobExecutorServiceTest {
 
             executor.executeAll();
 
-            verify(flowEngine, never()).startExecution(any(), any(), any(), any(), any(), anyBoolean());
+            verify(flowEngine, never()).startExecution(any(), any(), any(), any(), any(), any(), anyBoolean());
             verify(scriptExecutor, never()).execute(any());
             verify(repository, never()).updateAfterExecution(any(), any(), any(), any());
         }
@@ -372,7 +402,7 @@ class ScheduledJobExecutorServiceTest {
             when(repository.findDueJobs()).thenReturn(List.of(job));
             when(repository.findFlowById("flow-err")).thenReturn(Optional.of(Map.of(
                     "id", "flow-err", "active", true, "definition", "{}", "trigger_config", "{}")));
-            when(flowEngine.startExecution(any(), any(), any(), any(), any(), anyBoolean()))
+            when(flowEngine.startExecution(any(), any(), any(), any(), any(), any(), anyBoolean()))
                     .thenThrow(new RuntimeException("Boom"));
 
             executor.executeAll();


### PR DESCRIPTION
## Summary

Closes out the systemic flow-execution issues that started with [#772](https://github.com/cklinker/emf/pull/772). Two bundled fixes — they share file edits to the 5 call sites of `FlowEngine.startExecution`, so combined to avoid merge conflicts.

### 1. `trigger_record_id` was always NULL

[FlowEngine.startExecution](kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/flow/FlowEngine.java) hardcoded `null` for the parameter on `JdbcFlowStore.createExecution` even though the schema, store API, and UI all support it. Result: the "Trigger Record" column in the Execution History UI was always blank.

- Added `String triggerRecordId` parameter to `startExecution`.
- [FlowEventListener](kelta-worker/src/main/java/io/kelta/worker/listener/FlowEventListener.java) now passes `payload.getRecordId()` (the only path with a meaningful trigger record).
- [FlowExecutionController.runFlow](kelta-worker/src/main/java/io/kelta/worker/controller/FlowExecutionController.java) (manual run) passes `null`; the retry endpoint inherits the original execution's value via `exec.triggerRecordId()`.
- [FlowWebhookController](kelta-worker/src/main/java/io/kelta/worker/controller/FlowWebhookController.java) and [ScheduledJobExecutorService](kelta-worker/src/main/java/io/kelta/worker/service/ScheduledJobExecutorService.java) pass `null`.

### 2. Webhook + scheduled-job paths had the same tenant-slug bug as #772

The NATS path was fixed in #772 by resolving the slug via `TenantSlugResolver` and binding it through `TenantContext.runWithTenant(tenantId, tenantSlug, ...)`. The other two background paths had the same bug:

- **FlowWebhookController** is unauthenticated (line 56 comment), so the request filter that normally binds the slug doesn't run. Now resolves + binds via `TenantContextUtils.withTenant(tenantId, slug, …)` before calling the engine.
- **ScheduledJobExecutorService** runs on a scheduler thread with no inherited tenant context. The outer `TenantContextUtils.withTenant(tenantId, …)` wrapper bound only the id; switched to the new two-arg overload that binds both. This fixes FLOW jobs and also helps REPORT_EXPORT and DATA_EXPORT, which share the same wrapper.
- New `withTenant(tenantId, tenantSlug, …)` overload added to [TenantContextUtils](kelta-worker/src/main/java/io/kelta/worker/util/TenantContextUtils.java).

## Tests

- 7-arg `startExecution` mock signatures updated everywhere.
- New `FlowEventListenerTest` case verifies the record id is propagated as `triggerRecordId`.
- New `ScheduledJobExecutorServiceTest` case verifies the slug is bound at the moment the engine starts execution.
- 1041 worker tests + 13 platform `FlowEngineTest` cases pass.

## Out of scope

- Adding test files for `FlowWebhookController` / `FlowExecutionController` (none existed; that's a separate quality task).
- The cache-invalidation gap (`FlowConfigEventPublisher`) — handled in a follow-up PR.

## Test plan
- [x] `mvn test -f kelta-platform/pom.xml -pl runtime/runtime-core -Dtest=FlowEngineTest` — 13/13 pass
- [x] `mvn verify -f kelta-worker/pom.xml` — 1041/1041 pass
- [ ] Manual after deploy:
  - Update an order in `threadline-clothing` and check `SELECT trigger_record_id FROM flow_execution WHERE flow_id = 'f477fe36-…' ORDER BY started_at DESC LIMIT 1;` — should be the order's id (was NULL before).
  - Trigger a webhook against an AUTOLAUNCHED flow and confirm the execution succeeds (no "relation does not exist") instead of failing on schema fallback.
  - Same for a scheduled FLOW job's next run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)