### PR TITLE
fix(api-specs): clean OpenAPI JSON + native-image reflection for swagger models

### DIFF
--- a/kelta-platform/runtime/runtime-module-integration/src/main/java/io/kelta/runtime/module/integration/api/OpenApiSpecParser.java
+++ b/kelta-platform/runtime/runtime-module-integration/src/main/java/io/kelta/runtime/module/integration/api/OpenApiSpecParser.java
@@ -189,24 +189,23 @@ public class OpenApiSpecParser {
 
     /**
      * Converts a swagger-parser model object (Jackson-2 backed POJOs / Maps /
-     * Lists) into a Jackson-3 {@link JsonNode}. We round-trip via a Map so we
-     * don't need to share an ObjectMapper between the two Jackson versions.
+     * Lists) into a Jackson-3 {@link JsonNode}. Uses swagger-core's pre-configured
+     * Jackson-2 mapper so OpenAPI-specific serializers run (clean spec-style
+     * output, NON_NULL inclusion, polymorphic Schema handling); without this,
+     * a bare {@code new ObjectMapper()} dumps every internal field of swagger's
+     * POJOs (or fails outright on certain spec shapes).
      */
     @SuppressWarnings("unchecked")
     private JsonNode convert(Object value) {
         if (value == null) {
             return null;
         }
-        // swagger-parser hands back Jackson-2 POJOs; their toString isn't JSON,
-        // so we serialize via Jackson-2 first, then parse with Jackson-3.
         try {
-            com.fasterxml.jackson.databind.ObjectMapper jackson2 =
-                new com.fasterxml.jackson.databind.ObjectMapper();
-            String json = jackson2.writeValueAsString(value);
+            String json = io.swagger.v3.core.util.Json.mapper().writeValueAsString(value);
             return objectMapper.readTree(json);
         } catch (Exception e) {
-            // As a fallback, stuff the toString into an empty object — better
-            // to lose detail than fail the entire import.
+            log.warn("Failed to serialize swagger object of type {}: {}",
+                value.getClass().getName(), e.toString());
             ObjectNode fallback = objectMapper.createObjectNode();
             fallback.put("_unparsable", value.toString());
             return fallback;

--- a/kelta-platform/runtime/runtime-module-integration/src/main/java/io/kelta/runtime/module/integration/api/SwaggerModelRuntimeHints.java
+++ b/kelta-platform/runtime/runtime-module-integration/src/main/java/io/kelta/runtime/module/integration/api/SwaggerModelRuntimeHints.java
@@ -1,0 +1,99 @@
+package io.kelta.runtime.module.integration.api;
+
+import org.springframework.aot.hint.MemberCategory;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.RuntimeHintsRegistrar;
+import org.springframework.aot.hint.TypeReference;
+
+import java.util.List;
+
+/**
+ * Registers swagger-models classes for reflection in GraalVM native images.
+ *
+ * <p>{@link OpenApiSpecParser#convert(Object)} serializes swagger-parser POJOs
+ * via Jackson; without these hints, Jackson's bean introspector throws in a
+ * native image because the swagger-models classes aren't registered as
+ * reflective types — every operation field then falls through to the
+ * {@code _unparsable} branch and stores Java {@code toString()} dumps
+ * (PathParameter, QueryParameter, RequestBody, ApiResponses, ...) instead of
+ * proper OpenAPI JSON.
+ *
+ * <p>Wired via {@code aot.factories} so Spring's AOT processor picks it up
+ * during native compilation.
+ */
+public class SwaggerModelRuntimeHints implements RuntimeHintsRegistrar {
+
+    private static final List<String> SWAGGER_MODEL_CLASSES = List.of(
+        "io.swagger.v3.oas.models.Components",
+        "io.swagger.v3.oas.models.ExternalDocumentation",
+        "io.swagger.v3.oas.models.OpenAPI",
+        "io.swagger.v3.oas.models.Operation",
+        "io.swagger.v3.oas.models.PathItem",
+        "io.swagger.v3.oas.models.PathItem$HttpMethod",
+        "io.swagger.v3.oas.models.Paths",
+        "io.swagger.v3.oas.models.SpecVersion",
+        "io.swagger.v3.oas.models.callbacks.Callback",
+        "io.swagger.v3.oas.models.examples.Example",
+        "io.swagger.v3.oas.models.headers.Header",
+        "io.swagger.v3.oas.models.headers.Header$StyleEnum",
+        "io.swagger.v3.oas.models.info.Contact",
+        "io.swagger.v3.oas.models.info.Info",
+        "io.swagger.v3.oas.models.info.License",
+        "io.swagger.v3.oas.models.links.Link",
+        "io.swagger.v3.oas.models.links.LinkParameter",
+        "io.swagger.v3.oas.models.media.ArraySchema",
+        "io.swagger.v3.oas.models.media.BinarySchema",
+        "io.swagger.v3.oas.models.media.BooleanSchema",
+        "io.swagger.v3.oas.models.media.ByteArraySchema",
+        "io.swagger.v3.oas.models.media.ComposedSchema",
+        "io.swagger.v3.oas.models.media.Content",
+        "io.swagger.v3.oas.models.media.DateSchema",
+        "io.swagger.v3.oas.models.media.DateTimeSchema",
+        "io.swagger.v3.oas.models.media.Discriminator",
+        "io.swagger.v3.oas.models.media.EmailSchema",
+        "io.swagger.v3.oas.models.media.Encoding",
+        "io.swagger.v3.oas.models.media.Encoding$StyleEnum",
+        "io.swagger.v3.oas.models.media.EncodingProperty",
+        "io.swagger.v3.oas.models.media.EncodingProperty$StyleEnum",
+        "io.swagger.v3.oas.models.media.FileSchema",
+        "io.swagger.v3.oas.models.media.IntegerSchema",
+        "io.swagger.v3.oas.models.media.JsonSchema",
+        "io.swagger.v3.oas.models.media.MapSchema",
+        "io.swagger.v3.oas.models.media.MediaType",
+        "io.swagger.v3.oas.models.media.NumberSchema",
+        "io.swagger.v3.oas.models.media.ObjectSchema",
+        "io.swagger.v3.oas.models.media.PasswordSchema",
+        "io.swagger.v3.oas.models.media.Schema",
+        "io.swagger.v3.oas.models.media.StringSchema",
+        "io.swagger.v3.oas.models.media.UUIDSchema",
+        "io.swagger.v3.oas.models.media.XML",
+        "io.swagger.v3.oas.models.parameters.CookieParameter",
+        "io.swagger.v3.oas.models.parameters.HeaderParameter",
+        "io.swagger.v3.oas.models.parameters.Parameter",
+        "io.swagger.v3.oas.models.parameters.Parameter$StyleEnum",
+        "io.swagger.v3.oas.models.parameters.PathParameter",
+        "io.swagger.v3.oas.models.parameters.QueryParameter",
+        "io.swagger.v3.oas.models.parameters.RequestBody",
+        "io.swagger.v3.oas.models.responses.ApiResponse",
+        "io.swagger.v3.oas.models.responses.ApiResponses",
+        "io.swagger.v3.oas.models.security.OAuthFlow",
+        "io.swagger.v3.oas.models.security.OAuthFlows",
+        "io.swagger.v3.oas.models.security.Scopes",
+        "io.swagger.v3.oas.models.security.SecurityRequirement",
+        "io.swagger.v3.oas.models.security.SecurityScheme",
+        "io.swagger.v3.oas.models.security.SecurityScheme$In",
+        "io.swagger.v3.oas.models.security.SecurityScheme$Type",
+        "io.swagger.v3.oas.models.servers.Server",
+        "io.swagger.v3.oas.models.servers.ServerVariable",
+        "io.swagger.v3.oas.models.servers.ServerVariables",
+        "io.swagger.v3.oas.models.tags.Tag"
+    );
+
+    @Override
+    public void registerHints(RuntimeHints hints, ClassLoader classLoader) {
+        MemberCategory[] all = MemberCategory.values();
+        for (String name : SWAGGER_MODEL_CLASSES) {
+            hints.reflection().registerType(TypeReference.of(name), all);
+        }
+    }
+}

--- a/kelta-platform/runtime/runtime-module-integration/src/main/resources/META-INF/spring/aot.factories
+++ b/kelta-platform/runtime/runtime-module-integration/src/main/resources/META-INF/spring/aot.factories
@@ -1,0 +1,2 @@
+org.springframework.aot.hint.RuntimeHintsRegistrar=\
+io.kelta.runtime.module.integration.api.SwaggerModelRuntimeHints

--- a/kelta-platform/runtime/runtime-module-integration/src/test/java/io/kelta/runtime/module/integration/api/OpenApiSpecParserTest.java
+++ b/kelta-platform/runtime/runtime-module-integration/src/test/java/io/kelta/runtime/module/integration/api/OpenApiSpecParserTest.java
@@ -195,4 +195,43 @@ class OpenApiSpecParserTest {
             .toList();
         assertEquals(4, petOps.size(), "all 4 operations are tagged 'pet'");
     }
+
+    @Test
+    @DisplayName("Emits clean OpenAPI-style JSON, not swagger-model field dumps")
+    void emitsCleanJson() {
+        ParsedSpec parsed = parser.parse(PETSTORE_YAML);
+        ParsedSpec.ParsedOperation getPet = parsed.operations().stream()
+            .filter(op -> "getPetById".equals(op.operationId()))
+            .findFirst()
+            .orElseThrow();
+
+        String paramsJson = getPet.parametersSchema().toString();
+        // Bare ObjectMapper would dump swagger internals like exampleSetFlag,
+        // jsonSchema, jsonSchemaImpl, types, booleanSchemaValue. Json.mapper()
+        // omits these — assert they're gone.
+        assertFalse(paramsJson.contains("exampleSetFlag"),
+            "swagger internal field 'exampleSetFlag' should not leak into output: " + paramsJson);
+        assertFalse(paramsJson.contains("jsonSchemaImpl"),
+            "swagger internal field 'jsonSchemaImpl' should not leak into output: " + paramsJson);
+        assertFalse(paramsJson.contains("_unparsable"),
+            "convert() should not fall through to _unparsable on Petstore: " + paramsJson);
+        assertTrue(paramsJson.contains("\"name\":\"petId\""),
+            "should include the actual parameter name: " + paramsJson);
+    }
+
+    @Test
+    @DisplayName("convert() does not fall through to _unparsable for any operation field")
+    void noUnparsableFallback() {
+        ParsedSpec parsed = parser.parse(PETSTORE_YAML);
+        for (ParsedSpec.ParsedOperation op : parsed.operations()) {
+            for (var node : List.of(
+                op.parametersSchema() == null ? "" : op.parametersSchema().toString(),
+                op.requestBodySchema() == null ? "" : op.requestBodySchema().toString(),
+                op.responseSchemas() == null ? "" : op.responseSchemas().toString())) {
+                assertFalse(node.contains("_unparsable"),
+                    "Found _unparsable fallback in operation "
+                        + op.httpMethod() + " " + op.pathTemplate() + ": " + node);
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary
After importing the user's `sam-template - tasks OpenAPI Spec` (173 operations), every operation's parameters/requestBody/responses showed up as `_unparsable` blobs containing raw Java `toString()` dumps (`class PathParameter {\n class Parameter {...`). Two compounding bugs.

### 1. `OpenApiSpecParser.convert()` used a bare `new ObjectMapper()`
Even when serialization succeeded on JVM, output was a verbose dump of every internal swagger field — `exampleSetFlag`, `jsonSchema`, `jsonSchemaImpl`, `types`, `booleanSchemaValue`, etc. — instead of clean OpenAPI-spec JSON. Compare for one parameter:

**Before**
```json
{"name":"id","in":"path","description":null,"required":true,"deprecated":null,"allowEmptyValue":null,"$ref":null,"style":"SIMPLE","explode":false,...,"jsonSchemaImpl":null,"if":null,"else":null}
```

**After**
```json
{"name":"id","in":"path","required":true,"style":"simple","explode":false,"schema":{"type":"string"}}
```

Switched to `io.swagger.v3.core.util.Json.mapper()` — swagger-core's pre-configured mapper has the OpenAPI mixins registered and `NON_NULL` inclusion.

### 2. Worker is a GraalVM native image with no reflection metadata for swagger-models
This is the real production failure cause. `reflect-config.json` had **zero** entries for `io.swagger.v3.oas.models.**`, so Jackson's bean introspector throws on every swagger POJO at runtime → falls through to `_unparsable`. Confirmed by querying the DB on the deployed pod (`harbor.rzware.com/emf/emf-worker:main-b0cb928` is a native image with no `java` binary in the container).

Added `SwaggerModelRuntimeHints` (a `RuntimeHintsRegistrar` registering all 62 swagger-models classes for full reflection) wired via `META-INF/spring/aot.factories` so Spring AOT picks it up during native compilation.

### Diagnostic improvement
The `_unparsable` fallback used to silently swallow exceptions. Now it logs the failing class name + exception so future failures are debuggable.

## Changes
- `runtime-module-integration/src/main/java/.../OpenApiSpecParser.java` — use `Json.mapper()`, log fallback exceptions.
- `runtime-module-integration/src/main/java/.../SwaggerModelRuntimeHints.java` — new `RuntimeHintsRegistrar`.
- `runtime-module-integration/src/main/resources/META-INF/spring/aot.factories` — wire the registrar.
- `OpenApiSpecParserTest.java` — assert no `_unparsable` fallback and no swagger-internal field leaks.

## Testing
- [x] Tested against the user's actual spec (`/Users/craigklinker/Gitlab/billing-bp-service/apps/rest-api/open-api.yml`, 21k lines, 173 operations) — 0 `_unparsable` after fix.
- [x] `mvn verify -f kelta-worker/pom.xml` — pass
- [x] `mvn verify -f kelta-gateway/pom.xml` — pass
- [x] kelta-web lint/typecheck/format/tests — pass (605/605)
- [ ] After deploy: re-import the spec — operations show clean OpenAPI JSON in the UI instead of `_unparsable`.

## Note on existing DB data
`api_operation` rows imported before this fix still hold the bad `_unparsable` values. The user can re-import the spec to refresh them — `revision` will bump and the new parser produces clean JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)