### PR TITLE
fix(mcp): get_collection_schema filters fields by collectionId, not collectionName

### DIFF
--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/GetCollectionSchemaTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/GetCollectionSchemaTool.java
@@ -10,6 +10,8 @@ import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
 import org.springframework.stereotype.Component;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -19,6 +21,8 @@ import java.util.Map;
 
 @Component
 public class GetCollectionSchemaTool implements UserTool, AdminTool {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     private final GatewayHttpClient gateway;
 
@@ -58,15 +62,27 @@ public class GetCollectionSchemaTool implements UserTool, AdminTool {
                             return McpErrorMapper.toResult(collectionRes);
                         }
 
-                        GatewayHttpClient.Response fieldsRes = gateway.get(
-                                "/api/fields?filter[collectionName][EQ]="
-                                        + URLEncoder.encode(collection, StandardCharsets.UTF_8)
-                                        + "&page[size]=200");
+                        // The fields system collection links each field to its parent
+                        // by `collectionId` (a UUID), NOT by `collectionName`. Filtering
+                        // on `collectionName` returns HTTP 400 from the worker because
+                        // that column doesn't exist on the FieldDefinition entity, so
+                        // we have to extract the collection's id from the first
+                        // response and use that.
+                        String collectionId = extractCollectionId(collectionRes.body());
+                        GatewayHttpClient.Response fieldsRes = collectionId == null
+                                ? null
+                                : gateway.get(
+                                        "/api/fields?filter[collectionId][EQ]="
+                                                + URLEncoder.encode(collectionId, StandardCharsets.UTF_8)
+                                                + "&page[size]=200");
 
+                        String fieldsBody = (fieldsRes != null && fieldsRes.isSuccess())
+                                ? fieldsRes.body()
+                                : "null";
                         String combined = "{\n  \"collection\": "
                                 + collectionRes.body()
                                 + ",\n  \"fields\": "
-                                + (fieldsRes.isSuccess() ? fieldsRes.body() : "null")
+                                + fieldsBody
                                 + "\n}";
                         return CallToolResult.builder()
                                 .content(List.of(new TextContent(combined)))
@@ -76,5 +92,21 @@ public class GetCollectionSchemaTool implements UserTool, AdminTool {
                     }
                 })
                 .build();
+    }
+
+    /**
+     * Pull {@code data.id} out of a JSON:API single-resource response body.
+     * Returns null on any parse failure or if the id is missing — callers
+     * fall back to skipping the fields fetch in that case.
+     */
+    static String extractCollectionId(String body) {
+        if (body == null || body.isBlank()) return null;
+        try {
+            JsonNode root = OBJECT_MAPPER.readTree(body);
+            JsonNode id = root.path("data").path("id");
+            return id.isMissingNode() || id.isNull() ? null : id.asString();
+        } catch (RuntimeException e) {
+            return null;
+        }
     }
 }

--- a/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/GetCollectionSchemaToolTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/GetCollectionSchemaToolTest.java
@@ -1,0 +1,142 @@
+package io.kelta.mcp.tool.user;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import io.kelta.mcp.auth.RequestPatHolder;
+import io.kelta.mcp.client.GatewayHttpClient;
+import io.kelta.mcp.config.McpProperties;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestClient;
+
+import java.util.Map;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GetCollectionSchemaToolTest {
+
+    private static final String COLLECTION_BODY = """
+            {"data":{"id":"ec000100-0000-0000-0000-000000000003",\
+            "type":"collections",\
+            "attributes":{"name":"customers","systemCollection":false}}}""";
+    private static final String FIELDS_BODY = """
+            {"metadata":{"totalCount":18},\
+            "data":[{"id":"f1","type":"fields","attributes":{"name":"phone"}}]}""";
+
+    private WireMockServer wm;
+    private GetCollectionSchemaTool tool;
+
+    @BeforeEach
+    void setUp() {
+        wm = new WireMockServer(0);
+        wm.start();
+        GatewayHttpClient client = new GatewayHttpClient(
+                RestClient.builder(),
+                new McpProperties("http://localhost:" + wm.port(), 30, 60_000, null));
+        tool = new GetCollectionSchemaTool(client);
+        RequestPatHolder.set("klt_schema_test");
+    }
+
+    @AfterEach
+    void tearDown() {
+        RequestPatHolder.clear();
+        wm.stop();
+    }
+
+    @Test
+    void extractCollectionIdParsesJsonApiSingleResource() {
+        assertThat(GetCollectionSchemaTool.extractCollectionId(COLLECTION_BODY))
+                .isEqualTo("ec000100-0000-0000-0000-000000000003");
+    }
+
+    @Test
+    void extractCollectionIdReturnsNullForMalformedBodies() {
+        assertThat(GetCollectionSchemaTool.extractCollectionId(null)).isNull();
+        assertThat(GetCollectionSchemaTool.extractCollectionId("")).isNull();
+        assertThat(GetCollectionSchemaTool.extractCollectionId("not json")).isNull();
+        assertThat(GetCollectionSchemaTool.extractCollectionId("{\"data\":{}}")).isNull();
+    }
+
+    @Test
+    void fieldsAreFilteredByCollectionIdNotName() {
+        // Regression: the previous version filtered on `filter[collectionName]`
+        // which the worker rejected with HTTP 400 because no such column exists
+        // on FieldDefinition. The fix looks up the collection, extracts its id,
+        // and filters by `filter[collectionId]` — the actual foreign key.
+        wm.stubFor(get(urlEqualTo("/api/collections/customers"))
+                .willReturn(aResponse().withStatus(200).withBody(COLLECTION_BODY)));
+        wm.stubFor(get(urlEqualTo(
+                "/api/fields?filter[collectionId][EQ]=ec000100-0000-0000-0000-000000000003&page[size]=200"))
+                .willReturn(aResponse().withStatus(200).withBody(FIELDS_BODY)));
+
+        SyncToolSpecification spec = tool.toSpecification();
+        CallToolResult result = spec.callHandler().apply(null,
+                new CallToolRequest("get_collection_schema",
+                        Map.of("collection", "customers"), null));
+
+        assertThat(result.isError()).isNotEqualTo(Boolean.TRUE);
+        String text = ((TextContent) result.content().get(0)).text();
+        assertThat(text)
+                .contains("\"collection\":")
+                .contains("\"fields\":")
+                .contains("phone");
+
+        // Pin: the second outbound request must use the collectionId UUID
+        // filter, not the old (broken) collectionName filter.
+        wm.verify(WireMock.getRequestedFor(urlEqualTo(
+                "/api/fields?filter[collectionId][EQ]=ec000100-0000-0000-0000-000000000003&page[size]=200")));
+        wm.verify(0, WireMock.getRequestedFor(WireMock.urlMatching(
+                "/api/fields\\?filter\\[collectionName\\]\\[EQ\\]=.*")));
+    }
+
+    @Test
+    void surfacesNullFieldsWhenIdCannotBeExtracted() {
+        // If the collection response is missing a parseable data.id, we
+        // skip the fields fetch and return fields=null rather than
+        // forwarding a bogus filter or crashing.
+        wm.stubFor(get(urlEqualTo("/api/collections/customers"))
+                .willReturn(aResponse().withStatus(200).withBody("{\"data\":{}}")));
+
+        CallToolResult result = tool.toSpecification().callHandler().apply(null,
+                new CallToolRequest("get_collection_schema",
+                        Map.of("collection", "customers"), null));
+
+        assertThat(result.isError()).isNotEqualTo(Boolean.TRUE);
+        String text = ((TextContent) result.content().get(0)).text();
+        assertThat(text).contains("\"fields\": null");
+        // No second request — we don't know what to filter by.
+        wm.verify(0, WireMock.getRequestedFor(WireMock.urlMatching("/api/fields.*")));
+    }
+
+    @Test
+    void surfacesErrorWhenCollectionLookupFails() {
+        wm.stubFor(get(urlEqualTo("/api/collections/nope"))
+                .willReturn(aResponse().withStatus(404).withBody("{\"errors\":[{\"status\":\"404\"}]}")));
+
+        CallToolResult result = tool.toSpecification().callHandler().apply(null,
+                new CallToolRequest("get_collection_schema",
+                        Map.of("collection", "nope"), null));
+
+        assertThat(result.isError()).isEqualTo(Boolean.TRUE);
+        // No fields fetch attempted.
+        wm.verify(0, WireMock.getRequestedFor(WireMock.urlMatching("/api/fields.*")));
+    }
+
+    @Test
+    void rejectsCallWithoutCollectionArg() {
+        SyncToolSpecification spec = tool.toSpecification();
+        CallToolResult result = spec.callHandler().apply(null,
+                new CallToolRequest("get_collection_schema", Map.of(), null));
+
+        assertThat(result.isError()).isEqualTo(Boolean.TRUE);
+        wm.verify(0, WireMock.anyRequestedFor(WireMock.anyUrl()));
+    }
+}


### PR DESCRIPTION
## Summary

`get_collection_schema` was returning `fields: null` for every collection because it filtered the fields lookup on `collectionName` — a column that doesn't exist on `FieldDefinition`. The fields system collection links to its parent by `collectionId` (UUID).

Verified against the live gateway:

```
GET /threadline-clothing/api/fields?filter[collectionName][EQ]=customers   → HTTP 400  (errors:[{}])
GET /threadline-clothing/api/fields?filter[collectionId][EQ]=ec000100-...   → HTTP 200  (totalCount: 18)
```

So the tool always saw HTTP 400 from the fields call, fell back to its `fieldsRes.isSuccess() ? body : "null"` branch, and the LLM concluded the customers collection had no fields.

Same shape of bug as `isSystem` → `systemCollection` (#795). Worker silently drops the unknown filter column → 400 in this case (because the fields collection isn't system) → MCP swallows it → caller sees null.

## Fix

- Parse `data.id` out of the `/api/collections/{nameOrId}` response (Jackson3, matching the pattern in `CreateLayoutTool.extractId`).
- Use that UUID in `filter[collectionId][EQ]={uuid}` for the second call.
- If `data.id` can't be extracted, skip the fields fetch and surface `fields: null` cleanly rather than forwarding a bogus filter.

## Test plan

- [x] `mvn -f kelta-mcp/pom.xml test` — 132/132 pass (was 126; +6 from the new `GetCollectionSchemaToolTest`)
- [x] New tests pin the URL shape — both that the fix uses `filter[collectionId]` and that the broken `filter[collectionName]` URL is never emitted again
- [x] Graceful-fallback test for malformed collection responses (missing data.id)
- [ ] Post-deploy: in Cursor, `get_collection_schema(collection: "customers")` should return all 18 fields for `threadline-clothing`

🤖 Generated with [Claude Code](https://claude.com/claude-code)