### PR TITLE
fix(flow): broadcast flow config changes for multi-pod cache invalidation

### DIFF
--- a/kelta-platform/runtime/runtime-events/src/main/java/io/kelta/runtime/event/FlowChangedPayload.java
+++ b/kelta-platform/runtime/runtime-events/src/main/java/io/kelta/runtime/event/FlowChangedPayload.java
@@ -1,0 +1,70 @@
+package io.kelta.runtime.event;
+
+import java.util.Objects;
+
+/**
+ * Payload for {@code kelta.config.flow.changed.<tenantId>} events.
+ *
+ * <p>Carries just enough metadata for downstream listeners to invalidate the
+ * tenant-scoped flow trigger cache and refresh local state if needed. The full
+ * flow definition is intentionally not included — consumers that need it should
+ * load the row directly from the {@code flow} table.
+ */
+public class FlowChangedPayload {
+
+    private String id;
+    private String name;
+    private String flowType;
+    private boolean active;
+    private ChangeType changeType;
+
+    public FlowChangedPayload() {
+    }
+
+    public FlowChangedPayload(String id, String name, String flowType, boolean active,
+                               ChangeType changeType) {
+        this.id = id;
+        this.name = name;
+        this.flowType = flowType;
+        this.active = active;
+        this.changeType = changeType;
+    }
+
+    public String getId() { return id; }
+    public void setId(String id) { this.id = id; }
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+
+    public String getFlowType() { return flowType; }
+    public void setFlowType(String flowType) { this.flowType = flowType; }
+
+    public boolean isActive() { return active; }
+    public void setActive(boolean active) { this.active = active; }
+
+    public ChangeType getChangeType() { return changeType; }
+    public void setChangeType(ChangeType changeType) { this.changeType = changeType; }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof FlowChangedPayload that)) return false;
+        return active == that.active
+            && Objects.equals(id, that.id)
+            && Objects.equals(name, that.name)
+            && Objects.equals(flowType, that.flowType)
+            && changeType == that.changeType;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name, flowType, active, changeType);
+    }
+
+    @Override
+    public String toString() {
+        return "FlowChangedPayload{id=" + id + ", name=" + name
+            + ", flowType=" + flowType + ", active=" + active
+            + ", changeType=" + changeType + '}';
+    }
+}

--- a/kelta-worker/src/main/java/io/kelta/worker/config/FlowConfig.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/config/FlowConfig.java
@@ -19,6 +19,7 @@ import io.kelta.runtime.workflow.module.ModuleRegistry;
 import io.kelta.worker.flow.JdbcFlowStore;
 import io.kelta.worker.listener.CollectionConfigEventPublisher;
 import io.kelta.worker.listener.FieldConfigEventPublisher;
+import io.kelta.worker.listener.FlowConfigEventPublisher;
 import io.kelta.worker.listener.ApprovalProcessConfigHook;
 import io.kelta.worker.listener.ApprovalRecordLockHook;
 import io.kelta.worker.listener.CerbosPolicySyncHook;
@@ -258,6 +259,16 @@ public class FlowConfig {
             JdbcTemplate jdbcTemplate) {
         FieldConfigEventPublisher publisher =
                 new FieldConfigEventPublisher(eventPublisher, jdbcTemplate);
+        hookRegistry.register(publisher);
+        return publisher;
+    }
+
+    @Bean
+    public FlowConfigEventPublisher flowConfigEventPublisher(
+            BeforeSaveHookRegistry hookRegistry,
+            PlatformEventPublisher eventPublisher) {
+        FlowConfigEventPublisher publisher =
+                new FlowConfigEventPublisher(eventPublisher);
         hookRegistry.register(publisher);
         return publisher;
     }

--- a/kelta-worker/src/main/java/io/kelta/worker/config/NatsSubscriptionConfig.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/config/NatsSubscriptionConfig.java
@@ -92,6 +92,14 @@ public class NatsSubscriptionConfig {
                 "worker-credential-cache", "kelta.config.credential.changed.>",
                 credentialCacheInvalidationListener::handleCredentialChanged));
 
+        // Flow trigger cache invalidation — every pod drops the per-tenant
+        // FlowEventListener cache when a flow row changes (create/update/delete).
+        // Without this, flow edits made via the UI are invisible to pods that
+        // already populated their cache for that tenant until the pod restarts.
+        subscriptionManager.register(EventSubscription.broadcast(
+                "worker-flow-cache", "kelta.config.flow.changed.>",
+                flowEventListener::handleFlowConfigChanged));
+
         // Optional queue group subscriptions — only registered when the integration is enabled
         if (supersetCollectionSyncListener != null) {
             subscriptionManager.register(EventSubscription.queueGroup(
@@ -107,7 +115,7 @@ public class NatsSubscriptionConfig {
             log.info("Registered NATS subscription for Svix webhook publisher");
         }
 
-        log.info("Registered {} worker NATS subscriptions", 6
+        log.info("Registered {} worker NATS subscriptions", 7
                 + (supersetCollectionSyncListener != null ? 1 : 0)
                 + (svixWebhookPublisher != null ? 1 : 0));
     }

--- a/kelta-worker/src/main/java/io/kelta/worker/listener/FlowConfigEventPublisher.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/listener/FlowConfigEventPublisher.java
@@ -1,0 +1,93 @@
+package io.kelta.worker.listener;
+
+import io.kelta.runtime.event.ChangeType;
+import io.kelta.runtime.event.EventFactory;
+import io.kelta.runtime.event.FlowChangedPayload;
+import io.kelta.runtime.event.PlatformEvent;
+import io.kelta.runtime.event.PlatformEventPublisher;
+import io.kelta.runtime.workflow.BeforeSaveHook;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+
+/**
+ * Broadcasts {@code kelta.config.flow.changed.<tenantId>} after flow
+ * create/update/delete so all worker pods can invalidate the per-tenant
+ * trigger config cache held by {@link FlowEventListener}. Without this, a
+ * flow change made via the UI is invisible to pods that already populated
+ * their cache for that tenant — they'd keep using the stale snapshot until
+ * restart, which violates the multi-pod NATS rule documented in CLAUDE.md.
+ *
+ * <p>Subject prefix uses the tenant id (rather than the flow id like the
+ * collection/credential publishers) because the listener cache is keyed
+ * by tenant — every flow change for a tenant invalidates the same cache
+ * entry, so per-flow subjects would just create extra messages.
+ */
+public class FlowConfigEventPublisher implements BeforeSaveHook {
+
+    private static final Logger log = LoggerFactory.getLogger(FlowConfigEventPublisher.class);
+    static final String SUBJECT_PREFIX = "kelta.config.flow.changed.";
+    private static final String EVENT_TYPE = "kelta.config.flow.changed";
+
+    private final PlatformEventPublisher eventPublisher;
+
+    public FlowConfigEventPublisher(PlatformEventPublisher eventPublisher) {
+        this.eventPublisher = eventPublisher;
+    }
+
+    @Override public String getCollectionName() { return "flows"; }
+    @Override public int getOrder() { return 100; }
+
+    @Override
+    public void afterCreate(Map<String, Object> record, String tenantId) {
+        publish(record, ChangeType.CREATED, tenantId);
+    }
+
+    @Override
+    public void afterUpdate(String id, Map<String, Object> record,
+                             Map<String, Object> previous, String tenantId) {
+        publish(record, ChangeType.UPDATED, tenantId);
+    }
+
+    @Override
+    public void afterDelete(String id, String tenantId) {
+        FlowChangedPayload payload = new FlowChangedPayload();
+        payload.setId(id);
+        payload.setChangeType(ChangeType.DELETED);
+        send(payload, tenantId);
+    }
+
+    private void publish(Map<String, Object> record, ChangeType changeType, String tenantId) {
+        FlowChangedPayload payload = new FlowChangedPayload();
+        payload.setId(asString(record.get("id")));
+        payload.setName(asString(record.get("name")));
+        payload.setFlowType(asString(record.get("flowType")));
+        Object active = record.get("active");
+        payload.setActive(active instanceof Boolean b ? b : true);
+        payload.setChangeType(changeType);
+        if (payload.getId() == null) {
+            log.warn("Skipping flow changed event: record missing id");
+            return;
+        }
+        send(payload, tenantId);
+    }
+
+    private void send(FlowChangedPayload payload, String tenantId) {
+        if (tenantId == null || tenantId.isBlank()) {
+            log.warn("Skipping flow changed event for id={}: tenantId is blank", payload.getId());
+            return;
+        }
+        PlatformEvent<FlowChangedPayload> event =
+                EventFactory.createEvent(EVENT_TYPE, payload);
+        event.setTenantId(tenantId);
+        String subject = SUBJECT_PREFIX + tenantId;
+        log.info("Publishing flow {} event for {} (id={}) to '{}'",
+                payload.getChangeType(), payload.getName(), payload.getId(), subject);
+        eventPublisher.publish(subject, event);
+    }
+
+    private static String asString(Object v) {
+        return v == null ? null : v.toString();
+    }
+}

--- a/kelta-worker/src/main/java/io/kelta/worker/listener/FlowEventListener.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/listener/FlowEventListener.java
@@ -162,6 +162,27 @@ public class FlowEventListener {
     }
 
     /**
+     * Handles {@code kelta.config.flow.changed.<tenantId>} broadcast events.
+     * Drops the per-tenant trigger cache so the next record event re-queries
+     * the {@code flow} table and picks up the new/updated/deleted flow.
+     *
+     * @param message the raw JSON event message from NATS
+     */
+    public void handleFlowConfigChanged(String message) {
+        try {
+            var tree = objectMapper.readTree(message);
+            String tenantId = tree.path("tenantId").asText(null);
+            if (tenantId == null || tenantId.isBlank()) {
+                log.warn("Dropping flow config changed event with no tenantId");
+                return;
+            }
+            invalidateCache(tenantId);
+        } catch (Exception e) {
+            log.error("Failed to handle flow config changed event: {}", e.getMessage(), e);
+        }
+    }
+
+    /**
      * Invalidates all cached trigger configs.
      */
     public void invalidateAllCaches() {

--- a/kelta-worker/src/main/resources/META-INF/native-image/io.kelta/kelta-worker/reflect-config.json
+++ b/kelta-worker/src/main/resources/META-INF/native-image/io.kelta/kelta-worker/reflect-config.json
@@ -36,6 +36,12 @@
     "allDeclaredFields": true
   },
   {
+    "name": "io.kelta.runtime.event.FlowChangedPayload",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
     "name": "io.kelta.runtime.event.ChangeType",
     "allDeclaredConstructors": true,
     "allDeclaredMethods": true,

--- a/kelta-worker/src/test/java/io/kelta/worker/listener/FlowConfigEventPublisherTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/listener/FlowConfigEventPublisherTest.java
@@ -1,0 +1,118 @@
+package io.kelta.worker.listener;
+
+import io.kelta.runtime.event.ChangeType;
+import io.kelta.runtime.event.FlowChangedPayload;
+import io.kelta.runtime.event.PlatformEvent;
+import io.kelta.runtime.event.PlatformEventPublisher;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@DisplayName("FlowConfigEventPublisher")
+class FlowConfigEventPublisherTest {
+
+    private PlatformEventPublisher eventPublisher;
+    private FlowConfigEventPublisher publisher;
+
+    @BeforeEach
+    void setUp() {
+        eventPublisher = mock(PlatformEventPublisher.class);
+        publisher = new FlowConfigEventPublisher(eventPublisher);
+    }
+
+    @Test
+    @DisplayName("Should target the 'flows' system collection")
+    void shouldTargetFlows() {
+        assertThat(publisher.getCollectionName()).isEqualTo("flows");
+    }
+
+    @Test
+    @DisplayName("Should have order 100 so it runs after lifecycle hooks")
+    void shouldRunAfterLifecycleHooks() {
+        assertThat(publisher.getOrder()).isEqualTo(100);
+    }
+
+    @Test
+    @DisplayName("Should publish CREATED event with tenant-scoped subject")
+    void shouldPublishCreatedEvent() {
+        Map<String, Object> record = new HashMap<>(Map.of(
+                "id", "flow-1",
+                "name", "Update Customer Totals on Order Change",
+                "flowType", "RECORD_TRIGGERED",
+                "active", true));
+
+        publisher.afterCreate(record, "tenant-1");
+
+        ArgumentCaptor<String> subject = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<PlatformEvent> event = ArgumentCaptor.forClass(PlatformEvent.class);
+        verify(eventPublisher).publish(subject.capture(), event.capture());
+
+        assertThat(subject.getValue()).isEqualTo("kelta.config.flow.changed.tenant-1");
+        assertThat(event.getValue().getTenantId()).isEqualTo("tenant-1");
+        FlowChangedPayload payload = (FlowChangedPayload) event.getValue().getPayload();
+        assertThat(payload.getId()).isEqualTo("flow-1");
+        assertThat(payload.getName()).isEqualTo("Update Customer Totals on Order Change");
+        assertThat(payload.getFlowType()).isEqualTo("RECORD_TRIGGERED");
+        assertThat(payload.isActive()).isTrue();
+        assertThat(payload.getChangeType()).isEqualTo(ChangeType.CREATED);
+    }
+
+    @Test
+    @DisplayName("Should publish UPDATED event with tenant-scoped subject")
+    void shouldPublishUpdatedEvent() {
+        Map<String, Object> record = new HashMap<>(Map.of(
+                "id", "flow-1", "name", "x", "flowType", "RECORD_TRIGGERED", "active", true));
+        Map<String, Object> previous = new HashMap<>(record);
+
+        publisher.afterUpdate("flow-1", record, previous, "tenant-1");
+
+        ArgumentCaptor<PlatformEvent> event = ArgumentCaptor.forClass(PlatformEvent.class);
+        verify(eventPublisher).publish(eq("kelta.config.flow.changed.tenant-1"), event.capture());
+        assertThat(((FlowChangedPayload) event.getValue().getPayload()).getChangeType())
+                .isEqualTo(ChangeType.UPDATED);
+    }
+
+    @Test
+    @DisplayName("Should publish DELETED event with id only")
+    void shouldPublishDeletedEvent() {
+        publisher.afterDelete("flow-1", "tenant-1");
+
+        ArgumentCaptor<PlatformEvent> event = ArgumentCaptor.forClass(PlatformEvent.class);
+        verify(eventPublisher).publish(eq("kelta.config.flow.changed.tenant-1"), event.capture());
+        FlowChangedPayload payload = (FlowChangedPayload) event.getValue().getPayload();
+        assertThat(payload.getId()).isEqualTo("flow-1");
+        assertThat(payload.getChangeType()).isEqualTo(ChangeType.DELETED);
+    }
+
+    @Test
+    @DisplayName("Should skip publishing when the record is missing an id")
+    void shouldSkipWhenIdMissing() {
+        Map<String, Object> record = new HashMap<>(Map.of(
+                "name", "no-id-flow", "flowType", "RECORD_TRIGGERED", "active", true));
+
+        publisher.afterCreate(record, "tenant-1");
+
+        verify(eventPublisher, never()).publish(anyString(), any());
+    }
+
+    @Test
+    @DisplayName("Should skip publishing when tenantId is blank")
+    void shouldSkipWhenTenantIdBlank() {
+        Map<String, Object> record = new HashMap<>(Map.of(
+                "id", "flow-1", "name", "x", "flowType", "RECORD_TRIGGERED", "active", true));
+
+        publisher.afterCreate(record, "  ");
+
+        verify(eventPublisher, never()).publish(anyString(), any());
+    }
+}

--- a/kelta-worker/src/test/java/io/kelta/worker/listener/FlowEventListenerTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/listener/FlowEventListenerTest.java
@@ -254,6 +254,52 @@ class FlowEventListenerTest {
     }
 
     @Nested
+    @DisplayName("flow config changed broadcast")
+    class FlowConfigChanged {
+
+        @Test
+        @DisplayName("Should invalidate per-tenant cache when broadcast event arrives")
+        @SuppressWarnings("unchecked")
+        void shouldInvalidateCacheOnBroadcast() throws Exception {
+            String plainConfig = """
+                {"events": ["UPDATED"], "collection": "orders"}
+                """;
+            stubJdbcWithTriggerConfig(plainConfig);
+            when(triggerEvaluator.matchesRecordTrigger(any(), any())).thenReturn(false);
+
+            // Populate the cache via a record event
+            String recordEvent = buildRecordChangedMessage("tenant-1", "orders", ChangeType.UPDATED);
+            listener.handleRecordChanged(recordEvent);
+
+            // Send a flow config changed broadcast
+            String configEvent = """
+                {"eventType":"kelta.config.flow.changed","tenantId":"tenant-1",
+                 "payload":{"id":"flow-1","changeType":"UPDATED"}}
+                """;
+            listener.handleFlowConfigChanged(configEvent);
+
+            // Next record event should re-query the DB
+            listener.handleRecordChanged(recordEvent);
+            verify(jdbcTemplate, times(2)).query(anyString(), any(RowMapper.class), eq("tenant-1"));
+        }
+
+        @Test
+        @DisplayName("Should silently drop a malformed broadcast message")
+        void shouldDropMalformedBroadcast() {
+            // Should not throw
+            listener.handleFlowConfigChanged("not json");
+            // No assertion needed — the test passes if no exception escapes.
+        }
+
+        @Test
+        @DisplayName("Should drop broadcast with no tenantId")
+        void shouldDropBroadcastWithNoTenantId() {
+            listener.handleFlowConfigChanged("{\"payload\":{\"id\":\"flow-1\"}}");
+            // Cache should be untouched (no tenantId to invalidate).
+        }
+    }
+
+    @Nested
     @DisplayName("cache management")
     class CacheManagement {
 


### PR DESCRIPTION
## Summary

Closes the systemic gap identified during the [#772](https://github.com/cklinker/emf/pull/772) diagnosis: [FlowEventListener](kelta-worker/src/main/java/io/kelta/worker/listener/FlowEventListener.java) holds a per-tenant in-memory `triggerConfigCache` populated lazily on first record event for a tenant. The cache had an `invalidateCache(tenantId)` method but **no production caller**, and there was **no NATS broadcast** on flow create/update/delete — so a flow edit made via the UI was invisible to pods that already populated the cache for that tenant until the pod restarted. Violates the multi-pod NATS rule in `CLAUDE.md`.

## Changes

### New files
- [FlowChangedPayload](kelta-platform/runtime/runtime-events/src/main/java/io/kelta/runtime/event/FlowChangedPayload.java) — minimal payload (id, name, flowType, active, changeType).
- [FlowConfigEventPublisher](kelta-worker/src/main/java/io/kelta/worker/listener/FlowConfigEventPublisher.java) — `BeforeSaveHook` for the `flows` system collection. Publishes to `kelta.config.flow.changed.<tenantId>` after every create/update/delete. Mirrors the [CollectionConfigEventPublisher](kelta-worker/src/main/java/io/kelta/worker/listener/CollectionConfigEventPublisher.java) / [CredentialEventPublisher](kelta-worker/src/main/java/io/kelta/worker/listener/CredentialEventPublisher.java) pattern.
- [FlowConfigEventPublisherTest](kelta-worker/src/test/java/io/kelta/worker/listener/FlowConfigEventPublisherTest.java) — 7 cases (target collection, order, CREATED/UPDATED/DELETED, missing-id and blank-tenant guards).

### Modifications
- [FlowConfig.java](kelta-worker/src/main/java/io/kelta/worker/config/FlowConfig.java) — wires the new publisher into `BeforeSaveHookRegistry` (alongside the existing `CollectionConfigEventPublisher`/`FieldConfigEventPublisher`).
- [NatsSubscriptionConfig.java](kelta-worker/src/main/java/io/kelta/worker/config/NatsSubscriptionConfig.java) — adds a **broadcast** subscription on `kelta.config.flow.changed.>` that drops the per-tenant cache on every pod. Updated subscription count.
- [FlowEventListener.java](kelta-worker/src/main/java/io/kelta/worker/listener/FlowEventListener.java) — adds `handleFlowConfigChanged(String)` that parses the tenantId from the message envelope and calls the existing `invalidateCache(tenantId)`.
- [reflect-config.json](kelta-worker/src/main/resources/META-INF/native-image/io.kelta/kelta-worker/reflect-config.json) — registers `FlowChangedPayload` for native-image builds (alongside the other payload types).

### Why subject keyed by tenantId (not flow id)

The listener cache is keyed by tenant — every flow change for a tenant invalidates the same cache entry. Per-flow subjects (like `kelta.config.collection.changed.<id>`) would just create extra duplicate broadcasts for no benefit. The broadcast subscription uses `>` to catch all tenants.

## Test plan
- [x] `mvn install -f kelta-platform/pom.xml -pl runtime/runtime-events,runtime/runtime-core -am -DskipTests` — clean
- [x] `mvn test -f kelta-worker/pom.xml -Dtest="FlowConfigEventPublisherTest,FlowEventListenerTest"` — 21/21 pass (7 new + 14 existing)
- [x] `mvn verify -f kelta-worker/pom.xml` — 1049/1049 pass
- [ ] Manual multi-pod after deploy:
  - With ≥2 worker pods, edit a flow's `trigger_config` via the UI.
  - Trigger an update on each pod (round-robin) and confirm both honor the new config without a restart.
  - Tail logs for `Invalidated flow trigger cache for tenant <id>` on every pod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)