### PR TITLE
fix(worker): use @ConditionalOnProperty for encryption-key-gated beans

### DIFF
--- a/kelta-worker/src/main/java/io/kelta/worker/controller/CredentialController.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/controller/CredentialController.java
@@ -15,7 +15,7 @@ import io.kelta.worker.service.credential.CredentialTestService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -45,7 +45,7 @@ import java.util.stream.Collectors;
  */
 @RestController
 @RequestMapping("/api/credentials")
-@ConditionalOnBean(EncryptionService.class)
+@ConditionalOnProperty(name = "kelta.encryption.key")
 public class CredentialController {
 
     private static final Logger log = LoggerFactory.getLogger(CredentialController.class);

--- a/kelta-worker/src/main/java/io/kelta/worker/listener/CredentialCacheInvalidationListener.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/listener/CredentialCacheInvalidationListener.java
@@ -1,10 +1,9 @@
 package io.kelta.worker.listener;
 
-import io.kelta.crypto.EncryptionService;
 import io.kelta.worker.service.credential.CredentialResolver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
@@ -15,7 +14,7 @@ import tools.jackson.databind.ObjectMapper;
  * runs this listener so cache stays consistent across the fleet.
  */
 @Component
-@ConditionalOnBean(EncryptionService.class)
+@ConditionalOnProperty(name = "kelta.encryption.key")
 public class CredentialCacheInvalidationListener {
 
     private static final Logger log = LoggerFactory.getLogger(CredentialCacheInvalidationListener.class);

--- a/kelta-worker/src/main/java/io/kelta/worker/listener/OidcProviderSecretHook.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/listener/OidcProviderSecretHook.java
@@ -5,7 +5,7 @@ import io.kelta.runtime.workflow.BeforeSaveHook;
 import io.kelta.runtime.workflow.BeforeSaveResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 import java.util.HashMap;
@@ -25,7 +25,7 @@ import java.util.Map;
  * when kelta-auth needs to perform token exchange with the external IdP.
  */
 @Component
-@ConditionalOnBean(EncryptionService.class)
+@ConditionalOnProperty(name = "kelta.encryption.key")
 public class OidcProviderSecretHook implements BeforeSaveHook {
 
     private static final Logger log = LoggerFactory.getLogger(OidcProviderSecretHook.class);

--- a/kelta-worker/src/main/java/io/kelta/worker/service/credential/CredentialResolverImpl.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/service/credential/CredentialResolverImpl.java
@@ -10,7 +10,7 @@ import io.kelta.worker.service.SetupAuditService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
@@ -31,7 +31,7 @@ import java.util.concurrent.ConcurrentMap;
  * {@link io.kelta.worker.listener.CredentialCacheInvalidationListener}.
  */
 @Service
-@ConditionalOnBean(EncryptionService.class)
+@ConditionalOnProperty(name = "kelta.encryption.key")
 public class CredentialResolverImpl implements CredentialResolver {
 
     private static final Logger log = LoggerFactory.getLogger(CredentialResolverImpl.class);

--- a/kelta-worker/src/main/java/io/kelta/worker/service/credential/CredentialResolverPortAdapter.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/service/credential/CredentialResolverPortAdapter.java
@@ -6,7 +6,7 @@ import io.kelta.runtime.module.integration.spi.CredentialResolverPort;
 import io.kelta.worker.repository.CredentialOAuthTokenRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 
 import java.time.Instant;
@@ -22,7 +22,7 @@ import java.util.Optional;
  * a single uniform applyAuth path.
  */
 @Service
-@ConditionalOnBean(EncryptionService.class)
+@ConditionalOnProperty(name = "kelta.encryption.key")
 public class CredentialResolverPortAdapter implements CredentialResolverPort {
 
     private static final Logger log = LoggerFactory.getLogger(CredentialResolverPortAdapter.class);

--- a/kelta-worker/src/main/java/io/kelta/worker/service/credential/CredentialTestService.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/service/credential/CredentialTestService.java
@@ -10,7 +10,7 @@ import jakarta.mail.Session;
 import jakarta.mail.Transport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
@@ -31,7 +31,7 @@ import java.util.Properties;
  * </ul>
  */
 @Service
-@ConditionalOnBean(EncryptionService.class)
+@ConditionalOnProperty(name = "kelta.encryption.key")
 public class CredentialTestService {
 
     private static final Logger log = LoggerFactory.getLogger(CredentialTestService.class);


### PR DESCRIPTION
## Summary
- After [#781](https://github.com/cklinker/emf/pull/781) deployed, `GET /api/credentials/types` returned **404** in production. Gateway routed correctly, but `CredentialController` was never registered — `@ConditionalOnBean(EncryptionService.class)` skipped it even though `EncryptionService initialized with AES-256-GCM` appears in the worker startup log.
- Spring docs explicitly warn: `@ConditionalOnBean` "can only match the bean definitions that have been processed so far... it is strongly recommended to use this condition on auto-configuration classes only." `EncryptionAutoConfiguration` runs after component scan, so on a `@RestController` / `@Service` / `@Component` the condition fails consistently.
- Switch the six affected classes to `@ConditionalOnProperty(name = "kelta.encryption.key")`. Property conditions evaluate against the environment, not bean processing order — semantically more direct and correct here.

## How the 404 happened
1. Component scan processes `CredentialController` → evaluates `@ConditionalOnBean(EncryptionService.class)`.
2. `EncryptionService` bean from `EncryptionAutoConfiguration` hasn't been registered yet → condition false → controller skipped.
3. Auto-config phase runs later → `EncryptionService` bean created (logged), but the controller is already out.
4. Request `GET /api/credentials/types` → no controller match → falls through to `DynamicCollectionRouter` (system collection `credentials`) → treated as `GET /api/credentials/{id=types}` → no record → 404.

## Changes
Replace `@ConditionalOnBean(EncryptionService.class)` with `@ConditionalOnProperty(name = "kelta.encryption.key")` on:
- `CredentialController`
- `CredentialCacheInvalidationListener`
- `CredentialResolverImpl`
- `CredentialResolverPortAdapter`
- `CredentialTestService`
- `OidcProviderSecretHook` (pre-dated #773 with the same anti-pattern)

`FlowConfig.credentialEncryptionHook` is left as-is — `@ConditionalOnBean` on `@Bean` methods inside `@Configuration` classes works correctly because the bean factory is processed at the right time.

## Testing
- [x] `mvn verify -f kelta-worker/pom.xml` — 1070/1070 pass
- [x] `mvn verify -f kelta-gateway/pom.xml` — pass
- [x] `kelta-web` lint, typecheck, format, tests (605/605) — pass
- [ ] After deploy: `curl https://emf.rzware.com/threadline-clothing/api/credentials/types` → 200 with `{"data":[…]}`
- [ ] After deploy: `curl https://emf.rzware.com/threadline-clothing/api/credentials/templates` → 200
- [ ] After deploy: worker startup log still shows `EncryptionService initialized with AES-256-GCM`

🤖 Generated with [Claude Code](https://claude.com/claude-code)