### PR TITLE
fix(flow-designer): unwrap JSON:API in DebugTab and render node debug overlays

### DIFF
--- a/kelta-ui/app/src/pages/FlowDesignerPage/components/DebugTab.tsx
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/components/DebugTab.tsx
@@ -3,6 +3,7 @@ import { useQuery, useMutation } from '@tanstack/react-query'
 import { ReactFlowProvider } from '@xyflow/react'
 import type { Node, Edge } from '@xyflow/react'
 import { useApi } from '../../../context/ApiContext'
+import { unwrapResource, unwrapCollection } from '../../../utils/jsonapi'
 import { useToast, LoadingSpinner } from '../../../components'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
@@ -90,7 +91,8 @@ export function DebugTab({ executionId, nodes, edges }: DebugTabProps) {
     queryFn: async () => {
       const resp = await apiClient.fetch(`/api/flows/executions/${executionId}`)
       if (!resp.ok) throw new Error('Failed to load execution')
-      return (await resp.json()) as FlowExecution
+      const json = await resp.json()
+      return unwrapResource(json) as unknown as FlowExecution
     },
     refetchInterval: (query) => {
       const exec = query.state.data
@@ -105,8 +107,8 @@ export function DebugTab({ executionId, nodes, edges }: DebugTabProps) {
     queryFn: async () => {
       const resp = await apiClient.fetch(`/api/flows/executions/${executionId}/steps`)
       if (!resp.ok) throw new Error('Failed to load steps')
-      const json = (await resp.json()) as { steps: StepLog[] }
-      return json.steps || []
+      const json = await resp.json()
+      return unwrapCollection(json).data as unknown as StepLog[]
     },
     refetchInterval: () => {
       if (execution && (execution.status === 'RUNNING' || execution.status === 'WAITING'))

--- a/kelta-ui/app/src/pages/FlowDesignerPage/components/nodes/ChoiceNode.tsx
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/components/nodes/ChoiceNode.tsx
@@ -2,23 +2,35 @@ import React, { memo } from 'react'
 import { Handle, Position } from '@xyflow/react'
 import type { NodeProps, Node } from '@xyflow/react'
 import { GitBranch } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { DebugStatusBadge, type DebugStatus } from './DebugStatusBadge'
 
 export type ChoiceNodeData = {
   label: string
   ruleCount?: number
   stateType: string
+  debugStatus?: DebugStatus
+  debugDuration?: string | null
+  debugError?: string | null
+  debugBorderClass?: string
 }
 
 type ChoiceNodeType = Node<ChoiceNodeData, 'choice'>
 
 function ChoiceNodeComponent({ data, selected }: NodeProps<ChoiceNodeType>) {
+  const { debugStatus, debugDuration, debugError, debugBorderClass } = data
+  const isDebug = !!debugStatus || !!debugBorderClass
+
   return (
     <div
-      className={`flex min-w-[140px] flex-col items-center rounded-lg border-2 bg-amber-50 shadow-sm transition-all dark:bg-amber-950 ${
-        selected
-          ? 'border-amber-500 ring-2 ring-amber-500/30'
-          : 'border-amber-300 dark:border-amber-700'
-      }`}
+      className={cn(
+        'relative flex min-w-[140px] flex-col items-center rounded-lg border-2 bg-amber-50 shadow-sm transition-all dark:bg-amber-950',
+        !isDebug &&
+          (selected
+            ? 'border-amber-500 ring-2 ring-amber-500/30'
+            : 'border-amber-300 dark:border-amber-700'),
+        isDebug && debugBorderClass
+      )}
     >
       <Handle type="target" position={Position.Top} className="!bg-amber-400" />
       <div className="flex items-center gap-2 px-3 py-2">
@@ -35,6 +47,11 @@ function ChoiceNodeComponent({ data, selected }: NodeProps<ChoiceNodeType>) {
         </div>
       </div>
       <Handle type="source" position={Position.Bottom} className="!bg-amber-400" />
+      <DebugStatusBadge
+        status={debugStatus ?? null}
+        duration={debugDuration ?? null}
+        error={debugError ?? null}
+      />
     </div>
   )
 }

--- a/kelta-ui/app/src/pages/FlowDesignerPage/components/nodes/ControlNode.tsx
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/components/nodes/ControlNode.tsx
@@ -2,12 +2,18 @@ import React, { memo } from 'react'
 import { Handle, Position } from '@xyflow/react'
 import type { NodeProps, Node } from '@xyflow/react'
 import { Clock, ArrowRight, Columns, Repeat } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { DebugStatusBadge, type DebugStatus } from './DebugStatusBadge'
 
 export type ControlNodeData = {
   label: string
   stateType: 'Wait' | 'Pass' | 'Parallel' | 'Map'
   waitDuration?: string
   branchCount?: number
+  debugStatus?: DebugStatus
+  debugDuration?: string | null
+  debugError?: string | null
+  debugBorderClass?: string
 }
 
 type ControlNodeType = Node<ControlNodeData, 'control'>
@@ -59,6 +65,8 @@ const styleMap = {
 } as const
 
 function ControlNodeComponent({ data, selected }: NodeProps<ControlNodeType>) {
+  const { debugStatus, debugDuration, debugError, debugBorderClass } = data
+  const isDebug = !!debugStatus || !!debugBorderClass
   const Icon = iconMap[data.stateType]
   const style = styleMap[data.stateType]
 
@@ -73,9 +81,12 @@ function ControlNodeComponent({ data, selected }: NodeProps<ControlNodeType>) {
 
   return (
     <div
-      className={`flex min-w-[160px] flex-col rounded-lg border-2 shadow-sm transition-all ${style.bg} ${
-        selected ? style.selectedBorder : style.border
-      }`}
+      className={cn(
+        'relative flex min-w-[160px] flex-col rounded-lg border-2 shadow-sm transition-all',
+        style.bg,
+        !isDebug && (selected ? style.selectedBorder : style.border),
+        isDebug && debugBorderClass
+      )}
     >
       <Handle type="target" position={Position.Top} className={style.handle} />
       <div className="flex items-center gap-2 px-3 py-2">
@@ -86,6 +97,11 @@ function ControlNodeComponent({ data, selected }: NodeProps<ControlNodeType>) {
         </div>
       </div>
       <Handle type="source" position={Position.Bottom} className={style.handle} />
+      <DebugStatusBadge
+        status={debugStatus ?? null}
+        duration={debugDuration ?? null}
+        error={debugError ?? null}
+      />
     </div>
   )
 }

--- a/kelta-ui/app/src/pages/FlowDesignerPage/components/nodes/DebugStatusBadge.tsx
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/components/nodes/DebugStatusBadge.tsx
@@ -1,0 +1,36 @@
+import React from 'react'
+import { CheckCircle2, XCircle, Loader2, SkipForward } from 'lucide-react'
+
+export type DebugStatus = 'SUCCEEDED' | 'FAILED' | 'RUNNING' | 'SKIPPED' | null
+
+interface DebugStatusBadgeProps {
+  status: DebugStatus
+  duration: string | null
+  error: string | null
+}
+
+const statusIcon: Record<Exclude<DebugStatus, null>, React.ReactNode> = {
+  SUCCEEDED: <CheckCircle2 className="h-3.5 w-3.5 text-emerald-600" />,
+  FAILED: <XCircle className="h-3.5 w-3.5 text-red-600" />,
+  RUNNING: <Loader2 className="h-3.5 w-3.5 animate-spin text-blue-600" />,
+  SKIPPED: <SkipForward className="h-3.5 w-3.5 text-gray-400" />,
+}
+
+export function DebugStatusBadge({ status, duration, error }: DebugStatusBadgeProps) {
+  if (!status) return null
+  return (
+    <>
+      <div
+        className="absolute -right-1.5 -top-1.5 flex h-5 w-5 items-center justify-center rounded-full bg-card shadow-sm ring-1 ring-border"
+        title={error ?? status}
+      >
+        {statusIcon[status]}
+      </div>
+      {duration && (
+        <div className="absolute -bottom-2 right-1 rounded-full bg-card px-1.5 py-0.5 text-[10px] font-mono leading-none text-muted-foreground shadow-sm ring-1 ring-border">
+          {duration}
+        </div>
+      )}
+    </>
+  )
+}

--- a/kelta-ui/app/src/pages/FlowDesignerPage/components/nodes/TaskNode.tsx
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/components/nodes/TaskNode.tsx
@@ -2,23 +2,35 @@ import React, { memo } from 'react'
 import { Handle, Position } from '@xyflow/react'
 import type { NodeProps, Node } from '@xyflow/react'
 import { Cog } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { DebugStatusBadge, type DebugStatus } from './DebugStatusBadge'
 
 export type TaskNodeData = {
   label: string
   resource?: string
   stateType: string
+  debugStatus?: DebugStatus
+  debugDuration?: string | null
+  debugError?: string | null
+  debugBorderClass?: string
 }
 
 type TaskNodeType = Node<TaskNodeData, 'task'>
 
 function TaskNodeComponent({ data, selected }: NodeProps<TaskNodeType>) {
+  const { debugStatus, debugDuration, debugError, debugBorderClass } = data
+  const isDebug = !!debugStatus || !!debugBorderClass
+
   return (
     <div
-      className={`flex min-w-[180px] flex-col rounded-lg border-2 bg-blue-50 shadow-sm transition-all dark:bg-blue-950 ${
-        selected
-          ? 'border-blue-500 ring-2 ring-blue-500/30'
-          : 'border-blue-300 dark:border-blue-700'
-      }`}
+      className={cn(
+        'relative flex min-w-[180px] flex-col rounded-lg border-2 bg-blue-50 shadow-sm transition-all dark:bg-blue-950',
+        !isDebug &&
+          (selected
+            ? 'border-blue-500 ring-2 ring-blue-500/30'
+            : 'border-blue-300 dark:border-blue-700'),
+        isDebug && debugBorderClass
+      )}
     >
       <Handle type="target" position={Position.Top} className="!bg-blue-400" />
       <div className="flex items-center gap-2 px-3 py-2">
@@ -35,6 +47,11 @@ function TaskNodeComponent({ data, selected }: NodeProps<TaskNodeType>) {
         </div>
       </div>
       <Handle type="source" position={Position.Bottom} className="!bg-blue-400" />
+      <DebugStatusBadge
+        status={debugStatus ?? null}
+        duration={debugDuration ?? null}
+        error={debugError ?? null}
+      />
     </div>
   )
 }

--- a/kelta-ui/app/src/pages/FlowDesignerPage/components/nodes/TerminalNode.tsx
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/components/nodes/TerminalNode.tsx
@@ -2,31 +2,47 @@ import React, { memo } from 'react'
 import { Handle, Position } from '@xyflow/react'
 import type { NodeProps, Node } from '@xyflow/react'
 import { CheckCircle, XCircle } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { DebugStatusBadge, type DebugStatus } from './DebugStatusBadge'
 
 export type TerminalNodeData = {
   label: string
   stateType: 'Succeed' | 'Fail'
   error?: string
   cause?: string
+  debugStatus?: DebugStatus
+  debugDuration?: string | null
+  debugError?: string | null
+  debugBorderClass?: string
 }
 
 type TerminalNodeType = Node<TerminalNodeData, 'terminal'>
 
 function TerminalNodeComponent({ data, selected }: NodeProps<TerminalNodeType>) {
+  const { debugStatus, debugDuration, debugError, debugBorderClass } = data
+  const isDebug = !!debugStatus || !!debugBorderClass
   const isSuccess = data.stateType === 'Succeed'
   const Icon = isSuccess ? CheckCircle : XCircle
 
+  const naturalBorder = isSuccess
+    ? selected
+      ? 'border-green-500 bg-green-50 ring-2 ring-green-500/30 dark:bg-green-950'
+      : 'border-green-400 bg-green-50 dark:border-green-600 dark:bg-green-950'
+    : selected
+      ? 'border-red-500 bg-red-50 ring-2 ring-red-500/30 dark:bg-red-950'
+      : 'border-red-400 bg-red-50 dark:border-red-600 dark:bg-red-950'
+
+  // In debug mode, keep the natural background but let debugBorderClass override the border/ring.
+  const debugBackground = isSuccess ? 'bg-green-50 dark:bg-green-950' : 'bg-red-50 dark:bg-red-950'
+
   return (
     <div
-      className={`flex min-w-[120px] items-center gap-2 rounded-full border-2 px-4 py-2 shadow-sm transition-all ${
-        isSuccess
-          ? selected
-            ? 'border-green-500 bg-green-50 ring-2 ring-green-500/30 dark:bg-green-950'
-            : 'border-green-400 bg-green-50 dark:border-green-600 dark:bg-green-950'
-          : selected
-            ? 'border-red-500 bg-red-50 ring-2 ring-red-500/30 dark:bg-red-950'
-            : 'border-red-400 bg-red-50 dark:border-red-600 dark:bg-red-950'
-      }`}
+      className={cn(
+        'relative flex min-w-[120px] items-center gap-2 rounded-full border-2 px-4 py-2 shadow-sm transition-all',
+        !isDebug && naturalBorder,
+        isDebug && debugBackground,
+        isDebug && debugBorderClass
+      )}
     >
       <Handle
         type="target"
@@ -45,6 +61,11 @@ function TerminalNodeComponent({ data, selected }: NodeProps<TerminalNodeType>) 
       >
         {data.label}
       </span>
+      <DebugStatusBadge
+        status={debugStatus ?? null}
+        duration={debugDuration ?? null}
+        error={debugError ?? null}
+      />
     </div>
   )
 }

--- a/kelta-ui/app/src/pages/FlowDesignerPage/components/nodes/index.ts
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/components/nodes/index.ts
@@ -9,3 +9,6 @@ export type { TerminalNodeData } from './TerminalNode'
 
 export { ControlNode } from './ControlNode'
 export type { ControlNodeData } from './ControlNode'
+
+export { DebugStatusBadge } from './DebugStatusBadge'
+export type { DebugStatus } from './DebugStatusBadge'


### PR DESCRIPTION
## Summary

- **Bug 1 (root cause of "click does nothing"):** `DebugTab` parsed `/api/flows/executions/{id}` and `/executions/{id}/steps` as flat objects, but both controllers return JSON:API envelopes. `steps` was always `[]`, so clicking a node never populated the right-hand panel. `execution.status` / `startedBy` / `currentNodeId` were also undefined, hiding the Retry button and falling through to "Trigger"/"Complete" placeholder text. Fixed by routing both responses through the existing `unwrapResource` / `unwrapCollection` helpers (same pattern as #772 and #775).
- **Bug 2 (no visual execution feedback on the graph):** `FlowExecutionViewer` decorated each node's `data` with `debugStatus`, `debugDuration`, `debugError`, and `debugBorderClass`, but none of the node components read those fields. Added a shared `DebugStatusBadge` (status icon top-right, duration pill bottom-right, error tooltip on FAILED) and wired Task/Choice/Terminal/Control nodes to apply the override border class and render the badge whenever debug data is present. Behavior outside the Debug tab is unchanged.

## Test plan

- [ ] Open a record-triggered flow → Test → wait for completion
- [ ] From Executions tab, open the execution to launch the **Debug** tab
- [ ] Confirm `Started By` / `Current Node` show real values (not "Trigger"/"Complete" fallbacks)
- [ ] Confirm the bottom **Execution Timeline** strip is visible
- [ ] Confirm **Retry** button shows in the top bar for terminal executions
- [ ] Click a node in the graph → right panel switches from placeholder to step header with **Input / Output / Raw** tabs (and **Error** tab when applicable)
- [ ] Click a timeline segment → same panel populates
- [ ] Confirm traversed nodes show colored borders (green / red / blue / gray-with-opacity), status icon at top-right, duration pill at bottom-right; un-reached nodes appear faded
- [ ] Run a failing flow → verify red border + error tooltip on the badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)