### PR TITLE
feat(mcp): scaffold kelta-mcp service exposed at /mcp/user and /mcp/admin

### DIFF
--- a/.github/workflows/build-and-publish-containers.yml
+++ b/.github/workflows/build-and-publish-containers.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - 'kelta-ai/**'
       - 'kelta-gateway/**'
+      - 'kelta-mcp/**'
       - 'kelta-platform/runtime/**'
       - 'kelta-worker/**'
       - 'kelta-auth/**'
@@ -88,6 +89,9 @@ jobs:
       - name: Test AI Service
         run: mvn verify -f kelta-ai/pom.xml -B
 
+      - name: Test MCP Service
+        run: mvn verify -f kelta-mcp/pom.xml -B
+
   # ===========================================================================
   # Test Frontend
   # ===========================================================================
@@ -150,6 +154,9 @@ jobs:
           - service: ai
             dockerfile: kelta-ai/Dockerfile
             image: kelta-ai
+          - service: mcp
+            dockerfile: kelta-mcp/Dockerfile
+            image: kelta-mcp
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -262,6 +269,11 @@ jobs:
               # Update AI service deployment
               if [ -f "$DIR/ai-deployment.yaml" ]; then
                 sed -i "s|image: .*${PREFIX}-ai:.*|image: harbor.rzware.com/emf/${PREFIX}-ai:${IMAGE_TAG}|g" "$DIR/ai-deployment.yaml"
+              fi
+
+              # Update MCP service deployment
+              if [ -f "$DIR/mcp-deployment.yaml" ]; then
+                sed -i "s|image: .*${PREFIX}-mcp:.*|image: harbor.rzware.com/emf/${PREFIX}-mcp:${IMAGE_TAG}|g" "$DIR/mcp-deployment.yaml"
               fi
             fi
           done

--- a/kelta-mcp/CLAUDE.md
+++ b/kelta-mcp/CLAUDE.md
@@ -1,0 +1,88 @@
+# kelta-mcp
+
+Model Context Protocol (MCP) server for the Kelta platform. Exposes platform operations to MCP clients (e.g. Claude Code) over HTTP, authenticated by the user's Personal Access Token.
+
+## Endpoints
+
+Two MCP server instances run inside one Spring Boot process:
+
+| Path | Profile | Purpose |
+|------|---------|---------|
+| `/mcp/user` | data-plane | CRUD records, run flows, approvals, search |
+| `/mcp/admin` | control-plane | Define collections/fields/layouts/flows/etc. |
+
+Each endpoint has its own immutable tool registry — admin tools are not callable from `/mcp/user` (or vice versa).
+
+## Auth
+
+Every request to `/mcp/**` must carry `Authorization: Bearer klt_*`. The `McpAuthFilter` does a presence/prefix check only — the actual cryptographic validation happens at the gateway when tool calls are forwarded. The filter also strips client-supplied `X-Tenant-ID` / `X-Tenant-Slug` / `X-User-Id` headers so a client cannot impersonate another tenant; tenant is derived by the gateway from the PAT.
+
+PATs are kept in `PatSessionStore` keyed by MCP session id, evicted on idle timeout.
+
+## Package Layout
+
+```
+io.kelta.mcp/
+  config/          ← McpServerConfig (two server instances), McpProperties, WebConfig
+  auth/            ← McpAuthFilter, PatSessionStore
+  transport/       ← KeltaMcpEndpoints (path mounting)
+  tool/
+    shared/        ← JsonApiClient, AttributeMapper, ResponseShaper
+    user/          ← QueryCollectionTool, CreateRecordTool, ExecuteFlowTool, ...
+    admin/         ← CreateCollectionTool, CreateLayoutTool, CreateFlowTool, ...
+  resource/        ← MCP Resources for browsable schema/openapi
+  client/          ← GatewayHttpClient (in-cluster: http://emf-gateway:80)
+  error/           ← McpErrorMapper (gateway 4xx/5xx → MCP error result, redacts klt_)
+```
+
+## Key Patterns
+
+### MCP server wiring
+Each profile is wired with its own `HttpServletStreamableServerTransportProvider` (from `io.modelcontextprotocol.sdk:mcp`) and its own `McpSyncServer`. Tools are added to the server in `@Bean` methods so registration is static and visible.
+
+```java
+McpSyncServer server = McpServer.sync(transport)
+    .serverInfo("kelta-mcp-user", "1.0.0")
+    .capabilities(ServerCapabilities.builder().tools(true).build())
+    .build();
+server.addTool(new ListCollectionsTool().toSpecification(...));
+```
+
+### Tool definition
+Each tool is a class that produces a `McpServerFeatures.SyncToolSpecification`. The call handler builds an HTTP request, forwards through `GatewayHttpClient` (PAT pulled from `PatSessionStore` via the MCP session id), and shapes the JSON:API response into MCP `TextContent` / `JsonContent`.
+
+### No DB
+kelta-mcp is stateless. The runtime-core auto-configurations (`KeltaRuntimeAutoConfiguration`, `EncryptionAutoConfiguration`) are excluded in `McpApplication`. Component scan is restricted to `io.kelta.mcp` so we only depend on runtime-core for type definitions (CollectionDefinition, FieldDefinition, FieldType).
+
+## Configuration
+
+```yaml
+kelta:
+  mcp:
+    gateway-url: http://emf-gateway:80
+    session-ttl-minutes: 30
+    tool-timeout-ms: 60000
+```
+
+## Running Tests
+
+```bash
+mvn test -f kelta-mcp/pom.xml                                       # All tests
+mvn test -f kelta-mcp/pom.xml -Dtest=McpAuthFilterTest              # Single class
+mvn test -f kelta-mcp/pom.xml -Dtest="*Tool*"                        # Pattern
+```
+
+## Local Smoke Test
+
+```bash
+mvn spring-boot:run -f kelta-mcp/pom.xml
+
+claude mcp add kelta-local --transport http \
+  --url http://localhost:8080/mcp/user \
+  --header "Authorization: Bearer klt_smoke_test_token"
+# In a Claude Code session, ask: "use the kelta-local MCP server to call ping"
+```
+
+## Plan
+
+Full plan and phases live in `~/.claude/plans/i-would-like-to-kind-rivest.md`.

--- a/kelta-mcp/Dockerfile
+++ b/kelta-mcp/Dockerfile
@@ -1,0 +1,82 @@
+# Multi-stage build for Kelta MCP Server
+
+# =============================================================================
+# Stage 1: Build runtime-platform dependencies
+# =============================================================================
+FROM maven:3.9-eclipse-temurin-25 AS runtime-builder
+
+WORKDIR /kelta-platform
+
+# Copy only POMs first for dependency layer caching
+COPY kelta-platform/pom.xml ./
+COPY kelta-platform/runtime/pom.xml ./runtime/
+COPY kelta-platform/runtime/runtime-core/pom.xml ./runtime/runtime-core/
+COPY kelta-platform/runtime/runtime-events/pom.xml ./runtime/runtime-events/
+COPY kelta-platform/runtime/runtime-jsonapi/pom.xml ./runtime/runtime-jsonapi/
+COPY kelta-platform/runtime/runtime-module-core/pom.xml ./runtime/runtime-module-core/
+COPY kelta-platform/runtime/runtime-module-integration/pom.xml ./runtime/runtime-module-integration/
+COPY kelta-platform/runtime/runtime-messaging-nats/pom.xml ./runtime/runtime-messaging-nats/
+COPY kelta-platform/runtime/runtime-module-schema/pom.xml ./runtime/runtime-module-schema/
+
+# Download runtime dependencies (cached unless pom.xml changes)
+RUN mvn dependency:go-offline -B \
+    -pl runtime/runtime-core \
+    -am || true
+
+# Copy source and build only what kelta-mcp needs (runtime-core)
+COPY kelta-platform/runtime/runtime-core/src ./runtime/runtime-core/src
+COPY kelta-platform/runtime/runtime-events/src ./runtime/runtime-events/src
+
+RUN mvn clean install -DskipTests -B \
+    -pl runtime/runtime-core \
+    -am
+
+# =============================================================================
+# Stage 2: Build the application
+# =============================================================================
+FROM maven:3.9-eclipse-temurin-25 AS builder
+
+WORKDIR /build
+
+# Copy runtime artifacts from previous stage
+COPY --from=runtime-builder /root/.m2/repository/io/kelta /root/.m2/repository/io/kelta
+
+# Copy POM first for dependency layer caching
+COPY kelta-mcp/pom.xml .
+
+# Download dependencies (cached unless pom.xml changes)
+RUN mvn dependency:go-offline -B || true
+
+# Copy source and build
+COPY kelta-mcp/src ./src
+RUN mvn clean package -DskipTests -B && \
+    mv target/kelta-mcp-*.jar target/kelta-mcp.jar
+
+# =============================================================================
+# Stage 3: Runtime image
+# =============================================================================
+FROM eclipse-temurin:25-jre
+
+WORKDIR /app
+
+RUN groupadd -r kelta && useradd -r -g kelta kelta
+
+COPY --from=builder /build/target/kelta-mcp.jar app.jar
+
+RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/* && \
+    curl -fL -o opentelemetry-javaagent.jar \
+    https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v2.25.0/opentelemetry-javaagent.jar && \
+    test -s opentelemetry-javaagent.jar
+
+RUN chown -R kelta:kelta /app
+
+USER kelta
+
+EXPOSE 8080
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=60s --retries=3 \
+  CMD curl -f http://localhost:8080/actuator/health || exit 1
+
+ENV JAVA_OPTS="-XX:+UseContainerSupport -XX:+UseCompactObjectHeaders -XX:MaxRAMPercentage=75.0 -XX:+UseG1GC -javaagent:/app/opentelemetry-javaagent.jar"
+
+ENTRYPOINT ["sh", "-c", "java $JAVA_OPTS -jar app.jar"]

--- a/kelta-mcp/pom.xml
+++ b/kelta-mcp/pom.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>4.0.5</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>io.kelta</groupId>
+    <artifactId>kelta-mcp</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>Kelta MCP Server</name>
+    <description>Model Context Protocol server exposing the Kelta platform to MCP clients (e.g., Claude Code)</description>
+
+    <properties>
+        <java.version>25</java.version>
+        <maven.compiler.source>${java.version}</maven.compiler.source>
+        <maven.compiler.target>${java.version}</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <mcp-sdk.version>1.1.2</mcp-sdk.version>
+        <wiremock.version>3.10.0</wiremock.version>
+    </properties>
+
+    <dependencies>
+        <!-- Kelta Runtime Core (CollectionDefinition, FieldDefinition, FieldType) -->
+        <dependency>
+            <groupId>io.kelta</groupId>
+            <artifactId>runtime-core</artifactId>
+            <version>1.0.0-SNAPSHOT</version>
+        </dependency>
+
+        <!-- Spring Boot Starters -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webflux</artifactId>
+        </dependency>
+
+        <!-- Official MCP Java SDK (core + Jackson 3 + Servlet transport) -->
+        <dependency>
+            <groupId>io.modelcontextprotocol.sdk</groupId>
+            <artifactId>mcp</artifactId>
+            <version>${mcp-sdk.version}</version>
+        </dependency>
+
+        <!-- Structured JSON logging -->
+        <dependency>
+            <groupId>net.logstash.logback</groupId>
+            <artifactId>logstash-logback-encoder</artifactId>
+            <version>8.0</version>
+        </dependency>
+
+        <!-- OpenTelemetry auto-configuration with OTLP exporters -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-opentelemetry</artifactId>
+        </dependency>
+
+        <!-- Jackson 3 -->
+        <dependency>
+            <groupId>tools.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <!-- Testing -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock-standalone</artifactId>
+            <version>${wiremock.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.14.0</version>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                    <parameters>true</parameters>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/kelta-mcp/src/main/java/io/kelta/mcp/McpApplication.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/McpApplication.java
@@ -1,0 +1,27 @@
+package io.kelta.mcp;
+
+import io.kelta.crypto.EncryptionAutoConfiguration;
+import io.kelta.runtime.config.KeltaRuntimeAutoConfiguration;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+
+/**
+ * kelta-mcp is a stateless protocol adapter — it has no database, no Flyway,
+ * and no JPA. We use {@code runtime-core} for type definitions only
+ * ({@code CollectionDefinition}, {@code FieldDefinition}, {@code FieldType}),
+ * not for its Spring beans. Component scan is restricted to {@code io.kelta.mcp},
+ * and runtime-core's auto-configurations are excluded so we don't drag in a
+ * JdbcTemplate-backed schema migration engine, an encryption setup that needs
+ * platform secrets, or a Tomcat customizer meant for the data-plane.
+ */
+@SpringBootApplication(
+        scanBasePackages = "io.kelta.mcp",
+        exclude = {KeltaRuntimeAutoConfiguration.class, EncryptionAutoConfiguration.class}
+)
+@ConfigurationPropertiesScan
+public class McpApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(McpApplication.class, args);
+    }
+}

--- a/kelta-mcp/src/main/java/io/kelta/mcp/auth/McpAuthFilter.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/auth/McpAuthFilter.java
@@ -1,0 +1,118 @@
+package io.kelta.mcp.auth;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.Ordered;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+/**
+ * Servlet filter for MCP HTTP endpoints.
+ *
+ * <p>Enforces presence of {@code Authorization: Bearer klt_*}. Strips
+ * any client-supplied tenant headers so a client cannot impersonate
+ * another tenant — tenant is resolved by the gateway from the PAT.
+ *
+ * <p>This filter does NOT cryptographically validate the token. The
+ * gateway does that on the first forwarded API call. We only require
+ * the header to be present and prefix-correct so we never set up an
+ * MCP session for a fully unauthenticated client.
+ */
+@Component
+public class McpAuthFilter extends OncePerRequestFilter implements Ordered {
+
+    private static final Logger log = LoggerFactory.getLogger(McpAuthFilter.class);
+
+    private static final String AUTHORIZATION = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
+    private static final String PAT_PREFIX = "klt_";
+    private static final String MCP_PATH_PREFIX = "/mcp/";
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        return !request.getRequestURI().startsWith(MCP_PATH_PREFIX);
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain chain) throws ServletException, IOException {
+        String header = request.getHeader(AUTHORIZATION);
+        if (header == null || !header.startsWith(BEARER_PREFIX)) {
+            unauthorized(response, "missing_bearer", "Missing Authorization: Bearer header");
+            return;
+        }
+        String token = header.substring(BEARER_PREFIX.length());
+        if (!token.startsWith(PAT_PREFIX)) {
+            unauthorized(response, "invalid_token_prefix", "Token must be a Kelta PAT (klt_*)");
+            return;
+        }
+
+        chain.doFilter(new SanitizedRequest(request), response);
+    }
+
+    private static void unauthorized(HttpServletResponse response, String code, String message)
+            throws IOException {
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setHeader("WWW-Authenticate", "Bearer realm=\"kelta-mcp\", error=\"" + code + "\"");
+        response.getWriter().write("{\"error\":\"" + code + "\",\"message\":\"" + message + "\"}");
+    }
+
+    @Override
+    public int getOrder() {
+        return Ordered.HIGHEST_PRECEDENCE + 10;
+    }
+
+    /**
+     * Wrapper that hides client-supplied tenant headers — the tenant is
+     * always resolved by the gateway from the PAT. Without this, a
+     * malicious client could try {@code X-Tenant-ID: <other-tenant>}
+     * to escape its own tenant.
+     */
+    private static final class SanitizedRequest extends jakarta.servlet.http.HttpServletRequestWrapper {
+        private static final java.util.Set<String> STRIPPED = java.util.Set.of(
+                "x-tenant-id", "x-tenant-slug", "x-user-id");
+
+        SanitizedRequest(HttpServletRequest req) {
+            super(req);
+        }
+
+        @Override
+        public String getHeader(String name) {
+            if (name != null && STRIPPED.contains(name.toLowerCase(java.util.Locale.ROOT))) {
+                return null;
+            }
+            return super.getHeader(name);
+        }
+
+        @Override
+        public java.util.Enumeration<String> getHeaders(String name) {
+            if (name != null && STRIPPED.contains(name.toLowerCase(java.util.Locale.ROOT))) {
+                return java.util.Collections.emptyEnumeration();
+            }
+            return super.getHeaders(name);
+        }
+
+        @Override
+        public java.util.Enumeration<String> getHeaderNames() {
+            java.util.List<String> names = new java.util.ArrayList<>();
+            java.util.Enumeration<String> e = super.getHeaderNames();
+            while (e.hasMoreElements()) {
+                String n = e.nextElement();
+                if (!STRIPPED.contains(n.toLowerCase(java.util.Locale.ROOT))) {
+                    names.add(n);
+                }
+            }
+            return java.util.Collections.enumeration(names);
+        }
+    }
+}

--- a/kelta-mcp/src/main/java/io/kelta/mcp/auth/PatSessionStore.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/auth/PatSessionStore.java
@@ -1,0 +1,68 @@
+package io.kelta.mcp.auth;
+
+import io.kelta.mcp.config.McpProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * In-memory store of MCP session id -> Personal Access Token.
+ *
+ * <p>The PAT is captured when an MCP session is initialized (the HTTP request
+ * that opens the session carries {@code Authorization: Bearer klt_*}) and is
+ * then needed on every tool call to forward to the gateway. SSE frames carrying
+ * subsequent tool calls do not necessarily re-include the header, so we cache
+ * by session id.
+ *
+ * <p>Tokens are never persisted, never logged. Sessions evict on close,
+ * idle timeout, or pod shutdown.
+ */
+@Component
+public class PatSessionStore {
+
+    private static final Logger log = LoggerFactory.getLogger(PatSessionStore.class);
+
+    private record Entry(String pat, Instant lastSeen) {}
+
+    private final Map<String, Entry> sessions = new ConcurrentHashMap<>();
+    private final Duration idleTtl;
+
+    public PatSessionStore(McpProperties properties) {
+        this.idleTtl = Duration.ofMinutes(properties.sessionTtlMinutes());
+    }
+
+    public void put(String sessionId, String pat) {
+        sessions.put(sessionId, new Entry(pat, Instant.now()));
+    }
+
+    public String touchAndGet(String sessionId) {
+        Entry e = sessions.computeIfPresent(sessionId,
+                (k, v) -> new Entry(v.pat(), Instant.now()));
+        return e == null ? null : e.pat();
+    }
+
+    public void remove(String sessionId) {
+        sessions.remove(sessionId);
+    }
+
+    public int size() {
+        return sessions.size();
+    }
+
+    @Scheduled(fixedDelayString = "PT1M")
+    void evictIdle() {
+        Instant cutoff = Instant.now().minus(idleTtl);
+        int before = sessions.size();
+        sessions.entrySet().removeIf(e -> e.getValue().lastSeen().isBefore(cutoff));
+        int evicted = before - sessions.size();
+        if (evicted > 0) {
+            log.info("Evicted {} idle MCP sessions", evicted);
+        }
+    }
+}

--- a/kelta-mcp/src/main/java/io/kelta/mcp/config/McpProperties.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/config/McpProperties.java
@@ -1,0 +1,22 @@
+package io.kelta.mcp.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "kelta.mcp")
+public record McpProperties(
+        String gatewayUrl,
+        int sessionTtlMinutes,
+        int toolTimeoutMs
+) {
+    public McpProperties {
+        if (gatewayUrl == null || gatewayUrl.isBlank()) {
+            gatewayUrl = "http://emf-gateway:80";
+        }
+        if (sessionTtlMinutes <= 0) {
+            sessionTtlMinutes = 30;
+        }
+        if (toolTimeoutMs <= 0) {
+            toolTimeoutMs = 60_000;
+        }
+    }
+}

--- a/kelta-mcp/src/main/java/io/kelta/mcp/config/McpServerConfig.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/config/McpServerConfig.java
@@ -1,0 +1,114 @@
+package io.kelta.mcp.config;
+
+import io.modelcontextprotocol.server.McpServer;
+import io.modelcontextprotocol.server.McpServerFeatures;
+import io.modelcontextprotocol.server.McpSyncServer;
+import io.modelcontextprotocol.server.transport.HttpServletStreamableServerTransportProvider;
+import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.ServerCapabilities;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import io.modelcontextprotocol.spec.McpSchema.Tool;
+import org.springframework.boot.web.servlet.ServletRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Wires two independent MCP server instances inside a single Spring Boot
+ * process — one mounted at {@code /mcp/user} for data-plane work, one at
+ * {@code /mcp/admin} for control-plane work.
+ *
+ * <p>Each endpoint has its own transport provider, its own tool registry,
+ * and its own resource registry. Tools registered on one server are NOT
+ * visible from the other — this is the structural guarantee that prevents
+ * an admin tool from being callable through the user endpoint.
+ */
+@Configuration
+@EnableScheduling
+public class McpServerConfig {
+
+    private static final String SERVER_NAME = "kelta-mcp";
+    private static final String SERVER_VERSION = "1.0.0";
+
+    @Bean(name = "userTransportProvider")
+    public HttpServletStreamableServerTransportProvider userTransportProvider() {
+        return HttpServletStreamableServerTransportProvider.builder()
+                .mcpEndpoint("/mcp/user")
+                .build();
+    }
+
+    @Bean(name = "adminTransportProvider")
+    public HttpServletStreamableServerTransportProvider adminTransportProvider() {
+        return HttpServletStreamableServerTransportProvider.builder()
+                .mcpEndpoint("/mcp/admin")
+                .build();
+    }
+
+    @Bean(name = "userMcpServer")
+    public McpSyncServer userMcpServer(
+            @org.springframework.beans.factory.annotation.Qualifier("userTransportProvider")
+            HttpServletStreamableServerTransportProvider transport) {
+        McpSyncServer server = McpServer.sync(transport)
+                .serverInfo(SERVER_NAME + "-user", SERVER_VERSION)
+                .capabilities(ServerCapabilities.builder().tools(true).build())
+                .build();
+        server.addTool(pingTool("user"));
+        return server;
+    }
+
+    @Bean(name = "adminMcpServer")
+    public McpSyncServer adminMcpServer(
+            @org.springframework.beans.factory.annotation.Qualifier("adminTransportProvider")
+            HttpServletStreamableServerTransportProvider transport) {
+        McpSyncServer server = McpServer.sync(transport)
+                .serverInfo(SERVER_NAME + "-admin", SERVER_VERSION)
+                .capabilities(ServerCapabilities.builder().tools(true).build())
+                .build();
+        server.addTool(pingTool("admin"));
+        return server;
+    }
+
+    @Bean
+    public ServletRegistrationBean<HttpServletStreamableServerTransportProvider> userMcpServlet(
+            @org.springframework.beans.factory.annotation.Qualifier("userTransportProvider")
+            HttpServletStreamableServerTransportProvider transport) {
+        ServletRegistrationBean<HttpServletStreamableServerTransportProvider> reg =
+                new ServletRegistrationBean<>(transport, "/mcp/user", "/mcp/user/*");
+        reg.setName("mcpUserServlet");
+        reg.setLoadOnStartup(1);
+        return reg;
+    }
+
+    @Bean
+    public ServletRegistrationBean<HttpServletStreamableServerTransportProvider> adminMcpServlet(
+            @org.springframework.beans.factory.annotation.Qualifier("adminTransportProvider")
+            HttpServletStreamableServerTransportProvider transport) {
+        ServletRegistrationBean<HttpServletStreamableServerTransportProvider> reg =
+                new ServletRegistrationBean<>(transport, "/mcp/admin", "/mcp/admin/*");
+        reg.setName("mcpAdminServlet");
+        reg.setLoadOnStartup(1);
+        return reg;
+    }
+
+    private McpServerFeatures.SyncToolSpecification pingTool(String profile) {
+        McpSchema.JsonSchema emptyObject = new McpSchema.JsonSchema(
+                "object", Map.of(), List.of(), false, null, null);
+
+        Tool tool = Tool.builder()
+                .name("ping")
+                .description("Returns 'pong'. Smoke test that the " + profile + " MCP endpoint is reachable.")
+                .inputSchema(emptyObject)
+                .build();
+
+        return McpServerFeatures.SyncToolSpecification.builder()
+                .tool(tool)
+                .callHandler((exchange, request) -> CallToolResult.builder()
+                        .content(List.of(new TextContent("pong (" + profile + ")")))
+                        .build())
+                .build();
+    }
+}

--- a/kelta-mcp/src/main/java/io/kelta/mcp/config/WebConfig.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/config/WebConfig.java
@@ -1,0 +1,14 @@
+package io.kelta.mcp.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebConfig {
+
+    @Bean
+    public WebClient.Builder webClientBuilder() {
+        return WebClient.builder();
+    }
+}

--- a/kelta-mcp/src/main/resources/application.yml
+++ b/kelta-mcp/src/main/resources/application.yml
@@ -1,0 +1,47 @@
+server:
+  port: ${SERVER_PORT:8080}
+  shutdown: graceful
+
+spring:
+  threads:
+    virtual:
+      enabled: true
+  application:
+    name: kelta-mcp
+  lifecycle:
+    timeout-per-shutdown-phase: 30s
+
+kelta:
+  mcp:
+    gateway-url: ${GATEWAY_URL:http://emf-gateway:80}
+    session-ttl-minutes: ${MCP_SESSION_TTL_MINUTES:30}
+    tool-timeout-ms: ${MCP_TOOL_TIMEOUT_MS:60000}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,metrics
+  endpoint:
+    health:
+      show-details: always
+      probes:
+        enabled: true
+    metrics:
+      enabled: true
+  health:
+    readinessState:
+      enabled: true
+    livenessState:
+      enabled: true
+  otlp:
+    metrics:
+      export:
+        url: ${MANAGEMENT_OTLP_METRICS_EXPORT_URL:http://localhost:4318/v1/metrics}
+  tracing:
+    export:
+      enabled: true
+    sampling:
+      probability: ${OTEL_TRACES_SAMPLER_ARG:1.0}
+    propagation:
+      type: w3c

--- a/kelta-mcp/src/main/resources/logback-spring.xml
+++ b/kelta-mcp/src/main/resources/logback-spring.xml
@@ -1,0 +1,25 @@
+<configuration>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <includeMdcKeyName>traceId</includeMdcKeyName>
+            <includeMdcKeyName>spanId</includeMdcKeyName>
+            <includeMdcKeyName>tenantId</includeMdcKeyName>
+            <includeMdcKeyName>tenantSlug</includeMdcKeyName>
+            <includeMdcKeyName>userId</includeMdcKeyName>
+            <includeMdcKeyName>userEmail</includeMdcKeyName>
+            <includeMdcKeyName>correlationId</includeMdcKeyName>
+            <includeMdcKeyName>mcpSessionId</includeMdcKeyName>
+            <includeMdcKeyName>mcpProfile</includeMdcKeyName>
+            <includeMdcKeyName>mcpTool</includeMdcKeyName>
+            <customFields>{"service":"kelta-mcp"}</customFields>
+            <fieldNames>
+                <timestamp>@timestamp</timestamp>
+                <version>[ignore]</version>
+            </fieldNames>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+</configuration>

--- a/kelta-mcp/src/test/java/io/kelta/mcp/McpApplicationTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/McpApplicationTest.java
@@ -1,0 +1,55 @@
+package io.kelta.mcp;
+
+import io.modelcontextprotocol.server.McpSyncServer;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.servlet.ServletRegistrationBean;
+import org.springframework.test.context.TestPropertySource;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Smoke test: the application context starts and both MCP server instances
+ * are wired with their respective servlet registrations.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestPropertySource(properties = {
+        "kelta.mcp.gateway-url=http://localhost:9999",
+        "kelta.mcp.session-ttl-minutes=5",
+        "kelta.mcp.tool-timeout-ms=10000"
+})
+class McpApplicationTest {
+
+    @Autowired
+    @Qualifier("userMcpServer")
+    private McpSyncServer userServer;
+
+    @Autowired
+    @Qualifier("adminMcpServer")
+    private McpSyncServer adminServer;
+
+    @Autowired
+    private Map<String, ServletRegistrationBean<?>> servletRegistrations;
+
+    @Test
+    void bothMcpServersAreWired() {
+        assertThat(userServer).isNotNull();
+        assertThat(adminServer).isNotNull();
+        assertThat(userServer).isNotSameAs(adminServer);
+    }
+
+    @Test
+    void bothServletsAreRegisteredWithDistinctMappings() {
+        ServletRegistrationBean<?> userServlet = servletRegistrations.get("userMcpServlet");
+        ServletRegistrationBean<?> adminServlet = servletRegistrations.get("adminMcpServlet");
+
+        assertThat(userServlet).isNotNull();
+        assertThat(adminServlet).isNotNull();
+        assertThat(userServlet.getUrlMappings()).contains("/mcp/user", "/mcp/user/*");
+        assertThat(adminServlet.getUrlMappings()).contains("/mcp/admin", "/mcp/admin/*");
+    }
+}

--- a/kelta-mcp/src/test/java/io/kelta/mcp/auth/McpAuthFilterTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/auth/McpAuthFilterTest.java
@@ -1,0 +1,119 @@
+package io.kelta.mcp.auth;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentCaptor.forClass;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+class McpAuthFilterTest {
+
+    private final McpAuthFilter filter = new McpAuthFilter();
+
+    @Test
+    void rejectsRequestWithoutAuthorizationHeader() throws Exception {
+        MockHttpServletRequest req = new MockHttpServletRequest("POST", "/mcp/user");
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        FilterChain chain = mock(FilterChain.class);
+
+        filter.doFilter(req, res, chain);
+
+        assertThat(res.getStatus()).isEqualTo(401);
+        assertThat(res.getHeader("WWW-Authenticate")).contains("missing_bearer");
+        verify(chain, never()).doFilter(req, res);
+    }
+
+    @Test
+    void rejectsBearerTokenWithoutKltPrefix() throws Exception {
+        MockHttpServletRequest req = new MockHttpServletRequest("POST", "/mcp/user");
+        req.addHeader("Authorization", "Bearer eyJhbGciOiJIUzI1NiJ9.something.signature");
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        FilterChain chain = mock(FilterChain.class);
+
+        filter.doFilter(req, res, chain);
+
+        assertThat(res.getStatus()).isEqualTo(401);
+        assertThat(res.getHeader("WWW-Authenticate")).contains("invalid_token_prefix");
+        verify(chain, never()).doFilter(req, res);
+    }
+
+    @Test
+    void rejectsAuthorizationWithoutBearerScheme() throws Exception {
+        MockHttpServletRequest req = new MockHttpServletRequest("POST", "/mcp/admin");
+        req.addHeader("Authorization", "Basic dXNlcjpwYXNz");
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        FilterChain chain = mock(FilterChain.class);
+
+        filter.doFilter(req, res, chain);
+
+        assertThat(res.getStatus()).isEqualTo(401);
+        verify(chain, never()).doFilter(req, res);
+    }
+
+    @Test
+    void allowsValidKltBearerToken() throws Exception {
+        MockHttpServletRequest req = new MockHttpServletRequest("POST", "/mcp/user");
+        req.addHeader("Authorization", "Bearer klt_abc123def456");
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        FilterChain chain = mock(FilterChain.class);
+
+        filter.doFilter(req, res, chain);
+
+        assertThat(res.getStatus()).isEqualTo(200);
+        verify(chain, times(1)).doFilter(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.eq(res));
+    }
+
+    @Test
+    void skipsFilterForNonMcpPaths() throws Exception {
+        MockHttpServletRequest req = new MockHttpServletRequest("GET", "/actuator/health");
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        FilterChain chain = mock(FilterChain.class);
+
+        filter.doFilter(req, res, chain);
+
+        verify(chain, times(1)).doFilter(req, res);
+    }
+
+    @Test
+    void stripsClientSuppliedTenantHeaders() throws Exception {
+        MockHttpServletRequest req = new MockHttpServletRequest("POST", "/mcp/user");
+        req.addHeader("Authorization", "Bearer klt_abc");
+        req.addHeader("X-Tenant-ID", "00000000-0000-0000-0000-000000000999");
+        req.addHeader("X-Tenant-Slug", "evil-tenant");
+        req.addHeader("X-User-Id", "attacker@example.com");
+        req.addHeader("X-Trace-Id", "preserved");
+        MockHttpServletResponse res = new MockHttpServletResponse();
+
+        ArgumentCaptorChain chain = new ArgumentCaptorChain();
+
+        filter.doFilter(req, res, chain);
+
+        HttpServletRequest forwarded = chain.captured;
+        assertThat(forwarded).isNotNull();
+        assertThat(forwarded.getHeader("X-Tenant-ID")).isNull();
+        assertThat(forwarded.getHeader("X-Tenant-Slug")).isNull();
+        assertThat(forwarded.getHeader("X-User-Id")).isNull();
+        assertThat(forwarded.getHeader("Authorization")).isEqualTo("Bearer klt_abc");
+        assertThat(forwarded.getHeader("X-Trace-Id")).isEqualTo("preserved");
+        assertThat(Collections.list(forwarded.getHeaderNames()))
+                .doesNotContain("X-Tenant-ID", "X-Tenant-Slug", "X-User-Id");
+    }
+
+    private static final class ArgumentCaptorChain implements FilterChain {
+        HttpServletRequest captured;
+
+        @Override
+        public void doFilter(jakarta.servlet.ServletRequest request, jakarta.servlet.ServletResponse response) {
+            this.captured = (HttpServletRequest) request;
+        }
+    }
+}

--- a/kelta-mcp/src/test/java/io/kelta/mcp/auth/PatSessionStoreTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/auth/PatSessionStoreTest.java
@@ -1,0 +1,30 @@
+package io.kelta.mcp.auth;
+
+import io.kelta.mcp.config.McpProperties;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PatSessionStoreTest {
+
+    private final PatSessionStore store = new PatSessionStore(new McpProperties("http://gw", 30, 60_000));
+
+    @Test
+    void putsAndRetrievesPat() {
+        store.put("session-1", "klt_abc");
+        assertThat(store.touchAndGet("session-1")).isEqualTo("klt_abc");
+    }
+
+    @Test
+    void touchAndGetReturnsNullForUnknownSession() {
+        assertThat(store.touchAndGet("unknown")).isNull();
+    }
+
+    @Test
+    void removeDropsTheEntry() {
+        store.put("s2", "klt_xyz");
+        store.remove("s2");
+        assertThat(store.touchAndGet("s2")).isNull();
+        assertThat(store.size()).isZero();
+    }
+}


### PR DESCRIPTION
## Summary
- New stateless `kelta-mcp` Spring Boot service that exposes the Kelta platform to MCP clients (e.g. Claude Code) over HTTP. Two MCP server instances run in one process: `/mcp/user` (data-plane) and `/mcp/admin` (control-plane), each with its own immutable tool registry so admin tools are not reachable from the user endpoint and vice versa.
- Auth via Personal Access Tokens (`klt_*`). `McpAuthFilter` enforces presence/prefix at session-init and strips client-supplied `X-Tenant-ID` / `X-Tenant-Slug` / `X-User-Id` headers to prevent tenant spoofing. Cryptographic PAT validation happens at the gateway on each forwarded call.
- Phase 1 of the rollout: transport, auth, ping tool per profile. Subsequent phases add `GatewayHttpClient` and the actual tools (CRUD, flows, approvals, schema admin, layout admin, etc.).
- No DB. `runtime-core`'s auto-configurations are excluded so kelta-mcp doesn't drag in the JdbcTemplate-backed schema migration engine — runtime-core is kept only for type definitions.
- CI workflow updated: paths filter, matrix entry, test step, and a sed line in the deploy job so the homelab manifest gets auto-bumped to `:main-<sha>` on each main build.
- Companion homelab-argo PR: cklinker/homelab-argo `feature/emf-mcp-server` adds the k8s manifests and the `/mcp` IngressRoute rule.

Plan + risks live at `~/.claude/plans/i-would-like-to-kind-rivest.md` (local).

## Test plan
- [x] `mvn package -f kelta-mcp/pom.xml` builds clean (11 tests passing locally)
- [ ] CI build succeeds and pushes `harbor.rzware.com/emf/emf-mcp:latest` + `:main-<sha>`
- [ ] On merge, the deploy job sed-updates `homelab-argo/emf/mcp-deployment.yaml` to `:main-<sha>` automatically (assumes the homelab PR has merged first so the file exists on `main`)
- [ ] After ArgoCD picks it up: \`claude mcp add kelta-user --transport http --url https://emf.rzware.com/mcp/user --header "Authorization: Bearer klt_<pat>"\` then \`ping\` returns \`pong (user)\`
- [ ] Same with \`/mcp/admin\` returning \`pong (admin)\`
- [ ] Negative: \`curl -i https://emf.rzware.com/mcp/user\` (no auth) returns 401 with \`WWW-Authenticate: Bearer realm="kelta-mcp", error="missing_bearer"\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)