### PR TITLE
fix(worker): defensive copy + skip metadata paths in Cerbos record advice

### DIFF
--- a/kelta-worker/src/main/java/io/kelta/worker/interceptor/CerbosRecordAuthorizationAdvice.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/interceptor/CerbosRecordAuthorizationAdvice.java
@@ -111,12 +111,17 @@ public class CerbosRecordAuthorizationAdvice implements ResponseBodyAdvice<Objec
                 log.debug("Filtered {} records from response for user={} collection={}",
                         removed, email, collectionId);
             }
-            responseBody.put("data", filtered);
+            // Copy into a mutable map — controllers may return Map.of(...) which is immutable.
+            Map<String, Object> result = new LinkedHashMap<>(responseBody);
+            result.put("data", filtered);
+            return result;
         } else if (data instanceof Map<?, ?> singleRecord) {
             Map<String, Object> typedRecord = (Map<String, Object>) singleRecord;
             if (!isRecordAllowed(email, profileId, tenantId, collectionId, typedRecord, action)) {
                 log.debug("Denied single record for user={} collection={}", email, collectionId);
-                responseBody.put("data", null);
+                Map<String, Object> result = new LinkedHashMap<>(responseBody);
+                result.put("data", null);
+                return result;
             }
         }
 
@@ -153,7 +158,12 @@ public class CerbosRecordAuthorizationAdvice implements ResponseBodyAdvice<Objec
                 || path.startsWith("/api/oidc")
                 || path.startsWith("/api/tenants")
                 || path.startsWith("/api/metrics")
-                || path.startsWith("/api/flows");
+                || path.startsWith("/api/flows")
+                || path.startsWith("/api/api-specs")
+                || path.startsWith("/api/api-operations")
+                || path.startsWith("/api/credentials")
+                || path.startsWith("/api/connected-apps")
+                || path.startsWith("/api/devices");
     }
 
     private String extractCollectionId(String path) {

--- a/kelta-worker/src/test/java/io/kelta/worker/interceptor/CerbosRecordAuthorizationAdviceTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/interceptor/CerbosRecordAuthorizationAdviceTest.java
@@ -1,0 +1,289 @@
+package io.kelta.worker.interceptor;
+
+import io.kelta.worker.service.CerbosAuthorizationService;
+import io.kelta.worker.service.CerbosPermissionResolver;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.http.server.ServletServerHttpRequest;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CerbosRecordAuthorizationAdvice Tests")
+class CerbosRecordAuthorizationAdviceTest {
+
+    @Mock private CerbosAuthorizationService authzService;
+    @Mock private CerbosPermissionResolver permissionResolver;
+
+    private CerbosRecordAuthorizationAdvice advice;
+
+    @BeforeEach
+    void setUp() {
+        advice = new CerbosRecordAuthorizationAdvice(authzService, permissionResolver, true);
+    }
+
+    private ServletServerHttpRequest createRequest(String path) {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", path);
+        request.addHeader("X-User-Email", "user@example.com");
+        request.addHeader("X-User-Profile-Id", "profile-1");
+        request.addHeader("X-Cerbos-Scope", "tenant-1");
+        lenient().when(permissionResolver.hasIdentity(request)).thenReturn(true);
+        lenient().when(permissionResolver.getEmail(request)).thenReturn("user@example.com");
+        lenient().when(permissionResolver.getProfileId(request)).thenReturn("profile-1");
+        lenient().when(permissionResolver.getTenantId(request)).thenReturn("tenant-1");
+        return new ServletServerHttpRequest(request);
+    }
+
+    @Test
+    @DisplayName("Should not throw when controller returns immutable Map.of body (regression)")
+    void shouldNotThrowOnImmutableBody() {
+        var request = createRequest("/api/contacts");
+        when(authzService.batchCheckRecordAccess(any(), any(), any(), any(), anyList(), eq("read")))
+                .thenReturn(Set.of("1", "2"));
+
+        Map<String, Object> record1 = Map.of("id", "1", "name", "John");
+        Map<String, Object> record2 = Map.of("id", "2", "name", "Jane");
+        Map<String, Object> body = Map.of("data", List.of(record1, record2));
+
+        Object result = advice.beforeBodyWrite(body, null, MediaType.APPLICATION_JSON, null, request, null);
+
+        assertThat(result).isNotNull();
+        @SuppressWarnings("unchecked")
+        Map<String, Object> resultBody = (Map<String, Object>) result;
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> data = (List<Map<String, Object>>) resultBody.get("data");
+        assertThat(data).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("Should not mutate the input body when filtering list")
+    void shouldNotMutateInputBodyForList() {
+        var request = createRequest("/api/contacts");
+        when(authzService.batchCheckRecordAccess(any(), any(), any(), any(), anyList(), eq("read")))
+                .thenReturn(Set.of("1"));
+
+        Map<String, Object> record1 = Map.of("id", "1", "name", "John");
+        Map<String, Object> record2 = Map.of("id", "2", "name", "Jane");
+        List<Map<String, Object>> originalData = List.of(record1, record2);
+        Map<String, Object> body = Map.of("data", originalData);
+
+        Object result = advice.beforeBodyWrite(body, null, MediaType.APPLICATION_JSON, null, request, null);
+
+        // Result is a new map, not the input
+        assertThat(result).isNotSameAs(body);
+        // Input body still references the unfiltered list
+        assertThat(body.get("data")).isSameAs(originalData);
+        assertThat(((List<?>) body.get("data"))).hasSize(2);
+        // Result has the filtered list
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> filtered = (List<Map<String, Object>>) ((Map<String, Object>) result).get("data");
+        assertThat(filtered).hasSize(1);
+        assertThat(filtered.get(0).get("id")).isEqualTo("1");
+    }
+
+    @Test
+    @DisplayName("Should return new map with data:null when single record denied")
+    void shouldReturnNewMapWhenSingleRecordDenied() {
+        var request = createRequest("/api/contacts/123");
+        when(authzService.checkRecordAccess(any(), any(), any(), any(), eq("123"), anyMap(), eq("read")))
+                .thenReturn(false);
+
+        Map<String, Object> record = Map.of("id", "123", "attributes", Map.of("name", "John"));
+        Map<String, Object> body = Map.of("data", record);
+
+        Object result = advice.beforeBodyWrite(body, null, MediaType.APPLICATION_JSON, null, request, null);
+
+        assertThat(result).isNotSameAs(body);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> resultBody = (Map<String, Object>) result;
+        assertThat(resultBody).containsKey("data");
+        assertThat(resultBody.get("data")).isNull();
+        // Input untouched
+        assertThat(body.get("data")).isSameAs(record);
+    }
+
+    @Test
+    @DisplayName("Should return body unchanged when single record allowed")
+    void shouldReturnBodyUnchangedWhenSingleRecordAllowed() {
+        var request = createRequest("/api/contacts/123");
+        when(authzService.checkRecordAccess(any(), any(), any(), any(), eq("123"), anyMap(), eq("read")))
+                .thenReturn(true);
+
+        Map<String, Object> record = Map.of("id", "123", "attributes", Map.of("name", "John"));
+        Map<String, Object> body = Map.of("data", record);
+
+        Object result = advice.beforeBodyWrite(body, null, MediaType.APPLICATION_JSON, null, request, null);
+
+        assertThat(result).isSameAs(body);
+    }
+
+    @Test
+    @DisplayName("Should skip /api/api-specs paths")
+    void shouldSkipApiSpecsPaths() {
+        var request = createRequest("/api/api-specs/library");
+        Map<String, Object> body = Map.of("data", List.of(Map.of("id", "1", "name", "spec")));
+
+        Object result = advice.beforeBodyWrite(body, null, MediaType.APPLICATION_JSON, null, request, null);
+
+        assertThat(result).isSameAs(body);
+        verify(authzService, never()).batchCheckRecordAccess(any(), any(), any(), any(), anyList(), any());
+    }
+
+    @Test
+    @DisplayName("Should skip /api/api-operations paths")
+    void shouldSkipApiOperationsPaths() {
+        var request = createRequest("/api/api-operations/search");
+        Map<String, Object> body = Map.of("data", List.of(Map.of("id", "1")));
+
+        Object result = advice.beforeBodyWrite(body, null, MediaType.APPLICATION_JSON, null, request, null);
+
+        assertThat(result).isSameAs(body);
+        verify(authzService, never()).batchCheckRecordAccess(any(), any(), any(), any(), anyList(), any());
+    }
+
+    @Test
+    @DisplayName("Should skip /api/credentials paths")
+    void shouldSkipCredentialsPaths() {
+        var request = createRequest("/api/credentials/types");
+        Map<String, Object> body = Map.of("data", List.of(Map.of("id", "1", "name", "Basic Auth")));
+
+        Object result = advice.beforeBodyWrite(body, null, MediaType.APPLICATION_JSON, null, request, null);
+
+        assertThat(result).isSameAs(body);
+        verify(authzService, never()).batchCheckRecordAccess(any(), any(), any(), any(), anyList(), any());
+    }
+
+    @Test
+    @DisplayName("Should skip /api/connected-apps paths")
+    void shouldSkipConnectedAppsPaths() {
+        var request = createRequest("/api/connected-apps/app-1/tokens");
+        Map<String, Object> body = Map.of("data", List.of(Map.of("id", "1")));
+
+        Object result = advice.beforeBodyWrite(body, null, MediaType.APPLICATION_JSON, null, request, null);
+
+        assertThat(result).isSameAs(body);
+        verify(authzService, never()).batchCheckRecordAccess(any(), any(), any(), any(), anyList(), any());
+    }
+
+    @Test
+    @DisplayName("Should skip /api/devices path")
+    void shouldSkipDevicesPath() {
+        var request = createRequest("/api/devices");
+        Map<String, Object> body = Map.of("data", List.of(Map.of("id", "1")));
+
+        Object result = advice.beforeBodyWrite(body, null, MediaType.APPLICATION_JSON, null, request, null);
+
+        assertThat(result).isSameAs(body);
+        verify(authzService, never()).batchCheckRecordAccess(any(), any(), any(), any(), anyList(), any());
+    }
+
+    @Test
+    @DisplayName("Should skip existing metadata paths")
+    void shouldSkipExistingMetadataPaths() {
+        var request = createRequest("/api/collections/contacts");
+        Map<String, Object> body = Map.of("data", List.of(Map.of("id", "1")));
+
+        Object result = advice.beforeBodyWrite(body, null, MediaType.APPLICATION_JSON, null, request, null);
+
+        assertThat(result).isSameAs(body);
+        verify(authzService, never()).batchCheckRecordAccess(any(), any(), any(), any(), anyList(), any());
+    }
+
+    @Test
+    @DisplayName("Should skip /api/admin and /api/me paths")
+    void shouldSkipAdminAndMePaths() {
+        Map<String, Object> body = Map.of("data", List.of(Map.of("id", "1")));
+
+        var adminRequest = createRequest("/api/admin/settings");
+        assertThat(advice.beforeBodyWrite(body, null, MediaType.APPLICATION_JSON, null, adminRequest, null)).isSameAs(body);
+
+        var meRequest = createRequest("/api/me/tokens");
+        assertThat(advice.beforeBodyWrite(body, null, MediaType.APPLICATION_JSON, null, meRequest, null)).isSameAs(body);
+
+        verify(authzService, never()).batchCheckRecordAccess(any(), any(), any(), any(), anyList(), any());
+    }
+
+    @Test
+    @DisplayName("Should filter denied records from list response")
+    void shouldFilterDeniedRecords() {
+        var request = createRequest("/api/contacts");
+        when(authzService.batchCheckRecordAccess(any(), any(), any(), any(), anyList(), eq("read")))
+                .thenReturn(Set.of("1")); // Only id=1 allowed
+
+        Map<String, Object> record1 = new LinkedHashMap<>(Map.of("id", "1", "name", "John"));
+        Map<String, Object> record2 = new LinkedHashMap<>(Map.of("id", "2", "name", "Jane"));
+        Map<String, Object> body = new LinkedHashMap<>(Map.of("data", List.of(record1, record2)));
+
+        Object result = advice.beforeBodyWrite(body, null, MediaType.APPLICATION_JSON, null, request, null);
+
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> filtered = (List<Map<String, Object>>) ((Map<String, Object>) result).get("data");
+        assertThat(filtered).hasSize(1);
+        assertThat(filtered.get(0).get("id")).isEqualTo("1");
+    }
+
+    @Test
+    @DisplayName("Should skip when permissions disabled")
+    void shouldDoNothingWhenDisabled() {
+        var disabledAdvice = new CerbosRecordAuthorizationAdvice(authzService, permissionResolver, false);
+        assertThat(disabledAdvice.supports(null, null)).isFalse();
+    }
+
+    @Test
+    @DisplayName("Should skip non-/api/ paths")
+    void shouldSkipNonApiPaths() {
+        var request = createRequest("/internal/something");
+        Map<String, Object> body = Map.of("data", List.of(Map.of("id", "1")));
+
+        Object result = advice.beforeBodyWrite(body, null, MediaType.APPLICATION_JSON, null, request, null);
+
+        assertThat(result).isSameAs(body);
+        verify(authzService, never()).batchCheckRecordAccess(any(), any(), any(), any(), anyList(), any());
+    }
+
+    @Test
+    @DisplayName("Should skip when no identity is present")
+    void shouldSkipWhenNoIdentity() {
+        var request = createRequest("/api/contacts");
+        when(permissionResolver.hasIdentity(any())).thenReturn(false);
+
+        Map<String, Object> body = Map.of("data", List.of(Map.of("id", "1")));
+
+        Object result = advice.beforeBodyWrite(body, null, MediaType.APPLICATION_JSON, null, request, null);
+
+        assertThat(result).isSameAs(body);
+        verify(authzService, never()).batchCheckRecordAccess(any(), any(), any(), any(), anyList(), any());
+    }
+
+    @Test
+    @DisplayName("Should pass through non-Map body unchanged")
+    void shouldPassThroughNonMapBody() {
+        var request = createRequest("/api/contacts");
+        Object body = "plain string";
+
+        Object result = advice.beforeBodyWrite(body, null, MediaType.APPLICATION_JSON, null, request, null);
+
+        assertThat(result).isSameAs(body);
+        verify(authzService, never()).batchCheckRecordAccess(any(), any(), any(), any(), anyList(), any());
+    }
+
+    @Test
+    @DisplayName("Should pass through body without data key")
+    void shouldPassThroughBodyWithoutData() {
+        var request = createRequest("/api/contacts");
+        Map<String, Object> body = Map.of("meta", Map.of("count", 0));
+
+        Object result = advice.beforeBodyWrite(body, null, MediaType.APPLICATION_JSON, null, request, null);
+
+        assertThat(result).isSameAs(body);
+        verify(authzService, never()).batchCheckRecordAccess(any(), any(), any(), any(), anyList(), any());
+    }
+}


### PR DESCRIPTION
## Summary
- `GET /api/api-specs/library` and `GET /api/credentials/types` returned **HTTP 500** in production. Root cause: `CerbosRecordAuthorizationAdvice.beforeBodyWrite()` called `responseBody.put(...)` on the immutable `Map.of("data", X)` returned by the controllers — `UnsupportedOperationException` on every request.
- Fix the advice (not the controllers): build a new `LinkedHashMap` when filtering instead of mutating the input. This single change resolves the 500 for **all 11+ controllers** that return `Map.of(...)` for `/api/...` paths.
- Add `api-specs`, `api-operations`, `credentials`, `connected-apps`, and `devices` to `isMetadataPath()`. These endpoints return flat metadata (`{ id, name, ... }`), not JSON:API records (`{ id, type, attributes: {...} }`); without the exclusion, `Cerbos.batchCheckRecordAccess` would silently filter all rows once the 500 was fixed (200 with empty `data: []`).

## Stack trace (from worker pod logs)
```
java.lang.UnsupportedOperationException
  at java.util.ImmutableCollections$AbstractImmutableMap.put(ImmutableCollections.java:1318)
  at io.kelta.worker.interceptor.CerbosRecordAuthorizationAdvice.beforeBodyWrite(...:114)
```

## Changes
- `kelta-worker/src/main/java/io/kelta/worker/interceptor/CerbosRecordAuthorizationAdvice.java` — return a new map instead of mutating; expand `isMetadataPath()`.
- `kelta-worker/src/test/java/io/kelta/worker/interceptor/CerbosRecordAuthorizationAdviceTest.java` — new test covering immutable-body regression, single-record + list filtering, all new exclusion prefixes, and the existing skip paths.

## Testing
- [x] `mvn test -Dtest=CerbosRecordAuthorizationAdviceTest` — 17/17 pass
- [x] `mvn verify -f kelta-worker/pom.xml` — 1070/1070 pass
- [x] `mvn verify -f kelta-gateway/pom.xml` — pass
- [x] `kelta-web` lint, typecheck, format, tests (605/605) — pass
- [ ] After deploy: `curl https://emf.rzware.com/threadline-clothing/api/api-specs/library` returns 200
- [ ] After deploy: `curl https://emf.rzware.com/threadline-clothing/api/credentials/types` returns 200
- [ ] After deploy: `/threadline-clothing/api-specs` UI page loads without `<ErrorMessage>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)