### PR TITLE
feat(mcp): add ToolAnnotations safety hints + display titles to every tool

### DIFF
--- a/kelta-mcp/src/main/java/io/kelta/mcp/config/McpServerConfig.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/config/McpServerConfig.java
@@ -8,6 +8,7 @@ import io.kelta.mcp.resource.UserResource;
 import io.kelta.mcp.resource.UserResourceTemplate;
 import io.kelta.mcp.tool.AdminTool;
 import io.kelta.mcp.tool.Schemas;
+import io.kelta.mcp.tool.ToolHints;
 import io.kelta.mcp.tool.UserTool;
 import io.modelcontextprotocol.server.McpServer;
 import io.modelcontextprotocol.server.McpServerFeatures;
@@ -150,8 +151,10 @@ public class McpServerConfig {
     private McpServerFeatures.SyncToolSpecification pingTool(String profile) {
         Tool tool = Tool.builder()
                 .name("ping")
+                .title("Ping (" + profile + ")")
                 .description("Returns 'pong'. Smoke test that the " + profile + " MCP endpoint is reachable.")
                 .inputSchema(Schemas.empty())
+                .annotations(ToolHints.read())
                 .build();
 
         return McpServerFeatures.SyncToolSpecification.builder()

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/ToolHints.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/ToolHints.java
@@ -1,0 +1,72 @@
+package io.kelta.mcp.tool;
+
+import io.modelcontextprotocol.spec.McpSchema.ToolAnnotations;
+
+/**
+ * Tiny helpers that build {@link ToolAnnotations} for kelta-mcp tools.
+ *
+ * <p>The MCP protocol lets a server hint at a tool's safety / semantics so
+ * clients can make smarter UX choices: which tools to preload, which need
+ * an explicit user-confirm before invocation, which are safe to retry, etc.
+ * Today every kelta tool ships with no annotations at all, leaving clients
+ * with no signal that {@code query_collection} is a safe read or that
+ * {@code delete_record} is destructive.
+ *
+ * <p>Two factories cover everything in this codebase — every tool is either
+ * a read against the gateway ({@link #read()}) or a mutation
+ * ({@link #write(boolean, boolean)}). All tools call out to the in-cluster
+ * gateway, so {@code openWorldHint} is always {@code true}.
+ *
+ * <p>The friendly display title is set via {@code Tool.builder().title(...)}
+ * at the top level of the Tool object, not duplicated here — the SDK's
+ * {@code ToolAnnotations.title} field is a redundant alias.
+ *
+ * <p>Field reference (from the MCP spec):
+ * <ul>
+ *   <li>{@code readOnlyHint} — {@code true} means the tool does not modify
+ *       any state.</li>
+ *   <li>{@code destructiveHint} — only meaningful when
+ *       {@code readOnlyHint=false}; {@code true} means the tool may make
+ *       destructive updates (delete, overwrite, mass-mutate).</li>
+ *   <li>{@code idempotentHint} — {@code true} means repeating a call with
+ *       the same arguments has no additional effect; clients can retry
+ *       freely.</li>
+ *   <li>{@code openWorldHint} — {@code true} means the tool talks to systems
+ *       outside the LLM's own process (a gateway, an external API).</li>
+ *   <li>{@code returnDirect} — left {@code null}; we don't currently bypass
+ *       the model with raw tool output.</li>
+ * </ul>
+ */
+public final class ToolHints {
+
+    private ToolHints() {}
+
+    /**
+     * Annotations for a read-only tool: {@code readOnlyHint=true},
+     * {@code idempotentHint=true}, {@code openWorldHint=true}.
+     * {@code destructiveHint} is left {@code null} since it's only
+     * meaningful for mutating tools.
+     */
+    public static ToolAnnotations read() {
+        return new ToolAnnotations(null, true, null, true, true, null);
+    }
+
+    /**
+     * Annotations for a mutating tool: {@code readOnlyHint=false},
+     * {@code openWorldHint=true}. The caller declares whether the
+     * mutation may be destructive (deletes, overwrites) and whether
+     * repeating the call with the same arguments lands the system in
+     * the same state.
+     *
+     * @param destructive {@code true} if the call may delete or overwrite
+     *     existing data; {@code false} for additive operations like
+     *     creating a new record
+     * @param idempotent {@code true} if calling with the same arguments
+     *     produces the same end state; {@code false} when each call has a
+     *     fresh effect (e.g. creating a new record with auto-generated id,
+     *     starting a new flow execution)
+     */
+    public static ToolAnnotations write(boolean destructive, boolean idempotent) {
+        return new ToolAnnotations(null, false, destructive, idempotent, true, null);
+    }
+}

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/AddFieldTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/AddFieldTool.java
@@ -4,6 +4,7 @@ import io.kelta.mcp.client.GatewayHttpClient;
 import io.kelta.mcp.error.McpErrorMapper;
 import io.kelta.mcp.tool.AdminTool;
 import io.kelta.mcp.tool.Schemas;
+import io.kelta.mcp.tool.ToolHints;
 import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
@@ -41,8 +42,10 @@ public class AddFieldTool implements AdminTool {
 
         Tool tool = Tool.builder()
                 .name("add_field")
+                .title("Add Field")
                 .description("Add a field to an existing collection. Wraps POST /api/fields with a JSON:API body.")
                 .inputSchema(Schemas.object(properties, List.of("collectionName", "fieldName", "type")))
+                .annotations(ToolHints.write(false, false))
                 .build();
 
         return SyncToolSpecification.builder()

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/CreateCollectionTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/CreateCollectionTool.java
@@ -4,6 +4,7 @@ import io.kelta.mcp.client.GatewayHttpClient;
 import io.kelta.mcp.error.McpErrorMapper;
 import io.kelta.mcp.tool.AdminTool;
 import io.kelta.mcp.tool.Schemas;
+import io.kelta.mcp.tool.ToolHints;
 import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
@@ -64,8 +65,10 @@ public class CreateCollectionTool implements AdminTool {
 
         Tool tool = Tool.builder()
                 .name("create_collection")
+                .title("Create Collection")
                 .description("Create a new collection definition, optionally with an initial set of fields. The collection is created first; each field is then created in order. Returns a summary with the new collection id and per-field success/failure.")
                 .inputSchema(Schemas.object(properties, List.of("name")))
+                .annotations(ToolHints.write(false, false))
                 .build();
 
         return SyncToolSpecification.builder()

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/CreateFlowTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/CreateFlowTool.java
@@ -4,6 +4,7 @@ import io.kelta.mcp.client.GatewayHttpClient;
 import io.kelta.mcp.error.McpErrorMapper;
 import io.kelta.mcp.tool.AdminTool;
 import io.kelta.mcp.tool.Schemas;
+import io.kelta.mcp.tool.ToolHints;
 import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
@@ -38,8 +39,10 @@ public class CreateFlowTool implements AdminTool {
 
         Tool tool = Tool.builder()
                 .name("create_flow")
+                .title("Create Flow")
                 .description("Create a new automation flow. Wraps POST /api/flows. The definition payload is opaque to this tool — pass the flow-engine JSON directly.")
                 .inputSchema(Schemas.object(properties, List.of("name", "triggerType", "definition")))
+                .annotations(ToolHints.write(false, false))
                 .build();
 
         return SyncToolSpecification.builder()

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/CreateLayoutTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/CreateLayoutTool.java
@@ -4,6 +4,7 @@ import io.kelta.mcp.client.GatewayHttpClient;
 import io.kelta.mcp.error.McpErrorMapper;
 import io.kelta.mcp.tool.AdminTool;
 import io.kelta.mcp.tool.Schemas;
+import io.kelta.mcp.tool.ToolHints;
 import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
@@ -86,8 +87,10 @@ public class CreateLayoutTool implements AdminTool {
 
         Tool tool = Tool.builder()
                 .name("create_layout")
+                .title("Create Layout")
                 .description("Build a complete page layout in one call: layout + sections + fields per section. The layout is created first; sections and their fields follow. Returns a summary of what was created and any per-piece failures.")
                 .inputSchema(Schemas.object(properties, List.of("name", "collectionName", "sections")))
+                .annotations(ToolHints.write(false, false))
                 .build();
 
         return SyncToolSpecification.builder()

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/CreateListViewTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/CreateListViewTool.java
@@ -4,6 +4,7 @@ import io.kelta.mcp.client.GatewayHttpClient;
 import io.kelta.mcp.error.McpErrorMapper;
 import io.kelta.mcp.tool.AdminTool;
 import io.kelta.mcp.tool.Schemas;
+import io.kelta.mcp.tool.ToolHints;
 import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
@@ -37,8 +38,10 @@ public class CreateListViewTool implements AdminTool {
 
         Tool tool = Tool.builder()
                 .name("create_listview")
+                .title("Create List View")
                 .description("Create a saved list view (column set + filter + sort) for a collection. Wraps POST /api/listViews.")
                 .inputSchema(Schemas.object(properties, List.of("collectionName", "name", "displayedFields")))
+                .annotations(ToolHints.write(false, false))
                 .build();
 
         return SyncToolSpecification.builder()

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/CreatePicklistTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/CreatePicklistTool.java
@@ -4,6 +4,7 @@ import io.kelta.mcp.client.GatewayHttpClient;
 import io.kelta.mcp.error.McpErrorMapper;
 import io.kelta.mcp.tool.AdminTool;
 import io.kelta.mcp.tool.Schemas;
+import io.kelta.mcp.tool.ToolHints;
 import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
@@ -54,8 +55,10 @@ public class CreatePicklistTool implements AdminTool {
 
         Tool tool = Tool.builder()
                 .name("create_picklist")
+                .title("Create Picklist")
                 .description("Create a global picklist with its initial values. The picklist is created first; each value is then POSTed to /api/picklistValues with picklistName backreference.")
                 .inputSchema(Schemas.object(properties, List.of("name", "values")))
+                .annotations(ToolHints.write(false, false))
                 .build();
 
         return SyncToolSpecification.builder()

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/CreateValidationRuleTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/CreateValidationRuleTool.java
@@ -4,6 +4,7 @@ import io.kelta.mcp.client.GatewayHttpClient;
 import io.kelta.mcp.error.McpErrorMapper;
 import io.kelta.mcp.tool.AdminTool;
 import io.kelta.mcp.tool.Schemas;
+import io.kelta.mcp.tool.ToolHints;
 import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
@@ -37,8 +38,10 @@ public class CreateValidationRuleTool implements AdminTool {
 
         Tool tool = Tool.builder()
                 .name("create_validation_rule")
+                .title("Create Validation Rule")
                 .description("Create a validation rule on a collection. Records that fail the expression are rejected at create/update time.")
                 .inputSchema(Schemas.object(properties, List.of("collectionName", "name", "expression", "errorMessage")))
+                .annotations(ToolHints.write(false, false))
                 .build();
 
         return SyncToolSpecification.builder()

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/DeleteLayoutTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/DeleteLayoutTool.java
@@ -4,6 +4,7 @@ import io.kelta.mcp.client.GatewayHttpClient;
 import io.kelta.mcp.error.McpErrorMapper;
 import io.kelta.mcp.tool.AdminTool;
 import io.kelta.mcp.tool.Schemas;
+import io.kelta.mcp.tool.ToolHints;
 import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
@@ -32,8 +33,10 @@ public class DeleteLayoutTool implements AdminTool {
 
         Tool tool = Tool.builder()
                 .name("delete_layout")
+                .title("Delete Layout")
                 .description("Delete a page layout and (cascade) its sections and field assignments. Wraps DELETE /api/pageLayouts/{id}. Does NOT delete the underlying field definitions on the collection.")
                 .inputSchema(Schemas.object(properties, List.of("id")))
+                .annotations(ToolHints.write(true, true))
                 .build();
 
         return SyncToolSpecification.builder()

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/ImportApiSpecTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/ImportApiSpecTool.java
@@ -4,6 +4,7 @@ import io.kelta.mcp.client.GatewayHttpClient;
 import io.kelta.mcp.error.McpErrorMapper;
 import io.kelta.mcp.tool.AdminTool;
 import io.kelta.mcp.tool.Schemas;
+import io.kelta.mcp.tool.ToolHints;
 import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
@@ -32,8 +33,10 @@ public class ImportApiSpecTool implements AdminTool {
 
         Tool tool = Tool.builder()
                 .name("import_api_spec")
+                .title("Import API Spec")
                 .description("Import an external OpenAPI 3.x spec into the platform's API spec library. Operations are parsed and indexed so flows can call them. Wraps POST /api/api-specs/import. Returns a diff of added/changed/removed operations.")
                 .inputSchema(Schemas.object(properties, List.of("name", "raw")))
+                .annotations(ToolHints.write(false, false))
                 .build();
 
         return SyncToolSpecification.builder()

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/RemoveFieldTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/RemoveFieldTool.java
@@ -4,6 +4,7 @@ import io.kelta.mcp.client.GatewayHttpClient;
 import io.kelta.mcp.error.McpErrorMapper;
 import io.kelta.mcp.tool.AdminTool;
 import io.kelta.mcp.tool.Schemas;
+import io.kelta.mcp.tool.ToolHints;
 import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
@@ -32,8 +33,10 @@ public class RemoveFieldTool implements AdminTool {
 
         Tool tool = Tool.builder()
                 .name("remove_field")
+                .title("Remove Field")
                 .description("Remove a field from a collection. Wraps DELETE /api/fields/{id}. The field's data on existing records is dropped — irreversible.")
                 .inputSchema(Schemas.object(properties, List.of("id")))
+                .annotations(ToolHints.write(true, true))
                 .build();
 
         return SyncToolSpecification.builder()

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/UpdateCollectionTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/UpdateCollectionTool.java
@@ -4,6 +4,7 @@ import io.kelta.mcp.client.GatewayHttpClient;
 import io.kelta.mcp.error.McpErrorMapper;
 import io.kelta.mcp.tool.AdminTool;
 import io.kelta.mcp.tool.Schemas;
+import io.kelta.mcp.tool.ToolHints;
 import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
@@ -35,8 +36,10 @@ public class UpdateCollectionTool implements AdminTool {
 
         Tool tool = Tool.builder()
                 .name("update_collection")
+                .title("Update Collection")
                 .description("Update a collection's metadata (display field, description, tenant-scoping). PATCHes /api/collections/{id} — only supplied fields change.")
                 .inputSchema(Schemas.object(properties, List.of("id")))
+                .annotations(ToolHints.write(true, true))
                 .build();
 
         return SyncToolSpecification.builder()

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/UpdateFieldTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/UpdateFieldTool.java
@@ -4,6 +4,7 @@ import io.kelta.mcp.client.GatewayHttpClient;
 import io.kelta.mcp.error.McpErrorMapper;
 import io.kelta.mcp.tool.AdminTool;
 import io.kelta.mcp.tool.Schemas;
+import io.kelta.mcp.tool.ToolHints;
 import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
@@ -37,8 +38,10 @@ public class UpdateFieldTool implements AdminTool {
 
         Tool tool = Tool.builder()
                 .name("update_field")
+                .title("Update Field")
                 .description("Update a field's mutable attributes. Wraps PATCH /api/fields/{id}. Note: changing field type or fieldName is generally rejected by the platform — drop+recreate is the path for those.")
                 .inputSchema(Schemas.object(properties, List.of("id")))
+                .annotations(ToolHints.write(true, true))
                 .build();
 
         return SyncToolSpecification.builder()

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/UpdateFlowTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/UpdateFlowTool.java
@@ -4,6 +4,7 @@ import io.kelta.mcp.client.GatewayHttpClient;
 import io.kelta.mcp.error.McpErrorMapper;
 import io.kelta.mcp.tool.AdminTool;
 import io.kelta.mcp.tool.Schemas;
+import io.kelta.mcp.tool.ToolHints;
 import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
@@ -37,8 +38,10 @@ public class UpdateFlowTool implements AdminTool {
 
         Tool tool = Tool.builder()
                 .name("update_flow")
+                .title("Update Flow")
                 .description("Update an existing flow's metadata, definition, or active state. Wraps PATCH /api/flows/{id}. Toggling \"active\" enables or disables the trigger without redeploying the definition.")
                 .inputSchema(Schemas.object(properties, List.of("id")))
+                .annotations(ToolHints.write(true, true))
                 .build();
 
         return SyncToolSpecification.builder()

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/UpdateLayoutTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/UpdateLayoutTool.java
@@ -4,6 +4,7 @@ import io.kelta.mcp.client.GatewayHttpClient;
 import io.kelta.mcp.error.McpErrorMapper;
 import io.kelta.mcp.tool.AdminTool;
 import io.kelta.mcp.tool.Schemas;
+import io.kelta.mcp.tool.ToolHints;
 import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
@@ -35,8 +36,10 @@ public class UpdateLayoutTool implements AdminTool {
 
         Tool tool = Tool.builder()
                 .name("update_layout")
+                .title("Update Layout")
                 .description("Update a page layout's metadata (name, default flag, record type). PATCHes /api/pageLayouts/{id}. To restructure sections or fields, use delete_layout + create_layout — full section replacement isn't supported in a single tool call.")
                 .inputSchema(Schemas.object(properties, List.of("id")))
+                .annotations(ToolHints.write(true, true))
                 .build();
 
         return SyncToolSpecification.builder()

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/BulkApplyTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/BulkApplyTool.java
@@ -3,6 +3,7 @@ package io.kelta.mcp.tool.user;
 import io.kelta.mcp.client.GatewayHttpClient;
 import io.kelta.mcp.error.McpErrorMapper;
 import io.kelta.mcp.tool.Schemas;
+import io.kelta.mcp.tool.ToolHints;
 import io.kelta.mcp.tool.UserTool;
 import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
@@ -46,8 +47,10 @@ public class BulkApplyTool implements UserTool {
 
         Tool tool = Tool.builder()
                 .name("bulk_apply")
+                .title("Bulk Apply")
                 .description("Apply multiple record changes atomically via /api/_atomic. All operations succeed together or none do. Use this for multi-record changes that must roll back as a unit (e.g. moving line items between orders, rewiring relationships).")
                 .inputSchema(Schemas.object(properties, List.of("operations")))
+                .annotations(ToolHints.write(true, false))
                 .build();
 
         return SyncToolSpecification.builder()

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/CreateRecordTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/CreateRecordTool.java
@@ -3,6 +3,7 @@ package io.kelta.mcp.tool.user;
 import io.kelta.mcp.client.GatewayHttpClient;
 import io.kelta.mcp.error.McpErrorMapper;
 import io.kelta.mcp.tool.Schemas;
+import io.kelta.mcp.tool.ToolHints;
 import io.kelta.mcp.tool.UserTool;
 import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
@@ -36,8 +37,10 @@ public class CreateRecordTool implements UserTool {
 
         Tool tool = Tool.builder()
                 .name("create_record")
+                .title("Create Record")
                 .description("Create a single record in a collection. Wraps POST /api/{collection} in JSON:API format. Returns the created record on success (HTTP 201).")
                 .inputSchema(Schemas.object(properties, List.of("collection", "attributes")))
+                .annotations(ToolHints.write(false, false))
                 .build();
 
         return SyncToolSpecification.builder()

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/DeleteRecordTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/DeleteRecordTool.java
@@ -3,6 +3,7 @@ package io.kelta.mcp.tool.user;
 import io.kelta.mcp.client.GatewayHttpClient;
 import io.kelta.mcp.error.McpErrorMapper;
 import io.kelta.mcp.tool.Schemas;
+import io.kelta.mcp.tool.ToolHints;
 import io.kelta.mcp.tool.UserTool;
 import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
@@ -33,8 +34,10 @@ public class DeleteRecordTool implements UserTool {
 
         Tool tool = Tool.builder()
                 .name("delete_record")
+                .title("Delete Record")
                 .description("Delete a single record. Wraps DELETE /api/{collection}/{id}. Returns 204 No Content on success. Idempotent — deleting a non-existent record returns 404.")
                 .inputSchema(Schemas.object(properties, List.of("collection", "id")))
+                .annotations(ToolHints.write(true, true))
                 .build();
 
         return SyncToolSpecification.builder()

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/DescribeApiTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/DescribeApiTool.java
@@ -3,6 +3,7 @@ package io.kelta.mcp.tool.user;
 import io.kelta.mcp.client.GatewayHttpClient;
 import io.kelta.mcp.error.McpErrorMapper;
 import io.kelta.mcp.tool.Schemas;
+import io.kelta.mcp.tool.ToolHints;
 import io.kelta.mcp.tool.UserTool;
 import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
@@ -21,8 +22,10 @@ public class DescribeApiTool implements UserTool {
     public SyncToolSpecification toSpecification() {
         Tool tool = Tool.builder()
                 .name("describe_api")
+                .title("Describe API")
                 .description("Return the auto-generated OpenAPI 3.0 spec for the current tenant. The spec covers JSON:API CRUD on every collection — useful when you need exact request/response schemas. Specialized controllers (flows, approvals, bulk) are NOT in this spec; use the dedicated tools for those.")
                 .inputSchema(Schemas.empty())
+                .annotations(ToolHints.read())
                 .build();
 
         return SyncToolSpecification.builder()

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/ExecuteFlowTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/ExecuteFlowTool.java
@@ -3,6 +3,7 @@ package io.kelta.mcp.tool.user;
 import io.kelta.mcp.client.GatewayHttpClient;
 import io.kelta.mcp.error.McpErrorMapper;
 import io.kelta.mcp.tool.Schemas;
+import io.kelta.mcp.tool.ToolHints;
 import io.kelta.mcp.tool.UserTool;
 import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
@@ -34,8 +35,10 @@ public class ExecuteFlowTool implements UserTool {
 
         Tool tool = Tool.builder()
                 .name("execute_flow")
+                .title("Execute Flow")
                 .description("Trigger a flow execution. Returns the execution id; use get_flow_run to poll status.")
                 .inputSchema(Schemas.object(properties, List.of("flowId")))
+                .annotations(ToolHints.write(false, false))
                 .build();
 
         return SyncToolSpecification.builder()

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/GetCollectionSchemaTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/GetCollectionSchemaTool.java
@@ -4,6 +4,7 @@ import io.kelta.mcp.client.GatewayHttpClient;
 import io.kelta.mcp.error.McpErrorMapper;
 import io.kelta.mcp.tool.AdminTool;
 import io.kelta.mcp.tool.Schemas;
+import io.kelta.mcp.tool.ToolHints;
 import io.kelta.mcp.tool.UserTool;
 import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
@@ -34,8 +35,10 @@ public class GetCollectionSchemaTool implements UserTool, AdminTool {
 
         Tool tool = Tool.builder()
                 .name("get_collection_schema")
+                .title("Get Collection Schema")
                 .description("Return the full schema for a collection: metadata + all field definitions (type, required, unique, validation rules). Use this before constructing a query or create_record call to know what attributes are available.")
                 .inputSchema(Schemas.object(properties, List.of("collection")))
+                .annotations(ToolHints.read())
                 .build();
 
         return SyncToolSpecification.builder()

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/GetFlowRunTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/GetFlowRunTool.java
@@ -3,6 +3,7 @@ package io.kelta.mcp.tool.user;
 import io.kelta.mcp.client.GatewayHttpClient;
 import io.kelta.mcp.error.McpErrorMapper;
 import io.kelta.mcp.tool.Schemas;
+import io.kelta.mcp.tool.ToolHints;
 import io.kelta.mcp.tool.UserTool;
 import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
@@ -34,8 +35,10 @@ public class GetFlowRunTool implements UserTool {
 
         Tool tool = Tool.builder()
                 .name("get_flow_run")
+                .title("Get Flow Run")
                 .description("Fetch the status of a flow execution. Wraps GET /api/flows/executions/{executionId}, with optional step-by-step logs from /steps merged in. Use to poll a long-running flow.")
                 .inputSchema(Schemas.object(properties, List.of("executionId")))
+                .annotations(ToolHints.read())
                 .build();
 
         return SyncToolSpecification.builder()

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/GetRecordTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/GetRecordTool.java
@@ -3,6 +3,7 @@ package io.kelta.mcp.tool.user;
 import io.kelta.mcp.client.GatewayHttpClient;
 import io.kelta.mcp.error.McpErrorMapper;
 import io.kelta.mcp.tool.Schemas;
+import io.kelta.mcp.tool.ToolHints;
 import io.kelta.mcp.tool.UserTool;
 import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
@@ -36,8 +37,10 @@ public class GetRecordTool implements UserTool {
 
         Tool tool = Tool.builder()
                 .name("get_record")
+                .title("Get Record")
                 .description("Fetch a single record by id from a collection. Returns the JSON:API single-resource response.")
                 .inputSchema(Schemas.object(properties, List.of("collection", "id")))
+                .annotations(ToolHints.read())
                 .build();
 
         return SyncToolSpecification.builder()

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/ListApprovalsTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/ListApprovalsTool.java
@@ -3,6 +3,7 @@ package io.kelta.mcp.tool.user;
 import io.kelta.mcp.client.GatewayHttpClient;
 import io.kelta.mcp.error.McpErrorMapper;
 import io.kelta.mcp.tool.Schemas;
+import io.kelta.mcp.tool.ToolHints;
 import io.kelta.mcp.tool.UserTool;
 import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
@@ -34,8 +35,10 @@ public class ListApprovalsTool implements UserTool {
 
         Tool tool = Tool.builder()
                 .name("list_approvals")
+                .title("List Approvals")
                 .description("List approval instances, optionally filtered by status. Wraps the approvalInstances system collection. Useful to find what's waiting on you.")
                 .inputSchema(Schemas.object(properties, List.of()))
+                .annotations(ToolHints.read())
                 .build();
 
         return SyncToolSpecification.builder()

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/ListCollectionsTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/ListCollectionsTool.java
@@ -4,6 +4,7 @@ import io.kelta.mcp.client.GatewayHttpClient;
 import io.kelta.mcp.error.McpErrorMapper;
 import io.kelta.mcp.tool.AdminTool;
 import io.kelta.mcp.tool.Schemas;
+import io.kelta.mcp.tool.ToolHints;
 import io.kelta.mcp.tool.UserTool;
 import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
@@ -31,8 +32,10 @@ public class ListCollectionsTool implements UserTool, AdminTool {
 
         Tool tool = Tool.builder()
                 .name("list_collections")
+                .title("List Collections")
                 .description("List all collections available in the current tenant. Returns JSON:API formatted list with collection metadata. Use this to discover what data is available before querying.")
                 .inputSchema(Schemas.object(properties, List.of()))
+                .annotations(ToolHints.read())
                 .build();
 
         return SyncToolSpecification.builder()

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/QueryCollectionTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/QueryCollectionTool.java
@@ -3,6 +3,7 @@ package io.kelta.mcp.tool.user;
 import io.kelta.mcp.client.GatewayHttpClient;
 import io.kelta.mcp.error.McpErrorMapper;
 import io.kelta.mcp.tool.Schemas;
+import io.kelta.mcp.tool.ToolHints;
 import io.kelta.mcp.tool.UserTool;
 import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
@@ -79,6 +80,7 @@ public class QueryCollectionTool implements UserTool {
 
         Tool tool = Tool.builder()
                 .name("query_collection")
+                .title("Query Collection")
                 .description("""
                         List records from a Kelta collection (GET /api/{collection}). For one \
                         record by id use `get_record`; for full-text use `search`; for field \
@@ -108,6 +110,7 @@ public class QueryCollectionTool implements UserTool {
                             "pageSize": 25 }
                         """)
                 .inputSchema(Schemas.object(properties, List.of("collection")))
+                .annotations(ToolHints.read())
                 .build();
 
         return SyncToolSpecification.builder()

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/SearchTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/SearchTool.java
@@ -3,6 +3,7 @@ package io.kelta.mcp.tool.user;
 import io.kelta.mcp.client.GatewayHttpClient;
 import io.kelta.mcp.error.McpErrorMapper;
 import io.kelta.mcp.tool.Schemas;
+import io.kelta.mcp.tool.ToolHints;
 import io.kelta.mcp.tool.UserTool;
 import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
@@ -33,8 +34,10 @@ public class SearchTool implements UserTool {
 
         Tool tool = Tool.builder()
                 .name("search")
+                .title("Search")
                 .description("Cross-collection full-text search. Returns hits with collection name, record id, and matched snippet. Useful when you don't know which collection holds the answer.")
                 .inputSchema(Schemas.object(properties, List.of("query")))
+                .annotations(ToolHints.read())
                 .build();
 
         return SyncToolSpecification.builder()

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/SubmitForApprovalTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/SubmitForApprovalTool.java
@@ -3,6 +3,7 @@ package io.kelta.mcp.tool.user;
 import io.kelta.mcp.client.GatewayHttpClient;
 import io.kelta.mcp.error.McpErrorMapper;
 import io.kelta.mcp.tool.Schemas;
+import io.kelta.mcp.tool.ToolHints;
 import io.kelta.mcp.tool.UserTool;
 import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
@@ -34,8 +35,10 @@ public class SubmitForApprovalTool implements UserTool {
 
         Tool tool = Tool.builder()
                 .name("submit_for_approval")
+                .title("Submit for Approval")
                 .description("Submit a record for approval. Wraps POST /api/approvals/submit. Returns the new approval instance id; use list_approvals to track its status.")
                 .inputSchema(Schemas.object(properties, List.of("collectionId", "recordId")))
+                .annotations(ToolHints.write(false, false))
                 .build();
 
         return SyncToolSpecification.builder()

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/UpdateRecordTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/UpdateRecordTool.java
@@ -3,6 +3,7 @@ package io.kelta.mcp.tool.user;
 import io.kelta.mcp.client.GatewayHttpClient;
 import io.kelta.mcp.error.McpErrorMapper;
 import io.kelta.mcp.tool.Schemas;
+import io.kelta.mcp.tool.ToolHints;
 import io.kelta.mcp.tool.UserTool;
 import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
@@ -37,8 +38,10 @@ public class UpdateRecordTool implements UserTool {
 
         Tool tool = Tool.builder()
                 .name("update_record")
+                .title("Update Record")
                 .description("Update fields on a single record. Wraps PATCH /api/{collection}/{id}. Only the attributes you supply are modified — omitted fields keep their current values.")
                 .inputSchema(Schemas.object(properties, List.of("collection", "id")))
+                .annotations(ToolHints.write(true, true))
                 .build();
 
         return SyncToolSpecification.builder()

--- a/kelta-mcp/src/test/java/io/kelta/mcp/McpApplicationTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/McpApplicationTest.java
@@ -6,6 +6,8 @@ import io.kelta.mcp.tool.AdminTool;
 import io.kelta.mcp.tool.UserTool;
 import io.kelta.mcp.transport.KeltaMcpController;
 import io.modelcontextprotocol.server.McpSyncServer;
+import io.modelcontextprotocol.spec.McpSchema.Tool;
+import io.modelcontextprotocol.spec.McpSchema.ToolAnnotations;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -13,6 +15,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
 
 import java.util.List;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -133,6 +136,86 @@ class McpApplicationTest {
                 "create_flow",
                 "update_flow",
                 "import_api_spec");
+    }
+
+    @Test
+    void everyToolHasTitleAndAnnotations() {
+        // Every tool, user-side and admin-side, must publish a friendly title
+        // and the standard MCP safety hints. This pushes clients toward the
+        // right UX (preload safe reads, confirm destructive writes) and prevents
+        // a future tool from shipping with a blank annotations record.
+        List<Tool> all = java.util.stream.Stream.concat(
+                        userTools.stream().map(t -> t.toSpecification().tool()),
+                        adminTools.stream().map(t -> t.toSpecification().tool()))
+                .toList();
+
+        for (Tool t : all) {
+            assertThat(t.title())
+                    .as("tool %s must have a friendly title", t.name())
+                    .isNotBlank();
+            ToolAnnotations a = t.annotations();
+            assertThat(a)
+                    .as("tool %s must declare annotations", t.name())
+                    .isNotNull();
+            assertThat(a.openWorldHint())
+                    .as("tool %s must mark openWorldHint=true (calls the gateway)", t.name())
+                    .isTrue();
+            assertThat(a.readOnlyHint())
+                    .as("tool %s must declare readOnlyHint", t.name())
+                    .isNotNull();
+        }
+    }
+
+    @Test
+    void readToolsAreMarkedReadOnly() {
+        // Pinned by name so a future tool that switches kind without updating
+        // its hints fails this test loud and clear instead of silently
+        // misleading the client.
+        Set<String> readOnlyTools = Set.of(
+                "list_collections", "get_collection_schema", "query_collection",
+                "get_record", "search", "describe_api", "get_flow_run",
+                "list_approvals");
+        for (UserTool ut : userTools) {
+            Tool t = ut.toSpecification().tool();
+            if (!readOnlyTools.contains(t.name())) continue;
+            assertThat(t.annotations().readOnlyHint())
+                    .as("user tool %s should be read-only", t.name())
+                    .isTrue();
+            assertThat(t.annotations().idempotentHint())
+                    .as("user tool %s should be idempotent (read-only is always idempotent)", t.name())
+                    .isTrue();
+        }
+        // Shared admin-side reads.
+        for (AdminTool at : adminTools) {
+            Tool t = at.toSpecification().tool();
+            if (!Set.of("list_collections", "get_collection_schema").contains(t.name())) continue;
+            assertThat(t.annotations().readOnlyHint())
+                    .as("admin tool %s should be read-only", t.name())
+                    .isTrue();
+        }
+    }
+
+    @Test
+    void destructiveWritesAreMarkedDestructive() {
+        // Hard pin: tools that delete or overwrite must surface destructiveHint=true
+        // so clients can prompt for confirmation. Adding a destructive tool
+        // without flagging it here is a real safety regression — fail loud.
+        Set<String> destructive = Set.of(
+                "update_record", "delete_record", "bulk_apply",
+                "update_collection", "update_field", "remove_field",
+                "update_layout", "delete_layout", "update_flow");
+        for (UserTool ut : userTools) {
+            Tool t = ut.toSpecification().tool();
+            if (!destructive.contains(t.name())) continue;
+            assertThat(t.annotations().readOnlyHint()).as("%s readOnlyHint=false", t.name()).isFalse();
+            assertThat(t.annotations().destructiveHint()).as("%s destructiveHint=true", t.name()).isTrue();
+        }
+        for (AdminTool at : adminTools) {
+            Tool t = at.toSpecification().tool();
+            if (!destructive.contains(t.name())) continue;
+            assertThat(t.annotations().readOnlyHint()).as("%s readOnlyHint=false", t.name()).isFalse();
+            assertThat(t.annotations().destructiveHint()).as("%s destructiveHint=true", t.name()).isTrue();
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Every kelta MCP tool used to ship with **zero annotations** — clients had no signal which tools were safe reads vs. destructive mutations. This adds the standard MCP `ToolAnnotations` (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`) plus a friendly `title` to all 30 tools.
- Adds `ToolHints` helper with two factories: `read()` and `write(destructive, idempotent)`. All kelta tools call the gateway so `openWorldHint=true` is always set.
- Three coverage tests guarantee future tools can't ship without hints, and that read/destructive classifications stay correct.

## Classification

| Kind | Tools |
|---|---|
| **Read-only** (`readOnlyHint=true, idempotentHint=true`) | `list_collections`, `get_collection_schema`, `query_collection`, `get_record`, `search`, `describe_api`, `get_flow_run`, `list_approvals`, `ping` |
| **Non-destructive write** | `create_record`, `execute_flow`, `submit_for_approval`, `create_collection`, `add_field`, `create_validation_rule`, `create_picklist`, `create_layout`, `create_listview`, `create_flow`, `import_api_spec` |
| **Destructive write** (`destructiveHint=true`) | `update_record`, `delete_record`, `bulk_apply`, `update_collection`, `update_field`, `remove_field`, `update_layout`, `delete_layout`, `update_flow` |

## What clients get

- **Cursor / Claude Code CLI**: cleaner display names, more aggressive auto-approval of read tools, confirmation prompts on destructive ones.
- **Claude Desktop**: same — independent of the size-budget issue we fixed in #796, this is correctness/safety hygiene.
- **Future clients**: standard MCP signals they can pivot UX off, no kelta-specific knowledge required.

## Test plan

- [x] `mvn -f kelta-mcp/pom.xml test` — 129/129 unit tests pass
- [x] New `everyToolHasTitleAndAnnotations` walks all registered tools and asserts the contract
- [x] New `readToolsAreMarkedReadOnly` and `destructiveWritesAreMarkedDestructive` pin classifications by name so a future tool that flips kind without updating its hints fails loud
- [ ] Post-deploy: confirm `query_collection`, `list_collections`, etc. auto-approve on first use without a confirmation prompt
- [ ] Post-deploy: confirm `delete_record` shows a destructive-action warning before invocation

🤖 Generated with [Claude Code](https://claude.com/claude-code)