### PR TITLE
fix(mcp): align query operators with worker, fail fast on unsupported ops

### DIFF
--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/ListCollectionsTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/ListCollectionsTool.java
@@ -41,7 +41,10 @@ public class ListCollectionsTool implements UserTool, AdminTool {
                     boolean includeSystem = readBool(request.arguments(), "includeSystem", true);
                     String path = "/api/collections";
                     if (!includeSystem) {
-                        path += "?filter[isSystem][EQ]=false";
+                        // Field name is `systemCollection` on CollectionDefinition;
+                        // the previous `isSystem` filter was silently dropped by the
+                        // worker (unknown field), making the flag a no-op.
+                        path += "?filter[systemCollection][EQ]=false";
                     }
                     try {
                         return McpErrorMapper.toResult(gateway.get(path));

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/QueryCollectionTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/QueryCollectionTool.java
@@ -21,10 +21,32 @@ import java.util.Map;
 @Component
 public class QueryCollectionTool implements UserTool {
 
+    /**
+     * Operators the worker actually honors. The set comes from
+     * {@code io.kelta.runtime.query.FilterOperator} — the worker uppercases the
+     * URL token then does an enum {@code valueOf}, silently dropping any name
+     * that doesn't match. We mirror it exactly here so the MCP boundary
+     * rejects unsupported operators with a clear message instead of
+     * forwarding them to be silently dropped (which would produce confidently
+     * wrong query results to an LLM consumer).
+     *
+     * <p>Notable absences vs. common JSON:API conventions:
+     * <ul>
+     *   <li>{@code IN} / {@code NIN} — the URL parser only accepts scalar
+     *       values; IN is constructed programmatically by other call sites
+     *       and not URL-addressable.</li>
+     *   <li>{@code BETWEEN} — combine {@code GTE} + {@code LTE} on the same
+     *       field.</li>
+     *   <li>{@code STARTSWITH} / {@code ENDSWITH} / {@code IS_NULL} — wrong
+     *       spellings; the enum names are {@code STARTS} / {@code ENDS} /
+     *       {@code ISNULL}.</li>
+     * </ul>
+     */
     private static final List<String> ALLOWED_OPS = List.of(
             "EQ", "NEQ", "GT", "GTE", "LT", "LTE",
-            "IN", "NIN", "CONTAINS", "NOT_CONTAINS",
-            "STARTSWITH", "ENDSWITH", "BETWEEN", "EXISTS", "IS_NULL");
+            "CONTAINS", "STARTS", "ENDS",
+            "ICONTAINS", "ISTARTS", "IENDS", "IEQ",
+            "ISNULL");
 
     private final GatewayHttpClient gateway;
 
@@ -34,29 +56,129 @@ public class QueryCollectionTool implements UserTool {
 
     @Override
     public SyncToolSpecification toSpecification() {
-        Map<String, Object> filter = Schemas.freeObject(
-                "Filter expressions, keyed by field name. Each value is an object mapping operator -> value. "
-                + "Allowed operators: " + ALLOWED_OPS + ". Example: {\"status\":{\"EQ\":\"ACTIVE\"},"
-                + " \"createdAt\":{\"GTE\":\"2024-01-01T00:00:00Z\"}}.");
+        Map<String, Object> filter = Schemas.freeObject("""
+                Filter expressions, keyed by field name. Each value is an object mapping \
+                OPERATOR -> value. Multiple operators on one field combine with AND (use \
+                this for ranges); multiple fields combine with AND across each other. \
+                IMPORTANT: there is NO OR — for "match A or B" run two queries and union \
+                the results client-side.
+
+                Supported operators (operator name is case-insensitive; values are \
+                case-sensitive unless you use an I-prefixed variant):
+                  EQ, NEQ                       exact / not equal
+                  GT, GTE, LT, LTE              comparison (numbers, strings, ISO-8601 timestamps)
+                  CONTAINS, STARTS, ENDS        substring / prefix / suffix (case-sensitive)
+                  ICONTAINS, ISTARTS, IENDS,
+                  IEQ                           same matches, case-insensitive
+                  ISNULL                        value must be "true" or "false"
+
+                NOT supported (the call will be rejected with an error). Workarounds:
+                  • IN, NIN          — call this tool once per value, union results client-side
+                  • BETWEEN          — use GTE + LTE on the same field
+                  • STARTSWITH       — use STARTS (or ISTARTS for case-insensitive)
+                  • ENDSWITH         — use ENDS (or IENDS)
+                  • IS_NULL          — use ISNULL
+                  • NOT_CONTAINS,
+                    EXISTS           — not currently expressible as a single query
+
+                Example — created in 2026 AND status equals ACTIVE:
+                  { "createdAt": { "GTE": "2026-01-01T00:00:00Z", "LT": "2027-01-01T00:00:00Z" },
+                    "status":    { "EQ":  "ACTIVE" } }
+
+                Example — case-insensitive name search with a price ceiling:
+                  { "name":  { "ICONTAINS": "widget" },
+                    "price": { "LTE": 99.99 } }
+                """);
 
         Map<String, Object> properties = new LinkedHashMap<>();
         properties.put("collection", Schemas.string(
-                "Collection name (e.g. \"accounts\", \"users\")."));
+                "Collection name as it appears in `list_collections` "
+                + "(e.g. \"customers\", \"accounts\", \"orders\")."));
         properties.put("filter", filter);
         properties.put("sort", Schemas.string(
-                "Comma-separated sort fields. Prefix with '-' for descending. Example: \"lastName,-createdAt\"."));
+                "Comma-separated sort keys. Prefix '-' for descending. "
+                + "Examples: \"lastName\"  |  \"-createdAt\"  |  \"lastName,-createdAt\"."));
         properties.put("pageSize", Schemas.integer(
-                "Records per page (default 20).", 1, 200));
+                "Records per page (default 20, max 200). Set to 1 when you only need a count — "
+                + "the total is in `meta.totalCount` regardless of page size.", 1, 200));
         properties.put("pageNumber", Schemas.integer(
-                "Page number, 1-based (default 1).", 1, null));
+                "1-based page index (default 1). Response `links.next` / `links.prev` indicate "
+                + "further pages when present.", 1, null));
         properties.put("fields", Schemas.string(
-                "Comma-separated field names to include. Default: all."));
+                "Sparse fieldset — comma-separated attribute names to return per record. "
+                + "Default returns all attributes. Example: \"firstName,lastName,email\"."));
         properties.put("include", Schemas.string(
-                "Comma-separated relationship names to include in the response."));
+                "Comma-separated relationship names to eager-load. Each related record appears "
+                + "once in the top-level `included[]` array; `data[].relationships[name].data` "
+                + "references them by id + type. Example: \"account,owner\"."));
 
         Tool tool = Tool.builder()
                 .name("query_collection")
-                .description("List records from a collection with JSON:API filters/sort/paging. Returns the JSON:API list response with `data` and `meta` keys. Prefer this for browsing; use get_record for fetching a known id.")
+                .description("""
+                        Run a JSON:API list query against a Kelta collection (GET /api/{collection}).
+
+                        Use this for browsing or finding records by criteria. For a single record \
+                        by id use `get_record`; for cross-collection full-text search use `search`. \
+                        Before filtering on a field you've never seen, call `get_collection_schema` \
+                        to discover field names and types.
+
+                        Capabilities (every argument is optional except `collection`):
+                          • filter  — combine any number of fields and operators. All conditions \
+                        AND together; there is NO OR (run separate queries for "either / or"). \
+                        Supported ops: EQ NEQ GT GTE LT LTE CONTAINS STARTS ENDS ICONTAINS \
+                        ISTARTS IENDS IEQ ISNULL. See the `filter` argument for usage and \
+                        workarounds for unsupported names (IN, BETWEEN, etc.).
+                          • sort    — multi-key, '-' prefix for descending. Direct attributes only \
+                        (cannot sort by relationship fields).
+                          • page    — pageSize + pageNumber (1-based, default 20 / 1, max 1000). \
+                        Total record count is always at `meta.totalCount`, regardless of pageSize.
+                          • fields  — sparse fieldset: only return the columns you need.
+                          • include — eager-load related records (returned in top-level \
+                        `included[]`). Single hop only — nested includes like `account.owner` \
+                        are not supported.
+
+                        Returns the JSON:API envelope:
+                          {
+                            "data":     [ { "id": "...", "type": "<collection>",
+                                            "attributes": {...}, "relationships": {...} } ],
+                            "included": [ ... ],   // only when `include` is set
+                            "meta":     { "totalCount": N, "pageNumber": ...,
+                                          "pageSize": ..., "totalPages": ... },
+                            "links":    { "self": "...", "next": "...", "prev": "..." }
+                          }
+
+                        Common patterns:
+
+                          // count-only: pageSize=1 and read meta.totalCount
+                          { "collection": "customers", "pageSize": 1 }
+
+                          // most-recent N records of a given status
+                          { "collection": "orders",
+                            "filter":   { "status": { "EQ": "OPEN" } },
+                            "sort":     "-createdAt",
+                            "pageSize": 10 }
+
+                          // range query (BETWEEN-style) using two ops on one field
+                          { "collection": "orders",
+                            "filter": { "total": { "GTE": 100, "LTE": 1000 } } }
+
+                          // case-insensitive name search
+                          { "collection": "customers",
+                            "filter": { "lastName": { "ICONTAINS": "smith" } } }
+
+                          // records missing a value
+                          { "collection": "customers",
+                            "filter": { "phone": { "ISNULL": "true" } } }
+
+                          // selected fields plus an eager-loaded relationship
+                          { "collection": "customers",
+                            "fields":  "firstName,lastName,email",
+                            "include": "account",
+                            "pageSize": 25 }
+
+                          // pagination: walk pages with pageNumber, or follow links.next
+                          { "collection": "customers", "pageSize": 50, "pageNumber": 3 }
+                        """)
                 .inputSchema(Schemas.object(properties, List.of("collection")))
                 .build();
 
@@ -72,6 +194,13 @@ public class QueryCollectionTool implements UserTool {
                                 .content(List.of(new TextContent("Argument \"collection\" is required.")))
                                 .build();
                     }
+                    String opError = validateFilterOperators(args.get("filter"));
+                    if (opError != null) {
+                        return CallToolResult.builder()
+                                .isError(true)
+                                .content(List.of(new TextContent(opError)))
+                                .build();
+                    }
                     String collection = cv.toString();
                     String query = buildQueryString(args);
                     String path = "/api/" + URLEncoder.encode(collection, StandardCharsets.UTF_8)
@@ -83,6 +212,32 @@ public class QueryCollectionTool implements UserTool {
                     }
                 })
                 .build();
+    }
+
+    /**
+     * Returns a user-facing error message if {@code filter} contains an
+     * operator outside {@link #ALLOWED_OPS}, otherwise null. Validating at
+     * the MCP boundary turns a silent worker drop (which produces wrong
+     * results) into an actionable error the caller can correct.
+     */
+    static String validateFilterOperators(Object filter) {
+        if (!(filter instanceof Map<?, ?> filterMap)) return null;
+        for (Map.Entry<?, ?> e : filterMap.entrySet()) {
+            if (!(e.getValue() instanceof Map<?, ?> ops)) continue;
+            for (Object opKey : ops.keySet()) {
+                String op = String.valueOf(opKey).toUpperCase(Locale.ROOT);
+                if (!ALLOWED_OPS.contains(op)) {
+                    return "Unsupported filter operator \"" + opKey + "\" on field \""
+                            + e.getKey() + "\". Supported: " + ALLOWED_OPS
+                            + ". Workarounds — ranges: GTE+LTE on one field; "
+                            + "case-insensitive: ICONTAINS / ISTARTS / IENDS / IEQ; "
+                            + "null check: ISNULL with value \"true\"/\"false\"; "
+                            + "IN / OR are not supported in a single query — "
+                            + "run multiple calls and union client-side.";
+                }
+            }
+        }
+        return null;
     }
 
     static String buildQueryString(Map<String, Object> args) {

--- a/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/ListCollectionsToolTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/ListCollectionsToolTest.java
@@ -67,13 +67,13 @@ class ListCollectionsToolTest {
 
     @Test
     void includeSystemFalseAddsFilter() {
-        wm.stubFor(get(urlEqualTo("/api/collections?filter[isSystem][EQ]=false"))
+        wm.stubFor(get(urlEqualTo("/api/collections?filter[systemCollection][EQ]=false"))
                 .willReturn(aResponse().withStatus(200).withBody("{\"data\":[]}")));
 
         tool.toSpecification().callHandler().apply(null, new CallToolRequest(
                 "list_collections", Map.of("includeSystem", false), null));
 
-        wm.verify(WireMock.getRequestedFor(urlEqualTo("/api/collections?filter[isSystem][EQ]=false")));
+        wm.verify(WireMock.getRequestedFor(urlEqualTo("/api/collections?filter[systemCollection][EQ]=false")));
     }
 
     @Test

--- a/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/QueryCollectionToolTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/QueryCollectionToolTest.java
@@ -61,10 +61,70 @@ class QueryCollectionToolTest {
 
     @Test
     void buildQueryStringDropsUnknownOperators() {
+        // Defensive contract on the helper: anything that bypasses the
+        // call-handler validation still produces a clean URL with the
+        // unknown op stripped (rather than passed to the worker, which
+        // would silently drop it and return a wrong result set).
         String q = QueryCollectionTool.buildQueryString(Map.of(
                 "filter", Map.of("name", Map.of("BOGUS_OP", "x"))));
 
         assertThat(q).doesNotContain("BOGUS_OP");
+    }
+
+    @Test
+    void buildQueryStringPassesThroughCaseInsensitiveOperators() {
+        // ICONTAINS / ISTARTS / IENDS / IEQ are real worker operators; they
+        // must survive buildQueryString unchanged.
+        String q = QueryCollectionTool.buildQueryString(Map.of(
+                "filter", Map.of("lastName", Map.of("ICONTAINS", "smith"))));
+
+        assertThat(q).contains("filter[lastName][ICONTAINS]=smith");
+    }
+
+    @Test
+    void validateFilterOperatorsAcceptsKnownOperators() {
+        assertThat(QueryCollectionTool.validateFilterOperators(
+                Map.of("status", Map.of("EQ", "ACTIVE")))).isNull();
+        assertThat(QueryCollectionTool.validateFilterOperators(
+                Map.of("price", Map.of("GTE", 100, "LTE", 1000)))).isNull();
+        assertThat(QueryCollectionTool.validateFilterOperators(
+                Map.of("phone", Map.of("ISNULL", "true")))).isNull();
+    }
+
+    @Test
+    void validateFilterOperatorsRejectsUnsupportedNamesWithGuidance() {
+        // Operators that look plausible but the worker doesn't recognize
+        // — these used to be silently forwarded and dropped. Now the MCP
+        // layer rejects them with a message that points at the workaround.
+        assertThat(QueryCollectionTool.validateFilterOperators(
+                Map.of("status", Map.of("IN", "ACTIVE,PENDING"))))
+                .contains("IN")
+                .contains("Workarounds");
+        assertThat(QueryCollectionTool.validateFilterOperators(
+                Map.of("total", Map.of("BETWEEN", "100,1000"))))
+                .contains("BETWEEN")
+                .contains("GTE+LTE");
+        assertThat(QueryCollectionTool.validateFilterOperators(
+                Map.of("name", Map.of("STARTSWITH", "Foo"))))
+                .contains("STARTSWITH");
+        assertThat(QueryCollectionTool.validateFilterOperators(
+                Map.of("phone", Map.of("IS_NULL", "true"))))
+                .contains("IS_NULL");
+    }
+
+    @Test
+    void rejectsCallWithUnsupportedFilterOperator() {
+        SyncToolSpecification spec = tool.toSpecification();
+        CallToolRequest req = new CallToolRequest("query_collection", Map.of(
+                "collection", "customers",
+                "filter", Map.of("status", Map.of("BETWEEN", "A,B"))
+        ), null);
+
+        CallToolResult result = spec.callHandler().apply(null, req);
+
+        assertThat(result.isError()).isEqualTo(Boolean.TRUE);
+        // No HTTP call should have escaped to the gateway.
+        wm.verify(0, WireMock.anyRequestedFor(WireMock.anyUrl()));
     }
 
     @Test


### PR DESCRIPTION
## Summary

- `query_collection` advertised 15 filter operators but 8 of them (`IN`, `NIN`, `NOT_CONTAINS`, `BETWEEN`, `EXISTS`, `STARTSWITH`, `ENDSWITH`, `IS_NULL`) were silently dropped by the worker's `FilterOperator` enum — produced confidently wrong query results because nothing surfaced an error.
- `ALLOWED_OPS` now mirrors the worker exactly (`EQ NEQ GT GTE LT LTE CONTAINS STARTS ENDS ICONTAINS ISTARTS IENDS IEQ ISNULL`); the case-insensitive `I*` variants were already supported by the worker but never advertised here.
- The call handler now rejects unsupported operators at the MCP boundary with a message that points at the workaround (`GTE+LTE` for ranges, `ICONTAINS` for case-insensitive, multiple queries for IN/OR).
- Tool + filter argument descriptions rewritten as a real teaching surface for an LLM consumer: actual operator list, no-OR/no-IN-via-URL caveats, return envelope shape, and seven worked examples covering count-only, range, case-insensitive, ISNULL, sparse fieldsets, includes, and pagination.
- Drive-by fix: `list_collections` was filtering on `isSystem` but the field is `systemCollection`, so `includeSystem=false` was silently a no-op. Corrected.

## Test plan

- [x] `mvn -f kelta-mcp/pom.xml test` — 125/125 unit tests pass
- [x] New tests cover: operator validation accept-list, rejection error message content, full call-handler error result for an unsupported op, case-insensitive variants encode correctly
- [x] `ListCollectionsToolTest` updated for the new field name
- [ ] Post-deploy: in Claude Code, hit `query_collection` with `BETWEEN` / `IN` / `STARTSWITH` and confirm the error surfaces with the workaround text
- [ ] Post-deploy: `list_collections` with `includeSystem=false` actually filters out the ~60 system collections

🤖 Generated with [Claude Code](https://claude.com/claude-code)