### PR TITLE
fix(gateway): filter klt_ PATs at the bearer-token converter, not the decoder

### DIFF
--- a/kelta-gateway/src/main/java/io/kelta/gateway/auth/DynamicReactiveJwtDecoder.java
+++ b/kelta-gateway/src/main/java/io/kelta/gateway/auth/DynamicReactiveJwtDecoder.java
@@ -41,14 +41,6 @@ public class DynamicReactiveJwtDecoder implements ReactiveJwtDecoder {
     private static final Logger log = LoggerFactory.getLogger(DynamicReactiveJwtDecoder.class);
     private static final Duration PROVIDER_CACHE_TTL = Duration.ofMinutes(15);
     private static final String REDIS_PREFIX = "oidc:provider:";
-    /**
-     * Tokens with this prefix are Personal Access Tokens validated by
-     * {@link PatAuthenticationFilter} as a {@code GlobalFilter} before
-     * Spring Security's {@code AuthenticationWebFilter} runs. The JWT
-     * decoder must short-circuit them to {@link Mono#empty()} — otherwise
-     * {@code extractIssuer} fails parsing and the manager surfaces a 500.
-     */
-    private static final String PAT_PREFIX = "klt_";
 
     private final WebClient workerClient;
     private final ReactiveStringRedisTemplate redisTemplate;
@@ -116,17 +108,6 @@ public class DynamicReactiveJwtDecoder implements ReactiveJwtDecoder {
      * @throws JwtException if the token is invalid or the issuer is not registered for the tenant
      */
     public Mono<Jwt> decode(String token, String tenantId) throws JwtException {
-        // Personal Access Tokens (klt_*) are handled by PatAuthenticationFilter
-        // before Spring Security's AuthenticationWebFilter dispatches to this
-        // decoder. Returning Mono.empty() makes JwtReactiveAuthenticationManager
-        // emit no Authentication, which combined with anyExchange().permitAll()
-        // lets the request proceed with the PAT principal already populated by
-        // the global filter. Without this short-circuit the issuer parse fails
-        // and surfaces as HTTP 500 to the caller.
-        if (token != null && token.startsWith(PAT_PREFIX)) {
-            return Mono.empty();
-        }
-
         String issuer;
         try {
             issuer = extractIssuer(token);

--- a/kelta-gateway/src/main/java/io/kelta/gateway/auth/PatAwareBearerTokenConverter.java
+++ b/kelta-gateway/src/main/java/io/kelta/gateway/auth/PatAwareBearerTokenConverter.java
@@ -1,0 +1,60 @@
+package io.kelta.gateway.auth;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.server.resource.web.server.authentication.ServerBearerTokenAuthenticationConverter;
+import org.springframework.security.web.server.authentication.ServerAuthenticationConverter;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+/**
+ * Bearer-token converter for the {@code oauth2ResourceServer} chain that
+ * filters out Personal Access Tokens.
+ *
+ * <p>{@link PatAuthenticationFilter} (a {@code GlobalFilter} ordered
+ * before the Spring Security {@code WebFilterChainProxy}) already
+ * validates {@code klt_*} tokens, populates the gateway principal,
+ * and propagates {@code X-User-Id} downstream. By the time Spring
+ * Security's {@code AuthenticationWebFilter} runs, those requests
+ * are already authenticated as far as the gateway cares.
+ *
+ * <p>If we leave the default {@link ServerBearerTokenAuthenticationConverter}
+ * in place, it produces a {@code BearerTokenAuthenticationToken} for
+ * the {@code klt_*} token — and {@code JwtReactiveAuthenticationManager}
+ * either fails parsing it as a JWT (5xx) or, if the decoder swallows
+ * the token, leaves the manager with nothing to return and the
+ * {@code AuthenticationWebFilter} surfaces "No provider found".
+ *
+ * <p>Returning {@link Mono#empty()} from the converter for
+ * {@code klt_*} tokens makes {@code AuthenticationWebFilter} skip
+ * authentication entirely and continue the filter chain, which —
+ * combined with {@code anyExchange().permitAll()} — lets the request
+ * proceed with the principal that the global PAT filter already set.
+ */
+public final class PatAwareBearerTokenConverter implements ServerAuthenticationConverter {
+
+    static final String PAT_PREFIX = "klt_";
+    static final String AUTHORIZATION = "Authorization";
+    static final String BEARER_PREFIX = "Bearer ";
+
+    private final ServerAuthenticationConverter delegate;
+
+    public PatAwareBearerTokenConverter() {
+        this(new ServerBearerTokenAuthenticationConverter());
+    }
+
+    PatAwareBearerTokenConverter(ServerAuthenticationConverter delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public Mono<Authentication> convert(ServerWebExchange exchange) {
+        String header = exchange.getRequest().getHeaders().getFirst(AUTHORIZATION);
+        if (header != null && header.startsWith(BEARER_PREFIX)) {
+            String token = header.substring(BEARER_PREFIX.length());
+            if (token.startsWith(PAT_PREFIX)) {
+                return Mono.empty();
+            }
+        }
+        return delegate.convert(exchange);
+    }
+}

--- a/kelta-gateway/src/main/java/io/kelta/gateway/config/SecurityConfig.java
+++ b/kelta-gateway/src/main/java/io/kelta/gateway/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package io.kelta.gateway.config;
 
 import io.kelta.gateway.auth.DynamicReactiveJwtDecoder;
+import io.kelta.gateway.auth.PatAwareBearerTokenConverter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -124,7 +125,13 @@ public class SecurityConfig {
                 .pathMatchers("/actuator/**").authenticated()
                 .anyExchange().permitAll()
             )
-            .oauth2ResourceServer(oauth -> oauth.jwt(jwt -> jwt.jwtDecoder(reactiveJwtDecoder)))
+            .oauth2ResourceServer(oauth -> oauth
+                    // PATs (klt_*) are validated by PatAuthenticationFilter as a
+                    // GlobalFilter ordered before this chain. Filter them out at
+                    // the converter so AuthenticationWebFilter doesn't try to
+                    // authenticate them as JWTs (which surfaces 5xx).
+                    .bearerTokenConverter(new PatAwareBearerTokenConverter())
+                    .jwt(jwt -> jwt.jwtDecoder(reactiveJwtDecoder)))
             .build();
     }
 

--- a/kelta-gateway/src/test/java/io/kelta/gateway/auth/DynamicReactiveJwtDecoderTest.java
+++ b/kelta-gateway/src/test/java/io/kelta/gateway/auth/DynamicReactiveJwtDecoderTest.java
@@ -38,17 +38,6 @@ class DynamicReactiveJwtDecoderTest {
                 .verify();
     }
 
-    @Test
-    @DisplayName("should short-circuit klt_ PATs to Mono.empty() so AuthenticationWebFilter does not 500")
-    void skipsPatTokens() {
-        // PATs are validated by PatAuthenticationFilter as a GlobalFilter; the
-        // JWT manager would otherwise surface "Failed to parse JWT issuer" as
-        // an HTTP 500 from the resource server.
-        StepVerifier.create(decoder.decode("klt_AbCdEf123456789"))
-                .verifyComplete();
-        StepVerifier.create(decoder.decode("klt_AbCdEf123456789", "tenant-1"))
-                .verifyComplete();
-    }
 
     @Test
     @DisplayName("should reject token without issuer")

--- a/kelta-gateway/src/test/java/io/kelta/gateway/auth/PatAwareBearerTokenConverterTest.java
+++ b/kelta-gateway/src/test/java/io/kelta/gateway/auth/PatAwareBearerTokenConverterTest.java
@@ -1,0 +1,80 @@
+package io.kelta.gateway.auth;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.server.authentication.ServerAuthenticationConverter;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.util.List;
+
+class PatAwareBearerTokenConverterTest {
+
+    @Test
+    void returnsEmptyForKltPatToken() {
+        PatAwareBearerTokenConverter converter = new PatAwareBearerTokenConverter(
+                exchange -> Mono.error(new AssertionError("delegate should not run for klt_ tokens")));
+
+        MockServerWebExchange exchange = exchange("Bearer klt_AbCdEf12345");
+
+        StepVerifier.create(converter.convert(exchange))
+                .verifyComplete();
+    }
+
+    @Test
+    void delegatesForRealJwtToken() {
+        Authentication stub = new StubAuth();
+        ServerAuthenticationConverter delegate = exchange -> Mono.just(stub);
+        PatAwareBearerTokenConverter converter = new PatAwareBearerTokenConverter(delegate);
+
+        MockServerWebExchange exchange = exchange("Bearer eyJhbGciOiJIUzI1NiJ9.x.y");
+
+        StepVerifier.create(converter.convert(exchange))
+                .expectNext(stub)
+                .verifyComplete();
+    }
+
+    @Test
+    void delegatesWhenAuthorizationHeaderAbsent() {
+        Authentication stub = new StubAuth();
+        ServerAuthenticationConverter delegate = exchange -> Mono.just(stub);
+        PatAwareBearerTokenConverter converter = new PatAwareBearerTokenConverter(delegate);
+
+        MockServerWebExchange exchange = MockServerWebExchange.from(
+                MockServerHttpRequest.get("/api/anything").build());
+
+        StepVerifier.create(converter.convert(exchange))
+                .expectNext(stub)
+                .verifyComplete();
+    }
+
+    @Test
+    void delegatesWhenSchemeIsNotBearer() {
+        Authentication stub = new StubAuth();
+        ServerAuthenticationConverter delegate = exchange -> Mono.just(stub);
+        PatAwareBearerTokenConverter converter = new PatAwareBearerTokenConverter(delegate);
+
+        MockServerWebExchange exchange = exchange("Basic dXNlcjpwYXNz");
+
+        StepVerifier.create(converter.convert(exchange))
+                .expectNext(stub)
+                .verifyComplete();
+    }
+
+    private static MockServerWebExchange exchange(String authorization) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", authorization);
+        return MockServerWebExchange.from(
+                MockServerHttpRequest.get("/api/anything").headers(headers).build());
+    }
+
+    private static final class StubAuth extends AbstractAuthenticationToken {
+        StubAuth() { super(List.of()); }
+        @Override public Object getCredentials() { return null; }
+        @Override public Object getPrincipal() { return "stub"; }
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to cklinker/emf#790. That PR short-circuited \`DynamicReactiveJwtDecoder\` for \`klt_\` tokens to \`Mono.empty()\`. That stopped the \"Failed to parse JWT issuer\" 500 but moved the failure one frame up:

\`\`\`
java.lang.IllegalStateException: No provider found for class BearerTokenAuthenticationToken
  at AuthenticationWebFilter.lambda\$authenticate\$6
\`\`\`

\`JwtReactiveAuthenticationManager\` called the decoder, got empty, returned empty itself, and \`AuthenticationWebFilter\` treated that as \"no provider can handle this token\" and 500'd. \`Mono.empty()\` is also not a legal return from \`ReactiveJwtDecoder\` — the contract is \"emit a Jwt or throw JwtException\".

The right level to short-circuit is the **bearer-token converter**, before \`AuthenticationWebFilter\` even attempts authentication. If the converter returns \`Mono.empty()\`, the filter's \`switchIfEmpty\` branch just continues the chain — combined with \`anyExchange().permitAll()\` the request proceeds with the principal that \`PatAuthenticationFilter\` (GlobalFilter, order -99) already set on the exchange.

## Changes

- **\`PatAwareBearerTokenConverter\`** wraps Spring's \`ServerBearerTokenAuthenticationConverter\`. For Authorization headers starting with \`Bearer klt_\` it returns \`Mono.empty()\`; everything else (real JWTs, Basic, no auth) delegates unchanged.
- **\`SecurityConfig\`** wires it via \`.bearerTokenConverter(...)\` on the \`oauth2ResourceServer\` DSL.
- **\`DynamicReactiveJwtDecoder\`** reverted to pre-#790 behaviour. It treats \`klt_\` tokens like any other malformed JWT and throws \`JwtException\`. The decoder is no longer reached for \`klt_\` in normal flow because the converter filtered them out first; if a future code path calls \`decode()\` directly with one, the \`JwtException\` makes the failure mode obvious instead of returning a non-spec empty.

## Test plan

- [x] \`mvn test -f kelta-gateway/pom.xml\` — 427 passing in the full suite. New \`PatAwareBearerTokenConverterTest\` covers: filter case (klt_ → empty), delegate case (real JWT pass-through), no Authorization header, non-Bearer scheme.
- [x] \`DynamicReactiveJwtDecoderTest.rejectInvalidJwt\` restored to its original assertion (now passes again).
- [ ] After merge: \`curl -i -H \"Authorization: Bearer klt_<pat>\" https://emf.rzware.com/api/collections\` returns 200.
- [ ] Existing JWT (browser/UI) auth still works.
- [ ] Claude Desktop \"using kelta-user, list collections\" returns the result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)