### PR TITLE
fix(worker): @ConditionalOnProperty for credentialEncryptionHook

### DIFF
--- a/kelta-worker/src/main/java/io/kelta/worker/config/FlowConfig.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/config/FlowConfig.java
@@ -31,7 +31,7 @@ import io.kelta.worker.listener.RecordTypeEnforcementHook;
 import io.kelta.worker.listener.ValidationRuleRefreshHook;
 import io.kelta.crypto.EncryptionService;
 import io.kelta.runtime.credential.CredentialTypeRegistry;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import io.kelta.worker.handler.SubmitForApprovalActionHandler;
 import io.kelta.worker.repository.ApprovalRepository;
 import io.kelta.worker.service.ApprovalService;
@@ -304,7 +304,7 @@ public class FlowConfig {
     // ---------------------------------------------------------------------------
 
     @Bean
-    @ConditionalOnBean(EncryptionService.class)
+    @ConditionalOnProperty(name = "kelta.encryption.key")
     public CredentialEncryptionHook credentialEncryptionHook(
             BeforeSaveHookRegistry hookRegistry,
             EncryptionService encryptionService,


### PR DESCRIPTION
## Summary
- POST `/api/credentials` returned **500 in 9ms with no worker log entry**.
- Worker startup confirmed the cause: only `CredentialEventPublisher` was registered as a BeforeSaveHook for the `credentials` collection — the `CredentialEncryptionHook` was missing. Without it, the insert wrote NULL into `data_enc` and tripped the NOT NULL constraint → 500.
- Same root cause as [#782](https://github.com/cklinker/emf/pull/782): `@ConditionalOnBean(EncryptionService.class)` is unreliable when the dependency is auto-configured. I incorrectly thought `@Bean`-method usage was safe in that earlier PR — it isn't, because `FlowConfig` is processed before `EncryptionAutoConfiguration` runs.

## Worker startup log (before fix)
```
Registered BeforeSaveHook for collection 'credentials': CredentialEventPublisher (order=100)
```
(no `CredentialEncryptionHook (order=-100)` line — the bean was silently skipped)

## Changes
- [FlowConfig.java](kelta-worker/src/main/java/io/kelta/worker/config/FlowConfig.java) — replace `@ConditionalOnBean(EncryptionService.class)` on the `credentialEncryptionHook` `@Bean` with `@ConditionalOnProperty(name = "kelta.encryption.key")`. Property conditions are evaluated against the environment, not bean processing order, so they're reliable regardless of when EncryptionService gets registered.

## Testing
- [x] `mvn verify -f kelta-worker/pom.xml` — 1070/1070 pass
- [x] `mvn verify -f kelta-gateway/pom.xml` — pass
- [x] kelta-web lint/typecheck/format/tests — pass (605/605)
- [ ] After deploy: worker startup log shows `Registered BeforeSaveHook for collection 'credentials': CredentialEncryptionHook (order=-100)`
- [ ] After deploy: POST `/api/credentials` with a valid payload returns 201

## Out of scope
Other `@ConditionalOnBean` usages in the codebase (S3StorageService gates, FlowEngine gates, two more EncryptionService gates in kelta-auth) may have the same fragility but aren't currently reported as broken. Worth a follow-up audit; not addressing here to keep this PR small.

🤖 Generated with [Claude Code](https://claude.com/claude-code)