### PR TITLE
fix(mcp): Dockerfile build + Phase 2 read-only user tools

### DIFF
--- a/kelta-mcp/Dockerfile
+++ b/kelta-mcp/Dockerfile
@@ -2,6 +2,11 @@
 
 # =============================================================================
 # Stage 1: Build runtime-platform dependencies
+#
+# kelta-mcp only needs runtime-core at runtime, but runtime-core has compile
+# dependencies on runtime-events and runtime-jsonapi (e.g. JsonApiError,
+# AtomicResult), so all three must be built. We mirror kelta-ai's module
+# list for cache-key compatibility — Maven's -am handles the dep graph.
 # =============================================================================
 FROM maven:3.9-eclipse-temurin-25 AS runtime-builder
 
@@ -20,15 +25,16 @@ COPY kelta-platform/runtime/runtime-module-schema/pom.xml ./runtime/runtime-modu
 
 # Download runtime dependencies (cached unless pom.xml changes)
 RUN mvn dependency:go-offline -B \
-    -pl runtime/runtime-core \
+    -pl runtime/runtime-core,runtime/runtime-events,runtime/runtime-jsonapi \
     -am || true
 
-# Copy source and build only what kelta-mcp needs (runtime-core)
+# Copy source for runtime-core and its compile-time prerequisites
 COPY kelta-platform/runtime/runtime-core/src ./runtime/runtime-core/src
 COPY kelta-platform/runtime/runtime-events/src ./runtime/runtime-events/src
+COPY kelta-platform/runtime/runtime-jsonapi/src ./runtime/runtime-jsonapi/src
 
 RUN mvn clean install -DskipTests -B \
-    -pl runtime/runtime-core \
+    -pl runtime/runtime-core,runtime/runtime-events,runtime/runtime-jsonapi \
     -am
 
 # =============================================================================

--- a/kelta-mcp/pom.xml
+++ b/kelta-mcp/pom.xml
@@ -45,10 +45,6 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-webflux</artifactId>
-        </dependency>
 
         <!-- Official MCP Java SDK (core + Jackson 3 + Servlet transport) -->
         <dependency>

--- a/kelta-mcp/src/main/java/io/kelta/mcp/auth/McpAuthFilter.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/auth/McpAuthFilter.java
@@ -56,7 +56,12 @@ public class McpAuthFilter extends OncePerRequestFilter implements Ordered {
             return;
         }
 
-        chain.doFilter(new SanitizedRequest(request), response);
+        RequestPatHolder.set(token);
+        try {
+            chain.doFilter(new SanitizedRequest(request), response);
+        } finally {
+            RequestPatHolder.clear();
+        }
     }
 
     private static void unauthorized(HttpServletResponse response, String code, String message)

--- a/kelta-mcp/src/main/java/io/kelta/mcp/auth/RequestPatHolder.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/auth/RequestPatHolder.java
@@ -1,0 +1,32 @@
+package io.kelta.mcp.auth;
+
+/**
+ * Thread-local holder for the per-request Personal Access Token.
+ *
+ * <p>Set by {@link McpAuthFilter} on each /mcp/** request from the
+ * Authorization header, cleared in a {@code finally} block. Read by
+ * the gateway HTTP client when forwarding tool calls.
+ *
+ * <p>The MCP server runs in synchronous mode so the tool handler executes
+ * on the same thread that processed the inbound HTTP request — the PAT
+ * captured at filter time is the right PAT for any outbound calls made
+ * during that handler.
+ */
+public final class RequestPatHolder {
+
+    private static final ThreadLocal<String> CURRENT = new ThreadLocal<>();
+
+    private RequestPatHolder() {}
+
+    public static void set(String pat) {
+        CURRENT.set(pat);
+    }
+
+    public static String get() {
+        return CURRENT.get();
+    }
+
+    public static void clear() {
+        CURRENT.remove();
+    }
+}

--- a/kelta-mcp/src/main/java/io/kelta/mcp/client/GatewayHttpClient.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/client/GatewayHttpClient.java
@@ -1,0 +1,99 @@
+package io.kelta.mcp.client;
+
+import io.kelta.mcp.auth.RequestPatHolder;
+import io.kelta.mcp.config.McpProperties;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.JdkClientHttpRequestFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.util.Map;
+
+/**
+ * Synchronous HTTP client that forwards MCP tool calls through the
+ * Kelta gateway. The gateway validates the PAT, resolves the tenant,
+ * and applies Cerbos authorization — kelta-mcp does none of that.
+ *
+ * <p>The PAT is pulled from {@link RequestPatHolder} (set by the
+ * auth filter on the inbound HTTP request); we never store it in
+ * config and never log it.
+ */
+@Component
+public class GatewayHttpClient {
+
+    private final RestClient client;
+
+    public GatewayHttpClient(RestClient.Builder builder, McpProperties properties) {
+        // Pin HTTP/1.1 — the in-cluster gateway hop doesn't benefit from HTTP/2,
+        // and the JDK HttpClient's default h2c upgrade negotiation occasionally
+        // trips intermediaries (and WireMock in tests).
+        HttpClient http = HttpClient.newBuilder()
+                .version(HttpClient.Version.HTTP_1_1)
+                .build();
+        this.client = builder
+                .baseUrl(properties.gatewayUrl())
+                .requestFactory(new JdkClientHttpRequestFactory(http))
+                .build();
+    }
+
+    public Response get(String pathAndQuery) {
+        return exchange("GET", pathAndQuery, null);
+    }
+
+    public Response post(String pathAndQuery, Object body) {
+        return exchange("POST", pathAndQuery, body);
+    }
+
+    public Response patch(String pathAndQuery, Object body) {
+        return exchange("PATCH", pathAndQuery, body);
+    }
+
+    public Response delete(String pathAndQuery) {
+        return exchange("DELETE", pathAndQuery, null);
+    }
+
+    private Response exchange(String method, String pathAndQuery, Object body) {
+        String pat = RequestPatHolder.get();
+        if (pat == null) {
+            throw new IllegalStateException("No PAT in request context — auth filter must run before tool dispatch");
+        }
+        URI uri = URI.create(pathAndQuery);
+        RestClient.RequestBodySpec spec = client.method(HttpMethod.valueOf(method))
+                .uri(uri)
+                .header("Authorization", "Bearer " + pat)
+                .accept(MediaType.APPLICATION_JSON);
+
+        RestClient.RequestHeadersSpec<?> sendSpec = (body == null)
+                ? spec
+                : spec.contentType(MediaType.APPLICATION_JSON).body(body);
+
+        return sendSpec.exchange(
+                (req, res) -> new Response(res.getStatusCode(), res.bodyTo(String.class)),
+                true);
+    }
+
+    /**
+     * Raw HTTP response from the gateway. Body is the response payload as
+     * a string (JSON for normal API responses, anything for errors).
+     */
+    public record Response(HttpStatusCode status, String body) {
+        public boolean isSuccess() {
+            return status != null && status.is2xxSuccessful();
+        }
+
+        public Map<String, Object> jsonAsMap(tools.jackson.databind.ObjectMapper om) {
+            if (body == null || body.isBlank()) return Map.of();
+            try {
+                @SuppressWarnings("unchecked")
+                Map<String, Object> m = om.readValue(body, Map.class);
+                return m;
+            } catch (RuntimeException e) {
+                return Map.of("raw", body);
+            }
+        }
+    }
+}

--- a/kelta-mcp/src/main/java/io/kelta/mcp/config/McpProperties.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/config/McpProperties.java
@@ -6,7 +6,8 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public record McpProperties(
         String gatewayUrl,
         int sessionTtlMinutes,
-        int toolTimeoutMs
+        int toolTimeoutMs,
+        RateLimit rateLimit
 ) {
     public McpProperties {
         if (gatewayUrl == null || gatewayUrl.isBlank()) {
@@ -17,6 +18,22 @@ public record McpProperties(
         }
         if (toolTimeoutMs <= 0) {
             toolTimeoutMs = 60_000;
+        }
+        if (rateLimit == null) {
+            rateLimit = new RateLimit(60, 30.0);
+        }
+    }
+
+    /**
+     * Per-PAT token bucket.
+     *
+     * @param bucketCapacity   max tokens (defines burst tolerance)
+     * @param refillPerSecond  steady-state refill rate (tokens / second)
+     */
+    public record RateLimit(int bucketCapacity, double refillPerSecond) {
+        public RateLimit {
+            if (bucketCapacity <= 0) bucketCapacity = 60;
+            if (refillPerSecond <= 0) refillPerSecond = 30.0;
         }
     }
 }

--- a/kelta-mcp/src/main/java/io/kelta/mcp/config/McpServerConfig.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/config/McpServerConfig.java
@@ -1,6 +1,7 @@
 package io.kelta.mcp.config;
 
 import io.kelta.mcp.observe.ObservedToolDecorator;
+import io.kelta.mcp.observe.RateLimitedToolDecorator;
 import io.kelta.mcp.resource.UserResource;
 import io.kelta.mcp.resource.UserResourceTemplate;
 import io.kelta.mcp.tool.AdminTool;
@@ -62,7 +63,8 @@ public class McpServerConfig {
             List<UserTool> userTools,
             List<UserResource> userResources,
             List<UserResourceTemplate> userResourceTemplates,
-            ObservedToolDecorator decorator) {
+            ObservedToolDecorator decorator,
+            RateLimitedToolDecorator rateLimiter) {
         McpSyncServer server = McpServer.sync(transport)
                 .serverInfo(SERVER_NAME + "-user", SERVER_VERSION)
                 .capabilities(ServerCapabilities.builder()
@@ -70,9 +72,9 @@ public class McpServerConfig {
                         .resources(false, true)  // (subscribe, listChanged)
                         .build())
                 .build();
-        server.addTool(decorator.decorate(pingTool("user"), "user"));
+        server.addTool(wrap(pingTool("user"), "user", decorator, rateLimiter));
         for (UserTool tool : userTools) {
-            McpServerFeatures.SyncToolSpecification spec = decorator.decorate(tool.toSpecification(), "user");
+            McpServerFeatures.SyncToolSpecification spec = wrap(tool.toSpecification(), "user", decorator, rateLimiter);
             server.addTool(spec);
             log.info("Registered user tool: {}", spec.tool().name());
         }
@@ -94,18 +96,32 @@ public class McpServerConfig {
             @org.springframework.beans.factory.annotation.Qualifier("adminTransportProvider")
             HttpServletStreamableServerTransportProvider transport,
             List<AdminTool> adminTools,
-            ObservedToolDecorator decorator) {
+            ObservedToolDecorator decorator,
+            RateLimitedToolDecorator rateLimiter) {
         McpSyncServer server = McpServer.sync(transport)
                 .serverInfo(SERVER_NAME + "-admin", SERVER_VERSION)
                 .capabilities(ServerCapabilities.builder().tools(true).build())
                 .build();
-        server.addTool(decorator.decorate(pingTool("admin"), "admin"));
+        server.addTool(wrap(pingTool("admin"), "admin", decorator, rateLimiter));
         for (AdminTool tool : adminTools) {
-            McpServerFeatures.SyncToolSpecification spec = decorator.decorate(tool.toSpecification(), "admin");
+            McpServerFeatures.SyncToolSpecification spec = wrap(tool.toSpecification(), "admin", decorator, rateLimiter);
             server.addTool(spec);
             log.info("Registered admin tool: {}", spec.tool().name());
         }
         return server;
+    }
+
+    /**
+     * Decorator stack: rate limiter wraps observation, observation wraps the
+     * original tool. Rate-limited calls are rejected before the timer/counter
+     * fires — they show up in mcp.tool.rate_limited only.
+     */
+    private static McpServerFeatures.SyncToolSpecification wrap(
+            McpServerFeatures.SyncToolSpecification original,
+            String profile,
+            ObservedToolDecorator observed,
+            RateLimitedToolDecorator rateLimited) {
+        return rateLimited.decorate(observed.decorate(original, profile), profile);
     }
 
     @Bean

--- a/kelta-mcp/src/main/java/io/kelta/mcp/config/McpServerConfig.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/config/McpServerConfig.java
@@ -1,5 +1,7 @@
 package io.kelta.mcp.config;
 
+import io.kelta.mcp.resource.UserResource;
+import io.kelta.mcp.resource.UserResourceTemplate;
 import io.kelta.mcp.tool.Schemas;
 import io.kelta.mcp.tool.UserTool;
 import io.modelcontextprotocol.server.McpServer;
@@ -55,16 +57,31 @@ public class McpServerConfig {
     public McpSyncServer userMcpServer(
             @org.springframework.beans.factory.annotation.Qualifier("userTransportProvider")
             HttpServletStreamableServerTransportProvider transport,
-            List<UserTool> userTools) {
+            List<UserTool> userTools,
+            List<UserResource> userResources,
+            List<UserResourceTemplate> userResourceTemplates) {
         McpSyncServer server = McpServer.sync(transport)
                 .serverInfo(SERVER_NAME + "-user", SERVER_VERSION)
-                .capabilities(ServerCapabilities.builder().tools(true).build())
+                .capabilities(ServerCapabilities.builder()
+                        .tools(true)
+                        .resources(false, true)  // (subscribe, listChanged)
+                        .build())
                 .build();
         server.addTool(pingTool("user"));
         for (UserTool tool : userTools) {
             McpServerFeatures.SyncToolSpecification spec = tool.toSpecification();
             server.addTool(spec);
             log.info("Registered user tool: {}", spec.tool().name());
+        }
+        for (UserResource resource : userResources) {
+            McpServerFeatures.SyncResourceSpecification spec = resource.toSpecification();
+            server.addResource(spec);
+            log.info("Registered user resource: {}", spec.resource().uri());
+        }
+        for (UserResourceTemplate template : userResourceTemplates) {
+            McpServerFeatures.SyncResourceTemplateSpecification spec = template.toSpecification();
+            server.addResourceTemplate(spec);
+            log.info("Registered user resource template: {}", spec.resourceTemplate().uriTemplate());
         }
         return server;
     }

--- a/kelta-mcp/src/main/java/io/kelta/mcp/config/McpServerConfig.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/config/McpServerConfig.java
@@ -3,6 +3,7 @@ package io.kelta.mcp.config;
 import io.kelta.mcp.observe.ObservedToolDecorator;
 import io.kelta.mcp.resource.UserResource;
 import io.kelta.mcp.resource.UserResourceTemplate;
+import io.kelta.mcp.tool.AdminTool;
 import io.kelta.mcp.tool.Schemas;
 import io.kelta.mcp.tool.UserTool;
 import io.modelcontextprotocol.server.McpServer;
@@ -91,12 +92,19 @@ public class McpServerConfig {
     @Bean(name = "adminMcpServer")
     public McpSyncServer adminMcpServer(
             @org.springframework.beans.factory.annotation.Qualifier("adminTransportProvider")
-            HttpServletStreamableServerTransportProvider transport) {
+            HttpServletStreamableServerTransportProvider transport,
+            List<AdminTool> adminTools,
+            ObservedToolDecorator decorator) {
         McpSyncServer server = McpServer.sync(transport)
                 .serverInfo(SERVER_NAME + "-admin", SERVER_VERSION)
                 .capabilities(ServerCapabilities.builder().tools(true).build())
                 .build();
-        server.addTool(pingTool("admin"));
+        server.addTool(decorator.decorate(pingTool("admin"), "admin"));
+        for (AdminTool tool : adminTools) {
+            McpServerFeatures.SyncToolSpecification spec = decorator.decorate(tool.toSpecification(), "admin");
+            server.addTool(spec);
+            log.info("Registered admin tool: {}", spec.tool().name());
+        }
         return server;
     }
 

--- a/kelta-mcp/src/main/java/io/kelta/mcp/config/McpServerConfig.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/config/McpServerConfig.java
@@ -1,5 +1,6 @@
 package io.kelta.mcp.config;
 
+import io.kelta.mcp.observe.ObservedToolDecorator;
 import io.kelta.mcp.resource.UserResource;
 import io.kelta.mcp.resource.UserResourceTemplate;
 import io.kelta.mcp.tool.Schemas;
@@ -59,7 +60,8 @@ public class McpServerConfig {
             HttpServletStreamableServerTransportProvider transport,
             List<UserTool> userTools,
             List<UserResource> userResources,
-            List<UserResourceTemplate> userResourceTemplates) {
+            List<UserResourceTemplate> userResourceTemplates,
+            ObservedToolDecorator decorator) {
         McpSyncServer server = McpServer.sync(transport)
                 .serverInfo(SERVER_NAME + "-user", SERVER_VERSION)
                 .capabilities(ServerCapabilities.builder()
@@ -67,9 +69,9 @@ public class McpServerConfig {
                         .resources(false, true)  // (subscribe, listChanged)
                         .build())
                 .build();
-        server.addTool(pingTool("user"));
+        server.addTool(decorator.decorate(pingTool("user"), "user"));
         for (UserTool tool : userTools) {
-            McpServerFeatures.SyncToolSpecification spec = tool.toSpecification();
+            McpServerFeatures.SyncToolSpecification spec = decorator.decorate(tool.toSpecification(), "user");
             server.addTool(spec);
             log.info("Registered user tool: {}", spec.tool().name());
         }

--- a/kelta-mcp/src/main/java/io/kelta/mcp/config/McpServerConfig.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/config/McpServerConfig.java
@@ -1,21 +1,23 @@
 package io.kelta.mcp.config;
 
+import io.kelta.mcp.tool.Schemas;
+import io.kelta.mcp.tool.UserTool;
 import io.modelcontextprotocol.server.McpServer;
 import io.modelcontextprotocol.server.McpServerFeatures;
 import io.modelcontextprotocol.server.McpSyncServer;
 import io.modelcontextprotocol.server.transport.HttpServletStreamableServerTransportProvider;
-import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.ServerCapabilities;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.web.servlet.ServletRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 import java.util.List;
-import java.util.Map;
 
 /**
  * Wires two independent MCP server instances inside a single Spring Boot
@@ -31,6 +33,7 @@ import java.util.Map;
 @EnableScheduling
 public class McpServerConfig {
 
+    private static final Logger log = LoggerFactory.getLogger(McpServerConfig.class);
     private static final String SERVER_NAME = "kelta-mcp";
     private static final String SERVER_VERSION = "1.0.0";
 
@@ -51,12 +54,18 @@ public class McpServerConfig {
     @Bean(name = "userMcpServer")
     public McpSyncServer userMcpServer(
             @org.springframework.beans.factory.annotation.Qualifier("userTransportProvider")
-            HttpServletStreamableServerTransportProvider transport) {
+            HttpServletStreamableServerTransportProvider transport,
+            List<UserTool> userTools) {
         McpSyncServer server = McpServer.sync(transport)
                 .serverInfo(SERVER_NAME + "-user", SERVER_VERSION)
                 .capabilities(ServerCapabilities.builder().tools(true).build())
                 .build();
         server.addTool(pingTool("user"));
+        for (UserTool tool : userTools) {
+            McpServerFeatures.SyncToolSpecification spec = tool.toSpecification();
+            server.addTool(spec);
+            log.info("Registered user tool: {}", spec.tool().name());
+        }
         return server;
     }
 
@@ -95,13 +104,10 @@ public class McpServerConfig {
     }
 
     private McpServerFeatures.SyncToolSpecification pingTool(String profile) {
-        McpSchema.JsonSchema emptyObject = new McpSchema.JsonSchema(
-                "object", Map.of(), List.of(), false, null, null);
-
         Tool tool = Tool.builder()
                 .name("ping")
                 .description("Returns 'pong'. Smoke test that the " + profile + " MCP endpoint is reachable.")
-                .inputSchema(emptyObject)
+                .inputSchema(Schemas.empty())
                 .build();
 
         return McpServerFeatures.SyncToolSpecification.builder()

--- a/kelta-mcp/src/main/java/io/kelta/mcp/config/WebConfig.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/config/WebConfig.java
@@ -2,13 +2,13 @@ package io.kelta.mcp.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.client.RestClient;
 
 @Configuration
 public class WebConfig {
 
     @Bean
-    public WebClient.Builder webClientBuilder() {
-        return WebClient.builder();
+    public RestClient.Builder restClientBuilder() {
+        return RestClient.builder();
     }
 }

--- a/kelta-mcp/src/main/java/io/kelta/mcp/error/McpErrorMapper.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/error/McpErrorMapper.java
@@ -1,0 +1,57 @@
+package io.kelta.mcp.error;
+
+import io.kelta.mcp.client.GatewayHttpClient;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+
+import java.util.List;
+import java.util.regex.Pattern;
+
+/**
+ * Translates gateway HTTP responses into MCP {@link CallToolResult}s.
+ *
+ * <p>Normal 2xx responses become regular tool results carrying the body
+ * verbatim as text. 4xx/5xx responses become {@code isError: true} tool
+ * results with a short, human-readable message.
+ *
+ * <p>Token redaction: the gateway should never echo a PAT back, but we
+ * defensively scrub any {@code klt_…} substring before emitting MCP
+ * content. This is a belt-and-suspenders measure — if a regression in
+ * the gateway ever exposes the token in an error message, it will not
+ * leak through us.
+ */
+public final class McpErrorMapper {
+
+    private static final Pattern PAT_PATTERN = Pattern.compile("klt_[A-Za-z0-9]+");
+
+    private McpErrorMapper() {}
+
+    public static CallToolResult toResult(GatewayHttpClient.Response response) {
+        String body = redact(response.body());
+        if (response.isSuccess()) {
+            return CallToolResult.builder()
+                    .content(List.of(new TextContent(body == null ? "" : body)))
+                    .build();
+        }
+        int statusCode = response.status() == null ? 0 : response.status().value();
+        String message = "Gateway returned HTTP " + statusCode
+                + (body == null || body.isBlank() ? "" : " — " + body);
+        return CallToolResult.builder()
+                .isError(true)
+                .content(List.of(new TextContent(message)))
+                .build();
+    }
+
+    public static CallToolResult fromException(Throwable t) {
+        String message = redact(t.getClass().getSimpleName() + ": " + t.getMessage());
+        return CallToolResult.builder()
+                .isError(true)
+                .content(List.of(new TextContent("Tool call failed — " + message)))
+                .build();
+    }
+
+    static String redact(String input) {
+        if (input == null) return null;
+        return PAT_PATTERN.matcher(input).replaceAll("klt_***REDACTED***");
+    }
+}

--- a/kelta-mcp/src/main/java/io/kelta/mcp/observe/ObservedToolDecorator.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/observe/ObservedToolDecorator.java
@@ -1,0 +1,73 @@
+package io.kelta.mcp.observe;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.Timer;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+/**
+ * Wraps a {@link SyncToolSpecification} so every tool call emits a
+ * {@code mcp_tool_call_duration_seconds} histogram and a
+ * {@code mcp_tool_calls_total} counter — both tagged with
+ * {@code tool}, {@code profile}, and {@code status}
+ * ({@code success | error | exception}).
+ *
+ * <p>Also pushes {@code mcpTool} and {@code mcpProfile} into MDC for
+ * the duration of the call so structured logs and any spans the OTel
+ * agent emits during the call carry the same identifier.
+ */
+@Component
+public class ObservedToolDecorator {
+
+    private static final String DURATION_METRIC = "mcp.tool.call.duration";
+    private static final String COUNTER_METRIC = "mcp.tool.calls";
+
+    private final MeterRegistry registry;
+
+    public ObservedToolDecorator(MeterRegistry registry) {
+        this.registry = registry;
+    }
+
+    public SyncToolSpecification decorate(SyncToolSpecification original, String profile) {
+        String toolName = original.tool().name();
+        var originalHandler = original.callHandler();
+
+        return SyncToolSpecification.builder()
+                .tool(original.tool())
+                .callHandler((exchange, request) -> {
+                    long startNs = System.nanoTime();
+                    String status = "success";
+                    MDC.put("mcpTool", toolName);
+                    MDC.put("mcpProfile", profile);
+                    try {
+                        CallToolResult result = originalHandler.apply(exchange, request);
+                        if (Boolean.TRUE.equals(result.isError())) {
+                            status = "error";
+                        }
+                        return result;
+                    } catch (RuntimeException e) {
+                        status = "exception";
+                        throw e;
+                    } finally {
+                        Tags tags = Tags.of(
+                                "tool", toolName,
+                                "profile", profile,
+                                "status", status);
+                        Timer.builder(DURATION_METRIC)
+                                .tags(tags)
+                                .publishPercentileHistogram()
+                                .register(registry)
+                                .record(Duration.ofNanos(System.nanoTime() - startNs));
+                        registry.counter(COUNTER_METRIC, tags).increment();
+                        MDC.remove("mcpTool");
+                        MDC.remove("mcpProfile");
+                    }
+                })
+                .build();
+    }
+}

--- a/kelta-mcp/src/main/java/io/kelta/mcp/observe/PatRedactionFilter.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/observe/PatRedactionFilter.java
@@ -1,0 +1,41 @@
+package io.kelta.mcp.observe;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.filter.Filter;
+import ch.qos.logback.core.spi.FilterReply;
+
+import java.util.regex.Pattern;
+
+/**
+ * Defense-in-depth Logback filter that drops any log event whose
+ * formatted message contains a {@code klt_*} substring.
+ *
+ * <p>The application code already redacts PATs in error responses
+ * (see {@link io.kelta.mcp.error.McpErrorMapper#redact}) and never
+ * logs the token directly. This filter is a backstop: if any
+ * regression slips through and a log line ever contains a PAT, the
+ * filter denies the event so it never reaches the JSON appender.
+ *
+ * <p>Wired up in {@code logback-spring.xml} as a top-level filter on
+ * the CONSOLE appender.
+ */
+public final class PatRedactionFilter extends Filter<ILoggingEvent> {
+
+    private static final Pattern PAT_PATTERN = Pattern.compile("klt_[A-Za-z0-9]+");
+
+    @Override
+    public FilterReply decide(ILoggingEvent event) {
+        if (event == null) return FilterReply.NEUTRAL;
+        String message = event.getFormattedMessage();
+        if (message != null && PAT_PATTERN.matcher(message).find()) {
+            return FilterReply.DENY;
+        }
+        if (event.getThrowableProxy() != null) {
+            String tm = event.getThrowableProxy().getMessage();
+            if (tm != null && PAT_PATTERN.matcher(tm).find()) {
+                return FilterReply.DENY;
+            }
+        }
+        return FilterReply.NEUTRAL;
+    }
+}

--- a/kelta-mcp/src/main/java/io/kelta/mcp/observe/RateLimitedToolDecorator.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/observe/RateLimitedToolDecorator.java
@@ -1,0 +1,63 @@
+package io.kelta.mcp.observe;
+
+import io.kelta.mcp.auth.RequestPatHolder;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * Outer decorator that gates each tool call through the per-PAT
+ * token bucket. Rate-limited calls return an MCP error result without
+ * invoking the wrapped handler — so they don't show up in the regular
+ * mcp.tool.calls counter or the duration histogram, only in a
+ * dedicated mcp.tool.rate_limited counter.
+ *
+ * <p>This sits OUTSIDE the {@link ObservedToolDecorator} in the
+ * registration chain: rate-limited calls are not "tool executions",
+ * just rejected requests.
+ */
+@Component
+public class RateLimitedToolDecorator {
+
+    private static final String RATE_LIMITED_COUNTER = "mcp.tool.rate_limited";
+
+    private final RateLimiter limiter;
+    private final MeterRegistry registry;
+
+    public RateLimitedToolDecorator(RateLimiter limiter, MeterRegistry registry) {
+        this.limiter = limiter;
+        this.registry = registry;
+    }
+
+    public SyncToolSpecification decorate(SyncToolSpecification original, String profile) {
+        String toolName = original.tool().name();
+        var inner = original.callHandler();
+
+        return SyncToolSpecification.builder()
+                .tool(original.tool())
+                .callHandler((exchange, request) -> {
+                    String pat = RequestPatHolder.get();
+                    String bucketKey = pat == null ? "anonymous" : pat;
+                    if (!limiter.tryAcquire(bucketKey)) {
+                        Counter.builder(RATE_LIMITED_COUNTER)
+                                .tag("tool", toolName)
+                                .tag("profile", profile)
+                                .register(registry)
+                                .increment();
+                        return CallToolResult.builder()
+                                .isError(true)
+                                .content(List.of(new TextContent(
+                                        "Rate limit exceeded for tool \"" + toolName + "\". "
+                                        + "Slow down and retry shortly.")))
+                                .build();
+                    }
+                    return inner.apply(exchange, request);
+                })
+                .build();
+    }
+}

--- a/kelta-mcp/src/main/java/io/kelta/mcp/observe/RateLimiter.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/observe/RateLimiter.java
@@ -1,0 +1,71 @@
+package io.kelta.mcp.observe;
+
+import io.kelta.mcp.config.McpProperties;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * In-memory token-bucket rate limiter, keyed by PAT.
+ *
+ * <p>Each user (identified by their PAT — never logged) gets a bucket
+ * with {@code bucketCapacity} tokens that refills at
+ * {@code refillPerSecond}. Each tool call consumes one token; if the
+ * bucket is empty the call is rejected with a rate-limit error result.
+ *
+ * <p>Buckets are created lazily on first use. They are not evicted —
+ * a single bucket is ~64 bytes, and the worst-case footprint is one
+ * per active PAT, which is bounded by user count.
+ */
+@Component
+public class RateLimiter {
+
+    private final int capacity;
+    private final double refillPerSecond;
+    private final ConcurrentMap<String, Bucket> buckets = new ConcurrentHashMap<>();
+
+    public RateLimiter(McpProperties properties) {
+        this.capacity = properties.rateLimit().bucketCapacity();
+        this.refillPerSecond = properties.rateLimit().refillPerSecond();
+    }
+
+    /**
+     * Try to consume one token from the bucket for {@code key}.
+     * @return true if a token was consumed; false if the bucket was empty.
+     */
+    public boolean tryAcquire(String key) {
+        Bucket b = buckets.computeIfAbsent(key, k -> new Bucket(capacity, refillPerSecond));
+        return b.tryAcquire();
+    }
+
+    public int activeBucketCount() {
+        return buckets.size();
+    }
+
+    private static final class Bucket {
+        private final int capacity;
+        private final double refillPerSecond;
+        private double tokens;
+        private long lastRefillNanos;
+
+        Bucket(int capacity, double refillPerSecond) {
+            this.capacity = capacity;
+            this.refillPerSecond = refillPerSecond;
+            this.tokens = capacity;
+            this.lastRefillNanos = System.nanoTime();
+        }
+
+        synchronized boolean tryAcquire() {
+            long now = System.nanoTime();
+            double elapsedSeconds = (now - lastRefillNanos) / 1_000_000_000.0;
+            tokens = Math.min(capacity, tokens + elapsedSeconds * refillPerSecond);
+            lastRefillNanos = now;
+            if (tokens >= 1.0) {
+                tokens -= 1.0;
+                return true;
+            }
+            return false;
+        }
+    }
+}

--- a/kelta-mcp/src/main/java/io/kelta/mcp/observe/SessionStoreMetrics.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/observe/SessionStoreMetrics.java
@@ -1,0 +1,38 @@
+package io.kelta.mcp.observe;
+
+import io.kelta.mcp.auth.PatSessionStore;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import jakarta.annotation.PostConstruct;
+import org.springframework.stereotype.Component;
+
+/**
+ * Registers gauges for in-memory state we want to keep an eye on:
+ * how many MCP sessions are active, and how many distinct rate-limit
+ * buckets exist (a proxy for unique PATs that have made calls).
+ */
+@Component
+public class SessionStoreMetrics {
+
+    private final PatSessionStore sessionStore;
+    private final RateLimiter rateLimiter;
+    private final MeterRegistry registry;
+
+    public SessionStoreMetrics(PatSessionStore sessionStore,
+                               RateLimiter rateLimiter,
+                               MeterRegistry registry) {
+        this.sessionStore = sessionStore;
+        this.rateLimiter = rateLimiter;
+        this.registry = registry;
+    }
+
+    @PostConstruct
+    void register() {
+        Gauge.builder("mcp.sessions.active", sessionStore, PatSessionStore::size)
+                .description("MCP sessions currently held in PatSessionStore")
+                .register(registry);
+        Gauge.builder("mcp.rate_limit.buckets", rateLimiter, RateLimiter::activeBucketCount)
+                .description("Distinct PATs that have a rate-limit bucket")
+                .register(registry);
+    }
+}

--- a/kelta-mcp/src/main/java/io/kelta/mcp/resource/UserResource.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/resource/UserResource.java
@@ -1,0 +1,12 @@
+package io.kelta.mcp.resource;
+
+import io.modelcontextprotocol.server.McpServerFeatures.SyncResourceSpecification;
+
+/**
+ * Marker interface for static resources registered on {@code /mcp/user}.
+ * "Static" here means a fixed URI (not a template). Use
+ * {@link UserResourceTemplate} for URIs with parameters.
+ */
+public interface UserResource {
+    SyncResourceSpecification toSpecification();
+}

--- a/kelta-mcp/src/main/java/io/kelta/mcp/resource/UserResourceTemplate.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/resource/UserResourceTemplate.java
@@ -1,0 +1,11 @@
+package io.kelta.mcp.resource;
+
+import io.modelcontextprotocol.server.McpServerFeatures.SyncResourceTemplateSpecification;
+
+/**
+ * Marker interface for templated resources registered on {@code /mcp/user}.
+ * The URI carries variable segments (e.g. {@code kelta://collections/{name}}).
+ */
+public interface UserResourceTemplate {
+    SyncResourceTemplateSpecification toSpecification();
+}

--- a/kelta-mcp/src/main/java/io/kelta/mcp/resource/user/CollectionSchemaResource.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/resource/user/CollectionSchemaResource.java
@@ -1,0 +1,78 @@
+package io.kelta.mcp.resource.user;
+
+import io.kelta.mcp.client.GatewayHttpClient;
+import io.kelta.mcp.resource.UserResourceTemplate;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncResourceTemplateSpecification;
+import io.modelcontextprotocol.spec.McpSchema.ReadResourceResult;
+import io.modelcontextprotocol.spec.McpSchema.ResourceTemplate;
+import io.modelcontextprotocol.spec.McpSchema.TextResourceContents;
+import org.springframework.stereotype.Component;
+
+import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Templated resource: the full schema (collection metadata + fields) for a
+ * given collection. URI template: {@code kelta://collections/{name}}.
+ */
+@Component
+public class CollectionSchemaResource implements UserResourceTemplate {
+
+    static final String URI_TEMPLATE = "kelta://collections/{name}";
+    private static final Pattern URI_PATTERN = Pattern.compile("^kelta://collections/([^/]+)$");
+
+    private final GatewayHttpClient gateway;
+
+    public CollectionSchemaResource(GatewayHttpClient gateway) {
+        this.gateway = gateway;
+    }
+
+    @Override
+    public SyncResourceTemplateSpecification toSpecification() {
+        ResourceTemplate template = ResourceTemplate.builder()
+                .uriTemplate(URI_TEMPLATE)
+                .name("collection-schema")
+                .description("Full schema for a single collection: metadata plus all field definitions.")
+                .mimeType("application/json")
+                .build();
+
+        return new SyncResourceTemplateSpecification(template, (exchange, request) -> {
+            String requestUri = request.uri();
+            Matcher m = URI_PATTERN.matcher(requestUri);
+            String body;
+            if (!m.matches()) {
+                body = "{\"error\":\"unrecognized URI for collection-schema template: "
+                        + requestUri + "\"}";
+            } else {
+                String name = URLDecode(m.group(1));
+                String encoded = URLEncoder.encode(name, StandardCharsets.UTF_8);
+                GatewayHttpClient.Response collectionRes = gateway.get("/api/collections/" + encoded);
+                if (!collectionRes.isSuccess()) {
+                    body = "{\"error\":\"gateway returned " + collectionRes.status()
+                            + " for collection " + name + "\"}";
+                } else {
+                    GatewayHttpClient.Response fieldsRes = gateway.get(
+                            "/api/fields?filter[collectionName][EQ]=" + encoded + "&page[size]=200");
+                    body = "{\n  \"collection\": " + collectionRes.body()
+                            + ",\n  \"fields\": "
+                            + (fieldsRes.isSuccess() ? fieldsRes.body() : "null")
+                            + "\n}";
+                }
+            }
+            return new ReadResourceResult(List.of(
+                    new TextResourceContents(requestUri, "application/json", body)));
+        });
+    }
+
+    private static String URLDecode(String s) {
+        try {
+            return URI.create("dummy:" + s).getSchemeSpecificPart();
+        } catch (RuntimeException e) {
+            return s;
+        }
+    }
+}

--- a/kelta-mcp/src/main/java/io/kelta/mcp/resource/user/CollectionsResource.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/resource/user/CollectionsResource.java
@@ -1,0 +1,46 @@
+package io.kelta.mcp.resource.user;
+
+import io.kelta.mcp.client.GatewayHttpClient;
+import io.kelta.mcp.resource.UserResource;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncResourceSpecification;
+import io.modelcontextprotocol.spec.McpSchema.ReadResourceResult;
+import io.modelcontextprotocol.spec.McpSchema.Resource;
+import io.modelcontextprotocol.spec.McpSchema.TextResourceContents;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * Static resource: a JSON list of all collections in the current tenant.
+ * URI: {@code kelta://collections}.
+ */
+@Component
+public class CollectionsResource implements UserResource {
+
+    static final String URI = "kelta://collections";
+
+    private final GatewayHttpClient gateway;
+
+    public CollectionsResource(GatewayHttpClient gateway) {
+        this.gateway = gateway;
+    }
+
+    @Override
+    public SyncResourceSpecification toSpecification() {
+        Resource resource = Resource.builder()
+                .uri(URI)
+                .name("collections")
+                .description("Browseable list of all collections in the current tenant. JSON:API list format.")
+                .mimeType("application/json")
+                .build();
+
+        return new SyncResourceSpecification(resource, (exchange, request) -> {
+            GatewayHttpClient.Response response = gateway.get("/api/collections");
+            String body = response.isSuccess()
+                    ? response.body()
+                    : "{\"error\":\"gateway returned " + response.status() + "\"}";
+            return new ReadResourceResult(List.of(
+                    new TextResourceContents(URI, "application/json", body)));
+        });
+    }
+}

--- a/kelta-mcp/src/main/java/io/kelta/mcp/resource/user/OpenApiSpecResource.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/resource/user/OpenApiSpecResource.java
@@ -1,0 +1,50 @@
+package io.kelta.mcp.resource.user;
+
+import io.kelta.mcp.client.GatewayHttpClient;
+import io.kelta.mcp.resource.UserResource;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncResourceSpecification;
+import io.modelcontextprotocol.spec.McpSchema.ReadResourceResult;
+import io.modelcontextprotocol.spec.McpSchema.Resource;
+import io.modelcontextprotocol.spec.McpSchema.TextResourceContents;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * Static resource: the auto-generated OpenAPI 3.0 spec for the current
+ * tenant. URI: {@code kelta://openapi.json}.
+ *
+ * <p>Note: the spec only covers JSON:API CRUD on collections. Specialized
+ * controllers (flows, approvals, bulk) are not in it; use the dedicated
+ * tools for those.
+ */
+@Component
+public class OpenApiSpecResource implements UserResource {
+
+    static final String URI = "kelta://openapi.json";
+
+    private final GatewayHttpClient gateway;
+
+    public OpenApiSpecResource(GatewayHttpClient gateway) {
+        this.gateway = gateway;
+    }
+
+    @Override
+    public SyncResourceSpecification toSpecification() {
+        Resource resource = Resource.builder()
+                .uri(URI)
+                .name("openapi-spec")
+                .description("Auto-generated OpenAPI 3.0 spec for this tenant. Covers JSON:API CRUD on every collection.")
+                .mimeType("application/json")
+                .build();
+
+        return new SyncResourceSpecification(resource, (exchange, request) -> {
+            GatewayHttpClient.Response response = gateway.get("/api/docs/openapi.json");
+            String body = response.isSuccess()
+                    ? response.body()
+                    : "{\"error\":\"gateway returned " + response.status() + "\"}";
+            return new ReadResourceResult(List.of(
+                    new TextResourceContents(URI, "application/json", body)));
+        });
+    }
+}

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/AdminTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/AdminTool.java
@@ -1,0 +1,21 @@
+package io.kelta.mcp.tool;
+
+import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+
+/**
+ * Marker interface for tools registered on the {@code /mcp/admin}
+ * endpoint (control-plane: define collections/fields/layouts/flows).
+ *
+ * <p>Read-only browse tools may implement BOTH {@link UserTool} and
+ * {@link AdminTool} so they appear on both endpoints —
+ * {@code list_collections} and {@code get_collection_schema} are the
+ * canonical examples. Mutation tools live in only one list.
+ *
+ * <p>Spring autowires {@code List<AdminTool>} and the bean
+ * registration code on each server walks its own list — there is no
+ * way for a write-side user tool to leak into the admin surface (or
+ * vice versa) by accident.
+ */
+public interface AdminTool {
+    SyncToolSpecification toSpecification();
+}

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/Schemas.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/Schemas.java
@@ -1,0 +1,64 @@
+package io.kelta.mcp.tool;
+
+import io.modelcontextprotocol.spec.McpSchema;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Tiny helpers for building {@link io.modelcontextprotocol.spec.McpSchema.JsonSchema}
+ * input descriptors. The MCP SDK's {@code JsonSchema} record takes positional
+ * args; these helpers keep tool authors away from null-laden constructors and
+ * give consistent shapes.
+ */
+public final class Schemas {
+
+    private Schemas() {}
+
+    /** Empty no-args schema. */
+    public static McpSchema.JsonSchema empty() {
+        return new McpSchema.JsonSchema("object", Map.of(), List.of(), false, null, null);
+    }
+
+    /** Object schema with the given properties and required field names. */
+    public static McpSchema.JsonSchema object(Map<String, Object> properties, List<String> required) {
+        return new McpSchema.JsonSchema("object", properties, required, false, null, null);
+    }
+
+    /** Convenience for a string property descriptor. */
+    public static Map<String, Object> string(String description) {
+        Map<String, Object> m = new LinkedHashMap<>();
+        m.put("type", "string");
+        m.put("description", description);
+        return m;
+    }
+
+    /** Convenience for an integer property descriptor with optional bounds. */
+    public static Map<String, Object> integer(String description, Integer min, Integer max) {
+        Map<String, Object> m = new LinkedHashMap<>();
+        m.put("type", "integer");
+        m.put("description", description);
+        if (min != null) m.put("minimum", min);
+        if (max != null) m.put("maximum", max);
+        return m;
+    }
+
+    /** Convenience for a boolean property descriptor with default. */
+    public static Map<String, Object> bool(String description, boolean defaultValue) {
+        Map<String, Object> m = new LinkedHashMap<>();
+        m.put("type", "boolean");
+        m.put("description", description);
+        m.put("default", defaultValue);
+        return m;
+    }
+
+    /** Convenience for a free-form object property (e.g. filter / params). */
+    public static Map<String, Object> freeObject(String description) {
+        Map<String, Object> m = new LinkedHashMap<>();
+        m.put("type", "object");
+        m.put("description", description);
+        m.put("additionalProperties", true);
+        return m;
+    }
+}

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/UserTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/UserTool.java
@@ -1,0 +1,16 @@
+package io.kelta.mcp.tool;
+
+import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+
+/**
+ * Marker interface for tools registered on the {@code /mcp/user}
+ * endpoint. Each user tool exposes a single MCP tool specification.
+ *
+ * <p>Admin-side tools implement a separate {@code AdminTool}
+ * interface so the two registries are structurally distinct —
+ * a Spring autowire of {@code List<UserTool>} cannot accidentally
+ * pick up an admin tool.
+ */
+public interface UserTool {
+    SyncToolSpecification toSpecification();
+}

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/AddFieldTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/AddFieldTool.java
@@ -1,0 +1,91 @@
+package io.kelta.mcp.tool.admin;
+
+import io.kelta.mcp.client.GatewayHttpClient;
+import io.kelta.mcp.error.McpErrorMapper;
+import io.kelta.mcp.tool.AdminTool;
+import io.kelta.mcp.tool.Schemas;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import io.modelcontextprotocol.spec.McpSchema.Tool;
+import org.springframework.stereotype.Component;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class AddFieldTool implements AdminTool {
+
+    private final GatewayHttpClient gateway;
+
+    public AddFieldTool(GatewayHttpClient gateway) {
+        this.gateway = gateway;
+    }
+
+    @Override
+    public SyncToolSpecification toSpecification() {
+        Map<String, Object> properties = new LinkedHashMap<>();
+        properties.put("collectionName", Schemas.string("Collection the field belongs to."));
+        properties.put("fieldName", Schemas.string("Field name (camelCase recommended)."));
+        properties.put("type", Schemas.string(
+                "Field type: text, longText, number, integer, decimal, boolean, date, datetime, reference, picklist, multiPicklist, json, file, image."));
+        properties.put("required", Schemas.bool("Whether the field is required (default false).", false));
+        properties.put("unique", Schemas.bool("Whether values must be unique (default false).", false));
+        properties.put("description", Schemas.string("Optional description shown in the admin UI."));
+        properties.put("defaultValue", Schemas.string("Optional default value as a string. Numeric/boolean values are still passed as strings here."));
+        properties.put("validation", Schemas.freeObject(
+                "Optional validation config (regex, min/max, etc.) — shape depends on the field type."));
+        properties.put("referenceCollection", Schemas.string(
+                "For type=reference, the target collection name."));
+
+        Tool tool = Tool.builder()
+                .name("add_field")
+                .description("Add a field to an existing collection. Wraps POST /api/fields with a JSON:API body.")
+                .inputSchema(Schemas.object(properties, List.of("collectionName", "fieldName", "type")))
+                .build();
+
+        return SyncToolSpecification.builder()
+                .tool(tool)
+                .callHandler((exchange, request) -> {
+                    Map<String, Object> args = request.arguments();
+                    if (args == null) args = Map.of();
+                    Object cn = args.get("collectionName");
+                    Object fn = args.get("fieldName");
+                    Object t = args.get("type");
+                    if (cn == null || cn.toString().isBlank()
+                            || fn == null || fn.toString().isBlank()
+                            || t == null || t.toString().isBlank()) {
+                        return error("Arguments \"collectionName\", \"fieldName\", and \"type\" are required.");
+                    }
+
+                    Map<String, Object> attrs = new LinkedHashMap<>();
+                    attrs.put("collectionName", cn.toString());
+                    attrs.put("fieldName", fn.toString());
+                    attrs.put("type", t.toString());
+                    if (args.get("required") instanceof Boolean b) attrs.put("required", b);
+                    if (args.get("unique") instanceof Boolean b) attrs.put("unique", b);
+                    if (args.get("description") instanceof String s && !s.isBlank()) attrs.put("description", s);
+                    if (args.get("defaultValue") instanceof String s) attrs.put("defaultValue", s);
+                    if (args.get("validation") instanceof Map<?, ?> v) attrs.put("validation", v);
+                    if (args.get("referenceCollection") instanceof String s && !s.isBlank()) attrs.put("referenceCollection", s);
+
+                    Map<String, Object> body = Map.of("data", Map.of(
+                            "type", "fields",
+                            "attributes", attrs));
+                    try {
+                        return McpErrorMapper.toResult(gateway.post("/api/fields", body));
+                    } catch (RuntimeException e) {
+                        return McpErrorMapper.fromException(e);
+                    }
+                })
+                .build();
+    }
+
+    private static CallToolResult error(String message) {
+        return CallToolResult.builder()
+                .isError(true)
+                .content(List.of(new TextContent(message)))
+                .build();
+    }
+}

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/CreateCollectionTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/CreateCollectionTool.java
@@ -1,0 +1,154 @@
+package io.kelta.mcp.tool.admin;
+
+import io.kelta.mcp.client.GatewayHttpClient;
+import io.kelta.mcp.error.McpErrorMapper;
+import io.kelta.mcp.tool.AdminTool;
+import io.kelta.mcp.tool.Schemas;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import io.modelcontextprotocol.spec.McpSchema.Tool;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Composite admin tool: create a collection and (optionally) its initial
+ * fields in a single Claude tool call.
+ *
+ * <p>Wraps two underlying endpoints:
+ * <ol>
+ *   <li>POST /api/collections — create the collection metadata</li>
+ *   <li>POST /api/fields (per field) — create each requested field</li>
+ * </ol>
+ *
+ * <p>If field creation fails partway through, the collection is left
+ * in place — there's no atomic transaction across system collections,
+ * but the response surfaces which fields succeeded and which didn't,
+ * so a follow-up update_field/add_field call can recover.
+ */
+@Component
+public class CreateCollectionTool implements AdminTool {
+
+    private final GatewayHttpClient gateway;
+
+    public CreateCollectionTool(GatewayHttpClient gateway) {
+        this.gateway = gateway;
+    }
+
+    @Override
+    public SyncToolSpecification toSpecification() {
+        Map<String, Object> fieldItem = new LinkedHashMap<>();
+        fieldItem.put("type", "object");
+        fieldItem.put("description",
+                "{\"fieldName\":\"...\",\"type\":\"text|number|boolean|date|datetime|reference|picklist|...\","
+                + "\"required\":bool,\"unique\":bool,\"description\":\"...\"}");
+        fieldItem.put("additionalProperties", true);
+
+        Map<String, Object> fieldsArray = new LinkedHashMap<>();
+        fieldsArray.put("type", "array");
+        fieldsArray.put("description", "Optional initial field set. Each entry will be POSTed to /api/fields after the collection is created.");
+        fieldsArray.put("items", fieldItem);
+
+        Map<String, Object> properties = new LinkedHashMap<>();
+        properties.put("name", Schemas.string("Collection name (e.g. \"projects\"). Used as the URL slug — keep it kebab-cased or single-word."));
+        properties.put("displayFieldName", Schemas.string(
+                "Optional name of the field used as the human-readable label for a record (e.g. \"name\")."));
+        properties.put("description", Schemas.string("Optional description shown in the admin UI."));
+        properties.put("tenantScoped", Schemas.bool(
+                "Whether records are tenant-scoped (default true). Only set false for shared system data.", true));
+        properties.put("fields", fieldsArray);
+
+        Tool tool = Tool.builder()
+                .name("create_collection")
+                .description("Create a new collection definition, optionally with an initial set of fields. The collection is created first; each field is then created in order. Returns a summary with the new collection id and per-field success/failure.")
+                .inputSchema(Schemas.object(properties, List.of("name")))
+                .build();
+
+        return SyncToolSpecification.builder()
+                .tool(tool)
+                .callHandler((exchange, request) -> {
+                    Map<String, Object> args = request.arguments();
+                    if (args == null) args = Map.of();
+                    Object n = args.get("name");
+                    if (n == null || n.toString().isBlank()) {
+                        return error("Argument \"name\" is required.");
+                    }
+
+                    Map<String, Object> attrs = new LinkedHashMap<>();
+                    attrs.put("name", n.toString());
+                    if (args.get("displayFieldName") instanceof String s && !s.isBlank()) attrs.put("displayFieldName", s);
+                    if (args.get("description") instanceof String s && !s.isBlank()) attrs.put("description", s);
+                    if (args.get("tenantScoped") instanceof Boolean b) attrs.put("tenantScoped", b);
+
+                    Map<String, Object> body = Map.of("data", Map.of(
+                            "type", "collections",
+                            "attributes", attrs));
+
+                    GatewayHttpClient.Response collectionRes;
+                    try {
+                        collectionRes = gateway.post("/api/collections", body);
+                    } catch (RuntimeException e) {
+                        return McpErrorMapper.fromException(e);
+                    }
+                    if (!collectionRes.isSuccess()) {
+                        return McpErrorMapper.toResult(collectionRes);
+                    }
+
+                    Object fieldsObj = args.get("fields");
+                    if (!(fieldsObj instanceof List<?> fields) || fields.isEmpty()) {
+                        return CallToolResult.builder()
+                                .content(List.of(new TextContent(collectionRes.body())))
+                                .build();
+                    }
+
+                    List<Map<String, Object>> fieldResults = new ArrayList<>();
+                    for (int i = 0; i < fields.size(); i++) {
+                        Object item = fields.get(i);
+                        if (!(item instanceof Map<?, ?> fieldAttrs)) {
+                            fieldResults.add(Map.of("index", i, "error", "field entry must be an object"));
+                            continue;
+                        }
+                        Map<String, Object> fAttrs = new LinkedHashMap<>();
+                        for (Map.Entry<?, ?> e : fieldAttrs.entrySet()) {
+                            fAttrs.put(String.valueOf(e.getKey()), e.getValue());
+                        }
+                        fAttrs.putIfAbsent("collectionName", n.toString());
+
+                        Map<String, Object> fieldBody = Map.of("data", Map.of(
+                                "type", "fields",
+                                "attributes", fAttrs));
+                        GatewayHttpClient.Response fr;
+                        try {
+                            fr = gateway.post("/api/fields", fieldBody);
+                        } catch (RuntimeException e) {
+                            fieldResults.add(Map.of("index", i, "error", e.getClass().getSimpleName()));
+                            continue;
+                        }
+                        fieldResults.add(Map.of(
+                                "index", i,
+                                "fieldName", fAttrs.getOrDefault("fieldName", "?"),
+                                "status", fr.status() == null ? 0 : fr.status().value(),
+                                "body", fr.isSuccess() ? "ok" : fr.body()));
+                    }
+
+                    String summary = "{\n  \"collection\": " + collectionRes.body()
+                            + ",\n  \"fields\": " + fieldResults
+                            + "\n}";
+                    return CallToolResult.builder()
+                            .content(List.of(new TextContent(summary)))
+                            .build();
+                })
+                .build();
+    }
+
+    private static CallToolResult error(String message) {
+        return CallToolResult.builder()
+                .isError(true)
+                .content(List.of(new TextContent(message)))
+                .build();
+    }
+}

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/CreateFlowTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/CreateFlowTool.java
@@ -1,0 +1,83 @@
+package io.kelta.mcp.tool.admin;
+
+import io.kelta.mcp.client.GatewayHttpClient;
+import io.kelta.mcp.error.McpErrorMapper;
+import io.kelta.mcp.tool.AdminTool;
+import io.kelta.mcp.tool.Schemas;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import io.modelcontextprotocol.spec.McpSchema.Tool;
+import org.springframework.stereotype.Component;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class CreateFlowTool implements AdminTool {
+
+    private final GatewayHttpClient gateway;
+
+    public CreateFlowTool(GatewayHttpClient gateway) {
+        this.gateway = gateway;
+    }
+
+    @Override
+    public SyncToolSpecification toSpecification() {
+        Map<String, Object> properties = new LinkedHashMap<>();
+        properties.put("name", Schemas.string("Flow name (unique within tenant)."));
+        properties.put("description", Schemas.string("Optional description."));
+        properties.put("triggerType", Schemas.string(
+                "Trigger type: manual, recordCreated, recordUpdated, scheduled, webhook, etc."));
+        properties.put("triggerConfig", Schemas.freeObject(
+                "Trigger-specific config (e.g. {\"collectionName\":\"orders\"} for recordCreated)."));
+        properties.put("definition", Schemas.freeObject(
+                "Flow JSON definition: nodes, edges, conditions, actions. Shape is flow-engine specific."));
+        properties.put("active", Schemas.bool("Whether the flow is active on creation (default false).", false));
+
+        Tool tool = Tool.builder()
+                .name("create_flow")
+                .description("Create a new automation flow. Wraps POST /api/flows. The definition payload is opaque to this tool — pass the flow-engine JSON directly.")
+                .inputSchema(Schemas.object(properties, List.of("name", "triggerType", "definition")))
+                .build();
+
+        return SyncToolSpecification.builder()
+                .tool(tool)
+                .callHandler((exchange, request) -> {
+                    Map<String, Object> args = request.arguments();
+                    if (args == null) args = Map.of();
+                    Object name = args.get("name");
+                    Object trigger = args.get("triggerType");
+                    Object def = args.get("definition");
+                    if (name == null || name.toString().isBlank()
+                            || trigger == null || trigger.toString().isBlank()
+                            || !(def instanceof Map<?, ?> definition) || definition.isEmpty()) {
+                        return CallToolResult.builder()
+                                .isError(true)
+                                .content(List.of(new TextContent(
+                                        "Arguments \"name\", \"triggerType\", and a non-empty \"definition\" are required.")))
+                                .build();
+                    }
+
+                    Map<String, Object> attrs = new LinkedHashMap<>();
+                    attrs.put("name", name.toString());
+                    attrs.put("triggerType", trigger.toString());
+                    attrs.put("definition", definition);
+                    if (args.get("description") instanceof String s && !s.isBlank()) attrs.put("description", s);
+                    if (args.get("triggerConfig") instanceof Map<?, ?> tc) attrs.put("triggerConfig", tc);
+                    if (args.get("active") instanceof Boolean b) attrs.put("active", b);
+                    else attrs.put("active", false);
+
+                    Map<String, Object> body = Map.of("data", Map.of(
+                            "type", "flows",
+                            "attributes", attrs));
+                    try {
+                        return McpErrorMapper.toResult(gateway.post("/api/flows", body));
+                    } catch (RuntimeException e) {
+                        return McpErrorMapper.fromException(e);
+                    }
+                })
+                .build();
+    }
+}

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/CreateLayoutTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/CreateLayoutTool.java
@@ -1,0 +1,234 @@
+package io.kelta.mcp.tool.admin;
+
+import io.kelta.mcp.client.GatewayHttpClient;
+import io.kelta.mcp.error.McpErrorMapper;
+import io.kelta.mcp.tool.AdminTool;
+import io.kelta.mcp.tool.Schemas;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import io.modelcontextprotocol.spec.McpSchema.Tool;
+import org.springframework.stereotype.Component;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Composite admin tool: build a complete page layout (pageLayout +
+ * sections + per-section fields) in a single Claude tool call.
+ *
+ * <p>Wraps three underlying endpoints:
+ * <ol>
+ *   <li>POST /api/pageLayouts — layout container</li>
+ *   <li>POST /api/layoutSections — one per section, child of the layout</li>
+ *   <li>POST /api/layoutFields — one per field, child of its section</li>
+ * </ol>
+ *
+ * <p>The layout is created first; if it fails, no children are
+ * attempted. If a section fails, its child fields are skipped but
+ * other sections still proceed. The result documents which pieces
+ * succeeded so a follow-up call can recover.
+ */
+@Component
+public class CreateLayoutTool implements AdminTool {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private final GatewayHttpClient gateway;
+
+    public CreateLayoutTool(GatewayHttpClient gateway) {
+        this.gateway = gateway;
+    }
+
+    @Override
+    public SyncToolSpecification toSpecification() {
+        Map<String, Object> sectionFieldItem = new LinkedHashMap<>();
+        sectionFieldItem.put("type", "object");
+        sectionFieldItem.put("description",
+                "{\"fieldName\":\"...\",\"sortOrder\":number,\"width\":\"full|half|third\","
+                + "\"readOnly\":bool,\"required\":bool}");
+        sectionFieldItem.put("additionalProperties", true);
+
+        Map<String, Object> sectionFieldsArr = new LinkedHashMap<>();
+        sectionFieldsArr.put("type", "array");
+        sectionFieldsArr.put("description", "Fields in display order within this section.");
+        sectionFieldsArr.put("items", sectionFieldItem);
+
+        Map<String, Object> sectionItem = new LinkedHashMap<>();
+        sectionItem.put("type", "object");
+        sectionItem.put("description",
+                "{\"sectionName\":\"...\",\"columns\":1|2|3,\"sortOrder\":number,"
+                + "\"fields\":[{...}]}");
+        Map<String, Object> sectionProps = new LinkedHashMap<>();
+        sectionProps.put("sectionName", Schemas.string("Section heading."));
+        sectionProps.put("columns", Schemas.integer("Column count (1-3, default 2).", 1, 3));
+        sectionProps.put("sortOrder", Schemas.integer("Display order (auto-assigned if omitted).", 0, null));
+        sectionProps.put("fields", sectionFieldsArr);
+        sectionItem.put("properties", sectionProps);
+        sectionItem.put("additionalProperties", true);
+
+        Map<String, Object> sectionsArr = new LinkedHashMap<>();
+        sectionsArr.put("type", "array");
+        sectionsArr.put("description", "Sections in display order. Each section contains its own field list.");
+        sectionsArr.put("items", sectionItem);
+
+        Map<String, Object> properties = new LinkedHashMap<>();
+        properties.put("name", Schemas.string("Layout name (unique within collection)."));
+        properties.put("collectionName", Schemas.string("Collection this layout displays."));
+        properties.put("recordTypeName", Schemas.string(
+                "Optional record type the layout applies to (omit for collection-wide)."));
+        properties.put("isDefault", Schemas.bool("Whether this is the default layout for the collection.", false));
+        properties.put("sections", sectionsArr);
+
+        Tool tool = Tool.builder()
+                .name("create_layout")
+                .description("Build a complete page layout in one call: layout + sections + fields per section. The layout is created first; sections and their fields follow. Returns a summary of what was created and any per-piece failures.")
+                .inputSchema(Schemas.object(properties, List.of("name", "collectionName", "sections")))
+                .build();
+
+        return SyncToolSpecification.builder()
+                .tool(tool)
+                .callHandler((exchange, request) -> {
+                    Map<String, Object> args = request.arguments();
+                    if (args == null) args = Map.of();
+                    Object n = args.get("name");
+                    Object cn = args.get("collectionName");
+                    Object s = args.get("sections");
+                    if (n == null || n.toString().isBlank()
+                            || cn == null || cn.toString().isBlank()) {
+                        return error("Arguments \"name\" and \"collectionName\" are required.");
+                    }
+                    if (!(s instanceof List<?> sections)) {
+                        return error("Argument \"sections\" must be an array.");
+                    }
+
+                    Map<String, Object> layoutAttrs = new LinkedHashMap<>();
+                    layoutAttrs.put("name", n.toString());
+                    layoutAttrs.put("collectionName", cn.toString());
+                    if (args.get("recordTypeName") instanceof String r && !r.isBlank()) layoutAttrs.put("recordTypeName", r);
+                    if (args.get("isDefault") instanceof Boolean b) layoutAttrs.put("isDefault", b);
+
+                    Map<String, Object> layoutBody = Map.of("data", Map.of(
+                            "type", "pageLayouts",
+                            "attributes", layoutAttrs));
+
+                    GatewayHttpClient.Response layoutRes;
+                    try {
+                        layoutRes = gateway.post("/api/pageLayouts", layoutBody);
+                    } catch (RuntimeException e) {
+                        return McpErrorMapper.fromException(e);
+                    }
+                    if (!layoutRes.isSuccess()) {
+                        return McpErrorMapper.toResult(layoutRes);
+                    }
+                    String layoutId = extractId(layoutRes.body());
+
+                    List<Map<String, Object>> sectionResults = new ArrayList<>();
+                    for (int i = 0; i < sections.size(); i++) {
+                        Map<String, Object> sectionResult = createSection(layoutId, i, sections.get(i));
+                        sectionResults.add(sectionResult);
+                    }
+
+                    String summary = "{\n  \"layout\": " + layoutRes.body()
+                            + ",\n  \"sections\": " + sectionResults
+                            + "\n}";
+                    return CallToolResult.builder()
+                            .content(List.of(new TextContent(summary)))
+                            .build();
+                })
+                .build();
+    }
+
+    private Map<String, Object> createSection(String layoutId, int index, Object sectionRaw) {
+        if (!(sectionRaw instanceof Map<?, ?> sectionMap)) {
+            return Map.of("index", index, "error", "section entry must be an object");
+        }
+        Map<String, Object> sectionAttrs = new LinkedHashMap<>();
+        for (Map.Entry<?, ?> e : sectionMap.entrySet()) {
+            String key = String.valueOf(e.getKey());
+            if (!"fields".equals(key)) sectionAttrs.put(key, e.getValue());
+        }
+        if (layoutId != null) sectionAttrs.put("pageLayoutId", layoutId);
+        sectionAttrs.putIfAbsent("sortOrder", index);
+
+        Map<String, Object> sectionBody = Map.of("data", Map.of(
+                "type", "layoutSections",
+                "attributes", sectionAttrs));
+        GatewayHttpClient.Response sectionRes;
+        try {
+            sectionRes = gateway.post("/api/layoutSections", sectionBody);
+        } catch (RuntimeException e) {
+            return Map.of("index", index, "error", e.getClass().getSimpleName() + ": " + e.getMessage());
+        }
+        if (!sectionRes.isSuccess()) {
+            return Map.of(
+                    "index", index,
+                    "sectionName", sectionAttrs.getOrDefault("sectionName", "?"),
+                    "status", sectionRes.status() == null ? 0 : sectionRes.status().value(),
+                    "body", sectionRes.body());
+        }
+
+        String sectionId = extractId(sectionRes.body());
+        Object fieldsRaw = sectionMap.get("fields");
+        List<Map<String, Object>> fieldResults = new ArrayList<>();
+        if (fieldsRaw instanceof List<?> fields) {
+            for (int j = 0; j < fields.size(); j++) {
+                fieldResults.add(createLayoutField(sectionId, j, fields.get(j)));
+            }
+        }
+        return Map.of(
+                "index", index,
+                "sectionName", sectionAttrs.getOrDefault("sectionName", "?"),
+                "status", sectionRes.status() == null ? 0 : sectionRes.status().value(),
+                "fields", fieldResults);
+    }
+
+    private Map<String, Object> createLayoutField(String sectionId, int index, Object fieldRaw) {
+        if (!(fieldRaw instanceof Map<?, ?> fieldMap)) {
+            return Map.of("index", index, "error", "field entry must be an object");
+        }
+        Map<String, Object> fieldAttrs = new LinkedHashMap<>();
+        for (Map.Entry<?, ?> e : fieldMap.entrySet()) {
+            fieldAttrs.put(String.valueOf(e.getKey()), e.getValue());
+        }
+        if (sectionId != null) fieldAttrs.put("layoutSectionId", sectionId);
+        fieldAttrs.putIfAbsent("sortOrder", index);
+
+        Map<String, Object> body = Map.of("data", Map.of(
+                "type", "layoutFields",
+                "attributes", fieldAttrs));
+        GatewayHttpClient.Response fr;
+        try {
+            fr = gateway.post("/api/layoutFields", body);
+        } catch (RuntimeException e) {
+            return Map.of("index", index, "error", e.getClass().getSimpleName());
+        }
+        return Map.of(
+                "index", index,
+                "fieldName", fieldAttrs.getOrDefault("fieldName", "?"),
+                "status", fr.status() == null ? 0 : fr.status().value(),
+                "body", fr.isSuccess() ? "ok" : fr.body());
+    }
+
+    private static String extractId(String body) {
+        if (body == null) return null;
+        try {
+            JsonNode n = OBJECT_MAPPER.readTree(body);
+            JsonNode id = n.path("data").path("id");
+            return id.isMissingNode() || id.isNull() ? null : id.asString();
+        } catch (RuntimeException e) {
+            return null;
+        }
+    }
+
+    private static CallToolResult error(String message) {
+        return CallToolResult.builder()
+                .isError(true)
+                .content(List.of(new TextContent(message)))
+                .build();
+    }
+}

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/CreateListViewTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/CreateListViewTool.java
@@ -1,0 +1,81 @@
+package io.kelta.mcp.tool.admin;
+
+import io.kelta.mcp.client.GatewayHttpClient;
+import io.kelta.mcp.error.McpErrorMapper;
+import io.kelta.mcp.tool.AdminTool;
+import io.kelta.mcp.tool.Schemas;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import io.modelcontextprotocol.spec.McpSchema.Tool;
+import org.springframework.stereotype.Component;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class CreateListViewTool implements AdminTool {
+
+    private final GatewayHttpClient gateway;
+
+    public CreateListViewTool(GatewayHttpClient gateway) {
+        this.gateway = gateway;
+    }
+
+    @Override
+    public SyncToolSpecification toSpecification() {
+        Map<String, Object> properties = new LinkedHashMap<>();
+        properties.put("collectionName", Schemas.string("Collection the list view applies to."));
+        properties.put("name", Schemas.string("List view name (unique within collection)."));
+        properties.put("displayedFields", Schemas.string(
+                "Comma-separated field names to show as columns, in display order."));
+        properties.put("filter", Schemas.freeObject(
+                "Optional saved-filter expression in JSON:API filter shape, e.g. {\"status\":{\"EQ\":\"OPEN\"}}."));
+        properties.put("sort", Schemas.string("Default sort, e.g. \"-createdAt\"."));
+        properties.put("isDefault", Schemas.bool("Whether this is the default list view.", false));
+
+        Tool tool = Tool.builder()
+                .name("create_listview")
+                .description("Create a saved list view (column set + filter + sort) for a collection. Wraps POST /api/listViews.")
+                .inputSchema(Schemas.object(properties, List.of("collectionName", "name", "displayedFields")))
+                .build();
+
+        return SyncToolSpecification.builder()
+                .tool(tool)
+                .callHandler((exchange, request) -> {
+                    Map<String, Object> args = request.arguments();
+                    if (args == null) args = Map.of();
+                    Object cn = args.get("collectionName");
+                    Object name = args.get("name");
+                    Object df = args.get("displayedFields");
+                    if (cn == null || cn.toString().isBlank()
+                            || name == null || name.toString().isBlank()
+                            || df == null || df.toString().isBlank()) {
+                        return CallToolResult.builder()
+                                .isError(true)
+                                .content(List.of(new TextContent(
+                                        "Arguments \"collectionName\", \"name\", and \"displayedFields\" are required.")))
+                                .build();
+                    }
+
+                    Map<String, Object> attrs = new LinkedHashMap<>();
+                    attrs.put("collectionName", cn.toString());
+                    attrs.put("name", name.toString());
+                    attrs.put("displayedFields", df.toString());
+                    if (args.get("filter") instanceof Map<?, ?> f) attrs.put("filter", f);
+                    if (args.get("sort") instanceof String s && !s.isBlank()) attrs.put("sort", s);
+                    if (args.get("isDefault") instanceof Boolean b) attrs.put("isDefault", b);
+
+                    Map<String, Object> body = Map.of("data", Map.of(
+                            "type", "listViews",
+                            "attributes", attrs));
+                    try {
+                        return McpErrorMapper.toResult(gateway.post("/api/listViews", body));
+                    } catch (RuntimeException e) {
+                        return McpErrorMapper.fromException(e);
+                    }
+                })
+                .build();
+    }
+}

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/CreatePicklistTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/CreatePicklistTool.java
@@ -1,0 +1,139 @@
+package io.kelta.mcp.tool.admin;
+
+import io.kelta.mcp.client.GatewayHttpClient;
+import io.kelta.mcp.error.McpErrorMapper;
+import io.kelta.mcp.tool.AdminTool;
+import io.kelta.mcp.tool.Schemas;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import io.modelcontextprotocol.spec.McpSchema.Tool;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Composite admin tool: create a global picklist and its initial values
+ * in a single Claude tool call.
+ *
+ * <p>Wraps:
+ * <ol>
+ *   <li>POST /api/globalPicklists — create the picklist</li>
+ *   <li>POST /api/picklistValues (per value) — create each value</li>
+ * </ol>
+ */
+@Component
+public class CreatePicklistTool implements AdminTool {
+
+    private final GatewayHttpClient gateway;
+
+    public CreatePicklistTool(GatewayHttpClient gateway) {
+        this.gateway = gateway;
+    }
+
+    @Override
+    public SyncToolSpecification toSpecification() {
+        Map<String, Object> valueItem = new LinkedHashMap<>();
+        valueItem.put("type", "object");
+        valueItem.put("description",
+                "{\"value\":\"...\",\"label\":\"...\",\"sortOrder\":number,\"active\":bool}");
+        valueItem.put("additionalProperties", true);
+
+        Map<String, Object> valuesArray = new LinkedHashMap<>();
+        valuesArray.put("type", "array");
+        valuesArray.put("description", "Initial picklist values, in display order.");
+        valuesArray.put("items", valueItem);
+
+        Map<String, Object> properties = new LinkedHashMap<>();
+        properties.put("name", Schemas.string("Picklist name (unique within tenant)."));
+        properties.put("description", Schemas.string("Optional description."));
+        properties.put("values", valuesArray);
+
+        Tool tool = Tool.builder()
+                .name("create_picklist")
+                .description("Create a global picklist with its initial values. The picklist is created first; each value is then POSTed to /api/picklistValues with picklistName backreference.")
+                .inputSchema(Schemas.object(properties, List.of("name", "values")))
+                .build();
+
+        return SyncToolSpecification.builder()
+                .tool(tool)
+                .callHandler((exchange, request) -> {
+                    Map<String, Object> args = request.arguments();
+                    if (args == null) args = Map.of();
+                    Object n = args.get("name");
+                    Object vs = args.get("values");
+                    if (n == null || n.toString().isBlank()) {
+                        return error("Argument \"name\" is required.");
+                    }
+                    if (!(vs instanceof List<?> values) || values.isEmpty()) {
+                        return error("Argument \"values\" must be a non-empty array.");
+                    }
+
+                    Map<String, Object> attrs = new LinkedHashMap<>();
+                    attrs.put("name", n.toString());
+                    if (args.get("description") instanceof String s && !s.isBlank()) attrs.put("description", s);
+
+                    Map<String, Object> picklistBody = Map.of("data", Map.of(
+                            "type", "globalPicklists",
+                            "attributes", attrs));
+                    GatewayHttpClient.Response picklistRes;
+                    try {
+                        picklistRes = gateway.post("/api/globalPicklists", picklistBody);
+                    } catch (RuntimeException e) {
+                        return McpErrorMapper.fromException(e);
+                    }
+                    if (!picklistRes.isSuccess()) {
+                        return McpErrorMapper.toResult(picklistRes);
+                    }
+
+                    List<Map<String, Object>> valueResults = new ArrayList<>();
+                    for (int i = 0; i < values.size(); i++) {
+                        Object v = values.get(i);
+                        if (!(v instanceof Map<?, ?> vAttrs)) {
+                            valueResults.add(Map.of("index", i, "error", "value entry must be an object"));
+                            continue;
+                        }
+                        Map<String, Object> vMap = new LinkedHashMap<>();
+                        for (Map.Entry<?, ?> e : vAttrs.entrySet()) {
+                            vMap.put(String.valueOf(e.getKey()), e.getValue());
+                        }
+                        vMap.putIfAbsent("picklistName", n.toString());
+                        if (!vMap.containsKey("sortOrder")) vMap.put("sortOrder", i);
+
+                        Map<String, Object> valueBody = Map.of("data", Map.of(
+                                "type", "picklistValues",
+                                "attributes", vMap));
+                        GatewayHttpClient.Response vr;
+                        try {
+                            vr = gateway.post("/api/picklistValues", valueBody);
+                        } catch (RuntimeException e) {
+                            valueResults.add(Map.of("index", i, "error", e.getClass().getSimpleName()));
+                            continue;
+                        }
+                        valueResults.add(Map.of(
+                                "index", i,
+                                "value", vMap.getOrDefault("value", "?"),
+                                "status", vr.status() == null ? 0 : vr.status().value(),
+                                "body", vr.isSuccess() ? "ok" : vr.body()));
+                    }
+
+                    String summary = "{\n  \"picklist\": " + picklistRes.body()
+                            + ",\n  \"values\": " + valueResults
+                            + "\n}";
+                    return CallToolResult.builder()
+                            .content(List.of(new TextContent(summary)))
+                            .build();
+                })
+                .build();
+    }
+
+    private static CallToolResult error(String message) {
+        return CallToolResult.builder()
+                .isError(true)
+                .content(List.of(new TextContent(message)))
+                .build();
+    }
+}

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/CreateValidationRuleTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/CreateValidationRuleTool.java
@@ -1,0 +1,83 @@
+package io.kelta.mcp.tool.admin;
+
+import io.kelta.mcp.client.GatewayHttpClient;
+import io.kelta.mcp.error.McpErrorMapper;
+import io.kelta.mcp.tool.AdminTool;
+import io.kelta.mcp.tool.Schemas;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import io.modelcontextprotocol.spec.McpSchema.Tool;
+import org.springframework.stereotype.Component;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class CreateValidationRuleTool implements AdminTool {
+
+    private final GatewayHttpClient gateway;
+
+    public CreateValidationRuleTool(GatewayHttpClient gateway) {
+        this.gateway = gateway;
+    }
+
+    @Override
+    public SyncToolSpecification toSpecification() {
+        Map<String, Object> properties = new LinkedHashMap<>();
+        properties.put("collectionName", Schemas.string("Collection the rule applies to."));
+        properties.put("name", Schemas.string("Rule name (unique within collection)."));
+        properties.put("expression", Schemas.string(
+                "Boolean expression that must evaluate true. Failure triggers the rule. "
+                + "Reference fields with their attribute names (e.g. \"amount > 0\")."));
+        properties.put("errorMessage", Schemas.string(
+                "Error message shown to the user when the rule fails."));
+        properties.put("active", Schemas.bool("Whether the rule is active (default true).", true));
+
+        Tool tool = Tool.builder()
+                .name("create_validation_rule")
+                .description("Create a validation rule on a collection. Records that fail the expression are rejected at create/update time.")
+                .inputSchema(Schemas.object(properties, List.of("collectionName", "name", "expression", "errorMessage")))
+                .build();
+
+        return SyncToolSpecification.builder()
+                .tool(tool)
+                .callHandler((exchange, request) -> {
+                    Map<String, Object> args = request.arguments();
+                    if (args == null) args = Map.of();
+                    Object cn = args.get("collectionName");
+                    Object name = args.get("name");
+                    Object expr = args.get("expression");
+                    Object msg = args.get("errorMessage");
+                    if (cn == null || cn.toString().isBlank()
+                            || name == null || name.toString().isBlank()
+                            || expr == null || expr.toString().isBlank()
+                            || msg == null || msg.toString().isBlank()) {
+                        return CallToolResult.builder()
+                                .isError(true)
+                                .content(List.of(new TextContent(
+                                        "Arguments \"collectionName\", \"name\", \"expression\", and \"errorMessage\" are required.")))
+                                .build();
+                    }
+
+                    Map<String, Object> attrs = new LinkedHashMap<>();
+                    attrs.put("collectionName", cn.toString());
+                    attrs.put("name", name.toString());
+                    attrs.put("expression", expr.toString());
+                    attrs.put("errorMessage", msg.toString());
+                    if (args.get("active") instanceof Boolean b) attrs.put("active", b);
+                    else attrs.put("active", true);
+
+                    Map<String, Object> body = Map.of("data", Map.of(
+                            "type", "validationRules",
+                            "attributes", attrs));
+                    try {
+                        return McpErrorMapper.toResult(gateway.post("/api/validationRules", body));
+                    } catch (RuntimeException e) {
+                        return McpErrorMapper.fromException(e);
+                    }
+                })
+                .build();
+    }
+}

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/DeleteLayoutTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/DeleteLayoutTool.java
@@ -1,0 +1,67 @@
+package io.kelta.mcp.tool.admin;
+
+import io.kelta.mcp.client.GatewayHttpClient;
+import io.kelta.mcp.error.McpErrorMapper;
+import io.kelta.mcp.tool.AdminTool;
+import io.kelta.mcp.tool.Schemas;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import io.modelcontextprotocol.spec.McpSchema.Tool;
+import org.springframework.stereotype.Component;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class DeleteLayoutTool implements AdminTool {
+
+    private final GatewayHttpClient gateway;
+
+    public DeleteLayoutTool(GatewayHttpClient gateway) {
+        this.gateway = gateway;
+    }
+
+    @Override
+    public SyncToolSpecification toSpecification() {
+        Map<String, Object> properties = new LinkedHashMap<>();
+        properties.put("id", Schemas.string("Layout id (UUID)."));
+
+        Tool tool = Tool.builder()
+                .name("delete_layout")
+                .description("Delete a page layout and (cascade) its sections and field assignments. Wraps DELETE /api/pageLayouts/{id}. Does NOT delete the underlying field definitions on the collection.")
+                .inputSchema(Schemas.object(properties, List.of("id")))
+                .build();
+
+        return SyncToolSpecification.builder()
+                .tool(tool)
+                .callHandler((exchange, request) -> {
+                    Map<String, Object> args = request.arguments();
+                    if (args == null) args = Map.of();
+                    Object id = args.get("id");
+                    if (id == null || id.toString().isBlank()) {
+                        return CallToolResult.builder()
+                                .isError(true)
+                                .content(List.of(new TextContent("Argument \"id\" is required.")))
+                                .build();
+                    }
+                    String path = "/api/pageLayouts/" + URLEncoder.encode(id.toString(), StandardCharsets.UTF_8);
+                    try {
+                        GatewayHttpClient.Response response = gateway.delete(path);
+                        if (response.isSuccess()) {
+                            return CallToolResult.builder()
+                                    .content(List.of(new TextContent(
+                                            "Deleted pageLayout " + id + " (HTTP " + response.status().value() + ")")))
+                                    .build();
+                        }
+                        return McpErrorMapper.toResult(response);
+                    } catch (RuntimeException e) {
+                        return McpErrorMapper.fromException(e);
+                    }
+                })
+                .build();
+    }
+}

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/ImportApiSpecTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/ImportApiSpecTool.java
@@ -1,0 +1,68 @@
+package io.kelta.mcp.tool.admin;
+
+import io.kelta.mcp.client.GatewayHttpClient;
+import io.kelta.mcp.error.McpErrorMapper;
+import io.kelta.mcp.tool.AdminTool;
+import io.kelta.mcp.tool.Schemas;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import io.modelcontextprotocol.spec.McpSchema.Tool;
+import org.springframework.stereotype.Component;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class ImportApiSpecTool implements AdminTool {
+
+    private final GatewayHttpClient gateway;
+
+    public ImportApiSpecTool(GatewayHttpClient gateway) {
+        this.gateway = gateway;
+    }
+
+    @Override
+    public SyncToolSpecification toSpecification() {
+        Map<String, Object> properties = new LinkedHashMap<>();
+        properties.put("name", Schemas.string("Display name for the imported spec."));
+        properties.put("raw", Schemas.string("OpenAPI spec as raw JSON or YAML text."));
+        properties.put("sourceUrl", Schemas.string("Optional source URL the spec was downloaded from."));
+
+        Tool tool = Tool.builder()
+                .name("import_api_spec")
+                .description("Import an external OpenAPI 3.x spec into the platform's API spec library. Operations are parsed and indexed so flows can call them. Wraps POST /api/api-specs/import. Returns a diff of added/changed/removed operations.")
+                .inputSchema(Schemas.object(properties, List.of("name", "raw")))
+                .build();
+
+        return SyncToolSpecification.builder()
+                .tool(tool)
+                .callHandler((exchange, request) -> {
+                    Map<String, Object> args = request.arguments();
+                    if (args == null) args = Map.of();
+                    Object n = args.get("name");
+                    Object raw = args.get("raw");
+                    if (n == null || n.toString().isBlank()
+                            || raw == null || raw.toString().isBlank()) {
+                        return CallToolResult.builder()
+                                .isError(true)
+                                .content(List.of(new TextContent(
+                                        "Arguments \"name\" and \"raw\" are required.")))
+                                .build();
+                    }
+
+                    Map<String, Object> body = new LinkedHashMap<>();
+                    body.put("name", n.toString());
+                    body.put("raw", raw.toString());
+                    if (args.get("sourceUrl") instanceof String s && !s.isBlank()) body.put("sourceUrl", s);
+
+                    try {
+                        return McpErrorMapper.toResult(gateway.post("/api/api-specs/import", body));
+                    } catch (RuntimeException e) {
+                        return McpErrorMapper.fromException(e);
+                    }
+                })
+                .build();
+    }
+}

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/RemoveFieldTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/RemoveFieldTool.java
@@ -1,0 +1,67 @@
+package io.kelta.mcp.tool.admin;
+
+import io.kelta.mcp.client.GatewayHttpClient;
+import io.kelta.mcp.error.McpErrorMapper;
+import io.kelta.mcp.tool.AdminTool;
+import io.kelta.mcp.tool.Schemas;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import io.modelcontextprotocol.spec.McpSchema.Tool;
+import org.springframework.stereotype.Component;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class RemoveFieldTool implements AdminTool {
+
+    private final GatewayHttpClient gateway;
+
+    public RemoveFieldTool(GatewayHttpClient gateway) {
+        this.gateway = gateway;
+    }
+
+    @Override
+    public SyncToolSpecification toSpecification() {
+        Map<String, Object> properties = new LinkedHashMap<>();
+        properties.put("id", Schemas.string("Field id (UUID)."));
+
+        Tool tool = Tool.builder()
+                .name("remove_field")
+                .description("Remove a field from a collection. Wraps DELETE /api/fields/{id}. The field's data on existing records is dropped — irreversible.")
+                .inputSchema(Schemas.object(properties, List.of("id")))
+                .build();
+
+        return SyncToolSpecification.builder()
+                .tool(tool)
+                .callHandler((exchange, request) -> {
+                    Map<String, Object> args = request.arguments();
+                    if (args == null) args = Map.of();
+                    Object id = args.get("id");
+                    if (id == null || id.toString().isBlank()) {
+                        return CallToolResult.builder()
+                                .isError(true)
+                                .content(List.of(new TextContent("Argument \"id\" is required.")))
+                                .build();
+                    }
+                    String path = "/api/fields/" + URLEncoder.encode(id.toString(), StandardCharsets.UTF_8);
+                    try {
+                        GatewayHttpClient.Response response = gateway.delete(path);
+                        if (response.isSuccess()) {
+                            return CallToolResult.builder()
+                                    .content(List.of(new TextContent(
+                                            "Removed field " + id + " (HTTP " + response.status().value() + ")")))
+                                    .build();
+                        }
+                        return McpErrorMapper.toResult(response);
+                    } catch (RuntimeException e) {
+                        return McpErrorMapper.fromException(e);
+                    }
+                })
+                .build();
+    }
+}

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/UpdateCollectionTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/UpdateCollectionTool.java
@@ -1,0 +1,80 @@
+package io.kelta.mcp.tool.admin;
+
+import io.kelta.mcp.client.GatewayHttpClient;
+import io.kelta.mcp.error.McpErrorMapper;
+import io.kelta.mcp.tool.AdminTool;
+import io.kelta.mcp.tool.Schemas;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import io.modelcontextprotocol.spec.McpSchema.Tool;
+import org.springframework.stereotype.Component;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class UpdateCollectionTool implements AdminTool {
+
+    private final GatewayHttpClient gateway;
+
+    public UpdateCollectionTool(GatewayHttpClient gateway) {
+        this.gateway = gateway;
+    }
+
+    @Override
+    public SyncToolSpecification toSpecification() {
+        Map<String, Object> properties = new LinkedHashMap<>();
+        properties.put("id", Schemas.string("Collection id (UUID) or name."));
+        properties.put("displayFieldName", Schemas.string("New display field name."));
+        properties.put("description", Schemas.string("New description."));
+        properties.put("tenantScoped", Schemas.bool("New tenant-scoped flag.", true));
+
+        Tool tool = Tool.builder()
+                .name("update_collection")
+                .description("Update a collection's metadata (display field, description, tenant-scoping). PATCHes /api/collections/{id} — only supplied fields change.")
+                .inputSchema(Schemas.object(properties, List.of("id")))
+                .build();
+
+        return SyncToolSpecification.builder()
+                .tool(tool)
+                .callHandler((exchange, request) -> {
+                    Map<String, Object> args = request.arguments();
+                    if (args == null) args = Map.of();
+                    Object id = args.get("id");
+                    if (id == null || id.toString().isBlank()) {
+                        return error("Argument \"id\" is required.");
+                    }
+
+                    Map<String, Object> attrs = new LinkedHashMap<>();
+                    if (args.get("displayFieldName") instanceof String s && !s.isBlank()) attrs.put("displayFieldName", s);
+                    if (args.get("description") instanceof String s) attrs.put("description", s);
+                    if (args.get("tenantScoped") instanceof Boolean b) attrs.put("tenantScoped", b);
+                    if (attrs.isEmpty()) {
+                        return error("Provide at least one of displayFieldName, description, tenantScoped.");
+                    }
+
+                    Map<String, Object> body = Map.of("data", Map.of(
+                            "type", "collections",
+                            "id", id.toString(),
+                            "attributes", attrs));
+                    String path = "/api/collections/" + URLEncoder.encode(id.toString(), StandardCharsets.UTF_8);
+                    try {
+                        return McpErrorMapper.toResult(gateway.patch(path, body));
+                    } catch (RuntimeException e) {
+                        return McpErrorMapper.fromException(e);
+                    }
+                })
+                .build();
+    }
+
+    private static CallToolResult error(String message) {
+        return CallToolResult.builder()
+                .isError(true)
+                .content(List.of(new TextContent(message)))
+                .build();
+    }
+}

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/UpdateFieldTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/UpdateFieldTool.java
@@ -1,0 +1,83 @@
+package io.kelta.mcp.tool.admin;
+
+import io.kelta.mcp.client.GatewayHttpClient;
+import io.kelta.mcp.error.McpErrorMapper;
+import io.kelta.mcp.tool.AdminTool;
+import io.kelta.mcp.tool.Schemas;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import io.modelcontextprotocol.spec.McpSchema.Tool;
+import org.springframework.stereotype.Component;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class UpdateFieldTool implements AdminTool {
+
+    private final GatewayHttpClient gateway;
+
+    public UpdateFieldTool(GatewayHttpClient gateway) {
+        this.gateway = gateway;
+    }
+
+    @Override
+    public SyncToolSpecification toSpecification() {
+        Map<String, Object> properties = new LinkedHashMap<>();
+        properties.put("id", Schemas.string("Field id (UUID)."));
+        properties.put("required", Schemas.bool("New required flag.", false));
+        properties.put("unique", Schemas.bool("New unique flag.", false));
+        properties.put("description", Schemas.string("New description."));
+        properties.put("defaultValue", Schemas.string("New default value."));
+        properties.put("validation", Schemas.freeObject("New validation config."));
+
+        Tool tool = Tool.builder()
+                .name("update_field")
+                .description("Update a field's mutable attributes. Wraps PATCH /api/fields/{id}. Note: changing field type or fieldName is generally rejected by the platform — drop+recreate is the path for those.")
+                .inputSchema(Schemas.object(properties, List.of("id")))
+                .build();
+
+        return SyncToolSpecification.builder()
+                .tool(tool)
+                .callHandler((exchange, request) -> {
+                    Map<String, Object> args = request.arguments();
+                    if (args == null) args = Map.of();
+                    Object id = args.get("id");
+                    if (id == null || id.toString().isBlank()) {
+                        return error("Argument \"id\" is required.");
+                    }
+                    Map<String, Object> attrs = new LinkedHashMap<>();
+                    if (args.get("required") instanceof Boolean b) attrs.put("required", b);
+                    if (args.get("unique") instanceof Boolean b) attrs.put("unique", b);
+                    if (args.get("description") instanceof String s) attrs.put("description", s);
+                    if (args.get("defaultValue") instanceof String s) attrs.put("defaultValue", s);
+                    if (args.get("validation") instanceof Map<?, ?> v) attrs.put("validation", v);
+                    if (attrs.isEmpty()) {
+                        return error("Provide at least one of required, unique, description, defaultValue, validation.");
+                    }
+
+                    Map<String, Object> body = Map.of("data", Map.of(
+                            "type", "fields",
+                            "id", id.toString(),
+                            "attributes", attrs));
+                    String path = "/api/fields/" + URLEncoder.encode(id.toString(), StandardCharsets.UTF_8);
+                    try {
+                        return McpErrorMapper.toResult(gateway.patch(path, body));
+                    } catch (RuntimeException e) {
+                        return McpErrorMapper.fromException(e);
+                    }
+                })
+                .build();
+    }
+
+    private static CallToolResult error(String message) {
+        return CallToolResult.builder()
+                .isError(true)
+                .content(List.of(new TextContent(message)))
+                .build();
+    }
+}

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/UpdateFlowTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/UpdateFlowTool.java
@@ -1,0 +1,83 @@
+package io.kelta.mcp.tool.admin;
+
+import io.kelta.mcp.client.GatewayHttpClient;
+import io.kelta.mcp.error.McpErrorMapper;
+import io.kelta.mcp.tool.AdminTool;
+import io.kelta.mcp.tool.Schemas;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import io.modelcontextprotocol.spec.McpSchema.Tool;
+import org.springframework.stereotype.Component;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class UpdateFlowTool implements AdminTool {
+
+    private final GatewayHttpClient gateway;
+
+    public UpdateFlowTool(GatewayHttpClient gateway) {
+        this.gateway = gateway;
+    }
+
+    @Override
+    public SyncToolSpecification toSpecification() {
+        Map<String, Object> properties = new LinkedHashMap<>();
+        properties.put("id", Schemas.string("Flow id (UUID)."));
+        properties.put("name", Schemas.string("New flow name."));
+        properties.put("description", Schemas.string("New description."));
+        properties.put("triggerConfig", Schemas.freeObject("New trigger config."));
+        properties.put("definition", Schemas.freeObject("New flow definition."));
+        properties.put("active", Schemas.bool("Active flag — toggles enable/disable.", false));
+
+        Tool tool = Tool.builder()
+                .name("update_flow")
+                .description("Update an existing flow's metadata, definition, or active state. Wraps PATCH /api/flows/{id}. Toggling \"active\" enables or disables the trigger without redeploying the definition.")
+                .inputSchema(Schemas.object(properties, List.of("id")))
+                .build();
+
+        return SyncToolSpecification.builder()
+                .tool(tool)
+                .callHandler((exchange, request) -> {
+                    Map<String, Object> args = request.arguments();
+                    if (args == null) args = Map.of();
+                    Object id = args.get("id");
+                    if (id == null || id.toString().isBlank()) {
+                        return error("Argument \"id\" is required.");
+                    }
+                    Map<String, Object> attrs = new LinkedHashMap<>();
+                    if (args.get("name") instanceof String s && !s.isBlank()) attrs.put("name", s);
+                    if (args.get("description") instanceof String s) attrs.put("description", s);
+                    if (args.get("triggerConfig") instanceof Map<?, ?> tc) attrs.put("triggerConfig", tc);
+                    if (args.get("definition") instanceof Map<?, ?> d) attrs.put("definition", d);
+                    if (args.get("active") instanceof Boolean b) attrs.put("active", b);
+                    if (attrs.isEmpty()) {
+                        return error("Provide at least one of name, description, triggerConfig, definition, active.");
+                    }
+
+                    Map<String, Object> body = Map.of("data", Map.of(
+                            "type", "flows",
+                            "id", id.toString(),
+                            "attributes", attrs));
+                    String path = "/api/flows/" + URLEncoder.encode(id.toString(), StandardCharsets.UTF_8);
+                    try {
+                        return McpErrorMapper.toResult(gateway.patch(path, body));
+                    } catch (RuntimeException e) {
+                        return McpErrorMapper.fromException(e);
+                    }
+                })
+                .build();
+    }
+
+    private static CallToolResult error(String message) {
+        return CallToolResult.builder()
+                .isError(true)
+                .content(List.of(new TextContent(message)))
+                .build();
+    }
+}

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/UpdateLayoutTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/UpdateLayoutTool.java
@@ -1,0 +1,78 @@
+package io.kelta.mcp.tool.admin;
+
+import io.kelta.mcp.client.GatewayHttpClient;
+import io.kelta.mcp.error.McpErrorMapper;
+import io.kelta.mcp.tool.AdminTool;
+import io.kelta.mcp.tool.Schemas;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import io.modelcontextprotocol.spec.McpSchema.Tool;
+import org.springframework.stereotype.Component;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class UpdateLayoutTool implements AdminTool {
+
+    private final GatewayHttpClient gateway;
+
+    public UpdateLayoutTool(GatewayHttpClient gateway) {
+        this.gateway = gateway;
+    }
+
+    @Override
+    public SyncToolSpecification toSpecification() {
+        Map<String, Object> properties = new LinkedHashMap<>();
+        properties.put("id", Schemas.string("Layout id (UUID)."));
+        properties.put("name", Schemas.string("New name."));
+        properties.put("isDefault", Schemas.bool("New default-for-collection flag.", false));
+        properties.put("recordTypeName", Schemas.string("New record type assignment."));
+
+        Tool tool = Tool.builder()
+                .name("update_layout")
+                .description("Update a page layout's metadata (name, default flag, record type). PATCHes /api/pageLayouts/{id}. To restructure sections or fields, use delete_layout + create_layout — full section replacement isn't supported in a single tool call.")
+                .inputSchema(Schemas.object(properties, List.of("id")))
+                .build();
+
+        return SyncToolSpecification.builder()
+                .tool(tool)
+                .callHandler((exchange, request) -> {
+                    Map<String, Object> args = request.arguments();
+                    if (args == null) args = Map.of();
+                    Object id = args.get("id");
+                    if (id == null || id.toString().isBlank()) {
+                        return error("Argument \"id\" is required.");
+                    }
+                    Map<String, Object> attrs = new LinkedHashMap<>();
+                    if (args.get("name") instanceof String s && !s.isBlank()) attrs.put("name", s);
+                    if (args.get("isDefault") instanceof Boolean b) attrs.put("isDefault", b);
+                    if (args.get("recordTypeName") instanceof String s) attrs.put("recordTypeName", s);
+                    if (attrs.isEmpty()) {
+                        return error("Provide at least one of name, isDefault, recordTypeName.");
+                    }
+                    Map<String, Object> body = Map.of("data", Map.of(
+                            "type", "pageLayouts",
+                            "id", id.toString(),
+                            "attributes", attrs));
+                    String path = "/api/pageLayouts/" + URLEncoder.encode(id.toString(), StandardCharsets.UTF_8);
+                    try {
+                        return McpErrorMapper.toResult(gateway.patch(path, body));
+                    } catch (RuntimeException e) {
+                        return McpErrorMapper.fromException(e);
+                    }
+                })
+                .build();
+    }
+
+    private static CallToolResult error(String message) {
+        return CallToolResult.builder()
+                .isError(true)
+                .content(List.of(new TextContent(message)))
+                .build();
+    }
+}

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/BulkApplyTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/BulkApplyTool.java
@@ -1,0 +1,96 @@
+package io.kelta.mcp.tool.user;
+
+import io.kelta.mcp.client.GatewayHttpClient;
+import io.kelta.mcp.error.McpErrorMapper;
+import io.kelta.mcp.tool.Schemas;
+import io.kelta.mcp.tool.UserTool;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import io.modelcontextprotocol.spec.McpSchema.Tool;
+import org.springframework.stereotype.Component;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class BulkApplyTool implements UserTool {
+
+    private static final List<String> ALLOWED_OPS = List.of("add", "update", "remove");
+
+    private final GatewayHttpClient gateway;
+
+    public BulkApplyTool(GatewayHttpClient gateway) {
+        this.gateway = gateway;
+    }
+
+    @Override
+    public SyncToolSpecification toSpecification() {
+        Map<String, Object> opSchema = new LinkedHashMap<>();
+        opSchema.put("type", "object");
+        opSchema.put("description",
+                "One operation. {\"op\":\"add\"|\"update\"|\"remove\", \"type\":\"<collection>\", "
+                + "\"id\":\"<id>\" (required for update/remove), \"attributes\":{...} (for add/update), "
+                + "\"relationships\":{...} (optional for add/update)}");
+        opSchema.put("additionalProperties", true);
+
+        Map<String, Object> opsArray = new LinkedHashMap<>();
+        opsArray.put("type", "array");
+        opsArray.put("description", "Ordered list of operations. Applied as a single transaction — all succeed or all roll back.");
+        opsArray.put("items", opSchema);
+        opsArray.put("minItems", 1);
+
+        Map<String, Object> properties = new LinkedHashMap<>();
+        properties.put("operations", opsArray);
+
+        Tool tool = Tool.builder()
+                .name("bulk_apply")
+                .description("Apply multiple record changes atomically via /api/_atomic. All operations succeed together or none do. Use this for multi-record changes that must roll back as a unit (e.g. moving line items between orders, rewiring relationships).")
+                .inputSchema(Schemas.object(properties, List.of("operations")))
+                .build();
+
+        return SyncToolSpecification.builder()
+                .tool(tool)
+                .callHandler((exchange, request) -> {
+                    Map<String, Object> args = request.arguments();
+                    if (args == null) args = Map.of();
+                    Object opsObj = args.get("operations");
+                    if (!(opsObj instanceof List<?> ops) || ops.isEmpty()) {
+                        return error("Argument \"operations\" must be a non-empty array.");
+                    }
+                    for (int i = 0; i < ops.size(); i++) {
+                        Object o = ops.get(i);
+                        if (!(o instanceof Map<?, ?> op)) {
+                            return error("operations[" + i + "] must be an object.");
+                        }
+                        Object opName = op.get("op");
+                        if (opName == null || !ALLOWED_OPS.contains(opName.toString())) {
+                            return error("operations[" + i + "].op must be one of " + ALLOWED_OPS + ".");
+                        }
+                        if (op.get("type") == null) {
+                            return error("operations[" + i + "].type (collection name) is required.");
+                        }
+                        if (("update".equals(opName.toString()) || "remove".equals(opName.toString()))
+                                && op.get("id") == null) {
+                            return error("operations[" + i + "].id is required for update/remove.");
+                        }
+                    }
+
+                    Map<String, Object> body = Map.of("atomic:operations", ops);
+                    try {
+                        return McpErrorMapper.toResult(gateway.post("/api/_atomic", body));
+                    } catch (RuntimeException e) {
+                        return McpErrorMapper.fromException(e);
+                    }
+                })
+                .build();
+    }
+
+    private static CallToolResult error(String message) {
+        return CallToolResult.builder()
+                .isError(true)
+                .content(List.of(new TextContent(message)))
+                .build();
+    }
+}

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/CreateRecordTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/CreateRecordTool.java
@@ -1,0 +1,83 @@
+package io.kelta.mcp.tool.user;
+
+import io.kelta.mcp.client.GatewayHttpClient;
+import io.kelta.mcp.error.McpErrorMapper;
+import io.kelta.mcp.tool.Schemas;
+import io.kelta.mcp.tool.UserTool;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import io.modelcontextprotocol.spec.McpSchema.Tool;
+import org.springframework.stereotype.Component;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class CreateRecordTool implements UserTool {
+
+    private final GatewayHttpClient gateway;
+
+    public CreateRecordTool(GatewayHttpClient gateway) {
+        this.gateway = gateway;
+    }
+
+    @Override
+    public SyncToolSpecification toSpecification() {
+        Map<String, Object> properties = new LinkedHashMap<>();
+        properties.put("collection", Schemas.string("Collection name (e.g. \"accounts\")."));
+        properties.put("attributes", Schemas.freeObject(
+                "Field values for the new record, keyed by field name. Reference get_collection_schema to know what fields exist."));
+        properties.put("relationships", Schemas.freeObject(
+                "Optional JSON:API relationships object. Each entry maps a relationship name to {\"data\": {\"type\": \"...\", \"id\": \"...\"}} or an array thereof for to-many."));
+
+        Tool tool = Tool.builder()
+                .name("create_record")
+                .description("Create a single record in a collection. Wraps POST /api/{collection} in JSON:API format. Returns the created record on success (HTTP 201).")
+                .inputSchema(Schemas.object(properties, List.of("collection", "attributes")))
+                .build();
+
+        return SyncToolSpecification.builder()
+                .tool(tool)
+                .callHandler((exchange, request) -> {
+                    Map<String, Object> args = request.arguments();
+                    if (args == null) args = Map.of();
+                    Object cv = args.get("collection");
+                    Object av = args.get("attributes");
+                    if (cv == null || cv.toString().isBlank()) {
+                        return error("Argument \"collection\" is required.");
+                    }
+                    if (!(av instanceof Map<?, ?> attributes) || attributes.isEmpty()) {
+                        return error("Argument \"attributes\" must be a non-empty object.");
+                    }
+                    String collection = cv.toString();
+
+                    Map<String, Object> data = new LinkedHashMap<>();
+                    data.put("type", collection);
+                    data.put("attributes", attributes);
+                    Object rel = args.get("relationships");
+                    if (rel instanceof Map<?, ?> rmap && !rmap.isEmpty()) {
+                        data.put("relationships", rmap);
+                    }
+                    Map<String, Object> body = Map.of("data", data);
+
+                    String path = "/api/" + URLEncoder.encode(collection, StandardCharsets.UTF_8);
+                    try {
+                        return McpErrorMapper.toResult(gateway.post(path, body));
+                    } catch (RuntimeException e) {
+                        return McpErrorMapper.fromException(e);
+                    }
+                })
+                .build();
+    }
+
+    private static CallToolResult error(String message) {
+        return CallToolResult.builder()
+                .isError(true)
+                .content(List.of(new TextContent(message)))
+                .build();
+    }
+}

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/DeleteRecordTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/DeleteRecordTool.java
@@ -1,0 +1,70 @@
+package io.kelta.mcp.tool.user;
+
+import io.kelta.mcp.client.GatewayHttpClient;
+import io.kelta.mcp.error.McpErrorMapper;
+import io.kelta.mcp.tool.Schemas;
+import io.kelta.mcp.tool.UserTool;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import io.modelcontextprotocol.spec.McpSchema.Tool;
+import org.springframework.stereotype.Component;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class DeleteRecordTool implements UserTool {
+
+    private final GatewayHttpClient gateway;
+
+    public DeleteRecordTool(GatewayHttpClient gateway) {
+        this.gateway = gateway;
+    }
+
+    @Override
+    public SyncToolSpecification toSpecification() {
+        Map<String, Object> properties = new LinkedHashMap<>();
+        properties.put("collection", Schemas.string("Collection name."));
+        properties.put("id", Schemas.string("Record id to delete."));
+
+        Tool tool = Tool.builder()
+                .name("delete_record")
+                .description("Delete a single record. Wraps DELETE /api/{collection}/{id}. Returns 204 No Content on success. Idempotent — deleting a non-existent record returns 404.")
+                .inputSchema(Schemas.object(properties, List.of("collection", "id")))
+                .build();
+
+        return SyncToolSpecification.builder()
+                .tool(tool)
+                .callHandler((exchange, request) -> {
+                    Map<String, Object> args = request.arguments();
+                    if (args == null) args = Map.of();
+                    Object cv = args.get("collection");
+                    Object iv = args.get("id");
+                    if (cv == null || cv.toString().isBlank() || iv == null || iv.toString().isBlank()) {
+                        return CallToolResult.builder()
+                                .isError(true)
+                                .content(List.of(new TextContent("Arguments \"collection\" and \"id\" are required.")))
+                                .build();
+                    }
+                    String path = "/api/" + URLEncoder.encode(cv.toString(), StandardCharsets.UTF_8)
+                            + "/" + URLEncoder.encode(iv.toString(), StandardCharsets.UTF_8);
+                    try {
+                        GatewayHttpClient.Response response = gateway.delete(path);
+                        if (response.isSuccess()) {
+                            return CallToolResult.builder()
+                                    .content(List.of(new TextContent(
+                                            "Deleted " + cv + "/" + iv + " (HTTP " + response.status().value() + ")")))
+                                    .build();
+                        }
+                        return McpErrorMapper.toResult(response);
+                    } catch (RuntimeException e) {
+                        return McpErrorMapper.fromException(e);
+                    }
+                })
+                .build();
+    }
+}

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/DescribeApiTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/DescribeApiTool.java
@@ -1,0 +1,39 @@
+package io.kelta.mcp.tool.user;
+
+import io.kelta.mcp.client.GatewayHttpClient;
+import io.kelta.mcp.error.McpErrorMapper;
+import io.kelta.mcp.tool.Schemas;
+import io.kelta.mcp.tool.UserTool;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.spec.McpSchema.Tool;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DescribeApiTool implements UserTool {
+
+    private final GatewayHttpClient gateway;
+
+    public DescribeApiTool(GatewayHttpClient gateway) {
+        this.gateway = gateway;
+    }
+
+    @Override
+    public SyncToolSpecification toSpecification() {
+        Tool tool = Tool.builder()
+                .name("describe_api")
+                .description("Return the auto-generated OpenAPI 3.0 spec for the current tenant. The spec covers JSON:API CRUD on every collection — useful when you need exact request/response schemas. Specialized controllers (flows, approvals, bulk) are NOT in this spec; use the dedicated tools for those.")
+                .inputSchema(Schemas.empty())
+                .build();
+
+        return SyncToolSpecification.builder()
+                .tool(tool)
+                .callHandler((exchange, request) -> {
+                    try {
+                        return McpErrorMapper.toResult(gateway.get("/api/docs/openapi.json"));
+                    } catch (RuntimeException e) {
+                        return McpErrorMapper.fromException(e);
+                    }
+                })
+                .build();
+    }
+}

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/ExecuteFlowTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/ExecuteFlowTool.java
@@ -1,0 +1,67 @@
+package io.kelta.mcp.tool.user;
+
+import io.kelta.mcp.client.GatewayHttpClient;
+import io.kelta.mcp.error.McpErrorMapper;
+import io.kelta.mcp.tool.Schemas;
+import io.kelta.mcp.tool.UserTool;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import io.modelcontextprotocol.spec.McpSchema.Tool;
+import org.springframework.stereotype.Component;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class ExecuteFlowTool implements UserTool {
+
+    private final GatewayHttpClient gateway;
+
+    public ExecuteFlowTool(GatewayHttpClient gateway) {
+        this.gateway = gateway;
+    }
+
+    @Override
+    public SyncToolSpecification toSpecification() {
+        Map<String, Object> properties = new LinkedHashMap<>();
+        properties.put("flowId", Schemas.string("Flow id (UUID) or name. Wraps POST /api/flows/{flowId}/execute."));
+        properties.put("input", Schemas.freeObject(
+                "Optional input payload passed to the flow as the initial context. Shape is flow-specific."));
+
+        Tool tool = Tool.builder()
+                .name("execute_flow")
+                .description("Trigger a flow execution. Returns the execution id; use get_flow_run to poll status.")
+                .inputSchema(Schemas.object(properties, List.of("flowId")))
+                .build();
+
+        return SyncToolSpecification.builder()
+                .tool(tool)
+                .callHandler((exchange, request) -> {
+                    Map<String, Object> args = request.arguments();
+                    if (args == null) args = Map.of();
+                    Object f = args.get("flowId");
+                    if (f == null || f.toString().isBlank()) {
+                        return CallToolResult.builder()
+                                .isError(true)
+                                .content(List.of(new TextContent("Argument \"flowId\" is required.")))
+                                .build();
+                    }
+                    Object input = args.get("input");
+                    Object body = (input instanceof Map<?, ?>) ? input : Map.of();
+
+                    String path = "/api/flows/"
+                            + URLEncoder.encode(f.toString(), StandardCharsets.UTF_8)
+                            + "/execute";
+                    try {
+                        return McpErrorMapper.toResult(gateway.post(path, body));
+                    } catch (RuntimeException e) {
+                        return McpErrorMapper.fromException(e);
+                    }
+                })
+                .build();
+    }
+}

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/GetCollectionSchemaTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/GetCollectionSchemaTool.java
@@ -1,0 +1,79 @@
+package io.kelta.mcp.tool.user;
+
+import io.kelta.mcp.client.GatewayHttpClient;
+import io.kelta.mcp.error.McpErrorMapper;
+import io.kelta.mcp.tool.Schemas;
+import io.kelta.mcp.tool.UserTool;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import io.modelcontextprotocol.spec.McpSchema.Tool;
+import org.springframework.stereotype.Component;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class GetCollectionSchemaTool implements UserTool {
+
+    private final GatewayHttpClient gateway;
+
+    public GetCollectionSchemaTool(GatewayHttpClient gateway) {
+        this.gateway = gateway;
+    }
+
+    @Override
+    public SyncToolSpecification toSpecification() {
+        Map<String, Object> properties = new LinkedHashMap<>();
+        properties.put("collection", Schemas.string(
+                "Collection name or ID (e.g. \"accounts\" or a UUID). Looked up via /api/collections."));
+
+        Tool tool = Tool.builder()
+                .name("get_collection_schema")
+                .description("Return the full schema for a collection: metadata + all field definitions (type, required, unique, validation rules). Use this before constructing a query or create_record call to know what attributes are available.")
+                .inputSchema(Schemas.object(properties, List.of("collection")))
+                .build();
+
+        return SyncToolSpecification.builder()
+                .tool(tool)
+                .callHandler((exchange, request) -> {
+                    Map<String, Object> args = request.arguments();
+                    Object cv = args == null ? null : args.get("collection");
+                    if (cv == null || cv.toString().isBlank()) {
+                        return CallToolResult.builder()
+                                .isError(true)
+                                .content(List.of(new TextContent("Argument \"collection\" is required.")))
+                                .build();
+                    }
+                    String collection = cv.toString();
+
+                    try {
+                        GatewayHttpClient.Response collectionRes = gateway.get(
+                                "/api/collections/" + URLEncoder.encode(collection, StandardCharsets.UTF_8));
+                        if (!collectionRes.isSuccess()) {
+                            return McpErrorMapper.toResult(collectionRes);
+                        }
+
+                        GatewayHttpClient.Response fieldsRes = gateway.get(
+                                "/api/fields?filter[collectionName][EQ]="
+                                        + URLEncoder.encode(collection, StandardCharsets.UTF_8)
+                                        + "&page[size]=200");
+
+                        String combined = "{\n  \"collection\": "
+                                + collectionRes.body()
+                                + ",\n  \"fields\": "
+                                + (fieldsRes.isSuccess() ? fieldsRes.body() : "null")
+                                + "\n}";
+                        return CallToolResult.builder()
+                                .content(List.of(new TextContent(combined)))
+                                .build();
+                    } catch (RuntimeException e) {
+                        return McpErrorMapper.fromException(e);
+                    }
+                })
+                .build();
+    }
+}

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/GetCollectionSchemaTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/GetCollectionSchemaTool.java
@@ -2,6 +2,7 @@ package io.kelta.mcp.tool.user;
 
 import io.kelta.mcp.client.GatewayHttpClient;
 import io.kelta.mcp.error.McpErrorMapper;
+import io.kelta.mcp.tool.AdminTool;
 import io.kelta.mcp.tool.Schemas;
 import io.kelta.mcp.tool.UserTool;
 import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
@@ -17,7 +18,7 @@ import java.util.List;
 import java.util.Map;
 
 @Component
-public class GetCollectionSchemaTool implements UserTool {
+public class GetCollectionSchemaTool implements UserTool, AdminTool {
 
     private final GatewayHttpClient gateway;
 

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/GetFlowRunTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/GetFlowRunTool.java
@@ -1,0 +1,86 @@
+package io.kelta.mcp.tool.user;
+
+import io.kelta.mcp.client.GatewayHttpClient;
+import io.kelta.mcp.error.McpErrorMapper;
+import io.kelta.mcp.tool.Schemas;
+import io.kelta.mcp.tool.UserTool;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import io.modelcontextprotocol.spec.McpSchema.Tool;
+import org.springframework.stereotype.Component;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class GetFlowRunTool implements UserTool {
+
+    private final GatewayHttpClient gateway;
+
+    public GetFlowRunTool(GatewayHttpClient gateway) {
+        this.gateway = gateway;
+    }
+
+    @Override
+    public SyncToolSpecification toSpecification() {
+        Map<String, Object> properties = new LinkedHashMap<>();
+        properties.put("executionId", Schemas.string("Flow execution id returned by execute_flow."));
+        properties.put("includeSteps", Schemas.bool(
+                "If true, also fetch step-level execution logs and merge them into the response.", false));
+
+        Tool tool = Tool.builder()
+                .name("get_flow_run")
+                .description("Fetch the status of a flow execution. Wraps GET /api/flows/executions/{executionId}, with optional step-by-step logs from /steps merged in. Use to poll a long-running flow.")
+                .inputSchema(Schemas.object(properties, List.of("executionId")))
+                .build();
+
+        return SyncToolSpecification.builder()
+                .tool(tool)
+                .callHandler((exchange, request) -> {
+                    Map<String, Object> args = request.arguments();
+                    if (args == null) args = Map.of();
+                    Object id = args.get("executionId");
+                    if (id == null || id.toString().isBlank()) {
+                        return CallToolResult.builder()
+                                .isError(true)
+                                .content(List.of(new TextContent("Argument \"executionId\" is required.")))
+                                .build();
+                    }
+                    boolean includeSteps = readBool(args, "includeSteps", false);
+                    String encoded = URLEncoder.encode(id.toString(), StandardCharsets.UTF_8);
+                    try {
+                        GatewayHttpClient.Response runRes = gateway.get(
+                                "/api/flows/executions/" + encoded);
+                        if (!runRes.isSuccess()) {
+                            return McpErrorMapper.toResult(runRes);
+                        }
+                        if (!includeSteps) {
+                            return McpErrorMapper.toResult(runRes);
+                        }
+                        GatewayHttpClient.Response stepsRes = gateway.get(
+                                "/api/flows/executions/" + encoded + "/steps");
+                        String body = "{\n  \"execution\": " + runRes.body()
+                                + ",\n  \"steps\": "
+                                + (stepsRes.isSuccess() ? stepsRes.body() : "null")
+                                + "\n}";
+                        return CallToolResult.builder()
+                                .content(List.of(new TextContent(body)))
+                                .build();
+                    } catch (RuntimeException e) {
+                        return McpErrorMapper.fromException(e);
+                    }
+                })
+                .build();
+    }
+
+    private static boolean readBool(Map<String, Object> args, String key, boolean defaultValue) {
+        Object v = args.get(key);
+        if (v instanceof Boolean b) return b;
+        if (v instanceof String s) return Boolean.parseBoolean(s);
+        return defaultValue;
+    }
+}

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/GetRecordTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/GetRecordTool.java
@@ -1,0 +1,70 @@
+package io.kelta.mcp.tool.user;
+
+import io.kelta.mcp.client.GatewayHttpClient;
+import io.kelta.mcp.error.McpErrorMapper;
+import io.kelta.mcp.tool.Schemas;
+import io.kelta.mcp.tool.UserTool;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import io.modelcontextprotocol.spec.McpSchema.Tool;
+import org.springframework.stereotype.Component;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class GetRecordTool implements UserTool {
+
+    private final GatewayHttpClient gateway;
+
+    public GetRecordTool(GatewayHttpClient gateway) {
+        this.gateway = gateway;
+    }
+
+    @Override
+    public SyncToolSpecification toSpecification() {
+        Map<String, Object> properties = new LinkedHashMap<>();
+        properties.put("collection", Schemas.string("Collection name."));
+        properties.put("id", Schemas.string(
+                "Record id (UUID), or display field value if the collection has one (e.g. email for users)."));
+        properties.put("include", Schemas.string(
+                "Comma-separated relationship names to include in the response."));
+
+        Tool tool = Tool.builder()
+                .name("get_record")
+                .description("Fetch a single record by id from a collection. Returns the JSON:API single-resource response.")
+                .inputSchema(Schemas.object(properties, List.of("collection", "id")))
+                .build();
+
+        return SyncToolSpecification.builder()
+                .tool(tool)
+                .callHandler((exchange, request) -> {
+                    Map<String, Object> args = request.arguments();
+                    if (args == null) args = Map.of();
+                    Object cv = args.get("collection");
+                    Object iv = args.get("id");
+                    if (cv == null || cv.toString().isBlank() || iv == null || iv.toString().isBlank()) {
+                        return CallToolResult.builder()
+                                .isError(true)
+                                .content(List.of(new TextContent("Arguments \"collection\" and \"id\" are required.")))
+                                .build();
+                    }
+                    String path = "/api/" + URLEncoder.encode(cv.toString(), StandardCharsets.UTF_8)
+                            + "/" + URLEncoder.encode(iv.toString(), StandardCharsets.UTF_8);
+                    Object include = args.get("include");
+                    if (include != null && !include.toString().isBlank()) {
+                        path += "?include=" + URLEncoder.encode(include.toString(), StandardCharsets.UTF_8);
+                    }
+                    try {
+                        return McpErrorMapper.toResult(gateway.get(path));
+                    } catch (RuntimeException e) {
+                        return McpErrorMapper.fromException(e);
+                    }
+                })
+                .build();
+    }
+}

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/ListApprovalsTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/ListApprovalsTool.java
@@ -1,0 +1,74 @@
+package io.kelta.mcp.tool.user;
+
+import io.kelta.mcp.client.GatewayHttpClient;
+import io.kelta.mcp.error.McpErrorMapper;
+import io.kelta.mcp.tool.Schemas;
+import io.kelta.mcp.tool.UserTool;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.spec.McpSchema.Tool;
+import org.springframework.stereotype.Component;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class ListApprovalsTool implements UserTool {
+
+    private final GatewayHttpClient gateway;
+
+    public ListApprovalsTool(GatewayHttpClient gateway) {
+        this.gateway = gateway;
+    }
+
+    @Override
+    public SyncToolSpecification toSpecification() {
+        Map<String, Object> properties = new LinkedHashMap<>();
+        properties.put("status", Schemas.string(
+                "Filter by status: \"pending\", \"approved\", \"rejected\", or \"all\" (default: pending)."));
+        properties.put("pageSize", Schemas.integer("Records per page (default 20).", 1, 200));
+        properties.put("pageNumber", Schemas.integer("Page number, 1-based (default 1).", 1, null));
+
+        Tool tool = Tool.builder()
+                .name("list_approvals")
+                .description("List approval instances, optionally filtered by status. Wraps the approvalInstances system collection. Useful to find what's waiting on you.")
+                .inputSchema(Schemas.object(properties, List.of()))
+                .build();
+
+        return SyncToolSpecification.builder()
+                .tool(tool)
+                .callHandler((exchange, request) -> {
+                    Map<String, Object> args = request.arguments();
+                    if (args == null) args = Map.of();
+                    String status = String.valueOf(args.getOrDefault("status", "pending"));
+
+                    List<String> parts = new ArrayList<>();
+                    if (!"all".equalsIgnoreCase(status) && !status.isBlank()) {
+                        parts.add("filter[status][EQ]=" + URLEncoder.encode(
+                                status.toUpperCase(java.util.Locale.ROOT), StandardCharsets.UTF_8));
+                    }
+                    Object pageSize = args.get("pageSize");
+                    if (pageSize != null) {
+                        parts.add("page[size]=" + URLEncoder.encode(
+                                pageSize.toString(), StandardCharsets.UTF_8));
+                    }
+                    Object pageNumber = args.get("pageNumber");
+                    if (pageNumber != null) {
+                        parts.add("page[number]=" + URLEncoder.encode(
+                                pageNumber.toString(), StandardCharsets.UTF_8));
+                    }
+
+                    String path = "/api/approvalInstances"
+                            + (parts.isEmpty() ? "" : "?" + String.join("&", parts));
+                    try {
+                        return McpErrorMapper.toResult(gateway.get(path));
+                    } catch (RuntimeException e) {
+                        return McpErrorMapper.fromException(e);
+                    }
+                })
+                .build();
+    }
+}

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/ListCollectionsTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/ListCollectionsTool.java
@@ -1,0 +1,61 @@
+package io.kelta.mcp.tool.user;
+
+import io.kelta.mcp.client.GatewayHttpClient;
+import io.kelta.mcp.error.McpErrorMapper;
+import io.kelta.mcp.tool.Schemas;
+import io.kelta.mcp.tool.UserTool;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.spec.McpSchema.Tool;
+import org.springframework.stereotype.Component;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class ListCollectionsTool implements UserTool {
+
+    private final GatewayHttpClient gateway;
+
+    public ListCollectionsTool(GatewayHttpClient gateway) {
+        this.gateway = gateway;
+    }
+
+    @Override
+    public SyncToolSpecification toSpecification() {
+        Map<String, Object> properties = new LinkedHashMap<>();
+        properties.put("includeSystem", Schemas.bool(
+                "Include system collections (users, fields, layouts, etc.). Default true.",
+                true));
+
+        Tool tool = Tool.builder()
+                .name("list_collections")
+                .description("List all collections available in the current tenant. Returns JSON:API formatted list with collection metadata. Use this to discover what data is available before querying.")
+                .inputSchema(Schemas.object(properties, List.of()))
+                .build();
+
+        return SyncToolSpecification.builder()
+                .tool(tool)
+                .callHandler((exchange, request) -> {
+                    boolean includeSystem = readBool(request.arguments(), "includeSystem", true);
+                    String path = "/api/collections";
+                    if (!includeSystem) {
+                        path += "?filter[isSystem][EQ]=false";
+                    }
+                    try {
+                        return McpErrorMapper.toResult(gateway.get(path));
+                    } catch (RuntimeException e) {
+                        return McpErrorMapper.fromException(e);
+                    }
+                })
+                .build();
+    }
+
+    private static boolean readBool(Map<String, Object> args, String key, boolean defaultValue) {
+        if (args == null) return defaultValue;
+        Object v = args.get(key);
+        if (v instanceof Boolean b) return b;
+        if (v instanceof String s) return Boolean.parseBoolean(s);
+        return defaultValue;
+    }
+}

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/ListCollectionsTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/ListCollectionsTool.java
@@ -2,6 +2,7 @@ package io.kelta.mcp.tool.user;
 
 import io.kelta.mcp.client.GatewayHttpClient;
 import io.kelta.mcp.error.McpErrorMapper;
+import io.kelta.mcp.tool.AdminTool;
 import io.kelta.mcp.tool.Schemas;
 import io.kelta.mcp.tool.UserTool;
 import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
@@ -13,7 +14,7 @@ import java.util.List;
 import java.util.Map;
 
 @Component
-public class ListCollectionsTool implements UserTool {
+public class ListCollectionsTool implements UserTool, AdminTool {
 
     private final GatewayHttpClient gateway;
 

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/QueryCollectionTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/QueryCollectionTool.java
@@ -1,0 +1,120 @@
+package io.kelta.mcp.tool.user;
+
+import io.kelta.mcp.client.GatewayHttpClient;
+import io.kelta.mcp.error.McpErrorMapper;
+import io.kelta.mcp.tool.Schemas;
+import io.kelta.mcp.tool.UserTool;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import io.modelcontextprotocol.spec.McpSchema.Tool;
+import org.springframework.stereotype.Component;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+@Component
+public class QueryCollectionTool implements UserTool {
+
+    private static final List<String> ALLOWED_OPS = List.of(
+            "EQ", "NEQ", "GT", "GTE", "LT", "LTE",
+            "IN", "NIN", "CONTAINS", "NOT_CONTAINS",
+            "STARTSWITH", "ENDSWITH", "BETWEEN", "EXISTS", "IS_NULL");
+
+    private final GatewayHttpClient gateway;
+
+    public QueryCollectionTool(GatewayHttpClient gateway) {
+        this.gateway = gateway;
+    }
+
+    @Override
+    public SyncToolSpecification toSpecification() {
+        Map<String, Object> filter = Schemas.freeObject(
+                "Filter expressions, keyed by field name. Each value is an object mapping operator -> value. "
+                + "Allowed operators: " + ALLOWED_OPS + ". Example: {\"status\":{\"EQ\":\"ACTIVE\"},"
+                + " \"createdAt\":{\"GTE\":\"2024-01-01T00:00:00Z\"}}.");
+
+        Map<String, Object> properties = new LinkedHashMap<>();
+        properties.put("collection", Schemas.string(
+                "Collection name (e.g. \"accounts\", \"users\")."));
+        properties.put("filter", filter);
+        properties.put("sort", Schemas.string(
+                "Comma-separated sort fields. Prefix with '-' for descending. Example: \"lastName,-createdAt\"."));
+        properties.put("pageSize", Schemas.integer(
+                "Records per page (default 20).", 1, 200));
+        properties.put("pageNumber", Schemas.integer(
+                "Page number, 1-based (default 1).", 1, null));
+        properties.put("fields", Schemas.string(
+                "Comma-separated field names to include. Default: all."));
+        properties.put("include", Schemas.string(
+                "Comma-separated relationship names to include in the response."));
+
+        Tool tool = Tool.builder()
+                .name("query_collection")
+                .description("List records from a collection with JSON:API filters/sort/paging. Returns the JSON:API list response with `data` and `meta` keys. Prefer this for browsing; use get_record for fetching a known id.")
+                .inputSchema(Schemas.object(properties, List.of("collection")))
+                .build();
+
+        return SyncToolSpecification.builder()
+                .tool(tool)
+                .callHandler((exchange, request) -> {
+                    Map<String, Object> args = request.arguments();
+                    if (args == null) args = Map.of();
+                    Object cv = args.get("collection");
+                    if (cv == null || cv.toString().isBlank()) {
+                        return CallToolResult.builder()
+                                .isError(true)
+                                .content(List.of(new TextContent("Argument \"collection\" is required.")))
+                                .build();
+                    }
+                    String collection = cv.toString();
+                    String query = buildQueryString(args);
+                    String path = "/api/" + URLEncoder.encode(collection, StandardCharsets.UTF_8)
+                            + (query.isEmpty() ? "" : "?" + query);
+                    try {
+                        return McpErrorMapper.toResult(gateway.get(path));
+                    } catch (RuntimeException e) {
+                        return McpErrorMapper.fromException(e);
+                    }
+                })
+                .build();
+    }
+
+    static String buildQueryString(Map<String, Object> args) {
+        List<String> parts = new ArrayList<>();
+        Object filter = args.get("filter");
+        if (filter instanceof Map<?, ?> filterMap) {
+            for (Map.Entry<?, ?> e : filterMap.entrySet()) {
+                if (!(e.getValue() instanceof Map<?, ?> ops)) continue;
+                String fieldName = String.valueOf(e.getKey());
+                for (Map.Entry<?, ?> op : ops.entrySet()) {
+                    String opName = String.valueOf(op.getKey()).toUpperCase(Locale.ROOT);
+                    if (!ALLOWED_OPS.contains(opName)) continue;
+                    parts.add("filter[" + enc(fieldName) + "][" + opName + "]=" + enc(String.valueOf(op.getValue())));
+                }
+            }
+        }
+        Object sort = args.get("sort");
+        if (sort != null && !sort.toString().isBlank()) {
+            parts.add("sort=" + enc(sort.toString()));
+        }
+        Object pageSize = args.get("pageSize");
+        if (pageSize != null) parts.add("page[size]=" + enc(pageSize.toString()));
+        Object pageNumber = args.get("pageNumber");
+        if (pageNumber != null) parts.add("page[number]=" + enc(pageNumber.toString()));
+        Object fields = args.get("fields");
+        if (fields != null && !fields.toString().isBlank()) parts.add("fields=" + enc(fields.toString()));
+        Object include = args.get("include");
+        if (include != null && !include.toString().isBlank()) parts.add("include=" + enc(include.toString()));
+        return String.join("&", parts);
+    }
+
+    private static String enc(String s) {
+        return URLEncoder.encode(s, StandardCharsets.UTF_8);
+    }
+}

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/SearchTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/SearchTool.java
@@ -1,0 +1,66 @@
+package io.kelta.mcp.tool.user;
+
+import io.kelta.mcp.client.GatewayHttpClient;
+import io.kelta.mcp.error.McpErrorMapper;
+import io.kelta.mcp.tool.Schemas;
+import io.kelta.mcp.tool.UserTool;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import io.modelcontextprotocol.spec.McpSchema.Tool;
+import org.springframework.stereotype.Component;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class SearchTool implements UserTool {
+
+    private final GatewayHttpClient gateway;
+
+    public SearchTool(GatewayHttpClient gateway) {
+        this.gateway = gateway;
+    }
+
+    @Override
+    public SyncToolSpecification toSpecification() {
+        Map<String, Object> properties = new LinkedHashMap<>();
+        properties.put("query", Schemas.string("Free-text query (matches against searchable fields across all collections)."));
+        properties.put("limit", Schemas.integer("Maximum results to return (default 20).", 1, 100));
+
+        Tool tool = Tool.builder()
+                .name("search")
+                .description("Cross-collection full-text search. Returns hits with collection name, record id, and matched snippet. Useful when you don't know which collection holds the answer.")
+                .inputSchema(Schemas.object(properties, List.of("query")))
+                .build();
+
+        return SyncToolSpecification.builder()
+                .tool(tool)
+                .callHandler((exchange, request) -> {
+                    Map<String, Object> args = request.arguments();
+                    if (args == null) args = Map.of();
+                    Object q = args.get("query");
+                    if (q == null || q.toString().isBlank()) {
+                        return CallToolResult.builder()
+                                .isError(true)
+                                .content(List.of(new TextContent("Argument \"query\" is required.")))
+                                .build();
+                    }
+                    String path = "/api/_search?q="
+                            + URLEncoder.encode(q.toString(), StandardCharsets.UTF_8);
+                    Object limit = args.get("limit");
+                    if (limit != null) {
+                        path += "&limit=" + URLEncoder.encode(limit.toString(), StandardCharsets.UTF_8);
+                    }
+                    try {
+                        return McpErrorMapper.toResult(gateway.get(path));
+                    } catch (RuntimeException e) {
+                        return McpErrorMapper.fromException(e);
+                    }
+                })
+                .build();
+    }
+}

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/SubmitForApprovalTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/SubmitForApprovalTool.java
@@ -1,0 +1,73 @@
+package io.kelta.mcp.tool.user;
+
+import io.kelta.mcp.client.GatewayHttpClient;
+import io.kelta.mcp.error.McpErrorMapper;
+import io.kelta.mcp.tool.Schemas;
+import io.kelta.mcp.tool.UserTool;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import io.modelcontextprotocol.spec.McpSchema.Tool;
+import org.springframework.stereotype.Component;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class SubmitForApprovalTool implements UserTool {
+
+    private final GatewayHttpClient gateway;
+
+    public SubmitForApprovalTool(GatewayHttpClient gateway) {
+        this.gateway = gateway;
+    }
+
+    @Override
+    public SyncToolSpecification toSpecification() {
+        Map<String, Object> properties = new LinkedHashMap<>();
+        properties.put("collectionId", Schemas.string(
+                "Collection id (UUID) of the record being submitted. Use get_collection_schema to look up by name."));
+        properties.put("recordId", Schemas.string("Record id to submit for approval."));
+        properties.put("processId", Schemas.string(
+                "Optional approval process id. If omitted, the platform auto-selects a matching process."));
+
+        Tool tool = Tool.builder()
+                .name("submit_for_approval")
+                .description("Submit a record for approval. Wraps POST /api/approvals/submit. Returns the new approval instance id; use list_approvals to track its status.")
+                .inputSchema(Schemas.object(properties, List.of("collectionId", "recordId")))
+                .build();
+
+        return SyncToolSpecification.builder()
+                .tool(tool)
+                .callHandler((exchange, request) -> {
+                    Map<String, Object> args = request.arguments();
+                    if (args == null) args = Map.of();
+                    Object cId = args.get("collectionId");
+                    Object rId = args.get("recordId");
+                    if (cId == null || cId.toString().isBlank()
+                            || rId == null || rId.toString().isBlank()) {
+                        return CallToolResult.builder()
+                                .isError(true)
+                                .content(List.of(new TextContent(
+                                        "Arguments \"collectionId\" and \"recordId\" are required.")))
+                                .build();
+                    }
+
+                    Map<String, Object> body = new LinkedHashMap<>();
+                    body.put("collectionId", cId.toString());
+                    body.put("recordId", rId.toString());
+                    Object processId = args.get("processId");
+                    if (processId != null && !processId.toString().isBlank()) {
+                        body.put("processId", processId.toString());
+                    }
+
+                    try {
+                        return McpErrorMapper.toResult(gateway.post("/api/approvals/submit", body));
+                    } catch (RuntimeException e) {
+                        return McpErrorMapper.fromException(e);
+                    }
+                })
+                .build();
+    }
+}

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/UpdateRecordTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/UpdateRecordTool.java
@@ -1,0 +1,87 @@
+package io.kelta.mcp.tool.user;
+
+import io.kelta.mcp.client.GatewayHttpClient;
+import io.kelta.mcp.error.McpErrorMapper;
+import io.kelta.mcp.tool.Schemas;
+import io.kelta.mcp.tool.UserTool;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import io.modelcontextprotocol.spec.McpSchema.Tool;
+import org.springframework.stereotype.Component;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class UpdateRecordTool implements UserTool {
+
+    private final GatewayHttpClient gateway;
+
+    public UpdateRecordTool(GatewayHttpClient gateway) {
+        this.gateway = gateway;
+    }
+
+    @Override
+    public SyncToolSpecification toSpecification() {
+        Map<String, Object> properties = new LinkedHashMap<>();
+        properties.put("collection", Schemas.string("Collection name."));
+        properties.put("id", Schemas.string("Record id (UUID or display field value)."));
+        properties.put("attributes", Schemas.freeObject(
+                "Field values to update. Only the keys you include are modified — other fields are untouched (PATCH semantics)."));
+        properties.put("relationships", Schemas.freeObject(
+                "Optional JSON:API relationships object to replace; each entry maps a relationship name to a JSON:API resource identifier."));
+
+        Tool tool = Tool.builder()
+                .name("update_record")
+                .description("Update fields on a single record. Wraps PATCH /api/{collection}/{id}. Only the attributes you supply are modified — omitted fields keep their current values.")
+                .inputSchema(Schemas.object(properties, List.of("collection", "id")))
+                .build();
+
+        return SyncToolSpecification.builder()
+                .tool(tool)
+                .callHandler((exchange, request) -> {
+                    Map<String, Object> args = request.arguments();
+                    if (args == null) args = Map.of();
+                    Object cv = args.get("collection");
+                    Object iv = args.get("id");
+                    if (cv == null || cv.toString().isBlank() || iv == null || iv.toString().isBlank()) {
+                        return error("Arguments \"collection\" and \"id\" are required.");
+                    }
+                    Object av = args.get("attributes");
+                    Object rv = args.get("relationships");
+                    boolean hasAttrs = av instanceof Map<?, ?> am && !am.isEmpty();
+                    boolean hasRels = rv instanceof Map<?, ?> rm && !rm.isEmpty();
+                    if (!hasAttrs && !hasRels) {
+                        return error("Provide at least one of \"attributes\" or \"relationships\" to update.");
+                    }
+
+                    String collection = cv.toString();
+                    Map<String, Object> data = new LinkedHashMap<>();
+                    data.put("type", collection);
+                    data.put("id", iv.toString());
+                    if (hasAttrs) data.put("attributes", av);
+                    if (hasRels) data.put("relationships", rv);
+                    Map<String, Object> body = Map.of("data", data);
+
+                    String path = "/api/" + URLEncoder.encode(collection, StandardCharsets.UTF_8)
+                            + "/" + URLEncoder.encode(iv.toString(), StandardCharsets.UTF_8);
+                    try {
+                        return McpErrorMapper.toResult(gateway.patch(path, body));
+                    } catch (RuntimeException e) {
+                        return McpErrorMapper.fromException(e);
+                    }
+                })
+                .build();
+    }
+
+    private static CallToolResult error(String message) {
+        return CallToolResult.builder()
+                .isError(true)
+                .content(List.of(new TextContent(message)))
+                .build();
+    }
+}

--- a/kelta-mcp/src/main/resources/logback-spring.xml
+++ b/kelta-mcp/src/main/resources/logback-spring.xml
@@ -1,5 +1,9 @@
 <configuration>
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- Defense-in-depth: drop any event whose message contains a klt_* token.
+             Application code already redacts PATs (see McpErrorMapper); this is the
+             belt-and-suspenders backstop against future regressions. -->
+        <filter class="io.kelta.mcp.observe.PatRedactionFilter"/>
         <encoder class="net.logstash.logback.encoder.LogstashEncoder">
             <includeMdcKeyName>traceId</includeMdcKeyName>
             <includeMdcKeyName>spanId</includeMdcKeyName>

--- a/kelta-mcp/src/test/java/io/kelta/mcp/McpApplicationTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/McpApplicationTest.java
@@ -113,13 +113,22 @@ class McpApplicationTest {
     }
 
     @Test
-    void adminEndpointHasOnlyReadOnlyBrowseTools() {
+    void adminEndpointSurfaceMatchesPhase6() {
         List<String> names = adminTools.stream()
                 .map(t -> t.toSpecification().tool().name())
                 .toList();
         assertThat(names).containsExactlyInAnyOrder(
+                // shared read-only browse tools (also on /mcp/user)
                 "list_collections",
-                "get_collection_schema");
+                "get_collection_schema",
+                // schema admin (Phase 6)
+                "create_collection",
+                "update_collection",
+                "add_field",
+                "update_field",
+                "remove_field",
+                "create_validation_rule",
+                "create_picklist");
     }
 
     @Test

--- a/kelta-mcp/src/test/java/io/kelta/mcp/McpApplicationTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/McpApplicationTest.java
@@ -2,6 +2,7 @@ package io.kelta.mcp;
 
 import io.kelta.mcp.resource.UserResource;
 import io.kelta.mcp.resource.UserResourceTemplate;
+import io.kelta.mcp.tool.AdminTool;
 import io.kelta.mcp.tool.UserTool;
 import io.modelcontextprotocol.server.McpSyncServer;
 import org.junit.jupiter.api.Test;
@@ -47,6 +48,9 @@ class McpApplicationTest {
 
     @Autowired
     private List<UserResourceTemplate> userResourceTemplates;
+
+    @Autowired
+    private List<AdminTool> adminTools;
 
     @Test
     void bothMcpServersAreWired() {
@@ -106,5 +110,26 @@ class McpApplicationTest {
                 .map(t -> t.toSpecification().resourceTemplate().uriTemplate())
                 .toList();
         assertThat(templates).containsExactly("kelta://collections/{name}");
+    }
+
+    @Test
+    void adminEndpointHasOnlyReadOnlyBrowseTools() {
+        List<String> names = adminTools.stream()
+                .map(t -> t.toSpecification().tool().name())
+                .toList();
+        assertThat(names).containsExactlyInAnyOrder(
+                "list_collections",
+                "get_collection_schema");
+    }
+
+    @Test
+    void mutationToolsNeverLeakToAdminEndpoint() {
+        List<String> adminNames = adminTools.stream()
+                .map(t -> t.toSpecification().tool().name())
+                .toList();
+        // Hard guarantee: no write-side user tool can appear on the admin server.
+        assertThat(adminNames).doesNotContain(
+                "create_record", "update_record", "delete_record", "bulk_apply",
+                "execute_flow", "submit_for_approval", "list_approvals");
     }
 }

--- a/kelta-mcp/src/test/java/io/kelta/mcp/McpApplicationTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/McpApplicationTest.java
@@ -81,7 +81,11 @@ class McpApplicationTest {
                 "create_record",
                 "update_record",
                 "delete_record",
-                "bulk_apply"
+                "bulk_apply",
+                "execute_flow",
+                "get_flow_run",
+                "submit_for_approval",
+                "list_approvals"
         );
     }
 

--- a/kelta-mcp/src/test/java/io/kelta/mcp/McpApplicationTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/McpApplicationTest.java
@@ -113,7 +113,7 @@ class McpApplicationTest {
     }
 
     @Test
-    void adminEndpointSurfaceMatchesPhase6() {
+    void adminEndpointSurfaceCoversPhase6Through8() {
         List<String> names = adminTools.stream()
                 .map(t -> t.toSpecification().tool().name())
                 .toList();
@@ -128,7 +128,16 @@ class McpApplicationTest {
                 "update_field",
                 "remove_field",
                 "create_validation_rule",
-                "create_picklist");
+                "create_picklist",
+                // UI admin (Phase 7)
+                "create_layout",
+                "update_layout",
+                "delete_layout",
+                "create_listview",
+                // automation admin + integrations (Phase 8)
+                "create_flow",
+                "update_flow",
+                "import_api_spec");
     }
 
     @Test

--- a/kelta-mcp/src/test/java/io/kelta/mcp/McpApplicationTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/McpApplicationTest.java
@@ -1,5 +1,6 @@
 package io.kelta.mcp;
 
+import io.kelta.mcp.tool.UserTool;
 import io.modelcontextprotocol.server.McpSyncServer;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -8,6 +9,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.servlet.ServletRegistrationBean;
 import org.springframework.test.context.TestPropertySource;
 
+import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -35,6 +37,9 @@ class McpApplicationTest {
     @Autowired
     private Map<String, ServletRegistrationBean<?>> servletRegistrations;
 
+    @Autowired
+    private List<UserTool> userTools;
+
     @Test
     void bothMcpServersAreWired() {
         assertThat(userServer).isNotNull();
@@ -51,5 +56,20 @@ class McpApplicationTest {
         assertThat(adminServlet).isNotNull();
         assertThat(userServlet.getUrlMappings()).contains("/mcp/user", "/mcp/user/*");
         assertThat(adminServlet.getUrlMappings()).contains("/mcp/admin", "/mcp/admin/*");
+    }
+
+    @Test
+    void allReadOnlyUserToolsAreDiscovered() {
+        List<String> names = userTools.stream()
+                .map(t -> t.toSpecification().tool().name())
+                .toList();
+        assertThat(names).containsExactlyInAnyOrder(
+                "list_collections",
+                "get_collection_schema",
+                "query_collection",
+                "get_record",
+                "search",
+                "describe_api"
+        );
     }
 }

--- a/kelta-mcp/src/test/java/io/kelta/mcp/McpApplicationTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/McpApplicationTest.java
@@ -1,5 +1,7 @@
 package io.kelta.mcp;
 
+import io.kelta.mcp.resource.UserResource;
+import io.kelta.mcp.resource.UserResourceTemplate;
 import io.kelta.mcp.tool.UserTool;
 import io.modelcontextprotocol.server.McpSyncServer;
 import org.junit.jupiter.api.Test;
@@ -40,6 +42,12 @@ class McpApplicationTest {
     @Autowired
     private List<UserTool> userTools;
 
+    @Autowired
+    private List<UserResource> userResources;
+
+    @Autowired
+    private List<UserResourceTemplate> userResourceTemplates;
+
     @Test
     void bothMcpServersAreWired() {
         assertThat(userServer).isNotNull();
@@ -59,7 +67,7 @@ class McpApplicationTest {
     }
 
     @Test
-    void allReadOnlyUserToolsAreDiscovered() {
+    void allUserToolsAreDiscovered() {
         List<String> names = userTools.stream()
                 .map(t -> t.toSpecification().tool().name())
                 .toList();
@@ -69,7 +77,30 @@ class McpApplicationTest {
                 "query_collection",
                 "get_record",
                 "search",
-                "describe_api"
+                "describe_api",
+                "create_record",
+                "update_record",
+                "delete_record",
+                "bulk_apply"
         );
+    }
+
+    @Test
+    void userResourcesAreDiscovered() {
+        List<String> uris = userResources.stream()
+                .map(r -> r.toSpecification().resource().uri())
+                .toList();
+        assertThat(uris).containsExactlyInAnyOrder(
+                "kelta://collections",
+                "kelta://openapi.json"
+        );
+    }
+
+    @Test
+    void userResourceTemplatesAreDiscovered() {
+        List<String> templates = userResourceTemplates.stream()
+                .map(t -> t.toSpecification().resourceTemplate().uriTemplate())
+                .toList();
+        assertThat(templates).containsExactly("kelta://collections/{name}");
     }
 }

--- a/kelta-mcp/src/test/java/io/kelta/mcp/auth/McpAuthFilterTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/auth/McpAuthFilterTest.java
@@ -73,6 +73,40 @@ class McpAuthFilterTest {
     }
 
     @Test
+    void setsPatHolderDuringChainAndClearsAfter() throws Exception {
+        MockHttpServletRequest req = new MockHttpServletRequest("POST", "/mcp/user");
+        req.addHeader("Authorization", "Bearer klt_xyz_during_chain");
+        MockHttpServletResponse res = new MockHttpServletResponse();
+
+        String[] seenInChain = new String[1];
+        FilterChain chain = (request, response) -> {
+            seenInChain[0] = io.kelta.mcp.auth.RequestPatHolder.get();
+        };
+
+        filter.doFilter(req, res, chain);
+
+        assertThat(seenInChain[0]).isEqualTo("klt_xyz_during_chain");
+        assertThat(io.kelta.mcp.auth.RequestPatHolder.get()).isNull();
+    }
+
+    @Test
+    void clearsPatHolderEvenIfChainThrows() {
+        MockHttpServletRequest req = new MockHttpServletRequest("POST", "/mcp/user");
+        req.addHeader("Authorization", "Bearer klt_failing");
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        FilterChain chain = (request, response) -> {
+            throw new RuntimeException("simulated downstream failure");
+        };
+
+        try {
+            filter.doFilter(req, res, chain);
+        } catch (Exception ignored) {
+            // expected
+        }
+        assertThat(io.kelta.mcp.auth.RequestPatHolder.get()).isNull();
+    }
+
+    @Test
     void skipsFilterForNonMcpPaths() throws Exception {
         MockHttpServletRequest req = new MockHttpServletRequest("GET", "/actuator/health");
         MockHttpServletResponse res = new MockHttpServletResponse();

--- a/kelta-mcp/src/test/java/io/kelta/mcp/auth/PatSessionStoreTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/auth/PatSessionStoreTest.java
@@ -7,7 +7,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class PatSessionStoreTest {
 
-    private final PatSessionStore store = new PatSessionStore(new McpProperties("http://gw", 30, 60_000));
+    private final PatSessionStore store = new PatSessionStore(new McpProperties("http://gw", 30, 60_000, null));
 
     @Test
     void putsAndRetrievesPat() {

--- a/kelta-mcp/src/test/java/io/kelta/mcp/client/GatewayHttpClientTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/client/GatewayHttpClientTest.java
@@ -1,0 +1,138 @@
+package io.kelta.mcp.client;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder;
+import io.kelta.mcp.auth.RequestPatHolder;
+import io.kelta.mcp.config.McpProperties;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestClient;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.absent;
+import static com.github.tomakehurst.wiremock.client.WireMock.delete;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
+import static com.github.tomakehurst.wiremock.client.WireMock.patch;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class GatewayHttpClientTest {
+
+    private WireMockServer wm;
+    private GatewayHttpClient client;
+
+    @BeforeEach
+    void setUp() {
+        wm = new WireMockServer(0);
+        wm.start();
+        McpProperties props = new McpProperties("http://localhost:" + wm.port(), 30, 60_000);
+        client = new GatewayHttpClient(RestClient.builder(), props);
+        RequestPatHolder.set("klt_test_pat_value");
+    }
+
+    @AfterEach
+    void tearDown() {
+        RequestPatHolder.clear();
+        wm.stop();
+    }
+
+    @Test
+    void getForwardsBearerTokenInAuthorizationHeader() {
+        wm.stubFor(get(urlEqualTo("/api/collections"))
+                .willReturn(aResponse().withStatus(200).withBody("{\"data\":[]}")));
+
+        GatewayHttpClient.Response res = client.get("/api/collections");
+
+        assertThat(res.isSuccess()).isTrue();
+        assertThat(res.body()).isEqualTo("{\"data\":[]}");
+        wm.verify(getRequestedForUrl("/api/collections")
+                .withHeader("Authorization", equalTo("Bearer klt_test_pat_value"))
+                .withHeader("X-Tenant-ID", absent()));
+    }
+
+    @Test
+    void postSendsJsonBody() {
+        wm.stubFor(post(urlEqualTo("/api/accounts"))
+                .willReturn(aResponse().withStatus(201).withBody("{\"data\":{\"id\":\"a1\"}}")));
+
+        GatewayHttpClient.Response res = client.post("/api/accounts",
+                java.util.Map.of("data", java.util.Map.of("type", "accounts",
+                        "attributes", java.util.Map.of("name", "Acme"))));
+
+        assertThat(res.isSuccess()).isTrue();
+        wm.verify(postRequestedForUrl("/api/accounts")
+                .withHeader("Authorization", equalTo("Bearer klt_test_pat_value"))
+                .withHeader("Content-Type", equalTo("application/json"))
+                .withRequestBody(matchingJsonPath("$.data.attributes.name")));
+    }
+
+    @Test
+    void patchSendsJsonBody() {
+        wm.stubFor(patch(urlEqualTo("/api/accounts/a1"))
+                .willReturn(aResponse().withStatus(200).withBody("{\"data\":{}}")));
+
+        GatewayHttpClient.Response res = client.patch("/api/accounts/a1",
+                java.util.Map.of("data", java.util.Map.of("attributes", java.util.Map.of("name", "Acme2"))));
+
+        assertThat(res.isSuccess()).isTrue();
+        wm.verify(patchRequestedForUrl("/api/accounts/a1")
+                .withHeader("Authorization", equalTo("Bearer klt_test_pat_value")));
+    }
+
+    @Test
+    void deleteUsesNoBody() {
+        wm.stubFor(delete(urlEqualTo("/api/accounts/a1"))
+                .willReturn(aResponse().withStatus(204)));
+
+        GatewayHttpClient.Response res = client.delete("/api/accounts/a1");
+
+        assertThat(res.isSuccess()).isTrue();
+        wm.verify(deleteRequestedForUrl("/api/accounts/a1")
+                .withHeader("Authorization", equalTo("Bearer klt_test_pat_value")));
+    }
+
+    @Test
+    void surfaceErrorBodyOnNon2xx() {
+        wm.stubFor(get(urlEqualTo("/api/collections/missing"))
+                .willReturn(aResponse().withStatus(404).withBody("{\"errors\":[{\"detail\":\"not found\"}]}")));
+
+        GatewayHttpClient.Response res = client.get("/api/collections/missing");
+
+        assertThat(res.isSuccess()).isFalse();
+        assertThat(res.status().value()).isEqualTo(404);
+        assertThat(res.body()).contains("not found");
+    }
+
+    @Test
+    void rejectsCallWhenNoPatInContext() {
+        RequestPatHolder.clear();
+
+        assertThatThrownBy(() -> client.get("/api/collections"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("No PAT in request context");
+
+        wm.verify(0, getRequestedForUrl("/api/collections"));
+    }
+
+    private static RequestPatternBuilder getRequestedForUrl(String url) {
+        return WireMock.getRequestedFor(urlEqualTo(url));
+    }
+
+    private static RequestPatternBuilder postRequestedForUrl(String url) {
+        return WireMock.postRequestedFor(urlEqualTo(url));
+    }
+
+    private static RequestPatternBuilder patchRequestedForUrl(String url) {
+        return WireMock.patchRequestedFor(urlEqualTo(url));
+    }
+
+    private static RequestPatternBuilder deleteRequestedForUrl(String url) {
+        return WireMock.deleteRequestedFor(urlEqualTo(url));
+    }
+}

--- a/kelta-mcp/src/test/java/io/kelta/mcp/client/GatewayHttpClientTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/client/GatewayHttpClientTest.java
@@ -31,7 +31,7 @@ class GatewayHttpClientTest {
     void setUp() {
         wm = new WireMockServer(0);
         wm.start();
-        McpProperties props = new McpProperties("http://localhost:" + wm.port(), 30, 60_000);
+        McpProperties props = new McpProperties("http://localhost:" + wm.port(), 30, 60_000, null);
         client = new GatewayHttpClient(RestClient.builder(), props);
         RequestPatHolder.set("klt_test_pat_value");
     }

--- a/kelta-mcp/src/test/java/io/kelta/mcp/error/McpErrorMapperTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/error/McpErrorMapperTest.java
@@ -1,0 +1,102 @@
+package io.kelta.mcp.error;
+
+import io.kelta.mcp.client.GatewayHttpClient;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class McpErrorMapperTest {
+
+    @Test
+    void success200BecomesResultWithBodyAsText() {
+        GatewayHttpClient.Response response = new GatewayHttpClient.Response(
+                HttpStatus.OK, "{\"data\":[1,2,3]}");
+
+        CallToolResult result = McpErrorMapper.toResult(response);
+
+        assertThat(result.isError()).isNotEqualTo(Boolean.TRUE);
+        assertThat(result.content()).hasSize(1);
+        assertThat(((TextContent) result.content().get(0)).text())
+                .isEqualTo("{\"data\":[1,2,3]}");
+    }
+
+    @Test
+    void notFoundBecomesErrorResultWithStatusInMessage() {
+        GatewayHttpClient.Response response = new GatewayHttpClient.Response(
+                HttpStatus.NOT_FOUND, "{\"errors\":[{\"detail\":\"unknown collection\"}]}");
+
+        CallToolResult result = McpErrorMapper.toResult(response);
+
+        assertThat(result.isError()).isEqualTo(Boolean.TRUE);
+        String text = ((TextContent) result.content().get(0)).text();
+        assertThat(text).contains("404", "unknown collection");
+    }
+
+    @Test
+    void serverError500BecomesErrorResult() {
+        GatewayHttpClient.Response response = new GatewayHttpClient.Response(
+                HttpStatus.INTERNAL_SERVER_ERROR, "boom");
+
+        CallToolResult result = McpErrorMapper.toResult(response);
+
+        assertThat(result.isError()).isEqualTo(Boolean.TRUE);
+        assertThat(((TextContent) result.content().get(0)).text())
+                .contains("500", "boom");
+    }
+
+    @Test
+    void exceptionBecomesErrorResult() {
+        CallToolResult result = McpErrorMapper.fromException(
+                new RuntimeException("connect timeout"));
+
+        assertThat(result.isError()).isEqualTo(Boolean.TRUE);
+        assertThat(((TextContent) result.content().get(0)).text())
+                .contains("RuntimeException", "connect timeout");
+    }
+
+    @Test
+    void redactionScrubsPatTokensFromSuccessBody() {
+        GatewayHttpClient.Response response = new GatewayHttpClient.Response(
+                HttpStatus.OK, "leaked: klt_AbCdEf123456789012345");
+
+        CallToolResult result = McpErrorMapper.toResult(response);
+
+        assertThat(((TextContent) result.content().get(0)).text())
+                .contains("klt_***REDACTED***")
+                .doesNotContain("klt_AbCdEf123456789012345");
+    }
+
+    @Test
+    void redactionScrubsPatTokensFromErrorBody() {
+        GatewayHttpClient.Response response = new GatewayHttpClient.Response(
+                HttpStatus.UNAUTHORIZED,
+                "{\"message\":\"invalid token klt_topsecret999999999999999\"}");
+
+        CallToolResult result = McpErrorMapper.toResult(response);
+
+        String text = ((TextContent) result.content().get(0)).text();
+        assertThat(text)
+                .contains("klt_***REDACTED***")
+                .doesNotContain("klt_topsecret");
+    }
+
+    @Test
+    void redactionScrubsPatTokensFromExceptionMessage() {
+        CallToolResult result = McpErrorMapper.fromException(
+                new RuntimeException("auth failed for klt_DEADBEEF1234567890123456"));
+
+        assertThat(((TextContent) result.content().get(0)).text())
+                .contains("klt_***REDACTED***")
+                .doesNotContain("klt_DEADBEEF");
+    }
+
+    @Test
+    void redactionLeavesNonPatStringsAlone() {
+        assertThat(McpErrorMapper.redact("normal text with no token"))
+                .isEqualTo("normal text with no token");
+        assertThat(McpErrorMapper.redact(null)).isNull();
+    }
+}

--- a/kelta-mcp/src/test/java/io/kelta/mcp/observe/ObservedToolDecoratorTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/observe/ObservedToolDecoratorTest.java
@@ -1,0 +1,114 @@
+package io.kelta.mcp.observe;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import io.modelcontextprotocol.spec.McpSchema.Tool;
+import org.junit.jupiter.api.Test;
+import org.slf4j.MDC;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ObservedToolDecoratorTest {
+
+    private final MeterRegistry registry = new SimpleMeterRegistry();
+    private final ObservedToolDecorator decorator = new ObservedToolDecorator(registry);
+
+    private SyncToolSpecification stub(java.util.function.BiFunction<Object, CallToolRequest, CallToolResult> handler) {
+        Tool tool = Tool.builder()
+                .name("stub_tool")
+                .description("test")
+                .inputSchema(new io.modelcontextprotocol.spec.McpSchema.JsonSchema(
+                        "object", Map.of(), List.of(), false, null, null))
+                .build();
+        return SyncToolSpecification.builder()
+                .tool(tool)
+                .callHandler((exchange, req) -> handler.apply(exchange, req))
+                .build();
+    }
+
+    @Test
+    void recordsSuccessTimerAndCounter() {
+        SyncToolSpecification decorated = decorator.decorate(stub((ex, req) ->
+                CallToolResult.builder().content(List.of(new TextContent("ok"))).build()), "user");
+
+        decorated.callHandler().apply(null, new CallToolRequest("stub_tool", Map.of(), null));
+
+        assertThat(registry.counter("mcp.tool.calls",
+                "tool", "stub_tool", "profile", "user", "status", "success")
+                .count()).isEqualTo(1.0);
+        assertThat(registry.timer("mcp.tool.call.duration",
+                "tool", "stub_tool", "profile", "user", "status", "success")
+                .count()).isEqualTo(1L);
+    }
+
+    @Test
+    void taggedAsErrorWhenIsErrorTrue() {
+        SyncToolSpecification decorated = decorator.decorate(stub((ex, req) ->
+                CallToolResult.builder().isError(true)
+                        .content(List.of(new TextContent("nope"))).build()), "user");
+
+        decorated.callHandler().apply(null, new CallToolRequest("stub_tool", Map.of(), null));
+
+        assertThat(registry.counter("mcp.tool.calls",
+                "tool", "stub_tool", "profile", "user", "status", "error")
+                .count()).isEqualTo(1.0);
+    }
+
+    @Test
+    void taggedAsExceptionWhenHandlerThrows() {
+        SyncToolSpecification decorated = decorator.decorate(stub((ex, req) -> {
+            throw new RuntimeException("boom");
+        }), "admin");
+
+        assertThatThrownBy(() ->
+                decorated.callHandler().apply(null, new CallToolRequest("stub_tool", Map.of(), null)))
+                .isInstanceOf(RuntimeException.class);
+
+        assertThat(registry.counter("mcp.tool.calls",
+                "tool", "stub_tool", "profile", "admin", "status", "exception")
+                .count()).isEqualTo(1.0);
+    }
+
+    @Test
+    void mdcIsPopulatedDuringCallAndClearedAfter() {
+        AtomicReference<String> seenTool = new AtomicReference<>();
+        AtomicReference<String> seenProfile = new AtomicReference<>();
+
+        SyncToolSpecification decorated = decorator.decorate(stub((ex, req) -> {
+            seenTool.set(MDC.get("mcpTool"));
+            seenProfile.set(MDC.get("mcpProfile"));
+            return CallToolResult.builder().content(List.of(new TextContent("ok"))).build();
+        }), "user");
+
+        decorated.callHandler().apply(null, new CallToolRequest("stub_tool", Map.of(), null));
+
+        assertThat(seenTool.get()).isEqualTo("stub_tool");
+        assertThat(seenProfile.get()).isEqualTo("user");
+        assertThat(MDC.get("mcpTool")).isNull();
+        assertThat(MDC.get("mcpProfile")).isNull();
+    }
+
+    @Test
+    void mdcIsClearedEvenWhenHandlerThrows() {
+        SyncToolSpecification decorated = decorator.decorate(stub((ex, req) -> {
+            throw new RuntimeException("boom");
+        }), "user");
+
+        try {
+            decorated.callHandler().apply(null, new CallToolRequest("stub_tool", Map.of(), null));
+        } catch (RuntimeException ignored) {
+        }
+
+        assertThat(MDC.get("mcpTool")).isNull();
+        assertThat(MDC.get("mcpProfile")).isNull();
+    }
+}

--- a/kelta-mcp/src/test/java/io/kelta/mcp/observe/PatRedactionFilterTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/observe/PatRedactionFilterTest.java
@@ -1,0 +1,45 @@
+package io.kelta.mcp.observe;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.LoggingEvent;
+import ch.qos.logback.core.spi.FilterReply;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PatRedactionFilterTest {
+
+    private final PatRedactionFilter filter = new PatRedactionFilter();
+
+    private LoggingEvent event(String message) {
+        LoggingEvent e = new LoggingEvent();
+        e.setMessage(message);
+        e.setLevel(Level.INFO);
+        return e;
+    }
+
+    @Test
+    void allowsNormalMessages() {
+        assertThat(filter.decide(event("created collection projects")))
+                .isEqualTo(FilterReply.NEUTRAL);
+        assertThat(filter.decide(event("user submitted 17 records"))).isEqualTo(FilterReply.NEUTRAL);
+    }
+
+    @Test
+    void deniesEventsContainingPatToken() {
+        assertThat(filter.decide(event("auth failed for klt_AbCdEf12345")))
+                .isEqualTo(FilterReply.DENY);
+        assertThat(filter.decide(event("cached entry: klt_xyz987"))).isEqualTo(FilterReply.DENY);
+    }
+
+    @Test
+    void doesNotDenyMessagesContainingKltAsPlainWord() {
+        assertThat(filter.decide(event("Welcome to klt platform"))).isEqualTo(FilterReply.NEUTRAL);
+        assertThat(filter.decide(event("klt_ alone is not a token"))).isEqualTo(FilterReply.NEUTRAL);
+    }
+
+    @Test
+    void survivesNullEvent() {
+        assertThat(filter.decide(null)).isEqualTo(FilterReply.NEUTRAL);
+    }
+}

--- a/kelta-mcp/src/test/java/io/kelta/mcp/observe/RateLimitedToolDecoratorTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/observe/RateLimitedToolDecoratorTest.java
@@ -1,0 +1,92 @@
+package io.kelta.mcp.observe;
+
+import io.kelta.mcp.auth.RequestPatHolder;
+import io.kelta.mcp.config.McpProperties;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.JsonSchema;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import io.modelcontextprotocol.spec.McpSchema.Tool;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RateLimitedToolDecoratorTest {
+
+    private final MeterRegistry registry = new SimpleMeterRegistry();
+    private RateLimiter limiter;
+    private RateLimitedToolDecorator decorator;
+
+    @BeforeEach
+    void setUp() {
+        limiter = new RateLimiter(new McpProperties(
+                "http://gw", 30, 60_000,
+                new McpProperties.RateLimit(2, 0.0)));
+        decorator = new RateLimitedToolDecorator(limiter, registry);
+        RequestPatHolder.set("klt_decorator_test");
+    }
+
+    @AfterEach
+    void tearDown() {
+        RequestPatHolder.clear();
+    }
+
+    private SyncToolSpecification stub(AtomicInteger calls) {
+        Tool tool = Tool.builder()
+                .name("stub")
+                .description("test")
+                .inputSchema(new JsonSchema("object", Map.of(), List.of(), false, null, null))
+                .build();
+        return SyncToolSpecification.builder()
+                .tool(tool)
+                .callHandler((ex, req) -> {
+                    calls.incrementAndGet();
+                    return CallToolResult.builder().content(List.of(new TextContent("ok"))).build();
+                })
+                .build();
+    }
+
+    @Test
+    void allowsUpToCapacityThenReturnsRateLimitedResult() {
+        AtomicInteger calls = new AtomicInteger();
+        SyncToolSpecification decorated = decorator.decorate(stub(calls), "user");
+
+        for (int i = 0; i < 2; i++) {
+            CallToolResult r = decorated.callHandler().apply(null,
+                    new CallToolRequest("stub", Map.of(), null));
+            assertThat(r.isError()).isNotEqualTo(Boolean.TRUE);
+        }
+
+        CallToolResult limited = decorated.callHandler().apply(null,
+                new CallToolRequest("stub", Map.of(), null));
+        assertThat(limited.isError()).isEqualTo(Boolean.TRUE);
+        assertThat(((TextContent) limited.content().get(0)).text())
+                .contains("Rate limit exceeded");
+        // Inner handler should NOT have been invoked for the limited call.
+        assertThat(calls.get()).isEqualTo(2);
+    }
+
+    @Test
+    void rateLimitedCounterIncrements() {
+        AtomicInteger calls = new AtomicInteger();
+        SyncToolSpecification decorated = decorator.decorate(stub(calls), "user");
+
+        // Exhaust the bucket.
+        decorated.callHandler().apply(null, new CallToolRequest("stub", Map.of(), null));
+        decorated.callHandler().apply(null, new CallToolRequest("stub", Map.of(), null));
+        decorated.callHandler().apply(null, new CallToolRequest("stub", Map.of(), null));
+        decorated.callHandler().apply(null, new CallToolRequest("stub", Map.of(), null));
+
+        assertThat(registry.counter("mcp.tool.rate_limited",
+                "tool", "stub", "profile", "user").count()).isEqualTo(2.0);
+    }
+}

--- a/kelta-mcp/src/test/java/io/kelta/mcp/observe/RateLimiterTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/observe/RateLimiterTest.java
@@ -1,0 +1,64 @@
+package io.kelta.mcp.observe;
+
+import io.kelta.mcp.config.McpProperties;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RateLimiterTest {
+
+    @Test
+    void allowsUpToBucketCapacityImmediately() {
+        RateLimiter limiter = new RateLimiter(new McpProperties(
+                "http://gw", 30, 60_000,
+                new McpProperties.RateLimit(5, 1.0)));
+
+        for (int i = 0; i < 5; i++) {
+            assertThat(limiter.tryAcquire("klt_a")).as("call %d", i).isTrue();
+        }
+        assertThat(limiter.tryAcquire("klt_a")).isFalse();
+    }
+
+    @Test
+    void bucketsAreIsolatedPerKey() {
+        RateLimiter limiter = new RateLimiter(new McpProperties(
+                "http://gw", 30, 60_000,
+                new McpProperties.RateLimit(2, 0.0)));
+
+        assertThat(limiter.tryAcquire("klt_a")).isTrue();
+        assertThat(limiter.tryAcquire("klt_a")).isTrue();
+        assertThat(limiter.tryAcquire("klt_a")).isFalse();
+        // Different key gets its own fresh bucket.
+        assertThat(limiter.tryAcquire("klt_b")).isTrue();
+        assertThat(limiter.tryAcquire("klt_b")).isTrue();
+        assertThat(limiter.tryAcquire("klt_b")).isFalse();
+    }
+
+    @Test
+    void refillsOverTime() throws InterruptedException {
+        RateLimiter limiter = new RateLimiter(new McpProperties(
+                "http://gw", 30, 60_000,
+                new McpProperties.RateLimit(2, 100.0))); // 100/sec → ~10ms per token
+
+        assertThat(limiter.tryAcquire("klt_a")).isTrue();
+        assertThat(limiter.tryAcquire("klt_a")).isTrue();
+        assertThat(limiter.tryAcquire("klt_a")).isFalse();
+
+        Thread.sleep(60); // > 50ms → at least 5 tokens refilled (capped at capacity 2)
+
+        assertThat(limiter.tryAcquire("klt_a")).isTrue();
+        assertThat(limiter.tryAcquire("klt_a")).isTrue();
+    }
+
+    @Test
+    void activeBucketCountReflectsDistinctKeys() {
+        RateLimiter limiter = new RateLimiter(new McpProperties(
+                "http://gw", 30, 60_000,
+                new McpProperties.RateLimit(1, 1.0)));
+
+        limiter.tryAcquire("klt_a");
+        limiter.tryAcquire("klt_b");
+        limiter.tryAcquire("klt_a");
+        assertThat(limiter.activeBucketCount()).isEqualTo(2);
+    }
+}

--- a/kelta-mcp/src/test/java/io/kelta/mcp/resource/user/CollectionSchemaResourceTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/resource/user/CollectionSchemaResourceTest.java
@@ -1,0 +1,89 @@
+package io.kelta.mcp.resource.user;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import io.kelta.mcp.auth.RequestPatHolder;
+import io.kelta.mcp.client.GatewayHttpClient;
+import io.kelta.mcp.config.McpProperties;
+import io.modelcontextprotocol.spec.McpSchema.ReadResourceRequest;
+import io.modelcontextprotocol.spec.McpSchema.ReadResourceResult;
+import io.modelcontextprotocol.spec.McpSchema.TextResourceContents;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestClient;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CollectionSchemaResourceTest {
+
+    private WireMockServer wm;
+    private CollectionSchemaResource resource;
+
+    @BeforeEach
+    void setUp() {
+        wm = new WireMockServer(0);
+        wm.start();
+        GatewayHttpClient client = new GatewayHttpClient(
+                RestClient.builder(),
+                new McpProperties("http://localhost:" + wm.port(), 30, 60_000));
+        resource = new CollectionSchemaResource(client);
+        RequestPatHolder.set("klt_res_schema");
+    }
+
+    @AfterEach
+    void tearDown() {
+        RequestPatHolder.clear();
+        wm.stop();
+    }
+
+    @Test
+    void exposesTemplateUri() {
+        assertThat(resource.toSpecification().resourceTemplate().uriTemplate())
+                .isEqualTo("kelta://collections/{name}");
+    }
+
+    @Test
+    void resolvesNameFromUriAndCombinesCollectionAndFields() {
+        wm.stubFor(get(urlEqualTo("/api/collections/accounts"))
+                .willReturn(aResponse().withStatus(200)
+                        .withBody("{\"data\":{\"id\":\"c1\",\"attributes\":{\"name\":\"accounts\"}}}")));
+        wm.stubFor(get(urlEqualTo("/api/fields?filter[collectionName][EQ]=accounts&page[size]=200"))
+                .willReturn(aResponse().withStatus(200)
+                        .withBody("{\"data\":[{\"id\":\"f1\"}]}")));
+
+        ReadResourceResult result = resource.toSpecification().readHandler().apply(
+                null, new ReadResourceRequest("kelta://collections/accounts"));
+
+        TextResourceContents contents = (TextResourceContents) result.contents().get(0);
+        assertThat(contents.uri()).isEqualTo("kelta://collections/accounts");
+        assertThat(contents.text()).contains("\"collection\":", "\"fields\":", "c1", "f1");
+        wm.verify(WireMock.getRequestedFor(urlEqualTo("/api/collections/accounts")));
+        wm.verify(WireMock.getRequestedFor(
+                urlEqualTo("/api/fields?filter[collectionName][EQ]=accounts&page[size]=200")));
+    }
+
+    @Test
+    void returnsErrorPayloadForBadUri() {
+        ReadResourceResult result = resource.toSpecification().readHandler().apply(
+                null, new ReadResourceRequest("kelta://something-else"));
+
+        TextResourceContents contents = (TextResourceContents) result.contents().get(0);
+        assertThat(contents.text()).contains("error", "unrecognized");
+    }
+
+    @Test
+    void wrapsCollectionLookupErrorInJsonPayload() {
+        wm.stubFor(get(urlEqualTo("/api/collections/missing"))
+                .willReturn(aResponse().withStatus(404)));
+
+        ReadResourceResult result = resource.toSpecification().readHandler().apply(
+                null, new ReadResourceRequest("kelta://collections/missing"));
+
+        TextResourceContents contents = (TextResourceContents) result.contents().get(0);
+        assertThat(contents.text()).contains("error", "404");
+    }
+}

--- a/kelta-mcp/src/test/java/io/kelta/mcp/resource/user/CollectionSchemaResourceTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/resource/user/CollectionSchemaResourceTest.java
@@ -29,7 +29,7 @@ class CollectionSchemaResourceTest {
         wm.start();
         GatewayHttpClient client = new GatewayHttpClient(
                 RestClient.builder(),
-                new McpProperties("http://localhost:" + wm.port(), 30, 60_000));
+                new McpProperties("http://localhost:" + wm.port(), 30, 60_000, null));
         resource = new CollectionSchemaResource(client);
         RequestPatHolder.set("klt_res_schema");
     }

--- a/kelta-mcp/src/test/java/io/kelta/mcp/resource/user/CollectionsResourceTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/resource/user/CollectionsResourceTest.java
@@ -1,0 +1,76 @@
+package io.kelta.mcp.resource.user;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import io.kelta.mcp.auth.RequestPatHolder;
+import io.kelta.mcp.client.GatewayHttpClient;
+import io.kelta.mcp.config.McpProperties;
+import io.modelcontextprotocol.spec.McpSchema.ReadResourceRequest;
+import io.modelcontextprotocol.spec.McpSchema.ReadResourceResult;
+import io.modelcontextprotocol.spec.McpSchema.TextResourceContents;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestClient;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CollectionsResourceTest {
+
+    private WireMockServer wm;
+    private CollectionsResource resource;
+
+    @BeforeEach
+    void setUp() {
+        wm = new WireMockServer(0);
+        wm.start();
+        GatewayHttpClient client = new GatewayHttpClient(
+                RestClient.builder(),
+                new McpProperties("http://localhost:" + wm.port(), 30, 60_000));
+        resource = new CollectionsResource(client);
+        RequestPatHolder.set("klt_res_collections");
+    }
+
+    @AfterEach
+    void tearDown() {
+        RequestPatHolder.clear();
+        wm.stop();
+    }
+
+    @Test
+    void exposesKeltaCollectionsUri() {
+        assertThat(resource.toSpecification().resource().uri()).isEqualTo("kelta://collections");
+        assertThat(resource.toSpecification().resource().mimeType()).isEqualTo("application/json");
+    }
+
+    @Test
+    void readsCollectionListFromGateway() {
+        wm.stubFor(get(urlEqualTo("/api/collections"))
+                .willReturn(aResponse().withStatus(200)
+                        .withBody("{\"data\":[{\"id\":\"c1\",\"type\":\"collections\"}]}")));
+
+        ReadResourceResult result = resource.toSpecification().readHandler().apply(
+                null, new ReadResourceRequest("kelta://collections"));
+
+        assertThat(result.contents()).hasSize(1);
+        TextResourceContents contents = (TextResourceContents) result.contents().get(0);
+        assertThat(contents.uri()).isEqualTo("kelta://collections");
+        assertThat(contents.text()).contains("c1");
+        wm.verify(WireMock.getRequestedFor(urlEqualTo("/api/collections")));
+    }
+
+    @Test
+    void wrapsGatewayErrorInJsonPayload() {
+        wm.stubFor(get(urlEqualTo("/api/collections"))
+                .willReturn(aResponse().withStatus(503)));
+
+        ReadResourceResult result = resource.toSpecification().readHandler().apply(
+                null, new ReadResourceRequest("kelta://collections"));
+
+        TextResourceContents contents = (TextResourceContents) result.contents().get(0);
+        assertThat(contents.text()).contains("error", "503");
+    }
+}

--- a/kelta-mcp/src/test/java/io/kelta/mcp/resource/user/CollectionsResourceTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/resource/user/CollectionsResourceTest.java
@@ -29,7 +29,7 @@ class CollectionsResourceTest {
         wm.start();
         GatewayHttpClient client = new GatewayHttpClient(
                 RestClient.builder(),
-                new McpProperties("http://localhost:" + wm.port(), 30, 60_000));
+                new McpProperties("http://localhost:" + wm.port(), 30, 60_000, null));
         resource = new CollectionsResource(client);
         RequestPatHolder.set("klt_res_collections");
     }

--- a/kelta-mcp/src/test/java/io/kelta/mcp/tool/admin/AddFieldToolTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/tool/admin/AddFieldToolTest.java
@@ -1,0 +1,90 @@
+package io.kelta.mcp.tool.admin;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import io.kelta.mcp.auth.RequestPatHolder;
+import io.kelta.mcp.client.GatewayHttpClient;
+import io.kelta.mcp.config.McpProperties;
+import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestClient;
+
+import java.util.Map;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AddFieldToolTest {
+
+    private WireMockServer wm;
+    private AddFieldTool tool;
+
+    @BeforeEach
+    void setUp() {
+        wm = new WireMockServer(0);
+        wm.start();
+        GatewayHttpClient client = new GatewayHttpClient(
+                RestClient.builder(),
+                new McpProperties("http://localhost:" + wm.port(), 30, 60_000));
+        tool = new AddFieldTool(client);
+        RequestPatHolder.set("klt_addfield");
+    }
+
+    @AfterEach
+    void tearDown() {
+        RequestPatHolder.clear();
+        wm.stop();
+    }
+
+    @Test
+    void rejectsWithoutRequiredArgs() {
+        CallToolResult result = tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("add_field", Map.of("collectionName", "projects"), null));
+        assertThat(result.isError()).isEqualTo(Boolean.TRUE);
+    }
+
+    @Test
+    void postsJsonApiBodyWithRequiredAttributes() {
+        wm.stubFor(post(urlEqualTo("/api/fields"))
+                .willReturn(aResponse().withStatus(201).withBody("{\"data\":{\"id\":\"f1\"}}")));
+
+        CallToolResult result = tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("add_field", Map.of(
+                        "collectionName", "projects",
+                        "fieldName", "deadline",
+                        "type", "datetime",
+                        "required", true), null));
+
+        assertThat(result.isError()).isNotEqualTo(Boolean.TRUE);
+        wm.verify(WireMock.postRequestedFor(urlEqualTo("/api/fields"))
+                .withHeader("Authorization", equalTo("Bearer klt_addfield"))
+                .withRequestBody(matchingJsonPath("$.data.type", equalTo("fields")))
+                .withRequestBody(matchingJsonPath("$.data.attributes.collectionName", equalTo("projects")))
+                .withRequestBody(matchingJsonPath("$.data.attributes.fieldName", equalTo("deadline")))
+                .withRequestBody(matchingJsonPath("$.data.attributes.type", equalTo("datetime")))
+                .withRequestBody(matchingJsonPath("$.data.attributes.required", equalTo("true"))));
+    }
+
+    @Test
+    void includesReferenceCollectionForReferenceType() {
+        wm.stubFor(post(urlEqualTo("/api/fields"))
+                .willReturn(aResponse().withStatus(201).withBody("{}")));
+
+        tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("add_field", Map.of(
+                        "collectionName", "projects",
+                        "fieldName", "owner",
+                        "type", "reference",
+                        "referenceCollection", "users"), null));
+
+        wm.verify(WireMock.postRequestedFor(urlEqualTo("/api/fields"))
+                .withRequestBody(matchingJsonPath("$.data.attributes.referenceCollection", equalTo("users"))));
+    }
+}

--- a/kelta-mcp/src/test/java/io/kelta/mcp/tool/admin/AddFieldToolTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/tool/admin/AddFieldToolTest.java
@@ -32,7 +32,7 @@ class AddFieldToolTest {
         wm.start();
         GatewayHttpClient client = new GatewayHttpClient(
                 RestClient.builder(),
-                new McpProperties("http://localhost:" + wm.port(), 30, 60_000));
+                new McpProperties("http://localhost:" + wm.port(), 30, 60_000, null));
         tool = new AddFieldTool(client);
         RequestPatHolder.set("klt_addfield");
     }

--- a/kelta-mcp/src/test/java/io/kelta/mcp/tool/admin/CreateCollectionToolTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/tool/admin/CreateCollectionToolTest.java
@@ -1,0 +1,114 @@
+package io.kelta.mcp.tool.admin;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import io.kelta.mcp.auth.RequestPatHolder;
+import io.kelta.mcp.client.GatewayHttpClient;
+import io.kelta.mcp.config.McpProperties;
+import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestClient;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CreateCollectionToolTest {
+
+    private WireMockServer wm;
+    private CreateCollectionTool tool;
+
+    @BeforeEach
+    void setUp() {
+        wm = new WireMockServer(0);
+        wm.start();
+        GatewayHttpClient client = new GatewayHttpClient(
+                RestClient.builder(),
+                new McpProperties("http://localhost:" + wm.port(), 30, 60_000));
+        tool = new CreateCollectionTool(client);
+        RequestPatHolder.set("klt_create_coll");
+    }
+
+    @AfterEach
+    void tearDown() {
+        RequestPatHolder.clear();
+        wm.stop();
+    }
+
+    @Test
+    void rejectsWithoutName() {
+        CallToolResult result = tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("create_collection", Map.of(), null));
+        assertThat(result.isError()).isEqualTo(Boolean.TRUE);
+    }
+
+    @Test
+    void createsCollectionOnlyWhenNoFieldsSupplied() {
+        wm.stubFor(post(urlEqualTo("/api/collections"))
+                .willReturn(aResponse().withStatus(201)
+                        .withBody("{\"data\":{\"id\":\"c1\",\"type\":\"collections\"}}")));
+
+        CallToolResult result = tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("create_collection", Map.of(
+                        "name", "projects",
+                        "displayFieldName", "name",
+                        "description", "Project tracker"), null));
+
+        assertThat(result.isError()).isNotEqualTo(Boolean.TRUE);
+        wm.verify(WireMock.postRequestedFor(urlEqualTo("/api/collections"))
+                .withHeader("Authorization", equalTo("Bearer klt_create_coll"))
+                .withRequestBody(matchingJsonPath("$.data.attributes.name", equalTo("projects")))
+                .withRequestBody(matchingJsonPath("$.data.attributes.displayFieldName", equalTo("name"))));
+        wm.verify(0, WireMock.postRequestedFor(urlEqualTo("/api/fields")));
+    }
+
+    @Test
+    void createsCollectionThenEachField() {
+        wm.stubFor(post(urlEqualTo("/api/collections"))
+                .willReturn(aResponse().withStatus(201)
+                        .withBody("{\"data\":{\"id\":\"c1\"}}")));
+        wm.stubFor(post(urlEqualTo("/api/fields"))
+                .willReturn(aResponse().withStatus(201).withBody("{\"data\":{\"id\":\"f\"}}")));
+
+        CallToolResult result = tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("create_collection", Map.of(
+                        "name", "projects",
+                        "fields", List.of(
+                                Map.of("fieldName", "name", "type", "text", "required", true),
+                                Map.of("fieldName", "owner", "type", "reference",
+                                        "referenceCollection", "users"))), null));
+
+        assertThat(result.isError()).isNotEqualTo(Boolean.TRUE);
+        String text = ((TextContent) result.content().get(0)).text();
+        assertThat(text).contains("collection", "fields");
+        wm.verify(2, WireMock.postRequestedFor(urlEqualTo("/api/fields")));
+        wm.verify(WireMock.postRequestedFor(urlEqualTo("/api/fields"))
+                .withRequestBody(matchingJsonPath("$.data.attributes.fieldName", equalTo("name")))
+                .withRequestBody(matchingJsonPath("$.data.attributes.collectionName", equalTo("projects"))));
+    }
+
+    @Test
+    void shortCircuitsWhenCollectionCreationFails() {
+        wm.stubFor(post(urlEqualTo("/api/collections"))
+                .willReturn(aResponse().withStatus(409).withBody(
+                        "{\"errors\":[{\"detail\":\"already exists\"}]}")));
+
+        CallToolResult result = tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("create_collection", Map.of(
+                        "name", "projects",
+                        "fields", List.of(Map.of("fieldName", "name", "type", "text"))), null));
+
+        assertThat(result.isError()).isEqualTo(Boolean.TRUE);
+        wm.verify(0, WireMock.postRequestedFor(urlEqualTo("/api/fields")));
+    }
+}

--- a/kelta-mcp/src/test/java/io/kelta/mcp/tool/admin/CreateCollectionToolTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/tool/admin/CreateCollectionToolTest.java
@@ -34,7 +34,7 @@ class CreateCollectionToolTest {
         wm.start();
         GatewayHttpClient client = new GatewayHttpClient(
                 RestClient.builder(),
-                new McpProperties("http://localhost:" + wm.port(), 30, 60_000));
+                new McpProperties("http://localhost:" + wm.port(), 30, 60_000, null));
         tool = new CreateCollectionTool(client);
         RequestPatHolder.set("klt_create_coll");
     }

--- a/kelta-mcp/src/test/java/io/kelta/mcp/tool/admin/CreateFlowToolTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/tool/admin/CreateFlowToolTest.java
@@ -1,0 +1,78 @@
+package io.kelta.mcp.tool.admin;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import io.kelta.mcp.auth.RequestPatHolder;
+import io.kelta.mcp.client.GatewayHttpClient;
+import io.kelta.mcp.config.McpProperties;
+import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestClient;
+
+import java.util.Map;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CreateFlowToolTest {
+
+    private WireMockServer wm;
+    private CreateFlowTool tool;
+
+    @BeforeEach
+    void setUp() {
+        wm = new WireMockServer(0);
+        wm.start();
+        GatewayHttpClient client = new GatewayHttpClient(
+                RestClient.builder(),
+                new McpProperties("http://localhost:" + wm.port(), 30, 60_000));
+        tool = new CreateFlowTool(client);
+        RequestPatHolder.set("klt_flow_create");
+    }
+
+    @AfterEach
+    void tearDown() {
+        RequestPatHolder.clear();
+        wm.stop();
+    }
+
+    @Test
+    void rejectsWithoutDefinition() {
+        CallToolResult result = tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("create_flow", Map.of(
+                        "name", "f",
+                        "triggerType", "manual"), null));
+        assertThat(result.isError()).isEqualTo(Boolean.TRUE);
+    }
+
+    @Test
+    void postsFlowWithDefinitionPassedThrough() {
+        wm.stubFor(post(urlEqualTo("/api/flows"))
+                .willReturn(aResponse().withStatus(201).withBody("{\"data\":{\"id\":\"f1\"}}")));
+
+        CallToolResult result = tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("create_flow", Map.of(
+                        "name", "OnboardCustomer",
+                        "triggerType", "recordCreated",
+                        "triggerConfig", Map.of("collectionName", "customers"),
+                        "definition", Map.of(
+                                "nodes", java.util.List.of(Map.of("type", "start"))),
+                        "active", true), null));
+
+        assertThat(result.isError()).isNotEqualTo(Boolean.TRUE);
+        wm.verify(WireMock.postRequestedFor(urlEqualTo("/api/flows"))
+                .withHeader("Authorization", equalTo("Bearer klt_flow_create"))
+                .withRequestBody(matchingJsonPath("$.data.attributes.name", equalTo("OnboardCustomer")))
+                .withRequestBody(matchingJsonPath("$.data.attributes.triggerType", equalTo("recordCreated")))
+                .withRequestBody(matchingJsonPath("$.data.attributes.triggerConfig.collectionName", equalTo("customers")))
+                .withRequestBody(matchingJsonPath("$.data.attributes.definition.nodes[0].type", equalTo("start")))
+                .withRequestBody(matchingJsonPath("$.data.attributes.active", equalTo("true"))));
+    }
+}

--- a/kelta-mcp/src/test/java/io/kelta/mcp/tool/admin/CreateFlowToolTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/tool/admin/CreateFlowToolTest.java
@@ -32,7 +32,7 @@ class CreateFlowToolTest {
         wm.start();
         GatewayHttpClient client = new GatewayHttpClient(
                 RestClient.builder(),
-                new McpProperties("http://localhost:" + wm.port(), 30, 60_000));
+                new McpProperties("http://localhost:" + wm.port(), 30, 60_000, null));
         tool = new CreateFlowTool(client);
         RequestPatHolder.set("klt_flow_create");
     }

--- a/kelta-mcp/src/test/java/io/kelta/mcp/tool/admin/CreateLayoutToolTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/tool/admin/CreateLayoutToolTest.java
@@ -33,7 +33,7 @@ class CreateLayoutToolTest {
         wm.start();
         GatewayHttpClient client = new GatewayHttpClient(
                 RestClient.builder(),
-                new McpProperties("http://localhost:" + wm.port(), 30, 60_000));
+                new McpProperties("http://localhost:" + wm.port(), 30, 60_000, null));
         tool = new CreateLayoutTool(client);
         RequestPatHolder.set("klt_layout_test");
     }

--- a/kelta-mcp/src/test/java/io/kelta/mcp/tool/admin/CreateLayoutToolTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/tool/admin/CreateLayoutToolTest.java
@@ -1,0 +1,117 @@
+package io.kelta.mcp.tool.admin;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import io.kelta.mcp.auth.RequestPatHolder;
+import io.kelta.mcp.client.GatewayHttpClient;
+import io.kelta.mcp.config.McpProperties;
+import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestClient;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CreateLayoutToolTest {
+
+    private WireMockServer wm;
+    private CreateLayoutTool tool;
+
+    @BeforeEach
+    void setUp() {
+        wm = new WireMockServer(0);
+        wm.start();
+        GatewayHttpClient client = new GatewayHttpClient(
+                RestClient.builder(),
+                new McpProperties("http://localhost:" + wm.port(), 30, 60_000));
+        tool = new CreateLayoutTool(client);
+        RequestPatHolder.set("klt_layout_test");
+    }
+
+    @AfterEach
+    void tearDown() {
+        RequestPatHolder.clear();
+        wm.stop();
+    }
+
+    @Test
+    void rejectsWithoutNameOrCollection() {
+        CallToolResult r1 = tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("create_layout", Map.of(
+                        "collectionName", "projects",
+                        "sections", List.of()), null));
+        assertThat(r1.isError()).isEqualTo(Boolean.TRUE);
+
+        CallToolResult r2 = tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("create_layout", Map.of(
+                        "name", "main",
+                        "sections", List.of()), null));
+        assertThat(r2.isError()).isEqualTo(Boolean.TRUE);
+    }
+
+    @Test
+    void createsLayoutSectionsAndFieldsInOrder() {
+        wm.stubFor(post(urlEqualTo("/api/pageLayouts"))
+                .willReturn(aResponse().withStatus(201).withBody(
+                        "{\"data\":{\"id\":\"L1\",\"type\":\"pageLayouts\"}}")));
+        wm.stubFor(post(urlEqualTo("/api/layoutSections"))
+                .willReturn(aResponse().withStatus(201).withBody(
+                        "{\"data\":{\"id\":\"S1\",\"type\":\"layoutSections\"}}")));
+        wm.stubFor(post(urlEqualTo("/api/layoutFields"))
+                .willReturn(aResponse().withStatus(201).withBody(
+                        "{\"data\":{\"id\":\"F1\"}}")));
+
+        CallToolResult result = tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("create_layout", Map.of(
+                        "name", "ProjectsMain",
+                        "collectionName", "projects",
+                        "sections", List.of(
+                                Map.of("sectionName", "Overview",
+                                        "fields", List.of(
+                                                Map.of("fieldName", "name"),
+                                                Map.of("fieldName", "owner"))),
+                                Map.of("sectionName", "Status",
+                                        "fields", List.of(Map.of("fieldName", "stage"))))), null));
+
+        assertThat(result.isError()).isNotEqualTo(Boolean.TRUE);
+        wm.verify(WireMock.postRequestedFor(urlEqualTo("/api/pageLayouts"))
+                .withHeader("Authorization", equalTo("Bearer klt_layout_test"))
+                .withRequestBody(matchingJsonPath("$.data.attributes.name", equalTo("ProjectsMain")))
+                .withRequestBody(matchingJsonPath("$.data.attributes.collectionName", equalTo("projects"))));
+        wm.verify(2, WireMock.postRequestedFor(urlEqualTo("/api/layoutSections")));
+        wm.verify(3, WireMock.postRequestedFor(urlEqualTo("/api/layoutFields")));
+        // sortOrder defaulting + child references
+        wm.verify(WireMock.postRequestedFor(urlEqualTo("/api/layoutSections"))
+                .withRequestBody(matchingJsonPath("$.data.attributes.sectionName", equalTo("Status")))
+                .withRequestBody(matchingJsonPath("$.data.attributes.sortOrder", equalTo("1"))));
+        wm.verify(WireMock.postRequestedFor(urlEqualTo("/api/layoutFields"))
+                .withRequestBody(matchingJsonPath("$.data.attributes.layoutSectionId", equalTo("S1"))));
+    }
+
+    @Test
+    void shortCircuitsWhenLayoutCreationFails() {
+        wm.stubFor(post(urlEqualTo("/api/pageLayouts"))
+                .willReturn(aResponse().withStatus(409).withBody("{}")));
+
+        CallToolResult result = tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("create_layout", Map.of(
+                        "name", "L",
+                        "collectionName", "projects",
+                        "sections", List.of(Map.of("sectionName", "S",
+                                "fields", List.of(Map.of("fieldName", "x"))))), null));
+
+        assertThat(result.isError()).isEqualTo(Boolean.TRUE);
+        wm.verify(0, WireMock.postRequestedFor(urlEqualTo("/api/layoutSections")));
+        wm.verify(0, WireMock.postRequestedFor(urlEqualTo("/api/layoutFields")));
+    }
+}

--- a/kelta-mcp/src/test/java/io/kelta/mcp/tool/admin/CreatePicklistToolTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/tool/admin/CreatePicklistToolTest.java
@@ -33,7 +33,7 @@ class CreatePicklistToolTest {
         wm.start();
         GatewayHttpClient client = new GatewayHttpClient(
                 RestClient.builder(),
-                new McpProperties("http://localhost:" + wm.port(), 30, 60_000));
+                new McpProperties("http://localhost:" + wm.port(), 30, 60_000, null));
         tool = new CreatePicklistTool(client);
         RequestPatHolder.set("klt_picklist_test");
     }

--- a/kelta-mcp/src/test/java/io/kelta/mcp/tool/admin/CreatePicklistToolTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/tool/admin/CreatePicklistToolTest.java
@@ -1,0 +1,78 @@
+package io.kelta.mcp.tool.admin;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import io.kelta.mcp.auth.RequestPatHolder;
+import io.kelta.mcp.client.GatewayHttpClient;
+import io.kelta.mcp.config.McpProperties;
+import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestClient;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CreatePicklistToolTest {
+
+    private WireMockServer wm;
+    private CreatePicklistTool tool;
+
+    @BeforeEach
+    void setUp() {
+        wm = new WireMockServer(0);
+        wm.start();
+        GatewayHttpClient client = new GatewayHttpClient(
+                RestClient.builder(),
+                new McpProperties("http://localhost:" + wm.port(), 30, 60_000));
+        tool = new CreatePicklistTool(client);
+        RequestPatHolder.set("klt_picklist_test");
+    }
+
+    @AfterEach
+    void tearDown() {
+        RequestPatHolder.clear();
+        wm.stop();
+    }
+
+    @Test
+    void rejectsEmptyValuesArray() {
+        CallToolResult result = tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("create_picklist", Map.of(
+                        "name", "stages",
+                        "values", List.of()), null));
+        assertThat(result.isError()).isEqualTo(Boolean.TRUE);
+    }
+
+    @Test
+    void createsPicklistThenEachValueWithSortOrder() {
+        wm.stubFor(post(urlEqualTo("/api/globalPicklists"))
+                .willReturn(aResponse().withStatus(201).withBody("{\"data\":{\"id\":\"p1\"}}")));
+        wm.stubFor(post(urlEqualTo("/api/picklistValues"))
+                .willReturn(aResponse().withStatus(201).withBody("{\"data\":{\"id\":\"pv\"}}")));
+
+        CallToolResult result = tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("create_picklist", Map.of(
+                        "name", "stages",
+                        "values", List.of(
+                                Map.of("value", "OPEN", "label", "Open"),
+                                Map.of("value", "CLOSED", "label", "Closed"))), null));
+
+        assertThat(result.isError()).isNotEqualTo(Boolean.TRUE);
+        wm.verify(2, WireMock.postRequestedFor(urlEqualTo("/api/picklistValues")));
+        wm.verify(WireMock.postRequestedFor(urlEqualTo("/api/picklistValues"))
+                .withHeader("Authorization", equalTo("Bearer klt_picklist_test"))
+                .withRequestBody(matchingJsonPath("$.data.attributes.value", equalTo("OPEN")))
+                .withRequestBody(matchingJsonPath("$.data.attributes.picklistName", equalTo("stages")))
+                .withRequestBody(matchingJsonPath("$.data.attributes.sortOrder", equalTo("0"))));
+    }
+}

--- a/kelta-mcp/src/test/java/io/kelta/mcp/tool/admin/ImportApiSpecToolTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/tool/admin/ImportApiSpecToolTest.java
@@ -32,7 +32,7 @@ class ImportApiSpecToolTest {
         wm.start();
         GatewayHttpClient client = new GatewayHttpClient(
                 RestClient.builder(),
-                new McpProperties("http://localhost:" + wm.port(), 30, 60_000));
+                new McpProperties("http://localhost:" + wm.port(), 30, 60_000, null));
         tool = new ImportApiSpecTool(client);
         RequestPatHolder.set("klt_apispec_import");
     }

--- a/kelta-mcp/src/test/java/io/kelta/mcp/tool/admin/ImportApiSpecToolTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/tool/admin/ImportApiSpecToolTest.java
@@ -1,0 +1,72 @@
+package io.kelta.mcp.tool.admin;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import io.kelta.mcp.auth.RequestPatHolder;
+import io.kelta.mcp.client.GatewayHttpClient;
+import io.kelta.mcp.config.McpProperties;
+import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestClient;
+
+import java.util.Map;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ImportApiSpecToolTest {
+
+    private WireMockServer wm;
+    private ImportApiSpecTool tool;
+
+    @BeforeEach
+    void setUp() {
+        wm = new WireMockServer(0);
+        wm.start();
+        GatewayHttpClient client = new GatewayHttpClient(
+                RestClient.builder(),
+                new McpProperties("http://localhost:" + wm.port(), 30, 60_000));
+        tool = new ImportApiSpecTool(client);
+        RequestPatHolder.set("klt_apispec_import");
+    }
+
+    @AfterEach
+    void tearDown() {
+        RequestPatHolder.clear();
+        wm.stop();
+    }
+
+    @Test
+    void rejectsWithoutNameOrRaw() {
+        CallToolResult result = tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("import_api_spec", Map.of("name", "Stripe"), null));
+        assertThat(result.isError()).isEqualTo(Boolean.TRUE);
+    }
+
+    @Test
+    void postsRawSpecToImport() {
+        wm.stubFor(post(urlEqualTo("/api/api-specs/import"))
+                .willReturn(aResponse().withStatus(200).withBody(
+                        "{\"id\":\"s1\",\"diff\":{\"added\":[]}}")));
+
+        CallToolResult result = tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("import_api_spec", Map.of(
+                        "name", "Stripe",
+                        "raw", "{\"openapi\":\"3.0.0\"}",
+                        "sourceUrl", "https://stripe.com/openapi.json"), null));
+
+        assertThat(result.isError()).isNotEqualTo(Boolean.TRUE);
+        wm.verify(WireMock.postRequestedFor(urlEqualTo("/api/api-specs/import"))
+                .withHeader("Authorization", equalTo("Bearer klt_apispec_import"))
+                .withRequestBody(matchingJsonPath("$.name", equalTo("Stripe")))
+                .withRequestBody(matchingJsonPath("$.raw", equalTo("{\"openapi\":\"3.0.0\"}")))
+                .withRequestBody(matchingJsonPath("$.sourceUrl", equalTo("https://stripe.com/openapi.json"))));
+    }
+}

--- a/kelta-mcp/src/test/java/io/kelta/mcp/tool/admin/RemoveFieldToolTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/tool/admin/RemoveFieldToolTest.java
@@ -1,0 +1,64 @@
+package io.kelta.mcp.tool.admin;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import io.kelta.mcp.auth.RequestPatHolder;
+import io.kelta.mcp.client.GatewayHttpClient;
+import io.kelta.mcp.config.McpProperties;
+import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestClient;
+
+import java.util.Map;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.delete;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RemoveFieldToolTest {
+
+    private WireMockServer wm;
+    private RemoveFieldTool tool;
+
+    @BeforeEach
+    void setUp() {
+        wm = new WireMockServer(0);
+        wm.start();
+        GatewayHttpClient client = new GatewayHttpClient(
+                RestClient.builder(),
+                new McpProperties("http://localhost:" + wm.port(), 30, 60_000));
+        tool = new RemoveFieldTool(client);
+        RequestPatHolder.set("klt_rm_field");
+    }
+
+    @AfterEach
+    void tearDown() {
+        RequestPatHolder.clear();
+        wm.stop();
+    }
+
+    @Test
+    void rejectsWithoutId() {
+        CallToolResult result = tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("remove_field", Map.of(), null));
+        assertThat(result.isError()).isEqualTo(Boolean.TRUE);
+    }
+
+    @Test
+    void deletesAndConfirmsWithStatus() {
+        wm.stubFor(delete(urlEqualTo("/api/fields/f1"))
+                .willReturn(aResponse().withStatus(204)));
+
+        CallToolResult result = tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("remove_field", Map.of("id", "f1"), null));
+
+        assertThat(result.isError()).isNotEqualTo(Boolean.TRUE);
+        assertThat(((TextContent) result.content().get(0)).text()).contains("Removed field f1", "204");
+        wm.verify(WireMock.deleteRequestedFor(urlEqualTo("/api/fields/f1")));
+    }
+}

--- a/kelta-mcp/src/test/java/io/kelta/mcp/tool/admin/RemoveFieldToolTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/tool/admin/RemoveFieldToolTest.java
@@ -31,7 +31,7 @@ class RemoveFieldToolTest {
         wm.start();
         GatewayHttpClient client = new GatewayHttpClient(
                 RestClient.builder(),
-                new McpProperties("http://localhost:" + wm.port(), 30, 60_000));
+                new McpProperties("http://localhost:" + wm.port(), 30, 60_000, null));
         tool = new RemoveFieldTool(client);
         RequestPatHolder.set("klt_rm_field");
     }

--- a/kelta-mcp/src/test/java/io/kelta/mcp/tool/admin/UpdateFieldToolTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/tool/admin/UpdateFieldToolTest.java
@@ -1,0 +1,79 @@
+package io.kelta.mcp.tool.admin;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import io.kelta.mcp.auth.RequestPatHolder;
+import io.kelta.mcp.client.GatewayHttpClient;
+import io.kelta.mcp.config.McpProperties;
+import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestClient;
+
+import java.util.Map;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
+import static com.github.tomakehurst.wiremock.client.WireMock.patch;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UpdateFieldToolTest {
+
+    private WireMockServer wm;
+    private UpdateFieldTool tool;
+
+    @BeforeEach
+    void setUp() {
+        wm = new WireMockServer(0);
+        wm.start();
+        GatewayHttpClient client = new GatewayHttpClient(
+                RestClient.builder(),
+                new McpProperties("http://localhost:" + wm.port(), 30, 60_000));
+        tool = new UpdateFieldTool(client);
+        RequestPatHolder.set("klt_upd_field");
+    }
+
+    @AfterEach
+    void tearDown() {
+        RequestPatHolder.clear();
+        wm.stop();
+    }
+
+    @Test
+    void rejectsWithoutId() {
+        CallToolResult result = tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("update_field", Map.of("required", true), null));
+        assertThat(result.isError()).isEqualTo(Boolean.TRUE);
+    }
+
+    @Test
+    void rejectsWhenNoFieldsToUpdate() {
+        CallToolResult result = tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("update_field", Map.of("id", "f1"), null));
+        assertThat(result.isError()).isEqualTo(Boolean.TRUE);
+    }
+
+    @Test
+    void patchesIncludingIdAndType() {
+        wm.stubFor(patch(urlEqualTo("/api/fields/f1"))
+                .willReturn(aResponse().withStatus(200).withBody("{\"data\":{}}")));
+
+        CallToolResult result = tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("update_field", Map.of(
+                        "id", "f1",
+                        "required", true,
+                        "description", "Now required"), null));
+
+        assertThat(result.isError()).isNotEqualTo(Boolean.TRUE);
+        wm.verify(WireMock.patchRequestedFor(urlEqualTo("/api/fields/f1"))
+                .withHeader("Authorization", equalTo("Bearer klt_upd_field"))
+                .withRequestBody(matchingJsonPath("$.data.id", equalTo("f1")))
+                .withRequestBody(matchingJsonPath("$.data.type", equalTo("fields")))
+                .withRequestBody(matchingJsonPath("$.data.attributes.required", equalTo("true")))
+                .withRequestBody(matchingJsonPath("$.data.attributes.description", equalTo("Now required"))));
+    }
+}

--- a/kelta-mcp/src/test/java/io/kelta/mcp/tool/admin/UpdateFieldToolTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/tool/admin/UpdateFieldToolTest.java
@@ -32,7 +32,7 @@ class UpdateFieldToolTest {
         wm.start();
         GatewayHttpClient client = new GatewayHttpClient(
                 RestClient.builder(),
-                new McpProperties("http://localhost:" + wm.port(), 30, 60_000));
+                new McpProperties("http://localhost:" + wm.port(), 30, 60_000, null));
         tool = new UpdateFieldTool(client);
         RequestPatHolder.set("klt_upd_field");
     }

--- a/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/BulkApplyToolTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/BulkApplyToolTest.java
@@ -33,7 +33,7 @@ class BulkApplyToolTest {
         wm.start();
         GatewayHttpClient client = new GatewayHttpClient(
                 RestClient.builder(),
-                new McpProperties("http://localhost:" + wm.port(), 30, 60_000));
+                new McpProperties("http://localhost:" + wm.port(), 30, 60_000, null));
         tool = new BulkApplyTool(client);
         RequestPatHolder.set("klt_bulk_test");
     }

--- a/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/BulkApplyToolTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/BulkApplyToolTest.java
@@ -1,0 +1,97 @@
+package io.kelta.mcp.tool.user;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import io.kelta.mcp.auth.RequestPatHolder;
+import io.kelta.mcp.client.GatewayHttpClient;
+import io.kelta.mcp.config.McpProperties;
+import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestClient;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BulkApplyToolTest {
+
+    private WireMockServer wm;
+    private BulkApplyTool tool;
+
+    @BeforeEach
+    void setUp() {
+        wm = new WireMockServer(0);
+        wm.start();
+        GatewayHttpClient client = new GatewayHttpClient(
+                RestClient.builder(),
+                new McpProperties("http://localhost:" + wm.port(), 30, 60_000));
+        tool = new BulkApplyTool(client);
+        RequestPatHolder.set("klt_bulk_test");
+    }
+
+    @AfterEach
+    void tearDown() {
+        RequestPatHolder.clear();
+        wm.stop();
+    }
+
+    @Test
+    void rejectsEmptyOperations() {
+        CallToolResult result = tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("bulk_apply", Map.of("operations", List.of()), null));
+        assertThat(result.isError()).isEqualTo(Boolean.TRUE);
+    }
+
+    @Test
+    void rejectsUnknownOpName() {
+        CallToolResult result = tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("bulk_apply", Map.of("operations", List.of(
+                        Map.of("op", "destroy", "type", "accounts", "id", "a1"))), null));
+        assertThat(result.isError()).isEqualTo(Boolean.TRUE);
+    }
+
+    @Test
+    void requiresIdForUpdateAndRemove() {
+        CallToolResult update = tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("bulk_apply", Map.of("operations", List.of(
+                        Map.of("op", "update", "type", "accounts",
+                                "attributes", Map.of("name", "x")))), null));
+        assertThat(update.isError()).isEqualTo(Boolean.TRUE);
+
+        CallToolResult remove = tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("bulk_apply", Map.of("operations", List.of(
+                        Map.of("op", "remove", "type", "accounts"))), null));
+        assertThat(remove.isError()).isEqualTo(Boolean.TRUE);
+    }
+
+    @Test
+    void postsAtomicOperationsBundle() {
+        wm.stubFor(post(urlEqualTo("/api/_atomic"))
+                .willReturn(aResponse().withStatus(200).withBody("{\"atomic:results\":[]}")));
+
+        CallToolResult result = tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("bulk_apply", Map.of("operations", List.of(
+                        Map.of("op", "add", "type", "accounts",
+                                "attributes", Map.of("name", "Acme")),
+                        Map.of("op", "update", "type", "accounts", "id", "a2",
+                                "attributes", Map.of("name", "Updated")),
+                        Map.of("op", "remove", "type", "accounts", "id", "a3")
+                )), null));
+
+        assertThat(result.isError()).isNotEqualTo(Boolean.TRUE);
+        wm.verify(WireMock.postRequestedFor(urlEqualTo("/api/_atomic"))
+                .withHeader("Authorization", equalTo("Bearer klt_bulk_test"))
+                .withRequestBody(matchingJsonPath("$.['atomic:operations'][0].op", equalTo("add")))
+                .withRequestBody(matchingJsonPath("$.['atomic:operations'][1].op", equalTo("update")))
+                .withRequestBody(matchingJsonPath("$.['atomic:operations'][2].op", equalTo("remove"))));
+    }
+}

--- a/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/CreateRecordToolTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/CreateRecordToolTest.java
@@ -32,7 +32,7 @@ class CreateRecordToolTest {
         wm.start();
         GatewayHttpClient client = new GatewayHttpClient(
                 RestClient.builder(),
-                new McpProperties("http://localhost:" + wm.port(), 30, 60_000));
+                new McpProperties("http://localhost:" + wm.port(), 30, 60_000, null));
         tool = new CreateRecordTool(client);
         RequestPatHolder.set("klt_create_test");
     }

--- a/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/CreateRecordToolTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/CreateRecordToolTest.java
@@ -1,0 +1,98 @@
+package io.kelta.mcp.tool.user;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import io.kelta.mcp.auth.RequestPatHolder;
+import io.kelta.mcp.client.GatewayHttpClient;
+import io.kelta.mcp.config.McpProperties;
+import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestClient;
+
+import java.util.Map;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CreateRecordToolTest {
+
+    private WireMockServer wm;
+    private CreateRecordTool tool;
+
+    @BeforeEach
+    void setUp() {
+        wm = new WireMockServer(0);
+        wm.start();
+        GatewayHttpClient client = new GatewayHttpClient(
+                RestClient.builder(),
+                new McpProperties("http://localhost:" + wm.port(), 30, 60_000));
+        tool = new CreateRecordTool(client);
+        RequestPatHolder.set("klt_create_test");
+    }
+
+    @AfterEach
+    void tearDown() {
+        RequestPatHolder.clear();
+        wm.stop();
+    }
+
+    @Test
+    void rejectsCallWithoutCollection() {
+        CallToolResult result = tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("create_record", Map.of("attributes", Map.of("name", "x")), null));
+        assertThat(result.isError()).isEqualTo(Boolean.TRUE);
+    }
+
+    @Test
+    void rejectsCallWithEmptyAttributes() {
+        CallToolResult result = tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("create_record", Map.of(
+                        "collection", "accounts",
+                        "attributes", Map.of()), null));
+        assertThat(result.isError()).isEqualTo(Boolean.TRUE);
+    }
+
+    @Test
+    void postsJsonApiBodyToCollectionEndpoint() {
+        wm.stubFor(post(urlEqualTo("/api/accounts"))
+                .willReturn(aResponse().withStatus(201).withBody(
+                        "{\"data\":{\"type\":\"accounts\",\"id\":\"a1\",\"attributes\":{\"name\":\"Acme\"}}}")));
+
+        CallToolResult result = tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("create_record", Map.of(
+                        "collection", "accounts",
+                        "attributes", Map.of("name", "Acme", "industry", "Software")), null));
+
+        assertThat(result.isError()).isNotEqualTo(Boolean.TRUE);
+        wm.verify(WireMock.postRequestedFor(urlEqualTo("/api/accounts"))
+                .withHeader("Authorization", equalTo("Bearer klt_create_test"))
+                .withHeader("Content-Type", equalTo("application/json"))
+                .withRequestBody(matchingJsonPath("$.data.type", equalTo("accounts")))
+                .withRequestBody(matchingJsonPath("$.data.attributes.name", equalTo("Acme")))
+                .withRequestBody(matchingJsonPath("$.data.attributes.industry", equalTo("Software"))));
+    }
+
+    @Test
+    void includesRelationshipsBlockWhenProvided() {
+        wm.stubFor(post(urlEqualTo("/api/contacts"))
+                .willReturn(aResponse().withStatus(201).withBody("{\"data\":{}}")));
+
+        tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("create_record", Map.of(
+                        "collection", "contacts",
+                        "attributes", Map.of("firstName", "Alice"),
+                        "relationships", Map.of(
+                                "account", Map.of("data", Map.of("type", "accounts", "id", "a1")))
+                ), null));
+
+        wm.verify(WireMock.postRequestedFor(urlEqualTo("/api/contacts"))
+                .withRequestBody(matchingJsonPath("$.data.relationships.account.data.id", equalTo("a1"))));
+    }
+}

--- a/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/DeleteRecordToolTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/DeleteRecordToolTest.java
@@ -1,0 +1,79 @@
+package io.kelta.mcp.tool.user;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import io.kelta.mcp.auth.RequestPatHolder;
+import io.kelta.mcp.client.GatewayHttpClient;
+import io.kelta.mcp.config.McpProperties;
+import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestClient;
+
+import java.util.Map;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.delete;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DeleteRecordToolTest {
+
+    private WireMockServer wm;
+    private DeleteRecordTool tool;
+
+    @BeforeEach
+    void setUp() {
+        wm = new WireMockServer(0);
+        wm.start();
+        GatewayHttpClient client = new GatewayHttpClient(
+                RestClient.builder(),
+                new McpProperties("http://localhost:" + wm.port(), 30, 60_000));
+        tool = new DeleteRecordTool(client);
+        RequestPatHolder.set("klt_delete_test");
+    }
+
+    @AfterEach
+    void tearDown() {
+        RequestPatHolder.clear();
+        wm.stop();
+    }
+
+    @Test
+    void rejectsCallWithoutCollectionOrId() {
+        CallToolResult result = tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("delete_record", Map.of("collection", "accounts"), null));
+        assertThat(result.isError()).isEqualTo(Boolean.TRUE);
+    }
+
+    @Test
+    void deletesAndConfirmsWithStatus() {
+        wm.stubFor(delete(urlEqualTo("/api/accounts/a1"))
+                .willReturn(aResponse().withStatus(204)));
+
+        CallToolResult result = tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("delete_record", Map.of(
+                        "collection", "accounts",
+                        "id", "a1"), null));
+
+        assertThat(result.isError()).isNotEqualTo(Boolean.TRUE);
+        assertThat(((TextContent) result.content().get(0)).text()).contains("Deleted accounts/a1", "204");
+        wm.verify(WireMock.deleteRequestedFor(urlEqualTo("/api/accounts/a1")));
+    }
+
+    @Test
+    void notFoundBecomesIsErrorResult() {
+        wm.stubFor(delete(urlEqualTo("/api/accounts/missing"))
+                .willReturn(aResponse().withStatus(404).withBody("{\"errors\":[{\"detail\":\"not found\"}]}")));
+
+        CallToolResult result = tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("delete_record", Map.of(
+                        "collection", "accounts",
+                        "id", "missing"), null));
+
+        assertThat(result.isError()).isEqualTo(Boolean.TRUE);
+    }
+}

--- a/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/DeleteRecordToolTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/DeleteRecordToolTest.java
@@ -31,7 +31,7 @@ class DeleteRecordToolTest {
         wm.start();
         GatewayHttpClient client = new GatewayHttpClient(
                 RestClient.builder(),
-                new McpProperties("http://localhost:" + wm.port(), 30, 60_000));
+                new McpProperties("http://localhost:" + wm.port(), 30, 60_000, null));
         tool = new DeleteRecordTool(client);
         RequestPatHolder.set("klt_delete_test");
     }

--- a/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/ExecuteFlowToolTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/ExecuteFlowToolTest.java
@@ -32,7 +32,7 @@ class ExecuteFlowToolTest {
         wm.start();
         GatewayHttpClient client = new GatewayHttpClient(
                 RestClient.builder(),
-                new McpProperties("http://localhost:" + wm.port(), 30, 60_000));
+                new McpProperties("http://localhost:" + wm.port(), 30, 60_000, null));
         tool = new ExecuteFlowTool(client);
         RequestPatHolder.set("klt_flow_test");
     }

--- a/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/ExecuteFlowToolTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/ExecuteFlowToolTest.java
@@ -1,0 +1,80 @@
+package io.kelta.mcp.tool.user;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import io.kelta.mcp.auth.RequestPatHolder;
+import io.kelta.mcp.client.GatewayHttpClient;
+import io.kelta.mcp.config.McpProperties;
+import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestClient;
+
+import java.util.Map;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ExecuteFlowToolTest {
+
+    private WireMockServer wm;
+    private ExecuteFlowTool tool;
+
+    @BeforeEach
+    void setUp() {
+        wm = new WireMockServer(0);
+        wm.start();
+        GatewayHttpClient client = new GatewayHttpClient(
+                RestClient.builder(),
+                new McpProperties("http://localhost:" + wm.port(), 30, 60_000));
+        tool = new ExecuteFlowTool(client);
+        RequestPatHolder.set("klt_flow_test");
+    }
+
+    @AfterEach
+    void tearDown() {
+        RequestPatHolder.clear();
+        wm.stop();
+    }
+
+    @Test
+    void rejectsCallWithoutFlowId() {
+        CallToolResult result = tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("execute_flow", Map.of(), null));
+        assertThat(result.isError()).isEqualTo(Boolean.TRUE);
+    }
+
+    @Test
+    void postsExecuteWithEmptyBodyWhenNoInput() {
+        wm.stubFor(post(urlEqualTo("/api/flows/flow-123/execute"))
+                .willReturn(aResponse().withStatus(202).withBody("{\"executionId\":\"e1\"}")));
+
+        CallToolResult result = tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("execute_flow", Map.of("flowId", "flow-123"), null));
+
+        assertThat(result.isError()).isNotEqualTo(Boolean.TRUE);
+        wm.verify(WireMock.postRequestedFor(urlEqualTo("/api/flows/flow-123/execute"))
+                .withHeader("Authorization", equalTo("Bearer klt_flow_test")));
+    }
+
+    @Test
+    void passesInputThroughAsJsonBody() {
+        wm.stubFor(post(urlEqualTo("/api/flows/flow-123/execute"))
+                .willReturn(aResponse().withStatus(202).withBody("{}")));
+
+        tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("execute_flow", Map.of(
+                        "flowId", "flow-123",
+                        "input", Map.of("ticketId", "T-99", "priority", "high")), null));
+
+        wm.verify(WireMock.postRequestedFor(urlEqualTo("/api/flows/flow-123/execute"))
+                .withRequestBody(matchingJsonPath("$.ticketId", equalTo("T-99")))
+                .withRequestBody(matchingJsonPath("$.priority", equalTo("high"))));
+    }
+}

--- a/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/GetFlowRunToolTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/GetFlowRunToolTest.java
@@ -31,7 +31,7 @@ class GetFlowRunToolTest {
         wm.start();
         GatewayHttpClient client = new GatewayHttpClient(
                 RestClient.builder(),
-                new McpProperties("http://localhost:" + wm.port(), 30, 60_000));
+                new McpProperties("http://localhost:" + wm.port(), 30, 60_000, null));
         tool = new GetFlowRunTool(client);
         RequestPatHolder.set("klt_flowrun_test");
     }

--- a/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/GetFlowRunToolTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/GetFlowRunToolTest.java
@@ -1,0 +1,73 @@
+package io.kelta.mcp.tool.user;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import io.kelta.mcp.auth.RequestPatHolder;
+import io.kelta.mcp.client.GatewayHttpClient;
+import io.kelta.mcp.config.McpProperties;
+import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestClient;
+
+import java.util.Map;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GetFlowRunToolTest {
+
+    private WireMockServer wm;
+    private GetFlowRunTool tool;
+
+    @BeforeEach
+    void setUp() {
+        wm = new WireMockServer(0);
+        wm.start();
+        GatewayHttpClient client = new GatewayHttpClient(
+                RestClient.builder(),
+                new McpProperties("http://localhost:" + wm.port(), 30, 60_000));
+        tool = new GetFlowRunTool(client);
+        RequestPatHolder.set("klt_flowrun_test");
+    }
+
+    @AfterEach
+    void tearDown() {
+        RequestPatHolder.clear();
+        wm.stop();
+    }
+
+    @Test
+    void fetchesExecutionWithoutStepsByDefault() {
+        wm.stubFor(get(urlEqualTo("/api/flows/executions/e1"))
+                .willReturn(aResponse().withStatus(200).withBody("{\"status\":\"RUNNING\"}")));
+
+        CallToolResult result = tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("get_flow_run", Map.of("executionId", "e1"), null));
+
+        assertThat(result.isError()).isNotEqualTo(Boolean.TRUE);
+        wm.verify(WireMock.getRequestedFor(urlEqualTo("/api/flows/executions/e1")));
+        wm.verify(0, WireMock.getRequestedFor(urlEqualTo("/api/flows/executions/e1/steps")));
+    }
+
+    @Test
+    void mergesStepsWhenIncludeStepsTrue() {
+        wm.stubFor(get(urlEqualTo("/api/flows/executions/e1"))
+                .willReturn(aResponse().withStatus(200).withBody("{\"status\":\"DONE\"}")));
+        wm.stubFor(get(urlEqualTo("/api/flows/executions/e1/steps"))
+                .willReturn(aResponse().withStatus(200).withBody("[{\"stepId\":\"s1\"}]")));
+
+        CallToolResult result = tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("get_flow_run", Map.of(
+                        "executionId", "e1",
+                        "includeSteps", true), null));
+
+        String text = ((TextContent) result.content().get(0)).text();
+        assertThat(text).contains("\"execution\":", "\"steps\":", "DONE", "s1");
+    }
+}

--- a/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/ListApprovalsToolTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/ListApprovalsToolTest.java
@@ -28,7 +28,7 @@ class ListApprovalsToolTest {
         wm.start();
         GatewayHttpClient client = new GatewayHttpClient(
                 RestClient.builder(),
-                new McpProperties("http://localhost:" + wm.port(), 30, 60_000));
+                new McpProperties("http://localhost:" + wm.port(), 30, 60_000, null));
         tool = new ListApprovalsTool(client);
         RequestPatHolder.set("klt_listapproval_test");
     }

--- a/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/ListApprovalsToolTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/ListApprovalsToolTest.java
@@ -1,0 +1,79 @@
+package io.kelta.mcp.tool.user;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import io.kelta.mcp.auth.RequestPatHolder;
+import io.kelta.mcp.client.GatewayHttpClient;
+import io.kelta.mcp.config.McpProperties;
+import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestClient;
+
+import java.util.Map;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+
+class ListApprovalsToolTest {
+
+    private WireMockServer wm;
+    private ListApprovalsTool tool;
+
+    @BeforeEach
+    void setUp() {
+        wm = new WireMockServer(0);
+        wm.start();
+        GatewayHttpClient client = new GatewayHttpClient(
+                RestClient.builder(),
+                new McpProperties("http://localhost:" + wm.port(), 30, 60_000));
+        tool = new ListApprovalsTool(client);
+        RequestPatHolder.set("klt_listapproval_test");
+    }
+
+    @AfterEach
+    void tearDown() {
+        RequestPatHolder.clear();
+        wm.stop();
+    }
+
+    @Test
+    void defaultsToPendingFilter() {
+        wm.stubFor(get(urlEqualTo("/api/approvalInstances?filter[status][EQ]=PENDING"))
+                .willReturn(aResponse().withStatus(200).withBody("{\"data\":[]}")));
+
+        tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("list_approvals", Map.of(), null));
+
+        wm.verify(WireMock.getRequestedFor(
+                urlEqualTo("/api/approvalInstances?filter[status][EQ]=PENDING")));
+    }
+
+    @Test
+    void allStatusOmitsTheFilter() {
+        wm.stubFor(get(urlEqualTo("/api/approvalInstances"))
+                .willReturn(aResponse().withStatus(200).withBody("{\"data\":[]}")));
+
+        tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("list_approvals", Map.of("status", "all"), null));
+
+        wm.verify(WireMock.getRequestedFor(urlEqualTo("/api/approvalInstances")));
+    }
+
+    @Test
+    void appendsPagingParams() {
+        wm.stubFor(get(urlEqualTo("/api/approvalInstances?filter[status][EQ]=APPROVED&page[size]=50&page[number]=2"))
+                .willReturn(aResponse().withStatus(200).withBody("{\"data\":[]}")));
+
+        tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("list_approvals", Map.of(
+                        "status", "approved",
+                        "pageSize", 50,
+                        "pageNumber", 2), null));
+
+        wm.verify(WireMock.getRequestedFor(
+                urlEqualTo("/api/approvalInstances?filter[status][EQ]=APPROVED&page[size]=50&page[number]=2")));
+    }
+}

--- a/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/ListCollectionsToolTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/ListCollectionsToolTest.java
@@ -33,7 +33,7 @@ class ListCollectionsToolTest {
         wm.start();
         GatewayHttpClient client = new GatewayHttpClient(
                 RestClient.builder(),
-                new McpProperties("http://localhost:" + wm.port(), 30, 60_000));
+                new McpProperties("http://localhost:" + wm.port(), 30, 60_000, null));
         tool = new ListCollectionsTool(client);
         RequestPatHolder.set("klt_list_test");
     }

--- a/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/ListCollectionsToolTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/ListCollectionsToolTest.java
@@ -1,0 +1,90 @@
+package io.kelta.mcp.tool.user;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import io.kelta.mcp.auth.RequestPatHolder;
+import io.kelta.mcp.client.GatewayHttpClient;
+import io.kelta.mcp.config.McpProperties;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestClient;
+
+import java.util.Map;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ListCollectionsToolTest {
+
+    private WireMockServer wm;
+    private ListCollectionsTool tool;
+
+    @BeforeEach
+    void setUp() {
+        wm = new WireMockServer(0);
+        wm.start();
+        GatewayHttpClient client = new GatewayHttpClient(
+                RestClient.builder(),
+                new McpProperties("http://localhost:" + wm.port(), 30, 60_000));
+        tool = new ListCollectionsTool(client);
+        RequestPatHolder.set("klt_list_test");
+    }
+
+    @AfterEach
+    void tearDown() {
+        RequestPatHolder.clear();
+        wm.stop();
+    }
+
+    @Test
+    void toolHasExpectedNameAndRequiresNoArgs() {
+        SyncToolSpecification spec = tool.toSpecification();
+        assertThat(spec.tool().name()).isEqualTo("list_collections");
+        assertThat(spec.tool().inputSchema().required()).isEmpty();
+    }
+
+    @Test
+    void defaultIncludesAllCollections() {
+        wm.stubFor(get(urlEqualTo("/api/collections"))
+                .willReturn(aResponse().withStatus(200).withBody("{\"data\":[{\"id\":\"c1\"}]}")));
+
+        CallToolResult result = tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("list_collections", Map.of(), null));
+
+        assertThat(result.isError()).isNotEqualTo(Boolean.TRUE);
+        assertThat(((TextContent) result.content().get(0)).text()).contains("c1");
+        wm.verify(WireMock.getRequestedFor(urlEqualTo("/api/collections"))
+                .withHeader("Authorization", equalTo("Bearer klt_list_test")));
+    }
+
+    @Test
+    void includeSystemFalseAddsFilter() {
+        wm.stubFor(get(urlEqualTo("/api/collections?filter[isSystem][EQ]=false"))
+                .willReturn(aResponse().withStatus(200).withBody("{\"data\":[]}")));
+
+        tool.toSpecification().callHandler().apply(null, new CallToolRequest(
+                "list_collections", Map.of("includeSystem", false), null));
+
+        wm.verify(WireMock.getRequestedFor(urlEqualTo("/api/collections?filter[isSystem][EQ]=false")));
+    }
+
+    @Test
+    void gateway500BecomesIsErrorResult() {
+        wm.stubFor(get(urlEqualTo("/api/collections"))
+                .willReturn(aResponse().withStatus(500).withBody("boom")));
+
+        CallToolResult result = tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("list_collections", Map.of(), null));
+
+        assertThat(result.isError()).isEqualTo(Boolean.TRUE);
+        assertThat(((TextContent) result.content().get(0)).text()).contains("500");
+    }
+}

--- a/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/QueryCollectionToolTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/QueryCollectionToolTest.java
@@ -1,0 +1,99 @@
+package io.kelta.mcp.tool.user;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import io.kelta.mcp.auth.RequestPatHolder;
+import io.kelta.mcp.client.GatewayHttpClient;
+import io.kelta.mcp.config.McpProperties;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestClient;
+
+import java.util.Map;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class QueryCollectionToolTest {
+
+    private WireMockServer wm;
+    private QueryCollectionTool tool;
+
+    @BeforeEach
+    void setUp() {
+        wm = new WireMockServer(0);
+        wm.start();
+        GatewayHttpClient client = new GatewayHttpClient(
+                RestClient.builder(),
+                new McpProperties("http://localhost:" + wm.port(), 30, 60_000));
+        tool = new QueryCollectionTool(client);
+        RequestPatHolder.set("klt_q_test");
+    }
+
+    @AfterEach
+    void tearDown() {
+        RequestPatHolder.clear();
+        wm.stop();
+    }
+
+    @Test
+    void buildQueryStringEncodesFiltersSortAndPaging() {
+        String q = QueryCollectionTool.buildQueryString(Map.of(
+                "filter", Map.of("status", Map.of("EQ", "ACTIVE")),
+                "sort", "lastName,-createdAt",
+                "pageSize", 50,
+                "pageNumber", 2));
+
+        // JSON:API uses literal brackets (the gateway's Tomcat is configured
+        // to allow them in query strings). Field names and values are URL-encoded.
+        assertThat(q).contains("filter[status][EQ]=ACTIVE");
+        assertThat(q).contains("sort=lastName%2C-createdAt");
+        assertThat(q).contains("page[size]=50");
+        assertThat(q).contains("page[number]=2");
+    }
+
+    @Test
+    void buildQueryStringDropsUnknownOperators() {
+        String q = QueryCollectionTool.buildQueryString(Map.of(
+                "filter", Map.of("name", Map.of("BOGUS_OP", "x"))));
+
+        assertThat(q).doesNotContain("BOGUS_OP");
+    }
+
+    @Test
+    void rejectsCallWithoutCollection() {
+        SyncToolSpecification spec = tool.toSpecification();
+        CallToolRequest req = new CallToolRequest("query_collection", Map.of(), null);
+
+        CallToolResult result = spec.callHandler().apply(null, req);
+
+        assertThat(result.isError()).isEqualTo(Boolean.TRUE);
+        wm.verify(0, WireMock.anyRequestedFor(WireMock.anyUrl()));
+    }
+
+    @Test
+    void forwardsThroughGatewayWithLiteralBracketQueryParams() {
+        wm.stubFor(get(urlEqualTo("/api/users?filter[status][EQ]=ACTIVE&sort=lastName"))
+                .willReturn(aResponse().withStatus(200).withBody("{\"data\":[]}")));
+
+        SyncToolSpecification spec = tool.toSpecification();
+        CallToolRequest req = new CallToolRequest("query_collection", Map.of(
+                "collection", "users",
+                "filter", Map.of("status", Map.of("EQ", "ACTIVE")),
+                "sort", "lastName"
+        ), null);
+
+        CallToolResult result = spec.callHandler().apply(null, req);
+
+        assertThat(result.isError()).isNotEqualTo(Boolean.TRUE);
+        wm.verify(WireMock.getRequestedFor(urlEqualTo("/api/users?filter[status][EQ]=ACTIVE&sort=lastName"))
+                .withHeader("Authorization", equalTo("Bearer klt_q_test")));
+    }
+}

--- a/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/QueryCollectionToolTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/QueryCollectionToolTest.java
@@ -32,7 +32,7 @@ class QueryCollectionToolTest {
         wm.start();
         GatewayHttpClient client = new GatewayHttpClient(
                 RestClient.builder(),
-                new McpProperties("http://localhost:" + wm.port(), 30, 60_000));
+                new McpProperties("http://localhost:" + wm.port(), 30, 60_000, null));
         tool = new QueryCollectionTool(client);
         RequestPatHolder.set("klt_q_test");
     }

--- a/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/SubmitForApprovalToolTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/SubmitForApprovalToolTest.java
@@ -1,0 +1,84 @@
+package io.kelta.mcp.tool.user;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import io.kelta.mcp.auth.RequestPatHolder;
+import io.kelta.mcp.client.GatewayHttpClient;
+import io.kelta.mcp.config.McpProperties;
+import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestClient;
+
+import java.util.Map;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SubmitForApprovalToolTest {
+
+    private WireMockServer wm;
+    private SubmitForApprovalTool tool;
+
+    @BeforeEach
+    void setUp() {
+        wm = new WireMockServer(0);
+        wm.start();
+        GatewayHttpClient client = new GatewayHttpClient(
+                RestClient.builder(),
+                new McpProperties("http://localhost:" + wm.port(), 30, 60_000));
+        tool = new SubmitForApprovalTool(client);
+        RequestPatHolder.set("klt_submit_test");
+    }
+
+    @AfterEach
+    void tearDown() {
+        RequestPatHolder.clear();
+        wm.stop();
+    }
+
+    @Test
+    void rejectsCallWithoutCollectionOrRecord() {
+        CallToolResult result = tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("submit_for_approval", Map.of("collectionId", "c1"), null));
+        assertThat(result.isError()).isEqualTo(Boolean.TRUE);
+    }
+
+    @Test
+    void postsCollectionAndRecordIds() {
+        wm.stubFor(post(urlEqualTo("/api/approvals/submit"))
+                .willReturn(aResponse().withStatus(200).withBody("{\"instanceId\":\"i1\"}")));
+
+        CallToolResult result = tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("submit_for_approval", Map.of(
+                        "collectionId", "c1",
+                        "recordId", "r1"), null));
+
+        assertThat(result.isError()).isNotEqualTo(Boolean.TRUE);
+        wm.verify(WireMock.postRequestedFor(urlEqualTo("/api/approvals/submit"))
+                .withHeader("Authorization", equalTo("Bearer klt_submit_test"))
+                .withRequestBody(matchingJsonPath("$.collectionId", equalTo("c1")))
+                .withRequestBody(matchingJsonPath("$.recordId", equalTo("r1"))));
+    }
+
+    @Test
+    void includesProcessIdWhenProvided() {
+        wm.stubFor(post(urlEqualTo("/api/approvals/submit"))
+                .willReturn(aResponse().withStatus(200).withBody("{}")));
+
+        tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("submit_for_approval", Map.of(
+                        "collectionId", "c1",
+                        "recordId", "r1",
+                        "processId", "p1"), null));
+
+        wm.verify(WireMock.postRequestedFor(urlEqualTo("/api/approvals/submit"))
+                .withRequestBody(matchingJsonPath("$.processId", equalTo("p1"))));
+    }
+}

--- a/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/SubmitForApprovalToolTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/SubmitForApprovalToolTest.java
@@ -32,7 +32,7 @@ class SubmitForApprovalToolTest {
         wm.start();
         GatewayHttpClient client = new GatewayHttpClient(
                 RestClient.builder(),
-                new McpProperties("http://localhost:" + wm.port(), 30, 60_000));
+                new McpProperties("http://localhost:" + wm.port(), 30, 60_000, null));
         tool = new SubmitForApprovalTool(client);
         RequestPatHolder.set("klt_submit_test");
     }

--- a/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/UpdateRecordToolTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/UpdateRecordToolTest.java
@@ -32,7 +32,7 @@ class UpdateRecordToolTest {
         wm.start();
         GatewayHttpClient client = new GatewayHttpClient(
                 RestClient.builder(),
-                new McpProperties("http://localhost:" + wm.port(), 30, 60_000));
+                new McpProperties("http://localhost:" + wm.port(), 30, 60_000, null));
         tool = new UpdateRecordTool(client);
         RequestPatHolder.set("klt_update_test");
     }

--- a/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/UpdateRecordToolTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/UpdateRecordToolTest.java
@@ -1,0 +1,99 @@
+package io.kelta.mcp.tool.user;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import io.kelta.mcp.auth.RequestPatHolder;
+import io.kelta.mcp.client.GatewayHttpClient;
+import io.kelta.mcp.config.McpProperties;
+import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestClient;
+
+import java.util.Map;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
+import static com.github.tomakehurst.wiremock.client.WireMock.patch;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UpdateRecordToolTest {
+
+    private WireMockServer wm;
+    private UpdateRecordTool tool;
+
+    @BeforeEach
+    void setUp() {
+        wm = new WireMockServer(0);
+        wm.start();
+        GatewayHttpClient client = new GatewayHttpClient(
+                RestClient.builder(),
+                new McpProperties("http://localhost:" + wm.port(), 30, 60_000));
+        tool = new UpdateRecordTool(client);
+        RequestPatHolder.set("klt_update_test");
+    }
+
+    @AfterEach
+    void tearDown() {
+        RequestPatHolder.clear();
+        wm.stop();
+    }
+
+    @Test
+    void rejectsCallWithoutId() {
+        CallToolResult result = tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("update_record", Map.of(
+                        "collection", "accounts",
+                        "attributes", Map.of("name", "Acme2")), null));
+        assertThat(result.isError()).isEqualTo(Boolean.TRUE);
+    }
+
+    @Test
+    void rejectsCallWithoutAttrsOrRelationships() {
+        CallToolResult result = tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("update_record", Map.of(
+                        "collection", "accounts",
+                        "id", "a1"), null));
+        assertThat(result.isError()).isEqualTo(Boolean.TRUE);
+    }
+
+    @Test
+    void patchesWithJsonApiBodyAndIncludesId() {
+        wm.stubFor(patch(urlEqualTo("/api/accounts/a1"))
+                .willReturn(aResponse().withStatus(200).withBody("{\"data\":{}}")));
+
+        CallToolResult result = tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("update_record", Map.of(
+                        "collection", "accounts",
+                        "id", "a1",
+                        "attributes", Map.of("name", "Acme2")), null));
+
+        assertThat(result.isError()).isNotEqualTo(Boolean.TRUE);
+        wm.verify(WireMock.patchRequestedFor(urlEqualTo("/api/accounts/a1"))
+                .withHeader("Authorization", equalTo("Bearer klt_update_test"))
+                .withRequestBody(matchingJsonPath("$.data.type", equalTo("accounts")))
+                .withRequestBody(matchingJsonPath("$.data.id", equalTo("a1")))
+                .withRequestBody(matchingJsonPath("$.data.attributes.name", equalTo("Acme2"))));
+    }
+
+    @Test
+    void allowsRelationshipsOnlyUpdate() {
+        wm.stubFor(patch(urlEqualTo("/api/contacts/c1"))
+                .willReturn(aResponse().withStatus(200).withBody("{\"data\":{}}")));
+
+        tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("update_record", Map.of(
+                        "collection", "contacts",
+                        "id", "c1",
+                        "relationships", Map.of(
+                                "account", Map.of("data", Map.of("type", "accounts", "id", "a2")))
+                ), null));
+
+        wm.verify(WireMock.patchRequestedFor(urlEqualTo("/api/contacts/c1"))
+                .withRequestBody(matchingJsonPath("$.data.relationships.account.data.id", equalTo("a2"))));
+    }
+}

--- a/kelta-ui/app/src/pages/ApiTokensPage/ApiTokensPage.test.tsx
+++ b/kelta-ui/app/src/pages/ApiTokensPage/ApiTokensPage.test.tsx
@@ -1,0 +1,54 @@
+/**
+ * Focused tests for the helpers added in Phase 10 of the kelta-mcp
+ * rollout: the `claude mcp add` command builder + the MCP base URL
+ * resolver. These compose into the "Use with Claude Code" panel
+ * shown after token creation.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { resolveMcpBaseUrl, buildMcpAddCommand } from './ApiTokensPage'
+
+describe('buildMcpAddCommand', () => {
+  it('builds a user-profile command with the token in single quotes', () => {
+    const cmd = buildMcpAddCommand('user', 'https://emf.rzware.com', 'klt_abc123')
+    expect(cmd).toBe(
+      "claude mcp add kelta-user --transport http --url https://emf.rzware.com/mcp/user --header 'Authorization: Bearer klt_abc123'"
+    )
+  })
+
+  it('builds an admin-profile command at the right URL', () => {
+    const cmd = buildMcpAddCommand('admin', 'https://emf.rzware.com', 'klt_xyz')
+    expect(cmd).toContain('--url https://emf.rzware.com/mcp/admin')
+    expect(cmd).toContain('kelta-admin')
+  })
+
+  it('uses single quotes around the auth header so the token is opaque to the shell', () => {
+    const cmd = buildMcpAddCommand('user', 'https://emf.rzware.com', 'klt_token_with$pecial')
+    expect(cmd).toContain("'Authorization: Bearer klt_token_with$pecial'")
+  })
+})
+
+describe('resolveMcpBaseUrl', () => {
+  const originalEnv = import.meta.env.VITE_API_BASE_URL
+
+  beforeEach(() => {
+    // jsdom always sets window.location; reset the env var explicitly.
+    vi.stubEnv('VITE_API_BASE_URL', '')
+  })
+
+  afterEach(() => {
+    if (originalEnv !== undefined) {
+      vi.stubEnv('VITE_API_BASE_URL', originalEnv)
+    }
+    vi.unstubAllEnvs()
+  })
+
+  it('prefers VITE_API_BASE_URL when set', () => {
+    vi.stubEnv('VITE_API_BASE_URL', 'https://emf.rzware.com')
+    expect(resolveMcpBaseUrl()).toBe('https://emf.rzware.com')
+  })
+
+  it('falls back to window.location.origin when env is empty (local dev)', () => {
+    expect(resolveMcpBaseUrl()).toBe(window.location.origin)
+  })
+})

--- a/kelta-ui/app/src/pages/ApiTokensPage/ApiTokensPage.tsx
+++ b/kelta-ui/app/src/pages/ApiTokensPage/ApiTokensPage.tsx
@@ -340,6 +340,67 @@ function CreateTokenForm({
   )
 }
 
+/**
+ * Resolve the MCP server base URL for use-with-claude-code commands.
+ * Mirrors the API base URL convention: VITE_API_BASE_URL when set
+ * (production), otherwise the current page origin (local dev).
+ */
+export function resolveMcpBaseUrl(): string {
+  const apiBase = import.meta.env.VITE_API_BASE_URL || ''
+  if (apiBase) return apiBase
+  if (typeof window !== 'undefined' && window.location?.origin) {
+    return window.location.origin
+  }
+  return ''
+}
+
+export function buildMcpAddCommand(profile: 'user' | 'admin', mcpBaseUrl: string, token: string): string {
+  const url = `${mcpBaseUrl}/mcp/${profile}`
+  // Single-quoted shell strings keep the token opaque to the shell.
+  return `claude mcp add kelta-${profile} --transport http --url ${url} --header 'Authorization: Bearer ${token}'`
+}
+
+function CopyableCommandBlock({
+  label,
+  command,
+  testId,
+}: {
+  label: string
+  command: string
+  testId: string
+}): React.ReactElement {
+  const [copied, setCopied] = useState(false)
+
+  const handleCopy = useCallback(() => {
+    navigator.clipboard.writeText(command).then(() => {
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    })
+  }, [command])
+
+  return (
+    <div data-testid={testId}>
+      <div className="mb-1 text-xs font-medium text-muted-foreground">{label}</div>
+      <div className="flex items-start gap-2">
+        <code
+          className="flex-1 rounded bg-muted px-2 py-1.5 font-mono text-xs text-foreground break-all"
+          data-testid={`${testId}-value`}
+        >
+          {command}
+        </code>
+        <button
+          type="button"
+          className="shrink-0 rounded-md border border-border bg-secondary px-3 py-1.5 text-xs font-medium text-foreground hover:bg-muted"
+          onClick={handleCopy}
+          data-testid={`${testId}-copy`}
+        >
+          {copied ? 'Copied!' : 'Copy'}
+        </button>
+      </div>
+    </div>
+  )
+}
+
 function TokenCreatedDialog({
   token,
   onClose,
@@ -356,6 +417,10 @@ function TokenCreatedDialog({
     })
   }, [token])
 
+  const mcpBaseUrl = resolveMcpBaseUrl()
+  const userCommand = buildMcpAddCommand('user', mcpBaseUrl, token)
+  const adminCommand = buildMcpAddCommand('admin', mcpBaseUrl, token)
+
   return (
     <div
       className="fixed inset-0 z-[1000] flex items-center justify-center bg-black/50 p-4"
@@ -364,7 +429,7 @@ function TokenCreatedDialog({
       data-testid="token-created-dialog-overlay"
     >
       <div
-        className="w-full max-w-[600px] rounded-lg bg-card shadow-xl"
+        className="w-full max-w-[640px] rounded-lg bg-card shadow-xl"
         role="dialog"
         aria-modal="true"
         data-testid="token-created-dialog-modal"
@@ -380,7 +445,7 @@ function TokenCreatedDialog({
             &times;
           </button>
         </div>
-        <div className="p-6">
+        <div className="p-6 space-y-5">
           <div className="rounded-lg border border-amber-300 bg-amber-50 p-4 dark:border-amber-700 dark:bg-amber-950">
             <p className="mb-3 text-sm font-medium text-amber-800 dark:text-amber-300">
               Copy this token now. It will not be shown again.
@@ -402,7 +467,33 @@ function TokenCreatedDialog({
               </button>
             </div>
           </div>
-          <div className="mt-4 flex justify-end">
+
+          <div
+            className="rounded-lg border border-border bg-card p-4 space-y-3"
+            data-testid="claude-code-panel"
+          >
+            <div>
+              <h3 className="text-sm font-semibold text-foreground">Use with Claude Code</h3>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Run one or both of these in a terminal to register Kelta as an MCP server.
+                The <code className="font-mono">/mcp/user</code> endpoint exposes data-plane
+                tools (CRUD, flows, approvals); <code className="font-mono">/mcp/admin</code>{' '}
+                exposes control-plane tools (collection / layout / flow definition).
+              </p>
+            </div>
+            <CopyableCommandBlock
+              label="Data plane (CRUD, flows, approvals)"
+              command={userCommand}
+              testId="mcp-add-user"
+            />
+            <CopyableCommandBlock
+              label="Control plane (schema, layouts, flows definition)"
+              command={adminCommand}
+              testId="mcp-add-admin"
+            />
+          </div>
+
+          <div className="flex justify-end">
             <button
               type="button"
               className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"


### PR DESCRIPTION
## Summary

Fixes the post-merge build failure on cklinker/emf#787 (run [25010702894](https://github.com/cklinker/emf/actions/runs/25010702894)) and bundles Phase 2 of the kelta-mcp rollout.

### Build fix (commit \`9ec20428\`)
The first CI build of \`emf-mcp\` failed because \`runtime-core\` has compile-time references to \`runtime-jsonapi\` types (\`JsonApiError\`, \`AtomicResult\`, \`AtomicOperation\`). The kelta-mcp Dockerfile was building runtime-core in isolation with \`-pl runtime-core -am\` — but \`-am\` only pulls reactor-internal modules whose source is present in the build context, and runtime-jsonapi's source wasn't being copied. It worked locally because \`~/.m2\` was warm from earlier kelta-ai builds; CI runs in a clean buildkit context.

Fix: copy and build \`runtime-events\` + \`runtime-jsonapi\` alongside \`runtime-core\`. Verified with \`mvn -Dmaven.repo.local=/tmp/m2-fresh\` so the local repo couldn't mask the issue this time.

### Phase 2 — read-only user tools (commit \`5cb29d3a\`)
The \`/mcp/user\` endpoint now exposes six tools that forward through the gateway with the user's PAT:

| Tool | Wraps |
|---|---|
| \`list_collections\` | \`GET /api/collections\` (optional \`includeSystem\` flag) |
| \`get_collection_schema\` | combines \`/api/collections/{name}\` with the field list |
| \`query_collection\` | JSON:API list with structured filter/sort/paging args |
| \`get_record\` | \`GET /api/{collection}/{id}\` with optional include |
| \`search\` | \`GET /api/_search?q=\` |
| \`describe_api\` | \`GET /api/docs/openapi.json\` on demand |

Infrastructure:
- \`RequestPatHolder\`: thread-local PAT, captured by \`McpAuthFilter\`, cleared in \`finally\` (verified by an explicit test that an exception in the chain still clears the holder).
- \`GatewayHttpClient\`: sync \`RestClient\` pinned to HTTP/1.1 (the JDK HttpClient's default h2c upgrade trips intermediaries and WireMock). Refuses to call when no PAT is in context.
- \`McpErrorMapper\`: HTTP 4xx/5xx → \`isError: true\`. Defensively redacts any \`klt_*\` substring from success bodies, error bodies, and exception messages.
- \`UserTool\` interface: structural separation from admin tools. \`McpServerConfig\` autowires \`List<UserTool>\` and registers each.

## Test plan
- [x] \`mvn -Dmaven.repo.local=/tmp/m2-fresh package\` succeeds end-to-end (mirrors CI's clean buildkit context)
- [x] \`mvn test -f kelta-mcp/pom.xml\` — 36 passing (was 11)
- [ ] CI build-and-publish succeeds and pushes \`harbor.rzware.com/emf/emf-mcp:latest\` + \`:main-<sha>\`
- [ ] On merge, deploy job sed-updates homelab-argo's mcp-deployment.yaml to \`:main-<sha>\` (requires cklinker/homelab-argo#69 to merge first; that PR is already up)
- [ ] After ArgoCD syncs: \`claude mcp add kelta-user --transport http --url https://emf.rzware.com/mcp/user --header "Authorization: Bearer klt_<pat>"\` then \`list_collections\` returns the tenant's collections

🤖 Generated with [Claude Code](https://claude.com/claude-code)