### PR TITLE
fix(mcp): bind tenant slug per-session via the MCP URL, not deployment config

### DIFF
--- a/kelta-mcp/CLAUDE.md
+++ b/kelta-mcp/CLAUDE.md
@@ -4,20 +4,40 @@ Model Context Protocol (MCP) server for the Kelta platform. Exposes platform ope
 
 ## Endpoints
 
-Two MCP server instances run inside one Spring Boot process:
+Two MCP server instances run inside one Spring Boot process. The URL
+convention follows the rest of the Kelta platform — slug first:
 
-| Path | Profile | Purpose |
-|------|---------|---------|
-| `/mcp/user` | data-plane | CRUD records, run flows, approvals, search |
-| `/mcp/admin` | control-plane | Define collections/fields/layouts/flows/etc. |
+| URL | Profile | Purpose |
+|-----|---------|---------|
+| `/{tenantSlug}/mcp/user` | data-plane | CRUD records, run flows, approvals, search |
+| `/{tenantSlug}/mcp/admin` | control-plane | Define collections/fields/layouts/flows/etc. |
 
-Each endpoint has its own immutable tool registry — admin tools are not callable from `/mcp/user` (or vice versa).
+The slug binds each MCP session to a specific tenant — different
+PATs in different tenants get different MCP URLs in their Claude
+Code config, so a single deployment can serve any number of tenants.
+`McpAuthFilter` extracts the slug from the URL, rewrites the request
+to the canonical `/mcp/(user|admin)` path the SDK servlet is
+registered at, and stamps the slug as a request attribute.
+
+Each endpoint has its own immutable tool registry — admin tools are
+not callable from `/mcp/user` (or vice versa).
 
 ## Auth
 
-Every request to `/mcp/**` must carry `Authorization: Bearer klt_*`. The `McpAuthFilter` does a presence/prefix check only — the actual cryptographic validation happens at the gateway when tool calls are forwarded. The filter also strips client-supplied `X-Tenant-ID` / `X-Tenant-Slug` / `X-User-Id` headers so a client cannot impersonate another tenant; tenant is derived by the gateway from the PAT.
+Every request to `/{slug}/mcp/**` must carry `Authorization: Bearer
+klt_*`. `McpAuthFilter` does a presence/prefix check only — the
+gateway does the cryptographic validation when tool calls are
+forwarded. The filter strips any client-supplied `X-Tenant-ID` /
+`X-Tenant-Slug` / `X-User-Id` headers so a client can't impersonate
+another tenant; the slug binding is the URL itself.
 
-PATs are kept in `PatSessionStore` keyed by MCP session id, evicted on idle timeout.
+`KeltaTransportContextExtractor` picks both PAT and slug off the
+inbound request and packs them into the SDK's
+`McpTransportContext`. `PatPropagatingToolDecorator` reads them back
+on the Reactor scheduler thread and pushes them into
+`RequestPatHolder` / `RequestSlugHolder` for the duration of the
+tool handler — `GatewayHttpClient` reads from those for outbound
+calls.
 
 ## Package Layout
 
@@ -78,7 +98,7 @@ mvn test -f kelta-mcp/pom.xml -Dtest="*Tool*"                        # Pattern
 mvn spring-boot:run -f kelta-mcp/pom.xml
 
 claude mcp add kelta-local --transport http \
-  --url http://localhost:8080/mcp/user \
+  --url http://localhost:8080/threadline-clothing/mcp/user \
   --header "Authorization: Bearer klt_smoke_test_token"
 # In a Claude Code session, ask: "use the kelta-local MCP server to call ping"
 ```

--- a/kelta-mcp/src/main/java/io/kelta/mcp/auth/KeltaTransportContextExtractor.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/auth/KeltaTransportContextExtractor.java
@@ -4,6 +4,7 @@ import io.modelcontextprotocol.common.McpTransportContext;
 import io.modelcontextprotocol.server.McpTransportContextExtractor;
 import jakarta.servlet.http.HttpServletRequest;
 
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -12,34 +13,43 @@ import java.util.Map;
  * tool handlers — even though the handler runs on a Reactor scheduler
  * thread, not the servlet thread.
  *
- * <p>The {@code "pat"} key carries the PAT (without the {@code Bearer}
- * prefix). Tool decorators read it back via
- * {@code exchange.transportContext().get("pat")}.
+ * <p>{@code "pat"} carries the PAT (without the {@code Bearer} prefix).
+ * {@code "tenant_slug"} carries the tenant slug that
+ * {@link McpAuthFilter} extracted from the URL path. Tool decorators
+ * read both back via {@code exchange.transportContext().get(...)}.
  *
- * <p>{@link McpAuthFilter} still runs first and rejects any request
- * without a valid {@code Bearer klt_*} header — by the time this
- * extractor sees the request, presence is already guaranteed. We
- * defensively re-check anyway so a future routing change that bypasses
- * the filter can't silently leave the context empty.
+ * <p>{@link McpAuthFilter} runs first and rejects any request without
+ * a well-formed URL or a {@code Bearer klt_*} header — by the time
+ * this extractor sees the request both fields are guaranteed. We
+ * defensively re-check so a future routing change that bypasses the
+ * filter can't silently leave the context empty.
  */
 public final class KeltaTransportContextExtractor
         implements McpTransportContextExtractor<HttpServletRequest> {
 
     public static final String PAT_KEY = "pat";
+    public static final String TENANT_SLUG_KEY = "tenant_slug";
 
     private static final String AUTHORIZATION = "Authorization";
     private static final String BEARER_PREFIX = "Bearer ";
 
     @Override
     public McpTransportContext extract(HttpServletRequest request) {
+        Map<String, Object> values = new LinkedHashMap<>();
+
         String header = request.getHeader(AUTHORIZATION);
-        if (header == null || !header.startsWith(BEARER_PREFIX)) {
-            return McpTransportContext.EMPTY;
+        if (header != null && header.startsWith(BEARER_PREFIX)) {
+            String token = header.substring(BEARER_PREFIX.length());
+            if (!token.isEmpty()) {
+                values.put(PAT_KEY, token);
+            }
         }
-        String token = header.substring(BEARER_PREFIX.length());
-        if (token.isEmpty()) {
-            return McpTransportContext.EMPTY;
+
+        Object slug = request.getAttribute(McpAuthFilter.SLUG_ATTRIBUTE);
+        if (slug instanceof String s && !s.isEmpty()) {
+            values.put(TENANT_SLUG_KEY, s);
         }
-        return McpTransportContext.create(Map.of(PAT_KEY, token));
+
+        return values.isEmpty() ? McpTransportContext.EMPTY : McpTransportContext.create(values);
     }
 }

--- a/kelta-mcp/src/main/java/io/kelta/mcp/auth/McpAuthFilter.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/auth/McpAuthFilter.java
@@ -3,6 +3,7 @@ package io.kelta.mcp.auth;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
 import jakarta.servlet.http.HttpServletResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -13,38 +14,75 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Servlet filter for MCP HTTP endpoints.
  *
- * <p>Enforces presence of {@code Authorization: Bearer klt_*}. Strips
- * any client-supplied tenant headers so a client cannot impersonate
- * another tenant — tenant is resolved by the gateway from the PAT.
+ * <p>The MCP URL convention follows the rest of the Kelta platform:
+ * <pre>{@code
+ *   /{tenantSlug}/mcp/user
+ *   /{tenantSlug}/mcp/admin
+ * }</pre>
+ * The slug binds the request to a specific tenant — different PATs in
+ * different tenants get different MCP URLs in their Claude Code config,
+ * so a single deployment can serve any number of tenants.
  *
- * <p>This filter does NOT cryptographically validate the token. The
- * gateway does that on the first forwarded API call. We only require
- * the header to be present and prefix-correct so we never set up an
- * MCP session for a fully unauthenticated client.
+ * <p>This filter:
+ * <ol>
+ *   <li>Matches the URL pattern, extracts the slug, and rewrites the
+ *       request to the canonical {@code /mcp/(user|admin)} path the SDK
+ *       servlet is registered at. The slug rides along as a request
+ *       attribute the {@link KeltaTransportContextExtractor} reads.</li>
+ *   <li>Enforces presence of {@code Authorization: Bearer klt_*} —
+ *       cryptographic validation happens at the gateway on the first
+ *       forwarded API call. We just gate the session.</li>
+ *   <li>Strips client-supplied tenant headers so a client can't
+ *       impersonate another tenant.</li>
+ * </ol>
  */
 @Component
 public class McpAuthFilter extends OncePerRequestFilter implements Ordered {
 
     private static final Logger log = LoggerFactory.getLogger(McpAuthFilter.class);
 
+    /** Request attribute carrying the slug extracted from the URL. */
+    public static final String SLUG_ATTRIBUTE = "kelta.mcp.tenantSlug";
+
     private static final String AUTHORIZATION = "Authorization";
     private static final String BEARER_PREFIX = "Bearer ";
     private static final String PAT_PREFIX = "klt_";
-    private static final String MCP_PATH_PREFIX = "/mcp/";
+
+    /**
+     * Matches {@code /{tenantSlug}/mcp/(user|admin)[/...]}. The slug
+     * pattern mirrors {@code TenantSlugExtractionFilter} on the gateway
+     * so an invalid slug is rejected here rather than later.
+     */
+    private static final Pattern URL_PATTERN = Pattern.compile(
+            "^/(?<slug>[a-z][a-z0-9-]{1,61}[a-z0-9])/mcp/(?<profile>user|admin)(?<rest>/.*)?$");
 
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
-        return !request.getRequestURI().startsWith(MCP_PATH_PREFIX);
+        String path = request.getRequestURI();
+        return !path.contains("/mcp/");
     }
 
     @Override
     protected void doFilterInternal(HttpServletRequest request,
                                     HttpServletResponse response,
                                     FilterChain chain) throws ServletException, IOException {
+        Matcher m = URL_PATTERN.matcher(request.getRequestURI());
+        if (!m.matches()) {
+            unauthorized(response, "invalid_mcp_path",
+                    "Path must be /{tenantSlug}/mcp/(user|admin)");
+            return;
+        }
+        String slug = m.group("slug");
+        String profile = m.group("profile");
+        String rest = m.group("rest");
+        String canonicalPath = "/mcp/" + profile + (rest == null ? "" : rest);
+
         String header = request.getHeader(AUTHORIZATION);
         if (header == null || !header.startsWith(BEARER_PREFIX)) {
             unauthorized(response, "missing_bearer", "Missing Authorization: Bearer header");
@@ -56,9 +94,10 @@ public class McpAuthFilter extends OncePerRequestFilter implements Ordered {
             return;
         }
 
+        request.setAttribute(SLUG_ATTRIBUTE, slug);
         RequestPatHolder.set(token);
         try {
-            chain.doFilter(new SanitizedRequest(request), response);
+            chain.doFilter(new RewrittenRequest(new SanitizedRequest(request), canonicalPath), response);
         } finally {
             RequestPatHolder.clear();
         }
@@ -66,9 +105,14 @@ public class McpAuthFilter extends OncePerRequestFilter implements Ordered {
 
     private static void unauthorized(HttpServletResponse response, String code, String message)
             throws IOException {
-        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        int status = "invalid_mcp_path".equals(code) ? HttpStatus.NOT_FOUND.value()
+                : HttpStatus.UNAUTHORIZED.value();
+        response.setStatus(status);
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-        response.setHeader("WWW-Authenticate", "Bearer realm=\"kelta-mcp\", error=\"" + code + "\"");
+        if (status == HttpStatus.UNAUTHORIZED.value()) {
+            response.setHeader("WWW-Authenticate",
+                    "Bearer realm=\"kelta-mcp\", error=\"" + code + "\"");
+        }
         response.getWriter().write("{\"error\":\"" + code + "\",\"message\":\"" + message + "\"}");
     }
 
@@ -78,12 +122,12 @@ public class McpAuthFilter extends OncePerRequestFilter implements Ordered {
     }
 
     /**
-     * Wrapper that hides client-supplied tenant headers — the tenant is
-     * always resolved by the gateway from the PAT. Without this, a
-     * malicious client could try {@code X-Tenant-ID: <other-tenant>}
-     * to escape its own tenant.
+     * Wrapper that hides client-supplied tenant headers — the tenant
+     * is bound to the URL slug, not headers. Without this, a malicious
+     * client could try {@code X-Tenant-ID: <other-tenant>} to escape
+     * its own tenant.
      */
-    private static final class SanitizedRequest extends jakarta.servlet.http.HttpServletRequestWrapper {
+    private static final class SanitizedRequest extends HttpServletRequestWrapper {
         private static final java.util.Set<String> STRIPPED = java.util.Set.of(
                 "x-tenant-id", "x-tenant-slug", "x-user-id");
 
@@ -118,6 +162,50 @@ public class McpAuthFilter extends OncePerRequestFilter implements Ordered {
                 }
             }
             return java.util.Collections.enumeration(names);
+        }
+    }
+
+    /**
+     * Wrapper that rewrites the request URI / servlet path to the
+     * canonical SDK-registered path {@code /mcp/(user|admin)} after
+     * the slug has been extracted. The SDK servlet's path matching
+     * (and any session-id correlation) operates on this rewritten URI.
+     */
+    private static final class RewrittenRequest extends HttpServletRequestWrapper {
+        private final String canonicalPath;
+
+        RewrittenRequest(HttpServletRequest req, String canonicalPath) {
+            super(req);
+            this.canonicalPath = canonicalPath;
+        }
+
+        @Override
+        public String getRequestURI() {
+            return canonicalPath;
+        }
+
+        @Override
+        public StringBuffer getRequestURL() {
+            StringBuffer url = new StringBuffer();
+            url.append(getScheme()).append("://").append(getServerName());
+            int port = getServerPort();
+            if (port > 0
+                    && (("http".equalsIgnoreCase(getScheme()) && port != 80)
+                    || ("https".equalsIgnoreCase(getScheme()) && port != 443))) {
+                url.append(':').append(port);
+            }
+            url.append(canonicalPath);
+            return url;
+        }
+
+        @Override
+        public String getServletPath() {
+            return canonicalPath;
+        }
+
+        @Override
+        public String getPathInfo() {
+            return null;
         }
     }
 }

--- a/kelta-mcp/src/main/java/io/kelta/mcp/auth/RequestSlugHolder.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/auth/RequestSlugHolder.java
@@ -1,0 +1,31 @@
+package io.kelta.mcp.auth;
+
+/**
+ * Thread-local holder for the per-request tenant slug, the analogue
+ * of {@link RequestPatHolder} for the slug.
+ *
+ * <p>The slug travels in the MCP URL itself
+ * ({@code /mcp/{tenantSlug}/(user|admin)}) so a single deployment can
+ * serve PATs from any number of tenants — each Claude Code config has
+ * a distinct URL bound to the right slug. {@link McpAuthFilter}
+ * extracts the slug from the URL on intake; the propagating decorator
+ * pushes it into this holder for the duration of the tool handler.
+ */
+public final class RequestSlugHolder {
+
+    private static final ThreadLocal<String> CURRENT = new ThreadLocal<>();
+
+    private RequestSlugHolder() {}
+
+    public static void set(String slug) {
+        CURRENT.set(slug);
+    }
+
+    public static String get() {
+        return CURRENT.get();
+    }
+
+    public static void clear() {
+        CURRENT.remove();
+    }
+}

--- a/kelta-mcp/src/main/java/io/kelta/mcp/client/GatewayHttpClient.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/client/GatewayHttpClient.java
@@ -1,6 +1,7 @@
 package io.kelta.mcp.client;
 
 import io.kelta.mcp.auth.RequestPatHolder;
+import io.kelta.mcp.auth.RequestSlugHolder;
 import io.kelta.mcp.config.McpProperties;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatusCode;
@@ -19,22 +20,20 @@ import java.util.Map;
  * authorization — kelta-mcp does neither.
  *
  * <p>Tenant routing: the gateway routes by URL prefix
- * ({@code /{tenantSlug}/api/...}). We resolve the slug from
- * {@link McpProperties#tenantSlug()} and prepend it to every path the
- * tools build. Tools keep authoring plain {@code /api/...} paths and
- * never need to know about the slug. If no slug is configured, paths
- * pass through verbatim — appropriate for environments that resolve
- * the tenant some other way.
+ * ({@code /{tenantSlug}/api/...}). The slug for the current tool call
+ * comes from {@link RequestSlugHolder}, which {@code PatPropagatingToolDecorator}
+ * populated from the MCP transport context. The slug originally
+ * arrived in the inbound MCP URL ({@code /{tenantSlug}/mcp/(user|admin)})
+ * — that's the per-session binding mechanism, so a single
+ * deployment can serve any number of tenants concurrently.
  *
- * <p>The PAT is pulled from {@link RequestPatHolder} (populated by
- * {@code PatPropagatingToolDecorator} from the MCP transport context);
- * never stored in config, never logged.
+ * <p>The PAT is pulled from {@link RequestPatHolder} (same propagation
+ * mechanism); never stored in config, never logged.
  */
 @Component
 public class GatewayHttpClient {
 
     private final RestClient client;
-    private final String tenantPathPrefix;
 
     public GatewayHttpClient(RestClient.Builder builder, McpProperties properties) {
         // Pin HTTP/1.1 — the in-cluster gateway hop doesn't benefit from HTTP/2,
@@ -47,9 +46,6 @@ public class GatewayHttpClient {
                 .baseUrl(properties.gatewayUrl())
                 .requestFactory(new JdkClientHttpRequestFactory(http))
                 .build();
-        this.tenantPathPrefix = properties.tenantSlug().isEmpty()
-                ? ""
-                : "/" + properties.tenantSlug();
     }
 
     public Response get(String pathAndQuery) {
@@ -70,17 +66,17 @@ public class GatewayHttpClient {
 
     /**
      * Visible for testing — assemble the gateway-side URI for a tool path.
-     * Paths starting with {@code /tenants/} or already prefixed with
-     * {@code /{slug}/} are passed through unchanged so a tool can opt
-     * out of automatic prefixing if it ever needs to.
+     * Paths already prefixed with {@code /{slug}/} pass through unchanged
+     * so a tool can opt out of automatic prefixing if it ever needs to.
      */
     String buildPath(String pathAndQuery) {
-        if (tenantPathPrefix.isEmpty()) return pathAndQuery;
-        if (pathAndQuery.startsWith(tenantPathPrefix + "/")
-                || pathAndQuery.equals(tenantPathPrefix)) {
+        String slug = RequestSlugHolder.get();
+        if (slug == null || slug.isEmpty()) return pathAndQuery;
+        String prefix = "/" + slug;
+        if (pathAndQuery.startsWith(prefix + "/") || pathAndQuery.equals(prefix)) {
             return pathAndQuery;
         }
-        return tenantPathPrefix + pathAndQuery;
+        return prefix + pathAndQuery;
     }
 
     private Response exchange(String method, String pathAndQuery, Object body) {

--- a/kelta-mcp/src/main/java/io/kelta/mcp/config/McpProperties.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/config/McpProperties.java
@@ -5,7 +5,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = "kelta.mcp")
 public record McpProperties(
         String gatewayUrl,
-        String tenantSlug,
         int sessionTtlMinutes,
         int toolTimeoutMs,
         RateLimit rateLimit
@@ -13,15 +12,6 @@ public record McpProperties(
     public McpProperties {
         if (gatewayUrl == null || gatewayUrl.isBlank()) {
             gatewayUrl = "http://emf-gateway:80";
-        }
-        if (tenantSlug == null) {
-            tenantSlug = "";
-        } else {
-            tenantSlug = tenantSlug.trim();
-            // Strip a leading slash so callers can configure either form.
-            if (tenantSlug.startsWith("/")) {
-                tenantSlug = tenantSlug.substring(1);
-            }
         }
         if (sessionTtlMinutes <= 0) {
             sessionTtlMinutes = 30;

--- a/kelta-mcp/src/main/java/io/kelta/mcp/observe/PatPropagatingToolDecorator.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/observe/PatPropagatingToolDecorator.java
@@ -2,24 +2,35 @@ package io.kelta.mcp.observe;
 
 import io.kelta.mcp.auth.KeltaTransportContextExtractor;
 import io.kelta.mcp.auth.RequestPatHolder;
+import io.kelta.mcp.auth.RequestSlugHolder;
 import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
 import org.springframework.stereotype.Component;
 
 /**
- * Outermost decorator: copies the PAT from the SDK's transport context
- * (set by {@link KeltaTransportContextExtractor} during HTTP intake)
- * into {@link RequestPatHolder} for the duration of the tool handler.
+ * Outermost decorator: copies per-request data from the SDK's
+ * transport context (set by {@link KeltaTransportContextExtractor}
+ * during HTTP intake) into thread-local holders for the duration
+ * of the tool handler.
  *
  * <p>Why this exists: the MCP SDK dispatches sync tool handlers on
  * Reactor scheduler threads, not the servlet thread. The
- * {@code ThreadLocal} that the auth filter populates on the inbound
- * thread is therefore invisible to the handler. The transport context
- * is the SDK-blessed mechanism for thread-safe propagation; this
- * decorator bridges it back to the same {@code RequestPatHolder} the
- * downstream HTTP client already reads from.
+ * {@code ThreadLocal} the auth filter populates on the inbound
+ * thread is therefore invisible to the handler. The transport
+ * context is the SDK-blessed mechanism for thread-safe propagation;
+ * this decorator bridges it back into the holders the downstream
+ * HTTP client reads from.
  *
- * <p>Wraps OUTSIDE the rate limiter (which keys its bucket on the PAT)
- * and the observation decorator.
+ * <p>Two pieces of data ride along:
+ * <ul>
+ *   <li>{@link RequestPatHolder} — PAT for the {@code Authorization}
+ *       header on outbound calls.</li>
+ *   <li>{@link RequestSlugHolder} — tenant slug, parsed from the
+ *       MCP URL ({@code /{tenantSlug}/mcp/(user|admin)}), used as
+ *       the path prefix on every gateway call.</li>
+ * </ul>
+ *
+ * <p>Wraps OUTSIDE the rate limiter (which keys its bucket on the
+ * PAT) and the observation decorator.
  */
 @Component
 public class PatPropagatingToolDecorator {
@@ -30,16 +41,19 @@ public class PatPropagatingToolDecorator {
                 .tool(original.tool())
                 .callHandler((exchange, request) -> {
                     String pat = null;
+                    String slug = null;
                     if (exchange != null && exchange.transportContext() != null) {
-                        Object value = exchange.transportContext().get(KeltaTransportContextExtractor.PAT_KEY);
-                        if (value instanceof String s) pat = s;
+                        Object patValue = exchange.transportContext().get(KeltaTransportContextExtractor.PAT_KEY);
+                        if (patValue instanceof String s) pat = s;
+                        Object slugValue = exchange.transportContext().get(KeltaTransportContextExtractor.TENANT_SLUG_KEY);
+                        if (slugValue instanceof String s) slug = s;
                     }
-                    if (pat != null) {
-                        RequestPatHolder.set(pat);
-                    }
+                    if (pat != null) RequestPatHolder.set(pat);
+                    if (slug != null) RequestSlugHolder.set(slug);
                     try {
                         return inner.apply(exchange, request);
                     } finally {
+                        RequestSlugHolder.clear();
                         RequestPatHolder.clear();
                     }
                 })

--- a/kelta-mcp/src/main/resources/application.yml
+++ b/kelta-mcp/src/main/resources/application.yml
@@ -14,7 +14,6 @@ spring:
 kelta:
   mcp:
     gateway-url: ${GATEWAY_URL:http://emf-gateway:80}
-    tenant-slug: ${MCP_TENANT_SLUG:}
     session-ttl-minutes: ${MCP_SESSION_TTL_MINUTES:30}
     tool-timeout-ms: ${MCP_TOOL_TIMEOUT_MS:60000}
 

--- a/kelta-mcp/src/test/java/io/kelta/mcp/auth/KeltaTransportContextExtractorTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/auth/KeltaTransportContextExtractorTest.java
@@ -48,4 +48,27 @@ class KeltaTransportContextExtractorTest {
 
         assertThat(context).isSameAs(McpTransportContext.EMPTY);
     }
+
+    @Test
+    void includesTenantSlugFromRequestAttribute() {
+        MockHttpServletRequest req = new MockHttpServletRequest("POST", "/mcp/user");
+        req.addHeader("Authorization", "Bearer klt_token");
+        req.setAttribute(McpAuthFilter.SLUG_ATTRIBUTE, "threadline-clothing");
+
+        McpTransportContext context = extractor.extract(req);
+
+        assertThat(context.get(KeltaTransportContextExtractor.PAT_KEY)).isEqualTo("klt_token");
+        assertThat(context.get(KeltaTransportContextExtractor.TENANT_SLUG_KEY))
+                .isEqualTo("threadline-clothing");
+    }
+
+    @Test
+    void omitsSlugKeyWhenAttributeAbsent() {
+        MockHttpServletRequest req = new MockHttpServletRequest("POST", "/mcp/user");
+        req.addHeader("Authorization", "Bearer klt_token");
+
+        McpTransportContext context = extractor.extract(req);
+
+        assertThat(context.get(KeltaTransportContextExtractor.TENANT_SLUG_KEY)).isNull();
+    }
 }

--- a/kelta-mcp/src/test/java/io/kelta/mcp/auth/McpAuthFilterTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/auth/McpAuthFilterTest.java
@@ -9,7 +9,6 @@ import org.springframework.mock.web.MockHttpServletResponse;
 import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentCaptor.forClass;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -17,11 +16,15 @@ import static org.mockito.Mockito.verify;
 
 class McpAuthFilterTest {
 
+    private static final String SLUG = "threadline-clothing";
+    private static final String URL_USER = "/" + SLUG + "/mcp/user";
+    private static final String URL_ADMIN = "/" + SLUG + "/mcp/admin";
+
     private final McpAuthFilter filter = new McpAuthFilter();
 
     @Test
     void rejectsRequestWithoutAuthorizationHeader() throws Exception {
-        MockHttpServletRequest req = new MockHttpServletRequest("POST", "/mcp/user");
+        MockHttpServletRequest req = new MockHttpServletRequest("POST", URL_USER);
         MockHttpServletResponse res = new MockHttpServletResponse();
         FilterChain chain = mock(FilterChain.class);
 
@@ -34,7 +37,7 @@ class McpAuthFilterTest {
 
     @Test
     void rejectsBearerTokenWithoutKltPrefix() throws Exception {
-        MockHttpServletRequest req = new MockHttpServletRequest("POST", "/mcp/user");
+        MockHttpServletRequest req = new MockHttpServletRequest("POST", URL_USER);
         req.addHeader("Authorization", "Bearer eyJhbGciOiJIUzI1NiJ9.something.signature");
         MockHttpServletResponse res = new MockHttpServletResponse();
         FilterChain chain = mock(FilterChain.class);
@@ -48,7 +51,7 @@ class McpAuthFilterTest {
 
     @Test
     void rejectsAuthorizationWithoutBearerScheme() throws Exception {
-        MockHttpServletRequest req = new MockHttpServletRequest("POST", "/mcp/admin");
+        MockHttpServletRequest req = new MockHttpServletRequest("POST", URL_ADMIN);
         req.addHeader("Authorization", "Basic dXNlcjpwYXNz");
         MockHttpServletResponse res = new MockHttpServletResponse();
         FilterChain chain = mock(FilterChain.class);
@@ -60,8 +63,22 @@ class McpAuthFilterTest {
     }
 
     @Test
-    void allowsValidKltBearerToken() throws Exception {
+    void rejectsMcpUrlWithoutSlugPrefix() throws Exception {
         MockHttpServletRequest req = new MockHttpServletRequest("POST", "/mcp/user");
+        req.addHeader("Authorization", "Bearer klt_abc");
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        FilterChain chain = mock(FilterChain.class);
+
+        filter.doFilter(req, res, chain);
+
+        // Slug is required — pre-slug URL is treated as not-found.
+        assertThat(res.getStatus()).isEqualTo(404);
+        verify(chain, never()).doFilter(req, res);
+    }
+
+    @Test
+    void allowsValidKltBearerTokenWithSlugInUrl() throws Exception {
+        MockHttpServletRequest req = new MockHttpServletRequest("POST", URL_USER);
         req.addHeader("Authorization", "Bearer klt_abc123def456");
         MockHttpServletResponse res = new MockHttpServletResponse();
         FilterChain chain = mock(FilterChain.class);
@@ -73,25 +90,28 @@ class McpAuthFilterTest {
     }
 
     @Test
-    void setsPatHolderDuringChainAndClearsAfter() throws Exception {
-        MockHttpServletRequest req = new MockHttpServletRequest("POST", "/mcp/user");
+    void setsPatHolderAndSlugAttributeDuringChain() throws Exception {
+        MockHttpServletRequest req = new MockHttpServletRequest("POST", URL_USER);
         req.addHeader("Authorization", "Bearer klt_xyz_during_chain");
         MockHttpServletResponse res = new MockHttpServletResponse();
 
-        String[] seenInChain = new String[1];
+        String[] seenPat = new String[1];
+        Object[] seenSlug = new Object[1];
         FilterChain chain = (request, response) -> {
-            seenInChain[0] = io.kelta.mcp.auth.RequestPatHolder.get();
+            seenPat[0] = RequestPatHolder.get();
+            seenSlug[0] = ((HttpServletRequest) request).getAttribute(McpAuthFilter.SLUG_ATTRIBUTE);
         };
 
         filter.doFilter(req, res, chain);
 
-        assertThat(seenInChain[0]).isEqualTo("klt_xyz_during_chain");
-        assertThat(io.kelta.mcp.auth.RequestPatHolder.get()).isNull();
+        assertThat(seenPat[0]).isEqualTo("klt_xyz_during_chain");
+        assertThat(seenSlug[0]).isEqualTo(SLUG);
+        assertThat(RequestPatHolder.get()).isNull();
     }
 
     @Test
     void clearsPatHolderEvenIfChainThrows() {
-        MockHttpServletRequest req = new MockHttpServletRequest("POST", "/mcp/user");
+        MockHttpServletRequest req = new MockHttpServletRequest("POST", URL_USER);
         req.addHeader("Authorization", "Bearer klt_failing");
         MockHttpServletResponse res = new MockHttpServletResponse();
         FilterChain chain = (request, response) -> {
@@ -103,7 +123,7 @@ class McpAuthFilterTest {
         } catch (Exception ignored) {
             // expected
         }
-        assertThat(io.kelta.mcp.auth.RequestPatHolder.get()).isNull();
+        assertThat(RequestPatHolder.get()).isNull();
     }
 
     @Test
@@ -118,8 +138,24 @@ class McpAuthFilterTest {
     }
 
     @Test
+    void rewritesRequestUriToCanonicalSdkPath() throws Exception {
+        MockHttpServletRequest req = new MockHttpServletRequest("POST", URL_USER + "/messages");
+        req.addHeader("Authorization", "Bearer klt_abc");
+        MockHttpServletResponse res = new MockHttpServletResponse();
+
+        String[] seenUri = new String[1];
+        FilterChain chain = (request, response) -> {
+            seenUri[0] = ((HttpServletRequest) request).getRequestURI();
+        };
+
+        filter.doFilter(req, res, chain);
+
+        assertThat(seenUri[0]).isEqualTo("/mcp/user/messages");
+    }
+
+    @Test
     void stripsClientSuppliedTenantHeaders() throws Exception {
-        MockHttpServletRequest req = new MockHttpServletRequest("POST", "/mcp/user");
+        MockHttpServletRequest req = new MockHttpServletRequest("POST", URL_USER);
         req.addHeader("Authorization", "Bearer klt_abc");
         req.addHeader("X-Tenant-ID", "00000000-0000-0000-0000-000000000999");
         req.addHeader("X-Tenant-Slug", "evil-tenant");

--- a/kelta-mcp/src/test/java/io/kelta/mcp/auth/PatSessionStoreTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/auth/PatSessionStoreTest.java
@@ -7,7 +7,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class PatSessionStoreTest {
 
-    private final PatSessionStore store = new PatSessionStore(new McpProperties("http://gw", "", 30, 60_000, null));
+    private final PatSessionStore store = new PatSessionStore(new McpProperties("http://gw", 30, 60_000, null));
 
     @Test
     void putsAndRetrievesPat() {

--- a/kelta-mcp/src/test/java/io/kelta/mcp/client/GatewayHttpClientTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/client/GatewayHttpClientTest.java
@@ -31,7 +31,7 @@ class GatewayHttpClientTest {
     void setUp() {
         wm = new WireMockServer(0);
         wm.start();
-        McpProperties props = new McpProperties("http://localhost:" + wm.port(), "", 30, 60_000, null);
+        McpProperties props = new McpProperties("http://localhost:" + wm.port(), 30, 60_000, null);
         client = new GatewayHttpClient(RestClient.builder(), props);
         RequestPatHolder.set("klt_test_pat_value");
     }
@@ -121,43 +121,66 @@ class GatewayHttpClientTest {
     }
 
     @Test
-    void prependsTenantSlugToPathsWhenConfigured() {
-        McpProperties tenantedProps = new McpProperties(
-                "http://localhost:" + wm.port(), "threadline-clothing", 30, 60_000, null);
-        GatewayHttpClient tenantedClient = new GatewayHttpClient(RestClient.builder(), tenantedProps);
+    void prependsTenantSlugFromHolderToPaths() {
+        io.kelta.mcp.auth.RequestSlugHolder.set("threadline-clothing");
+        try {
+            wm.stubFor(get(urlEqualTo("/threadline-clothing/api/collections"))
+                    .willReturn(aResponse().withStatus(200).withBody("{\"data\":[]}")));
 
-        wm.stubFor(get(urlEqualTo("/threadline-clothing/api/collections"))
-                .willReturn(aResponse().withStatus(200).withBody("{\"data\":[]}")));
+            GatewayHttpClient.Response res = client.get("/api/collections");
 
-        GatewayHttpClient.Response res = tenantedClient.get("/api/collections");
-
-        assertThat(res.isSuccess()).isTrue();
-        wm.verify(getRequestedForUrl("/threadline-clothing/api/collections")
-                .withHeader("Authorization", equalTo("Bearer klt_test_pat_value")));
+            assertThat(res.isSuccess()).isTrue();
+            wm.verify(getRequestedForUrl("/threadline-clothing/api/collections")
+                    .withHeader("Authorization", equalTo("Bearer klt_test_pat_value")));
+        } finally {
+            io.kelta.mcp.auth.RequestSlugHolder.clear();
+        }
     }
 
     @Test
     void preservesPathThatIsAlreadyTenantPrefixed() {
-        McpProperties tenantedProps = new McpProperties(
-                "http://localhost:" + wm.port(), "threadline-clothing", 30, 60_000, null);
-        GatewayHttpClient tenantedClient = new GatewayHttpClient(RestClient.builder(), tenantedProps);
-
-        wm.stubFor(get(urlEqualTo("/threadline-clothing/api/collections"))
-                .willReturn(aResponse().withStatus(200).withBody("{\"data\":[]}")));
-
-        // Tool authored an already-prefixed path — don't double up.
-        GatewayHttpClient.Response res = tenantedClient.get("/threadline-clothing/api/collections");
-
-        assertThat(res.isSuccess()).isTrue();
-        wm.verify(getRequestedForUrl("/threadline-clothing/api/collections"));
+        io.kelta.mcp.auth.RequestSlugHolder.set("threadline-clothing");
+        try {
+            wm.stubFor(get(urlEqualTo("/threadline-clothing/api/collections"))
+                    .willReturn(aResponse().withStatus(200).withBody("{\"data\":[]}")));
+            // Tool authored an already-prefixed path — don't double up.
+            GatewayHttpClient.Response res = client.get("/threadline-clothing/api/collections");
+            assertThat(res.isSuccess()).isTrue();
+            wm.verify(getRequestedForUrl("/threadline-clothing/api/collections"));
+        } finally {
+            io.kelta.mcp.auth.RequestSlugHolder.clear();
+        }
     }
 
     @Test
-    void emptySlugLeavesPathsUnchanged() {
-        // The default client instance in setUp has no slug configured.
+    void emptyHolderLeavesPathsUnchanged() {
+        // No slug in the holder (the default in setUp).
         wm.stubFor(get(urlEqualTo("/api/anything")).willReturn(aResponse().withStatus(200)));
         client.get("/api/anything");
         wm.verify(getRequestedForUrl("/api/anything"));
+    }
+
+    @Test
+    void differentSlugsOnSameClientGoToDifferentTenants() {
+        // Same GatewayHttpClient instance — slug comes from per-request holder
+        // so two simultaneous PATs in different tenants both work.
+        wm.stubFor(get(urlEqualTo("/threadline-clothing/api/x"))
+                .willReturn(aResponse().withStatus(200).withBody("a")));
+        wm.stubFor(get(urlEqualTo("/another-tenant/api/x"))
+                .willReturn(aResponse().withStatus(200).withBody("b")));
+
+        io.kelta.mcp.auth.RequestSlugHolder.set("threadline-clothing");
+        try {
+            assertThat(client.get("/api/x").body()).isEqualTo("a");
+        } finally {
+            io.kelta.mcp.auth.RequestSlugHolder.clear();
+        }
+        io.kelta.mcp.auth.RequestSlugHolder.set("another-tenant");
+        try {
+            assertThat(client.get("/api/x").body()).isEqualTo("b");
+        } finally {
+            io.kelta.mcp.auth.RequestSlugHolder.clear();
+        }
     }
 
     private static RequestPatternBuilder getRequestedForUrl(String url) {

--- a/kelta-mcp/src/test/java/io/kelta/mcp/observe/PatPropagatingToolDecoratorTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/observe/PatPropagatingToolDecoratorTest.java
@@ -2,6 +2,7 @@ package io.kelta.mcp.observe;
 
 import io.kelta.mcp.auth.KeltaTransportContextExtractor;
 import io.kelta.mcp.auth.RequestPatHolder;
+import io.kelta.mcp.auth.RequestSlugHolder;
 import io.modelcontextprotocol.common.McpTransportContext;
 import io.modelcontextprotocol.server.McpAsyncServerExchange;
 import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
@@ -90,5 +91,27 @@ class PatPropagatingToolDecoratorTest {
         decorated.callHandler().apply(exchange, new CallToolRequest("stub", Map.of(), null));
 
         assertThat(seen.get()).isNull();
+    }
+
+    @Test
+    void copiesTenantSlugFromTransportContextIntoHolder() {
+        AtomicReference<String> seenPat = new AtomicReference<>();
+        AtomicReference<String> seenSlug = new AtomicReference<>();
+        SyncToolSpecification decorated = decorator.decorate(stub((ex, req) -> {
+            seenPat.set(RequestPatHolder.get());
+            seenSlug.set(RequestSlugHolder.get());
+            return CallToolResult.builder().content(List.of(new TextContent("ok"))).build();
+        }));
+
+        McpSyncServerExchange exchange = exchangeWithContext(McpTransportContext.create(Map.of(
+                KeltaTransportContextExtractor.PAT_KEY, "klt_session",
+                KeltaTransportContextExtractor.TENANT_SLUG_KEY, "threadline-clothing")));
+
+        decorated.callHandler().apply(exchange, new CallToolRequest("stub", Map.of(), null));
+
+        assertThat(seenPat.get()).isEqualTo("klt_session");
+        assertThat(seenSlug.get()).isEqualTo("threadline-clothing");
+        assertThat(RequestPatHolder.get()).isNull();
+        assertThat(RequestSlugHolder.get()).isNull();
     }
 }

--- a/kelta-mcp/src/test/java/io/kelta/mcp/observe/RateLimitedToolDecoratorTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/observe/RateLimitedToolDecoratorTest.java
@@ -29,7 +29,7 @@ class RateLimitedToolDecoratorTest {
     @BeforeEach
     void setUp() {
         limiter = new RateLimiter(new McpProperties(
-                "http://gw", "", 30, 60_000,
+                "http://gw", 30, 60_000,
                 new McpProperties.RateLimit(2, 0.0)));
         decorator = new RateLimitedToolDecorator(limiter, registry);
         RequestPatHolder.set("klt_decorator_test");

--- a/kelta-mcp/src/test/java/io/kelta/mcp/observe/RateLimiterTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/observe/RateLimiterTest.java
@@ -10,7 +10,7 @@ class RateLimiterTest {
     @Test
     void allowsUpToBucketCapacityImmediately() {
         RateLimiter limiter = new RateLimiter(new McpProperties(
-                "http://gw", "", 30, 60_000,
+                "http://gw", 30, 60_000,
                 new McpProperties.RateLimit(5, 1.0)));
 
         for (int i = 0; i < 5; i++) {
@@ -22,7 +22,7 @@ class RateLimiterTest {
     @Test
     void bucketsAreIsolatedPerKey() {
         RateLimiter limiter = new RateLimiter(new McpProperties(
-                "http://gw", "", 30, 60_000,
+                "http://gw", 30, 60_000,
                 new McpProperties.RateLimit(2, 0.0)));
 
         assertThat(limiter.tryAcquire("klt_a")).isTrue();
@@ -37,7 +37,7 @@ class RateLimiterTest {
     @Test
     void refillsOverTime() throws InterruptedException {
         RateLimiter limiter = new RateLimiter(new McpProperties(
-                "http://gw", "", 30, 60_000,
+                "http://gw", 30, 60_000,
                 new McpProperties.RateLimit(2, 100.0))); // 100/sec → ~10ms per token
 
         assertThat(limiter.tryAcquire("klt_a")).isTrue();
@@ -53,7 +53,7 @@ class RateLimiterTest {
     @Test
     void activeBucketCountReflectsDistinctKeys() {
         RateLimiter limiter = new RateLimiter(new McpProperties(
-                "http://gw", "", 30, 60_000,
+                "http://gw", 30, 60_000,
                 new McpProperties.RateLimit(1, 1.0)));
 
         limiter.tryAcquire("klt_a");

--- a/kelta-mcp/src/test/java/io/kelta/mcp/resource/user/CollectionSchemaResourceTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/resource/user/CollectionSchemaResourceTest.java
@@ -29,7 +29,7 @@ class CollectionSchemaResourceTest {
         wm.start();
         GatewayHttpClient client = new GatewayHttpClient(
                 RestClient.builder(),
-                new McpProperties("http://localhost:" + wm.port(), "", 30, 60_000, null));
+                new McpProperties("http://localhost:" + wm.port(), 30, 60_000, null));
         resource = new CollectionSchemaResource(client);
         RequestPatHolder.set("klt_res_schema");
     }

--- a/kelta-mcp/src/test/java/io/kelta/mcp/resource/user/CollectionsResourceTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/resource/user/CollectionsResourceTest.java
@@ -29,7 +29,7 @@ class CollectionsResourceTest {
         wm.start();
         GatewayHttpClient client = new GatewayHttpClient(
                 RestClient.builder(),
-                new McpProperties("http://localhost:" + wm.port(), "", 30, 60_000, null));
+                new McpProperties("http://localhost:" + wm.port(), 30, 60_000, null));
         resource = new CollectionsResource(client);
         RequestPatHolder.set("klt_res_collections");
     }

--- a/kelta-mcp/src/test/java/io/kelta/mcp/tool/admin/AddFieldToolTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/tool/admin/AddFieldToolTest.java
@@ -32,7 +32,7 @@ class AddFieldToolTest {
         wm.start();
         GatewayHttpClient client = new GatewayHttpClient(
                 RestClient.builder(),
-                new McpProperties("http://localhost:" + wm.port(), "", 30, 60_000, null));
+                new McpProperties("http://localhost:" + wm.port(), 30, 60_000, null));
         tool = new AddFieldTool(client);
         RequestPatHolder.set("klt_addfield");
     }

--- a/kelta-mcp/src/test/java/io/kelta/mcp/tool/admin/CreateCollectionToolTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/tool/admin/CreateCollectionToolTest.java
@@ -34,7 +34,7 @@ class CreateCollectionToolTest {
         wm.start();
         GatewayHttpClient client = new GatewayHttpClient(
                 RestClient.builder(),
-                new McpProperties("http://localhost:" + wm.port(), "", 30, 60_000, null));
+                new McpProperties("http://localhost:" + wm.port(), 30, 60_000, null));
         tool = new CreateCollectionTool(client);
         RequestPatHolder.set("klt_create_coll");
     }

--- a/kelta-mcp/src/test/java/io/kelta/mcp/tool/admin/CreateFlowToolTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/tool/admin/CreateFlowToolTest.java
@@ -32,7 +32,7 @@ class CreateFlowToolTest {
         wm.start();
         GatewayHttpClient client = new GatewayHttpClient(
                 RestClient.builder(),
-                new McpProperties("http://localhost:" + wm.port(), "", 30, 60_000, null));
+                new McpProperties("http://localhost:" + wm.port(), 30, 60_000, null));
         tool = new CreateFlowTool(client);
         RequestPatHolder.set("klt_flow_create");
     }

--- a/kelta-mcp/src/test/java/io/kelta/mcp/tool/admin/CreateLayoutToolTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/tool/admin/CreateLayoutToolTest.java
@@ -33,7 +33,7 @@ class CreateLayoutToolTest {
         wm.start();
         GatewayHttpClient client = new GatewayHttpClient(
                 RestClient.builder(),
-                new McpProperties("http://localhost:" + wm.port(), "", 30, 60_000, null));
+                new McpProperties("http://localhost:" + wm.port(), 30, 60_000, null));
         tool = new CreateLayoutTool(client);
         RequestPatHolder.set("klt_layout_test");
     }

--- a/kelta-mcp/src/test/java/io/kelta/mcp/tool/admin/CreatePicklistToolTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/tool/admin/CreatePicklistToolTest.java
@@ -33,7 +33,7 @@ class CreatePicklistToolTest {
         wm.start();
         GatewayHttpClient client = new GatewayHttpClient(
                 RestClient.builder(),
-                new McpProperties("http://localhost:" + wm.port(), "", 30, 60_000, null));
+                new McpProperties("http://localhost:" + wm.port(), 30, 60_000, null));
         tool = new CreatePicklistTool(client);
         RequestPatHolder.set("klt_picklist_test");
     }

--- a/kelta-mcp/src/test/java/io/kelta/mcp/tool/admin/ImportApiSpecToolTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/tool/admin/ImportApiSpecToolTest.java
@@ -32,7 +32,7 @@ class ImportApiSpecToolTest {
         wm.start();
         GatewayHttpClient client = new GatewayHttpClient(
                 RestClient.builder(),
-                new McpProperties("http://localhost:" + wm.port(), "", 30, 60_000, null));
+                new McpProperties("http://localhost:" + wm.port(), 30, 60_000, null));
         tool = new ImportApiSpecTool(client);
         RequestPatHolder.set("klt_apispec_import");
     }

--- a/kelta-mcp/src/test/java/io/kelta/mcp/tool/admin/RemoveFieldToolTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/tool/admin/RemoveFieldToolTest.java
@@ -31,7 +31,7 @@ class RemoveFieldToolTest {
         wm.start();
         GatewayHttpClient client = new GatewayHttpClient(
                 RestClient.builder(),
-                new McpProperties("http://localhost:" + wm.port(), "", 30, 60_000, null));
+                new McpProperties("http://localhost:" + wm.port(), 30, 60_000, null));
         tool = new RemoveFieldTool(client);
         RequestPatHolder.set("klt_rm_field");
     }

--- a/kelta-mcp/src/test/java/io/kelta/mcp/tool/admin/UpdateFieldToolTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/tool/admin/UpdateFieldToolTest.java
@@ -32,7 +32,7 @@ class UpdateFieldToolTest {
         wm.start();
         GatewayHttpClient client = new GatewayHttpClient(
                 RestClient.builder(),
-                new McpProperties("http://localhost:" + wm.port(), "", 30, 60_000, null));
+                new McpProperties("http://localhost:" + wm.port(), 30, 60_000, null));
         tool = new UpdateFieldTool(client);
         RequestPatHolder.set("klt_upd_field");
     }

--- a/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/BulkApplyToolTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/BulkApplyToolTest.java
@@ -33,7 +33,7 @@ class BulkApplyToolTest {
         wm.start();
         GatewayHttpClient client = new GatewayHttpClient(
                 RestClient.builder(),
-                new McpProperties("http://localhost:" + wm.port(), "", 30, 60_000, null));
+                new McpProperties("http://localhost:" + wm.port(), 30, 60_000, null));
         tool = new BulkApplyTool(client);
         RequestPatHolder.set("klt_bulk_test");
     }

--- a/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/CreateRecordToolTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/CreateRecordToolTest.java
@@ -32,7 +32,7 @@ class CreateRecordToolTest {
         wm.start();
         GatewayHttpClient client = new GatewayHttpClient(
                 RestClient.builder(),
-                new McpProperties("http://localhost:" + wm.port(), "", 30, 60_000, null));
+                new McpProperties("http://localhost:" + wm.port(), 30, 60_000, null));
         tool = new CreateRecordTool(client);
         RequestPatHolder.set("klt_create_test");
     }

--- a/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/DeleteRecordToolTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/DeleteRecordToolTest.java
@@ -31,7 +31,7 @@ class DeleteRecordToolTest {
         wm.start();
         GatewayHttpClient client = new GatewayHttpClient(
                 RestClient.builder(),
-                new McpProperties("http://localhost:" + wm.port(), "", 30, 60_000, null));
+                new McpProperties("http://localhost:" + wm.port(), 30, 60_000, null));
         tool = new DeleteRecordTool(client);
         RequestPatHolder.set("klt_delete_test");
     }

--- a/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/ExecuteFlowToolTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/ExecuteFlowToolTest.java
@@ -32,7 +32,7 @@ class ExecuteFlowToolTest {
         wm.start();
         GatewayHttpClient client = new GatewayHttpClient(
                 RestClient.builder(),
-                new McpProperties("http://localhost:" + wm.port(), "", 30, 60_000, null));
+                new McpProperties("http://localhost:" + wm.port(), 30, 60_000, null));
         tool = new ExecuteFlowTool(client);
         RequestPatHolder.set("klt_flow_test");
     }

--- a/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/GetFlowRunToolTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/GetFlowRunToolTest.java
@@ -31,7 +31,7 @@ class GetFlowRunToolTest {
         wm.start();
         GatewayHttpClient client = new GatewayHttpClient(
                 RestClient.builder(),
-                new McpProperties("http://localhost:" + wm.port(), "", 30, 60_000, null));
+                new McpProperties("http://localhost:" + wm.port(), 30, 60_000, null));
         tool = new GetFlowRunTool(client);
         RequestPatHolder.set("klt_flowrun_test");
     }

--- a/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/ListApprovalsToolTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/ListApprovalsToolTest.java
@@ -28,7 +28,7 @@ class ListApprovalsToolTest {
         wm.start();
         GatewayHttpClient client = new GatewayHttpClient(
                 RestClient.builder(),
-                new McpProperties("http://localhost:" + wm.port(), "", 30, 60_000, null));
+                new McpProperties("http://localhost:" + wm.port(), 30, 60_000, null));
         tool = new ListApprovalsTool(client);
         RequestPatHolder.set("klt_listapproval_test");
     }

--- a/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/ListCollectionsToolTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/ListCollectionsToolTest.java
@@ -33,7 +33,7 @@ class ListCollectionsToolTest {
         wm.start();
         GatewayHttpClient client = new GatewayHttpClient(
                 RestClient.builder(),
-                new McpProperties("http://localhost:" + wm.port(), "", 30, 60_000, null));
+                new McpProperties("http://localhost:" + wm.port(), 30, 60_000, null));
         tool = new ListCollectionsTool(client);
         RequestPatHolder.set("klt_list_test");
     }

--- a/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/QueryCollectionToolTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/QueryCollectionToolTest.java
@@ -32,7 +32,7 @@ class QueryCollectionToolTest {
         wm.start();
         GatewayHttpClient client = new GatewayHttpClient(
                 RestClient.builder(),
-                new McpProperties("http://localhost:" + wm.port(), "", 30, 60_000, null));
+                new McpProperties("http://localhost:" + wm.port(), 30, 60_000, null));
         tool = new QueryCollectionTool(client);
         RequestPatHolder.set("klt_q_test");
     }

--- a/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/SubmitForApprovalToolTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/SubmitForApprovalToolTest.java
@@ -32,7 +32,7 @@ class SubmitForApprovalToolTest {
         wm.start();
         GatewayHttpClient client = new GatewayHttpClient(
                 RestClient.builder(),
-                new McpProperties("http://localhost:" + wm.port(), "", 30, 60_000, null));
+                new McpProperties("http://localhost:" + wm.port(), 30, 60_000, null));
         tool = new SubmitForApprovalTool(client);
         RequestPatHolder.set("klt_submit_test");
     }

--- a/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/UpdateRecordToolTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/UpdateRecordToolTest.java
@@ -32,7 +32,7 @@ class UpdateRecordToolTest {
         wm.start();
         GatewayHttpClient client = new GatewayHttpClient(
                 RestClient.builder(),
-                new McpProperties("http://localhost:" + wm.port(), "", 30, 60_000, null));
+                new McpProperties("http://localhost:" + wm.port(), 30, 60_000, null));
         tool = new UpdateRecordTool(client);
         RequestPatHolder.set("klt_update_test");
     }

--- a/kelta-ui/app/src/pages/ApiTokensPage/ApiTokensPage.test.tsx
+++ b/kelta-ui/app/src/pages/ApiTokensPage/ApiTokensPage.test.tsx
@@ -9,21 +9,36 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { resolveMcpBaseUrl, buildMcpAddCommand } from './ApiTokensPage'
 
 describe('buildMcpAddCommand', () => {
-  it('builds a user-profile command with the token in single quotes', () => {
-    const cmd = buildMcpAddCommand('user', 'https://emf.rzware.com', 'klt_abc123')
+  it('builds a user-profile URL with the slug before /mcp/...', () => {
+    const cmd = buildMcpAddCommand(
+      'user',
+      'https://emf.rzware.com',
+      'threadline-clothing',
+      'klt_abc123',
+    )
     expect(cmd).toBe(
-      "claude mcp add kelta-user --transport http --url https://emf.rzware.com/mcp/user --header 'Authorization: Bearer klt_abc123'"
+      "claude mcp add kelta-user --transport http --url https://emf.rzware.com/threadline-clothing/mcp/user --header 'Authorization: Bearer klt_abc123'",
     )
   })
 
-  it('builds an admin-profile command at the right URL', () => {
-    const cmd = buildMcpAddCommand('admin', 'https://emf.rzware.com', 'klt_xyz')
-    expect(cmd).toContain('--url https://emf.rzware.com/mcp/admin')
+  it('builds an admin-profile command at the right slug-prefixed URL', () => {
+    const cmd = buildMcpAddCommand(
+      'admin',
+      'https://emf.rzware.com',
+      'another-tenant',
+      'klt_xyz',
+    )
+    expect(cmd).toContain('--url https://emf.rzware.com/another-tenant/mcp/admin')
     expect(cmd).toContain('kelta-admin')
   })
 
   it('uses single quotes around the auth header so the token is opaque to the shell', () => {
-    const cmd = buildMcpAddCommand('user', 'https://emf.rzware.com', 'klt_token_with$pecial')
+    const cmd = buildMcpAddCommand(
+      'user',
+      'https://emf.rzware.com',
+      't',
+      'klt_token_with$pecial',
+    )
     expect(cmd).toContain("'Authorization: Bearer klt_token_with$pecial'")
   })
 })

--- a/kelta-ui/app/src/pages/ApiTokensPage/ApiTokensPage.tsx
+++ b/kelta-ui/app/src/pages/ApiTokensPage/ApiTokensPage.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useCallback, useRef, useEffect } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useApi } from '../../context/ApiContext'
+import { getTenantSlug } from '../../context/TenantContext'
 import { useToast, ConfirmDialog } from '../../components'
 import type { PersonalAccessToken } from '@kelta/sdk'
 import { cn } from '@/lib/utils'
@@ -354,8 +355,15 @@ export function resolveMcpBaseUrl(): string {
   return ''
 }
 
-export function buildMcpAddCommand(profile: 'user' | 'admin', mcpBaseUrl: string, token: string): string {
-  const url = `${mcpBaseUrl}/mcp/${profile}`
+export function buildMcpAddCommand(
+  profile: 'user' | 'admin',
+  mcpBaseUrl: string,
+  tenantSlug: string,
+  token: string,
+): string {
+  // Slug binds the URL to a tenant (matches the platform-wide /{slug}/...
+  // convention). Different PAT in a different tenant → different URL.
+  const url = `${mcpBaseUrl}/${tenantSlug}/mcp/${profile}`
   // Single-quoted shell strings keep the token opaque to the shell.
   return `claude mcp add kelta-${profile} --transport http --url ${url} --header 'Authorization: Bearer ${token}'`
 }
@@ -418,8 +426,9 @@ function TokenCreatedDialog({
   }, [token])
 
   const mcpBaseUrl = resolveMcpBaseUrl()
-  const userCommand = buildMcpAddCommand('user', mcpBaseUrl, token)
-  const adminCommand = buildMcpAddCommand('admin', mcpBaseUrl, token)
+  const tenantSlug = getTenantSlug() || '<your-tenant-slug>'
+  const userCommand = buildMcpAddCommand('user', mcpBaseUrl, tenantSlug, token)
+  const adminCommand = buildMcpAddCommand('admin', mcpBaseUrl, tenantSlug, token)
 
   return (
     <div


### PR DESCRIPTION
## Summary

PR #792 baked \`MCP_TENANT_SLUG\` into the configmap, which is wrong: each user's PAT belongs to a different tenant, so a deployment-level pin only works for one tenant at a time. The slug needs to come from the request itself.

The platform already routes everything by URL prefix (\`/{tenantSlug}/api/...\`), so the MCP URL now follows the same shape:

\`\`\`
/{tenantSlug}/mcp/user
/{tenantSlug}/mcp/admin
\`\`\`

Each Claude Code config has its own URL bound to the right slug. A single emf-mcp deployment serves any number of tenants concurrently — the slug rides along per session, not per pod.

## Wire-through

- \`McpAuthFilter\` regex-matches \`/{slug}/mcp/(user|admin)[/...]\`, extracts the slug, stamps it as a request attribute, and rewrites the request URI to the canonical \`/mcp/(user|admin)\` path the SDK servlet is registered at. Bad URLs return 404 with an explanatory body before any auth check runs.
- \`KeltaTransportContextExtractor\` pulls the slug attribute alongside the PAT and packs both into the SDK transport context.
- \`PatPropagatingToolDecorator\` reads them on the Reactor scheduler thread and pushes into \`RequestPatHolder\` + new \`RequestSlugHolder\`.
- \`GatewayHttpClient\` prepends \`/{slug}\` to every outgoing path; the slug source is the per-request holder, so two simultaneous sessions in different tenants on the same client instance both work.
- Reverts \`MCP_TENANT_SLUG\` / \`kelta.mcp.tenant-slug\` from \`McpProperties\`, \`application.yml\`, and tests.

## UI

\`kelta-ui\`'s \`TokenCreatedDialog\` now interpolates the active tenant slug (from \`getTenantSlug()\`) into the \`claude mcp add\` commands so the URL the user copies is already correct for their session.

## Companion PR

cklinker/homelab-argo \`feature/emf-mcp-url-slug-routing\` — flips the IngressRoute to \`PathRegexp\` matching \`/{slug}/mcp/(user|admin)\` and removes \`MCP_TENANT_SLUG\` from the configmap.

## Test plan

- [x] \`mvn test -f kelta-mcp/pom.xml\` — 125 passing (was 119).
- [x] \`npm test\` for the UI — 5 vitest cases passing.
- [ ] After merge + homelab tag bump: \`claude mcp add kelta-user --url https://emf.rzware.com/threadline-clothing/mcp/user --header 'Authorization: Bearer klt_<pat>'\` connects, and \"list collections\" returns the tenant's collections.
- [ ] Same for a different tenant's PAT against \`/another-tenant/mcp/user\` on the same deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)