### PR TITLE
fix(mcp): propagate PAT via McpTransportContext (live tool calls were 500ing)

### DIFF
--- a/kelta-mcp/src/main/java/io/kelta/mcp/auth/KeltaTransportContextExtractor.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/auth/KeltaTransportContextExtractor.java
@@ -1,0 +1,45 @@
+package io.kelta.mcp.auth;
+
+import io.modelcontextprotocol.common.McpTransportContext;
+import io.modelcontextprotocol.server.McpTransportContextExtractor;
+import jakarta.servlet.http.HttpServletRequest;
+
+import java.util.Map;
+
+/**
+ * Extracts per-request data from the inbound HTTP request and packs
+ * it into an {@link McpTransportContext} that the SDK propagates to
+ * tool handlers — even though the handler runs on a Reactor scheduler
+ * thread, not the servlet thread.
+ *
+ * <p>The {@code "pat"} key carries the PAT (without the {@code Bearer}
+ * prefix). Tool decorators read it back via
+ * {@code exchange.transportContext().get("pat")}.
+ *
+ * <p>{@link McpAuthFilter} still runs first and rejects any request
+ * without a valid {@code Bearer klt_*} header — by the time this
+ * extractor sees the request, presence is already guaranteed. We
+ * defensively re-check anyway so a future routing change that bypasses
+ * the filter can't silently leave the context empty.
+ */
+public final class KeltaTransportContextExtractor
+        implements McpTransportContextExtractor<HttpServletRequest> {
+
+    public static final String PAT_KEY = "pat";
+
+    private static final String AUTHORIZATION = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    @Override
+    public McpTransportContext extract(HttpServletRequest request) {
+        String header = request.getHeader(AUTHORIZATION);
+        if (header == null || !header.startsWith(BEARER_PREFIX)) {
+            return McpTransportContext.EMPTY;
+        }
+        String token = header.substring(BEARER_PREFIX.length());
+        if (token.isEmpty()) {
+            return McpTransportContext.EMPTY;
+        }
+        return McpTransportContext.create(Map.of(PAT_KEY, token));
+    }
+}

--- a/kelta-mcp/src/main/java/io/kelta/mcp/config/McpServerConfig.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/config/McpServerConfig.java
@@ -1,6 +1,8 @@
 package io.kelta.mcp.config;
 
+import io.kelta.mcp.auth.KeltaTransportContextExtractor;
 import io.kelta.mcp.observe.ObservedToolDecorator;
+import io.kelta.mcp.observe.PatPropagatingToolDecorator;
 import io.kelta.mcp.observe.RateLimitedToolDecorator;
 import io.kelta.mcp.resource.UserResource;
 import io.kelta.mcp.resource.UserResourceTemplate;
@@ -46,6 +48,7 @@ public class McpServerConfig {
     public HttpServletStreamableServerTransportProvider userTransportProvider() {
         return HttpServletStreamableServerTransportProvider.builder()
                 .mcpEndpoint("/mcp/user")
+                .contextExtractor(new KeltaTransportContextExtractor())
                 .build();
     }
 
@@ -53,6 +56,7 @@ public class McpServerConfig {
     public HttpServletStreamableServerTransportProvider adminTransportProvider() {
         return HttpServletStreamableServerTransportProvider.builder()
                 .mcpEndpoint("/mcp/admin")
+                .contextExtractor(new KeltaTransportContextExtractor())
                 .build();
     }
 
@@ -64,7 +68,8 @@ public class McpServerConfig {
             List<UserResource> userResources,
             List<UserResourceTemplate> userResourceTemplates,
             ObservedToolDecorator decorator,
-            RateLimitedToolDecorator rateLimiter) {
+            RateLimitedToolDecorator rateLimiter,
+            PatPropagatingToolDecorator patPropagator) {
         McpSyncServer server = McpServer.sync(transport)
                 .serverInfo(SERVER_NAME + "-user", SERVER_VERSION)
                 .capabilities(ServerCapabilities.builder()
@@ -72,9 +77,10 @@ public class McpServerConfig {
                         .resources(false, true)  // (subscribe, listChanged)
                         .build())
                 .build();
-        server.addTool(wrap(pingTool("user"), "user", decorator, rateLimiter));
+        server.addTool(wrap(pingTool("user"), "user", decorator, rateLimiter, patPropagator));
         for (UserTool tool : userTools) {
-            McpServerFeatures.SyncToolSpecification spec = wrap(tool.toSpecification(), "user", decorator, rateLimiter);
+            McpServerFeatures.SyncToolSpecification spec = wrap(
+                    tool.toSpecification(), "user", decorator, rateLimiter, patPropagator);
             server.addTool(spec);
             log.info("Registered user tool: {}", spec.tool().name());
         }
@@ -97,14 +103,16 @@ public class McpServerConfig {
             HttpServletStreamableServerTransportProvider transport,
             List<AdminTool> adminTools,
             ObservedToolDecorator decorator,
-            RateLimitedToolDecorator rateLimiter) {
+            RateLimitedToolDecorator rateLimiter,
+            PatPropagatingToolDecorator patPropagator) {
         McpSyncServer server = McpServer.sync(transport)
                 .serverInfo(SERVER_NAME + "-admin", SERVER_VERSION)
                 .capabilities(ServerCapabilities.builder().tools(true).build())
                 .build();
-        server.addTool(wrap(pingTool("admin"), "admin", decorator, rateLimiter));
+        server.addTool(wrap(pingTool("admin"), "admin", decorator, rateLimiter, patPropagator));
         for (AdminTool tool : adminTools) {
-            McpServerFeatures.SyncToolSpecification spec = wrap(tool.toSpecification(), "admin", decorator, rateLimiter);
+            McpServerFeatures.SyncToolSpecification spec = wrap(
+                    tool.toSpecification(), "admin", decorator, rateLimiter, patPropagator);
             server.addTool(spec);
             log.info("Registered admin tool: {}", spec.tool().name());
         }
@@ -112,16 +120,25 @@ public class McpServerConfig {
     }
 
     /**
-     * Decorator stack: rate limiter wraps observation, observation wraps the
-     * original tool. Rate-limited calls are rejected before the timer/counter
-     * fires — they show up in mcp.tool.rate_limited only.
+     * Decorator stack, outermost → innermost:
+     *  1. PAT propagator — copies the PAT from McpTransportContext into
+     *     the per-thread RequestPatHolder (handlers run on a Reactor
+     *     scheduler thread, not the servlet thread).
+     *  2. Rate limiter — keys its bucket on the now-populated PAT;
+     *     rate-limited calls return an error before observation runs.
+     *  3. Observation — timer + counter, tagged with status.
+     *  4. Original tool.
      */
     private static McpServerFeatures.SyncToolSpecification wrap(
             McpServerFeatures.SyncToolSpecification original,
             String profile,
             ObservedToolDecorator observed,
-            RateLimitedToolDecorator rateLimited) {
-        return rateLimited.decorate(observed.decorate(original, profile), profile);
+            RateLimitedToolDecorator rateLimited,
+            PatPropagatingToolDecorator patPropagator) {
+        return patPropagator.decorate(
+                rateLimited.decorate(
+                        observed.decorate(original, profile),
+                        profile));
     }
 
     @Bean

--- a/kelta-mcp/src/main/java/io/kelta/mcp/observe/PatPropagatingToolDecorator.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/observe/PatPropagatingToolDecorator.java
@@ -1,0 +1,48 @@
+package io.kelta.mcp.observe;
+
+import io.kelta.mcp.auth.KeltaTransportContextExtractor;
+import io.kelta.mcp.auth.RequestPatHolder;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import org.springframework.stereotype.Component;
+
+/**
+ * Outermost decorator: copies the PAT from the SDK's transport context
+ * (set by {@link KeltaTransportContextExtractor} during HTTP intake)
+ * into {@link RequestPatHolder} for the duration of the tool handler.
+ *
+ * <p>Why this exists: the MCP SDK dispatches sync tool handlers on
+ * Reactor scheduler threads, not the servlet thread. The
+ * {@code ThreadLocal} that the auth filter populates on the inbound
+ * thread is therefore invisible to the handler. The transport context
+ * is the SDK-blessed mechanism for thread-safe propagation; this
+ * decorator bridges it back to the same {@code RequestPatHolder} the
+ * downstream HTTP client already reads from.
+ *
+ * <p>Wraps OUTSIDE the rate limiter (which keys its bucket on the PAT)
+ * and the observation decorator.
+ */
+@Component
+public class PatPropagatingToolDecorator {
+
+    public SyncToolSpecification decorate(SyncToolSpecification original) {
+        var inner = original.callHandler();
+        return SyncToolSpecification.builder()
+                .tool(original.tool())
+                .callHandler((exchange, request) -> {
+                    String pat = null;
+                    if (exchange != null && exchange.transportContext() != null) {
+                        Object value = exchange.transportContext().get(KeltaTransportContextExtractor.PAT_KEY);
+                        if (value instanceof String s) pat = s;
+                    }
+                    if (pat != null) {
+                        RequestPatHolder.set(pat);
+                    }
+                    try {
+                        return inner.apply(exchange, request);
+                    } finally {
+                        RequestPatHolder.clear();
+                    }
+                })
+                .build();
+    }
+}

--- a/kelta-mcp/src/test/java/io/kelta/mcp/auth/KeltaTransportContextExtractorTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/auth/KeltaTransportContextExtractorTest.java
@@ -1,0 +1,51 @@
+package io.kelta.mcp.auth;
+
+import io.modelcontextprotocol.common.McpTransportContext;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class KeltaTransportContextExtractorTest {
+
+    private final KeltaTransportContextExtractor extractor = new KeltaTransportContextExtractor();
+
+    @Test
+    void extractsBearerTokenFromAuthorizationHeader() {
+        MockHttpServletRequest req = new MockHttpServletRequest("POST", "/mcp/user");
+        req.addHeader("Authorization", "Bearer klt_token_value");
+
+        McpTransportContext context = extractor.extract(req);
+
+        assertThat(context.get(KeltaTransportContextExtractor.PAT_KEY)).isEqualTo("klt_token_value");
+    }
+
+    @Test
+    void returnsEmptyContextWhenAuthorizationMissing() {
+        MockHttpServletRequest req = new MockHttpServletRequest("POST", "/mcp/user");
+
+        McpTransportContext context = extractor.extract(req);
+
+        assertThat(context).isSameAs(McpTransportContext.EMPTY);
+    }
+
+    @Test
+    void returnsEmptyContextWhenSchemeIsNotBearer() {
+        MockHttpServletRequest req = new MockHttpServletRequest("POST", "/mcp/user");
+        req.addHeader("Authorization", "Basic dXNlcjpwYXNz");
+
+        McpTransportContext context = extractor.extract(req);
+
+        assertThat(context).isSameAs(McpTransportContext.EMPTY);
+    }
+
+    @Test
+    void returnsEmptyContextWhenBearerTokenIsBlank() {
+        MockHttpServletRequest req = new MockHttpServletRequest("POST", "/mcp/user");
+        req.addHeader("Authorization", "Bearer ");
+
+        McpTransportContext context = extractor.extract(req);
+
+        assertThat(context).isSameAs(McpTransportContext.EMPTY);
+    }
+}

--- a/kelta-mcp/src/test/java/io/kelta/mcp/observe/PatPropagatingToolDecoratorTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/observe/PatPropagatingToolDecoratorTest.java
@@ -1,0 +1,94 @@
+package io.kelta.mcp.observe;
+
+import io.kelta.mcp.auth.KeltaTransportContextExtractor;
+import io.kelta.mcp.auth.RequestPatHolder;
+import io.modelcontextprotocol.common.McpTransportContext;
+import io.modelcontextprotocol.server.McpAsyncServerExchange;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.server.McpSyncServerExchange;
+import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.JsonSchema;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import io.modelcontextprotocol.spec.McpSchema.Tool;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class PatPropagatingToolDecoratorTest {
+
+    private final PatPropagatingToolDecorator decorator = new PatPropagatingToolDecorator();
+
+    private SyncToolSpecification stub(java.util.function.BiFunction<McpSyncServerExchange, CallToolRequest, CallToolResult> handler) {
+        Tool tool = Tool.builder()
+                .name("stub")
+                .description("test")
+                .inputSchema(new JsonSchema("object", Map.of(), List.of(), false, null, null))
+                .build();
+        return SyncToolSpecification.builder()
+                .tool(tool)
+                .callHandler(handler::apply)
+                .build();
+    }
+
+    private McpSyncServerExchange exchangeWithContext(McpTransportContext ctx) {
+        McpAsyncServerExchange asyncExchange = mock(McpAsyncServerExchange.class);
+        when(asyncExchange.transportContext()).thenReturn(ctx);
+        return new McpSyncServerExchange(asyncExchange);
+    }
+
+    @Test
+    void copiesPatFromTransportContextIntoHolderForDurationOfCall() {
+        AtomicReference<String> seen = new AtomicReference<>();
+        SyncToolSpecification decorated = decorator.decorate(stub((ex, req) -> {
+            seen.set(RequestPatHolder.get());
+            return CallToolResult.builder().content(List.of(new TextContent("ok"))).build();
+        }));
+
+        McpSyncServerExchange exchange = exchangeWithContext(
+                McpTransportContext.create(Map.of(KeltaTransportContextExtractor.PAT_KEY, "klt_propagated")));
+
+        decorated.callHandler().apply(exchange, new CallToolRequest("stub", Map.of(), null));
+
+        assertThat(seen.get()).isEqualTo("klt_propagated");
+        assertThat(RequestPatHolder.get()).isNull(); // cleared after
+    }
+
+    @Test
+    void clearsHolderEvenWhenInnerHandlerThrows() {
+        SyncToolSpecification decorated = decorator.decorate(stub((ex, req) -> {
+            throw new RuntimeException("boom");
+        }));
+
+        McpSyncServerExchange exchange = exchangeWithContext(
+                McpTransportContext.create(Map.of(KeltaTransportContextExtractor.PAT_KEY, "klt_x")));
+
+        try {
+            decorated.callHandler().apply(exchange, new CallToolRequest("stub", Map.of(), null));
+        } catch (RuntimeException ignored) {
+        }
+
+        assertThat(RequestPatHolder.get()).isNull();
+    }
+
+    @Test
+    void doesNothingWhenContextHasNoPat() {
+        AtomicReference<String> seen = new AtomicReference<>();
+        SyncToolSpecification decorated = decorator.decorate(stub((ex, req) -> {
+            seen.set(RequestPatHolder.get());
+            return CallToolResult.builder().content(List.of(new TextContent("ok"))).build();
+        }));
+
+        McpSyncServerExchange exchange = exchangeWithContext(McpTransportContext.EMPTY);
+
+        decorated.callHandler().apply(exchange, new CallToolRequest("stub", Map.of(), null));
+
+        assertThat(seen.get()).isNull();
+    }
+}


### PR DESCRIPTION
## Summary

Live MCP tool calls from Claude Desktop were failing with \`IllegalStateException: No PAT in request context — auth filter must run before tool dispatch\`. The SDK runs sync tool handlers on a Reactor scheduler thread, not the Tomcat servlet thread, so the \`ThreadLocal\` that \`McpAuthFilter\` populated was empty by the time \`GatewayHttpClient\` read it.

This fix uses the SDK's intended mechanism for per-request context propagation: \`McpTransportContextExtractor\`. The extractor pulls the bearer token off the inbound \`HttpServletRequest\` at intake and packs it into an \`McpTransportContext\` that the SDK propagates across the thread hop. A new outermost \`PatPropagatingToolDecorator\` reads it back via \`exchange.transportContext()\` and re-populates \`RequestPatHolder\` for the handler's duration — so the rate limiter, the gateway client, and every existing tool keep working unchanged.

\`McpAuthFilter\` is still the first line of defense (rejects malformed-bearer requests at the HTTP layer before the SDK runs). The extractor defensively re-checks the prefix and returns \`McpTransportContext.EMPTY\` on anything off-shape.

## Test plan

- [x] \`mvn test -f kelta-mcp/pom.xml\` — 116 passing (was 109; 7 new for the extractor and propagating decorator)
- [ ] CI build pushes \`emf-mcp:main-<sha>\`, ArgoCD rolls the deployment
- [ ] After rollout, ask Claude Desktop "using kelta-user, list collections" — should return JSON, not \`No PAT in request context\`
- [ ] \`mcp.tool.calls{tool=\"list_collections\",profile=\"user\",status=\"success\"}\` increments

## Operational impact

Zero data-plane risk. Stateless service, no DB, no migrations. The decorator chain ordering changed (PatPropagating now outer of RateLimited and Observed) but tool semantics are unchanged. \`RequestPatHolder\` (ThreadLocal) is still used by \`GatewayHttpClient\` — no callers needed updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)