### PR TITLE
fix(gateway): skip klt_ PATs in JWT decoder so PAT auth doesn't 500

### DIFF
--- a/kelta-gateway/src/main/java/io/kelta/gateway/auth/DynamicReactiveJwtDecoder.java
+++ b/kelta-gateway/src/main/java/io/kelta/gateway/auth/DynamicReactiveJwtDecoder.java
@@ -41,6 +41,14 @@ public class DynamicReactiveJwtDecoder implements ReactiveJwtDecoder {
     private static final Logger log = LoggerFactory.getLogger(DynamicReactiveJwtDecoder.class);
     private static final Duration PROVIDER_CACHE_TTL = Duration.ofMinutes(15);
     private static final String REDIS_PREFIX = "oidc:provider:";
+    /**
+     * Tokens with this prefix are Personal Access Tokens validated by
+     * {@link PatAuthenticationFilter} as a {@code GlobalFilter} before
+     * Spring Security's {@code AuthenticationWebFilter} runs. The JWT
+     * decoder must short-circuit them to {@link Mono#empty()} — otherwise
+     * {@code extractIssuer} fails parsing and the manager surfaces a 500.
+     */
+    private static final String PAT_PREFIX = "klt_";
 
     private final WebClient workerClient;
     private final ReactiveStringRedisTemplate redisTemplate;
@@ -108,6 +116,17 @@ public class DynamicReactiveJwtDecoder implements ReactiveJwtDecoder {
      * @throws JwtException if the token is invalid or the issuer is not registered for the tenant
      */
     public Mono<Jwt> decode(String token, String tenantId) throws JwtException {
+        // Personal Access Tokens (klt_*) are handled by PatAuthenticationFilter
+        // before Spring Security's AuthenticationWebFilter dispatches to this
+        // decoder. Returning Mono.empty() makes JwtReactiveAuthenticationManager
+        // emit no Authentication, which combined with anyExchange().permitAll()
+        // lets the request proceed with the PAT principal already populated by
+        // the global filter. Without this short-circuit the issuer parse fails
+        // and surfaces as HTTP 500 to the caller.
+        if (token != null && token.startsWith(PAT_PREFIX)) {
+            return Mono.empty();
+        }
+
         String issuer;
         try {
             issuer = extractIssuer(token);

--- a/kelta-gateway/src/test/java/io/kelta/gateway/auth/DynamicReactiveJwtDecoderTest.java
+++ b/kelta-gateway/src/test/java/io/kelta/gateway/auth/DynamicReactiveJwtDecoderTest.java
@@ -39,6 +39,18 @@ class DynamicReactiveJwtDecoderTest {
     }
 
     @Test
+    @DisplayName("should short-circuit klt_ PATs to Mono.empty() so AuthenticationWebFilter does not 500")
+    void skipsPatTokens() {
+        // PATs are validated by PatAuthenticationFilter as a GlobalFilter; the
+        // JWT manager would otherwise surface "Failed to parse JWT issuer" as
+        // an HTTP 500 from the resource server.
+        StepVerifier.create(decoder.decode("klt_AbCdEf123456789"))
+                .verifyComplete();
+        StepVerifier.create(decoder.decode("klt_AbCdEf123456789", "tenant-1"))
+                .verifyComplete();
+    }
+
+    @Test
     @DisplayName("should reject token without issuer")
     void rejectTokenWithoutIssuer() {
         String header = Base64.getUrlEncoder().withoutPadding().encodeToString("{}".getBytes());


### PR DESCRIPTION
## Summary

Every PAT-authenticated API call was returning \`HTTP 500 — {\"errors\":[{}]}\`. Reproducing against staging with a real PAT:

\`\`\`
curl -i -H \"Authorization: Bearer klt_<token>\" https://emf.rzware.com/api/collections
HTTP/2 500
\`\`\`

Gateway logs show:

\`\`\`
org.springframework.security.oauth2.jwt.JwtException: Failed to parse JWT issuer: Invalid JWT format
  at io.kelta.gateway.auth.DynamicReactiveJwtDecoder.decode(DynamicReactiveJwtDecoder.java:115)
\`\`\`

\`PatAuthenticationFilter\` (a \`GlobalFilter\` at order -99) DOES authenticate \`klt_\` tokens correctly and populates the principal. But Spring Security's \`AuthenticationWebFilter\` still runs afterwards as part of the \`SecurityWebFilterChain\` that the \`oauth2ResourceServer\` DSL adds. It pulls the raw Authorization header, builds a \`BearerTokenAuthenticationToken\`, and hands it to \`JwtReactiveAuthenticationManager\` → \`DynamicReactiveJwtDecoder.decode()\`. \`extractIssuer\` Base64-decodes what it expects to be a JWT segment, fails on the \`klt_\` prefix, and the manager surfaces the failure as 500.

\`SecurityConfig\`'s \`anyExchange().permitAll()\` doesn't save us — that's authorization, not authentication, and the authn failure short-circuits the chain before permitAll is consulted.

## Fix

Return \`Mono.empty()\` from the JWT decoder when the token starts with \`klt_\`. \`JwtReactiveAuthenticationManager\` treats an empty result as \"no Authentication produced\" rather than an error; combined with \`permitAll()\` the request proceeds with the principal that the GlobalFilter already populated. Real malformed JWTs still raise \`JwtException\` exactly as before.

## Impact

Unblocks every PAT-authenticated path:
- kelta-mcp tool calls (Claude Code / Claude Desktop)
- Any CLI / script using PATs from \`/api/me/tokens\`
- Service-to-service calls using PATs

Browser-based JWT auth is untouched. CI gates are still in place. Reactive flow on the JWT branch is unchanged — only the early \`klt_\` short-circuit is added.

## Test plan

- [x] \`mvn test -f kelta-gateway/pom.xml -Dtest=DynamicReactiveJwtDecoderTest\` — 12 passing (was 11). New \`skipsPatTokens\` case asserts both \`decode(token)\` and \`decode(token, tenantId)\` emit \`Mono.empty\` for a klt_ token, while the existing \`rejectInvalidJwt\` case still expects \`JwtException\` for a non-PAT malformed JWT.
- [ ] After merge: \`curl -i -H \"Authorization: Bearer klt_<pat>\" https://emf.rzware.com/api/collections\` returns 200 with collection JSON.
- [ ] Claude Desktop \"using kelta-user, list collections\" returns the result, not an error.
- [ ] Existing JWT (browser/UI) auth still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)