### PR TITLE
feat(mcp): switch to stateless transport so pod restarts are invisible to clients

### DIFF
--- a/kelta-mcp/src/main/java/io/kelta/mcp/config/McpServerConfig.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/config/McpServerConfig.java
@@ -10,10 +10,10 @@ import io.kelta.mcp.tool.AdminTool;
 import io.kelta.mcp.tool.Schemas;
 import io.kelta.mcp.tool.ToolHints;
 import io.kelta.mcp.tool.UserTool;
+import io.kelta.mcp.transport.HttpServletStatelessServerTransportProvider;
 import io.modelcontextprotocol.server.McpServer;
-import io.modelcontextprotocol.server.McpServerFeatures;
-import io.modelcontextprotocol.server.McpSyncServer;
-import io.modelcontextprotocol.server.transport.HttpServletStreamableServerTransportProvider;
+import io.modelcontextprotocol.server.McpStatelessServerFeatures;
+import io.modelcontextprotocol.server.McpStatelessSyncServer;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.ServerCapabilities;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
@@ -35,6 +35,20 @@ import java.util.List;
  * and its own resource registry. Tools registered on one server are NOT
  * visible from the other — this is the structural guarantee that prevents
  * an admin tool from being callable through the user endpoint.
+ *
+ * <p><b>Transport mode: stateless.</b> We use the SDK's
+ * {@code McpStatelessSyncServer} + a custom
+ * {@link HttpServletStatelessServerTransportProvider} adapter. The earlier
+ * streamable transport kept per-pod session state in memory, so every pod
+ * restart wiped the session map and the next request from a connected
+ * client returned {@code -32603 Session not found}. Stateless mode avoids
+ * the problem by construction — every request carries everything it needs
+ * (PAT in {@code Authorization}, tenant slug in the URL), so pod restarts
+ * are invisible to clients.
+ *
+ * <p>Trade-off: server-initiated SSE notifications ({@code listChanged},
+ * resource subscriptions) aren't available in stateless mode. We don't use
+ * those today and aren't planning to.
  */
 @Configuration
 @EnableScheduling
@@ -45,52 +59,48 @@ public class McpServerConfig {
     private static final String SERVER_VERSION = "1.0.0";
 
     @Bean(name = "userTransportProvider")
-    public HttpServletStreamableServerTransportProvider userTransportProvider() {
-        return HttpServletStreamableServerTransportProvider.builder()
-                .mcpEndpoint("/mcp/user")
-                .contextExtractor(new KeltaTransportContextExtractor())
-                .build();
+    public HttpServletStatelessServerTransportProvider userTransportProvider() {
+        return new HttpServletStatelessServerTransportProvider(
+                new KeltaTransportContextExtractor());
     }
 
     @Bean(name = "adminTransportProvider")
-    public HttpServletStreamableServerTransportProvider adminTransportProvider() {
-        return HttpServletStreamableServerTransportProvider.builder()
-                .mcpEndpoint("/mcp/admin")
-                .contextExtractor(new KeltaTransportContextExtractor())
-                .build();
+    public HttpServletStatelessServerTransportProvider adminTransportProvider() {
+        return new HttpServletStatelessServerTransportProvider(
+                new KeltaTransportContextExtractor());
     }
 
     @Bean(name = "userMcpServer")
-    public McpSyncServer userMcpServer(
+    public McpStatelessSyncServer userMcpServer(
             @org.springframework.beans.factory.annotation.Qualifier("userTransportProvider")
-            HttpServletStreamableServerTransportProvider transport,
+            HttpServletStatelessServerTransportProvider transport,
             List<UserTool> userTools,
             List<UserResource> userResources,
             List<UserResourceTemplate> userResourceTemplates,
             ObservedToolDecorator decorator,
             RateLimitedToolDecorator rateLimiter,
             PatPropagatingToolDecorator patPropagator) {
-        McpSyncServer server = McpServer.sync(transport)
+        McpStatelessSyncServer server = McpServer.sync(transport)
                 .serverInfo(SERVER_NAME + "-user", SERVER_VERSION)
                 .capabilities(ServerCapabilities.builder()
                         .tools(true)
-                        .resources(false, true)  // (subscribe, listChanged)
+                        .resources(false, false)  // (subscribe, listChanged): both off in stateless
                         .build())
                 .build();
         server.addTool(wrap(pingTool("user"), "user", decorator, rateLimiter, patPropagator));
         for (UserTool tool : userTools) {
-            McpServerFeatures.SyncToolSpecification spec = wrap(
+            McpStatelessServerFeatures.SyncToolSpecification spec = wrap(
                     tool.toSpecification(), "user", decorator, rateLimiter, patPropagator);
             server.addTool(spec);
             log.info("Registered user tool: {}", spec.tool().name());
         }
         for (UserResource resource : userResources) {
-            McpServerFeatures.SyncResourceSpecification spec = resource.toSpecification();
+            McpStatelessServerFeatures.SyncResourceSpecification spec = resource.toSpecification();
             server.addResource(spec);
             log.info("Registered user resource: {}", spec.resource().uri());
         }
         for (UserResourceTemplate template : userResourceTemplates) {
-            McpServerFeatures.SyncResourceTemplateSpecification spec = template.toSpecification();
+            McpStatelessServerFeatures.SyncResourceTemplateSpecification spec = template.toSpecification();
             server.addResourceTemplate(spec);
             log.info("Registered user resource template: {}", spec.resourceTemplate().uriTemplate());
         }
@@ -98,20 +108,20 @@ public class McpServerConfig {
     }
 
     @Bean(name = "adminMcpServer")
-    public McpSyncServer adminMcpServer(
+    public McpStatelessSyncServer adminMcpServer(
             @org.springframework.beans.factory.annotation.Qualifier("adminTransportProvider")
-            HttpServletStreamableServerTransportProvider transport,
+            HttpServletStatelessServerTransportProvider transport,
             List<AdminTool> adminTools,
             ObservedToolDecorator decorator,
             RateLimitedToolDecorator rateLimiter,
             PatPropagatingToolDecorator patPropagator) {
-        McpSyncServer server = McpServer.sync(transport)
+        McpStatelessSyncServer server = McpServer.sync(transport)
                 .serverInfo(SERVER_NAME + "-admin", SERVER_VERSION)
                 .capabilities(ServerCapabilities.builder().tools(true).build())
                 .build();
         server.addTool(wrap(pingTool("admin"), "admin", decorator, rateLimiter, patPropagator));
         for (AdminTool tool : adminTools) {
-            McpServerFeatures.SyncToolSpecification spec = wrap(
+            McpStatelessServerFeatures.SyncToolSpecification spec = wrap(
                     tool.toSpecification(), "admin", decorator, rateLimiter, patPropagator);
             server.addTool(spec);
             log.info("Registered admin tool: {}", spec.tool().name());
@@ -122,15 +132,15 @@ public class McpServerConfig {
     /**
      * Decorator stack, outermost → innermost:
      *  1. PAT propagator — copies the PAT from McpTransportContext into
-     *     the per-thread RequestPatHolder (handlers run on a Reactor
-     *     scheduler thread, not the servlet thread).
+     *     the per-thread RequestPatHolder (the gateway client reads it
+     *     from there).
      *  2. Rate limiter — keys its bucket on the now-populated PAT;
      *     rate-limited calls return an error before observation runs.
      *  3. Observation — timer + counter, tagged with status.
      *  4. Original tool.
      */
-    private static McpServerFeatures.SyncToolSpecification wrap(
-            McpServerFeatures.SyncToolSpecification original,
+    private static McpStatelessServerFeatures.SyncToolSpecification wrap(
+            McpStatelessServerFeatures.SyncToolSpecification original,
             String profile,
             ObservedToolDecorator observed,
             RateLimitedToolDecorator rateLimited,
@@ -145,10 +155,10 @@ public class McpServerConfig {
     // ServletRegistrationBean. KeltaMcpController dispatches to them via
     // @RequestMapping("/{tenantSlug}/mcp/{profile:user|admin}") so the slug
     // stays in the URL end-to-end. The transports are still Spring beans
-    // (above) so McpSyncServer can attach them to its tool/resource registries
+    // (above) so McpServer can attach them to its tool/resource registries
     // — they're just not bound to a servlet container path.
 
-    private McpServerFeatures.SyncToolSpecification pingTool(String profile) {
+    private McpStatelessServerFeatures.SyncToolSpecification pingTool(String profile) {
         Tool tool = Tool.builder()
                 .name("ping")
                 .title("Ping (" + profile + ")")
@@ -157,9 +167,9 @@ public class McpServerConfig {
                 .annotations(ToolHints.read())
                 .build();
 
-        return McpServerFeatures.SyncToolSpecification.builder()
+        return McpStatelessServerFeatures.SyncToolSpecification.builder()
                 .tool(tool)
-                .callHandler((exchange, request) -> CallToolResult.builder()
+                .callHandler((context, request) -> CallToolResult.builder()
                         .content(List.of(new TextContent("pong (" + profile + ")")))
                         .build())
                 .build();

--- a/kelta-mcp/src/main/java/io/kelta/mcp/observe/ObservedToolDecorator.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/observe/ObservedToolDecorator.java
@@ -3,7 +3,7 @@ package io.kelta.mcp.observe;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.Timer;
-import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import org.slf4j.MDC;
 import org.springframework.stereotype.Component;
@@ -39,13 +39,13 @@ public class ObservedToolDecorator {
 
         return SyncToolSpecification.builder()
                 .tool(original.tool())
-                .callHandler((exchange, request) -> {
+                .callHandler((context, request) -> {
                     long startNs = System.nanoTime();
                     String status = "success";
                     MDC.put("mcpTool", toolName);
                     MDC.put("mcpProfile", profile);
                     try {
-                        CallToolResult result = originalHandler.apply(exchange, request);
+                        CallToolResult result = originalHandler.apply(context, request);
                         if (Boolean.TRUE.equals(result.isError())) {
                             status = "error";
                         }

--- a/kelta-mcp/src/main/java/io/kelta/mcp/observe/PatPropagatingToolDecorator.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/observe/PatPropagatingToolDecorator.java
@@ -3,7 +3,7 @@ package io.kelta.mcp.observe;
 import io.kelta.mcp.auth.KeltaTransportContextExtractor;
 import io.kelta.mcp.auth.RequestPatHolder;
 import io.kelta.mcp.auth.RequestSlugHolder;
-import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncToolSpecification;
 import org.springframework.stereotype.Component;
 
 /**
@@ -12,13 +12,17 @@ import org.springframework.stereotype.Component;
  * during HTTP intake) into thread-local holders for the duration
  * of the tool handler.
  *
- * <p>Why this exists: the MCP SDK dispatches sync tool handlers on
- * Reactor scheduler threads, not the servlet thread. The
- * {@code ThreadLocal} the auth filter populates on the inbound
- * thread is therefore invisible to the handler. The transport
- * context is the SDK-blessed mechanism for thread-safe propagation;
- * this decorator bridges it back into the holders the downstream
- * HTTP client reads from.
+ * <p>Why this exists: the gateway HTTP client reads PAT/slug from
+ * thread-local holders rather than threading the context through
+ * every method signature. The transport context is the SDK-blessed
+ * mechanism for thread-safe propagation; this decorator bridges it
+ * back into the holders the gateway client reads from.
+ *
+ * <p>In stateless mode the {@code McpTransportContext} flows directly
+ * to the tool handler as the first BiFunction argument — no
+ * {@code exchange.transportContext()} hop needed (and no Reactor
+ * scheduler thread switch in the way), so this decorator is now a
+ * straight set-then-clear around the inner handler.
  *
  * <p>Two pieces of data ride along:
  * <ul>
@@ -39,19 +43,19 @@ public class PatPropagatingToolDecorator {
         var inner = original.callHandler();
         return SyncToolSpecification.builder()
                 .tool(original.tool())
-                .callHandler((exchange, request) -> {
+                .callHandler((context, request) -> {
                     String pat = null;
                     String slug = null;
-                    if (exchange != null && exchange.transportContext() != null) {
-                        Object patValue = exchange.transportContext().get(KeltaTransportContextExtractor.PAT_KEY);
+                    if (context != null) {
+                        Object patValue = context.get(KeltaTransportContextExtractor.PAT_KEY);
                         if (patValue instanceof String s) pat = s;
-                        Object slugValue = exchange.transportContext().get(KeltaTransportContextExtractor.TENANT_SLUG_KEY);
+                        Object slugValue = context.get(KeltaTransportContextExtractor.TENANT_SLUG_KEY);
                         if (slugValue instanceof String s) slug = s;
                     }
                     if (pat != null) RequestPatHolder.set(pat);
                     if (slug != null) RequestSlugHolder.set(slug);
                     try {
-                        return inner.apply(exchange, request);
+                        return inner.apply(context, request);
                     } finally {
                         RequestSlugHolder.clear();
                         RequestPatHolder.clear();

--- a/kelta-mcp/src/main/java/io/kelta/mcp/observe/RateLimitedToolDecorator.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/observe/RateLimitedToolDecorator.java
@@ -3,7 +3,7 @@ package io.kelta.mcp.observe;
 import io.kelta.mcp.auth.RequestPatHolder;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
-import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
 import org.springframework.stereotype.Component;
@@ -40,7 +40,7 @@ public class RateLimitedToolDecorator {
 
         return SyncToolSpecification.builder()
                 .tool(original.tool())
-                .callHandler((exchange, request) -> {
+                .callHandler((context, request) -> {
                     String pat = RequestPatHolder.get();
                     String bucketKey = pat == null ? "anonymous" : pat;
                     if (!limiter.tryAcquire(bucketKey)) {
@@ -56,7 +56,7 @@ public class RateLimitedToolDecorator {
                                         + "Slow down and retry shortly.")))
                                 .build();
                     }
-                    return inner.apply(exchange, request);
+                    return inner.apply(context, request);
                 })
                 .build();
     }

--- a/kelta-mcp/src/main/java/io/kelta/mcp/resource/UserResource.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/resource/UserResource.java
@@ -1,6 +1,6 @@
 package io.kelta.mcp.resource;
 
-import io.modelcontextprotocol.server.McpServerFeatures.SyncResourceSpecification;
+import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncResourceSpecification;
 
 /**
  * Marker interface for static resources registered on {@code /mcp/user}.

--- a/kelta-mcp/src/main/java/io/kelta/mcp/resource/UserResourceTemplate.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/resource/UserResourceTemplate.java
@@ -1,6 +1,6 @@
 package io.kelta.mcp.resource;
 
-import io.modelcontextprotocol.server.McpServerFeatures.SyncResourceTemplateSpecification;
+import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncResourceTemplateSpecification;
 
 /**
  * Marker interface for templated resources registered on {@code /mcp/user}.

--- a/kelta-mcp/src/main/java/io/kelta/mcp/resource/user/CollectionSchemaResource.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/resource/user/CollectionSchemaResource.java
@@ -2,7 +2,7 @@ package io.kelta.mcp.resource.user;
 
 import io.kelta.mcp.client.GatewayHttpClient;
 import io.kelta.mcp.resource.UserResourceTemplate;
-import io.modelcontextprotocol.server.McpServerFeatures.SyncResourceTemplateSpecification;
+import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncResourceTemplateSpecification;
 import io.modelcontextprotocol.spec.McpSchema.ReadResourceResult;
 import io.modelcontextprotocol.spec.McpSchema.ResourceTemplate;
 import io.modelcontextprotocol.spec.McpSchema.TextResourceContents;
@@ -40,7 +40,7 @@ public class CollectionSchemaResource implements UserResourceTemplate {
                 .mimeType("application/json")
                 .build();
 
-        return new SyncResourceTemplateSpecification(template, (exchange, request) -> {
+        return new SyncResourceTemplateSpecification(template, (context, request) -> {
             String requestUri = request.uri();
             Matcher m = URI_PATTERN.matcher(requestUri);
             String body;

--- a/kelta-mcp/src/main/java/io/kelta/mcp/resource/user/CollectionsResource.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/resource/user/CollectionsResource.java
@@ -2,7 +2,7 @@ package io.kelta.mcp.resource.user;
 
 import io.kelta.mcp.client.GatewayHttpClient;
 import io.kelta.mcp.resource.UserResource;
-import io.modelcontextprotocol.server.McpServerFeatures.SyncResourceSpecification;
+import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncResourceSpecification;
 import io.modelcontextprotocol.spec.McpSchema.ReadResourceResult;
 import io.modelcontextprotocol.spec.McpSchema.Resource;
 import io.modelcontextprotocol.spec.McpSchema.TextResourceContents;
@@ -34,7 +34,7 @@ public class CollectionsResource implements UserResource {
                 .mimeType("application/json")
                 .build();
 
-        return new SyncResourceSpecification(resource, (exchange, request) -> {
+        return new SyncResourceSpecification(resource, (context, request) -> {
             GatewayHttpClient.Response response = gateway.get("/api/collections");
             String body = response.isSuccess()
                     ? response.body()

--- a/kelta-mcp/src/main/java/io/kelta/mcp/resource/user/OpenApiSpecResource.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/resource/user/OpenApiSpecResource.java
@@ -2,7 +2,7 @@ package io.kelta.mcp.resource.user;
 
 import io.kelta.mcp.client.GatewayHttpClient;
 import io.kelta.mcp.resource.UserResource;
-import io.modelcontextprotocol.server.McpServerFeatures.SyncResourceSpecification;
+import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncResourceSpecification;
 import io.modelcontextprotocol.spec.McpSchema.ReadResourceResult;
 import io.modelcontextprotocol.spec.McpSchema.Resource;
 import io.modelcontextprotocol.spec.McpSchema.TextResourceContents;
@@ -38,7 +38,7 @@ public class OpenApiSpecResource implements UserResource {
                 .mimeType("application/json")
                 .build();
 
-        return new SyncResourceSpecification(resource, (exchange, request) -> {
+        return new SyncResourceSpecification(resource, (context, request) -> {
             GatewayHttpClient.Response response = gateway.get("/api/docs/openapi.json");
             String body = response.isSuccess()
                     ? response.body()

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/AdminTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/AdminTool.java
@@ -1,6 +1,6 @@
 package io.kelta.mcp.tool;
 
-import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncToolSpecification;
 
 /**
  * Marker interface for tools registered on the {@code /mcp/admin}

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/UserTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/UserTool.java
@@ -1,6 +1,6 @@
 package io.kelta.mcp.tool;
 
-import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncToolSpecification;
 
 /**
  * Marker interface for tools registered on the {@code /mcp/user}

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/AddFieldTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/AddFieldTool.java
@@ -5,7 +5,7 @@ import io.kelta.mcp.error.McpErrorMapper;
 import io.kelta.mcp.tool.AdminTool;
 import io.kelta.mcp.tool.Schemas;
 import io.kelta.mcp.tool.ToolHints;
-import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
@@ -50,7 +50,7 @@ public class AddFieldTool implements AdminTool {
 
         return SyncToolSpecification.builder()
                 .tool(tool)
-                .callHandler((exchange, request) -> {
+                .callHandler((context, request) -> {
                     Map<String, Object> args = request.arguments();
                     if (args == null) args = Map.of();
                     Object cn = args.get("collectionName");

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/CreateCollectionTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/CreateCollectionTool.java
@@ -5,7 +5,7 @@ import io.kelta.mcp.error.McpErrorMapper;
 import io.kelta.mcp.tool.AdminTool;
 import io.kelta.mcp.tool.Schemas;
 import io.kelta.mcp.tool.ToolHints;
-import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
@@ -73,7 +73,7 @@ public class CreateCollectionTool implements AdminTool {
 
         return SyncToolSpecification.builder()
                 .tool(tool)
-                .callHandler((exchange, request) -> {
+                .callHandler((context, request) -> {
                     Map<String, Object> args = request.arguments();
                     if (args == null) args = Map.of();
                     Object n = args.get("name");

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/CreateFlowTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/CreateFlowTool.java
@@ -5,7 +5,7 @@ import io.kelta.mcp.error.McpErrorMapper;
 import io.kelta.mcp.tool.AdminTool;
 import io.kelta.mcp.tool.Schemas;
 import io.kelta.mcp.tool.ToolHints;
-import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
@@ -47,7 +47,7 @@ public class CreateFlowTool implements AdminTool {
 
         return SyncToolSpecification.builder()
                 .tool(tool)
-                .callHandler((exchange, request) -> {
+                .callHandler((context, request) -> {
                     Map<String, Object> args = request.arguments();
                     if (args == null) args = Map.of();
                     Object name = args.get("name");

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/CreateLayoutTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/CreateLayoutTool.java
@@ -5,7 +5,7 @@ import io.kelta.mcp.error.McpErrorMapper;
 import io.kelta.mcp.tool.AdminTool;
 import io.kelta.mcp.tool.Schemas;
 import io.kelta.mcp.tool.ToolHints;
-import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
@@ -95,7 +95,7 @@ public class CreateLayoutTool implements AdminTool {
 
         return SyncToolSpecification.builder()
                 .tool(tool)
-                .callHandler((exchange, request) -> {
+                .callHandler((context, request) -> {
                     Map<String, Object> args = request.arguments();
                     if (args == null) args = Map.of();
                     Object n = args.get("name");

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/CreateListViewTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/CreateListViewTool.java
@@ -5,7 +5,7 @@ import io.kelta.mcp.error.McpErrorMapper;
 import io.kelta.mcp.tool.AdminTool;
 import io.kelta.mcp.tool.Schemas;
 import io.kelta.mcp.tool.ToolHints;
-import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
@@ -46,7 +46,7 @@ public class CreateListViewTool implements AdminTool {
 
         return SyncToolSpecification.builder()
                 .tool(tool)
-                .callHandler((exchange, request) -> {
+                .callHandler((context, request) -> {
                     Map<String, Object> args = request.arguments();
                     if (args == null) args = Map.of();
                     Object cn = args.get("collectionName");

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/CreatePicklistTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/CreatePicklistTool.java
@@ -5,7 +5,7 @@ import io.kelta.mcp.error.McpErrorMapper;
 import io.kelta.mcp.tool.AdminTool;
 import io.kelta.mcp.tool.Schemas;
 import io.kelta.mcp.tool.ToolHints;
-import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
@@ -63,7 +63,7 @@ public class CreatePicklistTool implements AdminTool {
 
         return SyncToolSpecification.builder()
                 .tool(tool)
-                .callHandler((exchange, request) -> {
+                .callHandler((context, request) -> {
                     Map<String, Object> args = request.arguments();
                     if (args == null) args = Map.of();
                     Object n = args.get("name");

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/CreateValidationRuleTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/CreateValidationRuleTool.java
@@ -5,7 +5,7 @@ import io.kelta.mcp.error.McpErrorMapper;
 import io.kelta.mcp.tool.AdminTool;
 import io.kelta.mcp.tool.Schemas;
 import io.kelta.mcp.tool.ToolHints;
-import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
@@ -46,7 +46,7 @@ public class CreateValidationRuleTool implements AdminTool {
 
         return SyncToolSpecification.builder()
                 .tool(tool)
-                .callHandler((exchange, request) -> {
+                .callHandler((context, request) -> {
                     Map<String, Object> args = request.arguments();
                     if (args == null) args = Map.of();
                     Object cn = args.get("collectionName");

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/DeleteLayoutTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/DeleteLayoutTool.java
@@ -5,7 +5,7 @@ import io.kelta.mcp.error.McpErrorMapper;
 import io.kelta.mcp.tool.AdminTool;
 import io.kelta.mcp.tool.Schemas;
 import io.kelta.mcp.tool.ToolHints;
-import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
@@ -41,7 +41,7 @@ public class DeleteLayoutTool implements AdminTool {
 
         return SyncToolSpecification.builder()
                 .tool(tool)
-                .callHandler((exchange, request) -> {
+                .callHandler((context, request) -> {
                     Map<String, Object> args = request.arguments();
                     if (args == null) args = Map.of();
                     Object id = args.get("id");

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/ImportApiSpecTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/ImportApiSpecTool.java
@@ -5,7 +5,7 @@ import io.kelta.mcp.error.McpErrorMapper;
 import io.kelta.mcp.tool.AdminTool;
 import io.kelta.mcp.tool.Schemas;
 import io.kelta.mcp.tool.ToolHints;
-import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
@@ -41,7 +41,7 @@ public class ImportApiSpecTool implements AdminTool {
 
         return SyncToolSpecification.builder()
                 .tool(tool)
-                .callHandler((exchange, request) -> {
+                .callHandler((context, request) -> {
                     Map<String, Object> args = request.arguments();
                     if (args == null) args = Map.of();
                     Object n = args.get("name");

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/RemoveFieldTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/RemoveFieldTool.java
@@ -5,7 +5,7 @@ import io.kelta.mcp.error.McpErrorMapper;
 import io.kelta.mcp.tool.AdminTool;
 import io.kelta.mcp.tool.Schemas;
 import io.kelta.mcp.tool.ToolHints;
-import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
@@ -41,7 +41,7 @@ public class RemoveFieldTool implements AdminTool {
 
         return SyncToolSpecification.builder()
                 .tool(tool)
-                .callHandler((exchange, request) -> {
+                .callHandler((context, request) -> {
                     Map<String, Object> args = request.arguments();
                     if (args == null) args = Map.of();
                     Object id = args.get("id");

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/UpdateCollectionTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/UpdateCollectionTool.java
@@ -5,7 +5,7 @@ import io.kelta.mcp.error.McpErrorMapper;
 import io.kelta.mcp.tool.AdminTool;
 import io.kelta.mcp.tool.Schemas;
 import io.kelta.mcp.tool.ToolHints;
-import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
@@ -44,7 +44,7 @@ public class UpdateCollectionTool implements AdminTool {
 
         return SyncToolSpecification.builder()
                 .tool(tool)
-                .callHandler((exchange, request) -> {
+                .callHandler((context, request) -> {
                     Map<String, Object> args = request.arguments();
                     if (args == null) args = Map.of();
                     Object id = args.get("id");

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/UpdateFieldTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/UpdateFieldTool.java
@@ -5,7 +5,7 @@ import io.kelta.mcp.error.McpErrorMapper;
 import io.kelta.mcp.tool.AdminTool;
 import io.kelta.mcp.tool.Schemas;
 import io.kelta.mcp.tool.ToolHints;
-import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
@@ -46,7 +46,7 @@ public class UpdateFieldTool implements AdminTool {
 
         return SyncToolSpecification.builder()
                 .tool(tool)
-                .callHandler((exchange, request) -> {
+                .callHandler((context, request) -> {
                     Map<String, Object> args = request.arguments();
                     if (args == null) args = Map.of();
                     Object id = args.get("id");

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/UpdateFlowTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/UpdateFlowTool.java
@@ -5,7 +5,7 @@ import io.kelta.mcp.error.McpErrorMapper;
 import io.kelta.mcp.tool.AdminTool;
 import io.kelta.mcp.tool.Schemas;
 import io.kelta.mcp.tool.ToolHints;
-import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
@@ -46,7 +46,7 @@ public class UpdateFlowTool implements AdminTool {
 
         return SyncToolSpecification.builder()
                 .tool(tool)
-                .callHandler((exchange, request) -> {
+                .callHandler((context, request) -> {
                     Map<String, Object> args = request.arguments();
                     if (args == null) args = Map.of();
                     Object id = args.get("id");

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/UpdateLayoutTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/UpdateLayoutTool.java
@@ -5,7 +5,7 @@ import io.kelta.mcp.error.McpErrorMapper;
 import io.kelta.mcp.tool.AdminTool;
 import io.kelta.mcp.tool.Schemas;
 import io.kelta.mcp.tool.ToolHints;
-import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
@@ -44,7 +44,7 @@ public class UpdateLayoutTool implements AdminTool {
 
         return SyncToolSpecification.builder()
                 .tool(tool)
-                .callHandler((exchange, request) -> {
+                .callHandler((context, request) -> {
                     Map<String, Object> args = request.arguments();
                     if (args == null) args = Map.of();
                     Object id = args.get("id");

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/BulkApplyTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/BulkApplyTool.java
@@ -5,7 +5,7 @@ import io.kelta.mcp.error.McpErrorMapper;
 import io.kelta.mcp.tool.Schemas;
 import io.kelta.mcp.tool.ToolHints;
 import io.kelta.mcp.tool.UserTool;
-import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
@@ -55,7 +55,7 @@ public class BulkApplyTool implements UserTool {
 
         return SyncToolSpecification.builder()
                 .tool(tool)
-                .callHandler((exchange, request) -> {
+                .callHandler((context, request) -> {
                     Map<String, Object> args = request.arguments();
                     if (args == null) args = Map.of();
                     Object opsObj = args.get("operations");

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/CreateRecordTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/CreateRecordTool.java
@@ -5,7 +5,7 @@ import io.kelta.mcp.error.McpErrorMapper;
 import io.kelta.mcp.tool.Schemas;
 import io.kelta.mcp.tool.ToolHints;
 import io.kelta.mcp.tool.UserTool;
-import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
@@ -45,7 +45,7 @@ public class CreateRecordTool implements UserTool {
 
         return SyncToolSpecification.builder()
                 .tool(tool)
-                .callHandler((exchange, request) -> {
+                .callHandler((context, request) -> {
                     Map<String, Object> args = request.arguments();
                     if (args == null) args = Map.of();
                     Object cv = args.get("collection");

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/DeleteRecordTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/DeleteRecordTool.java
@@ -5,7 +5,7 @@ import io.kelta.mcp.error.McpErrorMapper;
 import io.kelta.mcp.tool.Schemas;
 import io.kelta.mcp.tool.ToolHints;
 import io.kelta.mcp.tool.UserTool;
-import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
@@ -42,7 +42,7 @@ public class DeleteRecordTool implements UserTool {
 
         return SyncToolSpecification.builder()
                 .tool(tool)
-                .callHandler((exchange, request) -> {
+                .callHandler((context, request) -> {
                     Map<String, Object> args = request.arguments();
                     if (args == null) args = Map.of();
                     Object cv = args.get("collection");

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/DescribeApiTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/DescribeApiTool.java
@@ -5,7 +5,7 @@ import io.kelta.mcp.error.McpErrorMapper;
 import io.kelta.mcp.tool.Schemas;
 import io.kelta.mcp.tool.ToolHints;
 import io.kelta.mcp.tool.UserTool;
-import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
 import org.springframework.stereotype.Component;
 
@@ -30,7 +30,7 @@ public class DescribeApiTool implements UserTool {
 
         return SyncToolSpecification.builder()
                 .tool(tool)
-                .callHandler((exchange, request) -> {
+                .callHandler((context, request) -> {
                     try {
                         return McpErrorMapper.toResult(gateway.get("/api/docs/openapi.json"));
                     } catch (RuntimeException e) {

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/ExecuteFlowTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/ExecuteFlowTool.java
@@ -5,7 +5,7 @@ import io.kelta.mcp.error.McpErrorMapper;
 import io.kelta.mcp.tool.Schemas;
 import io.kelta.mcp.tool.ToolHints;
 import io.kelta.mcp.tool.UserTool;
-import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
@@ -43,7 +43,7 @@ public class ExecuteFlowTool implements UserTool {
 
         return SyncToolSpecification.builder()
                 .tool(tool)
-                .callHandler((exchange, request) -> {
+                .callHandler((context, request) -> {
                     Map<String, Object> args = request.arguments();
                     if (args == null) args = Map.of();
                     Object f = args.get("flowId");

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/GetCollectionSchemaTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/GetCollectionSchemaTool.java
@@ -6,7 +6,7 @@ import io.kelta.mcp.tool.AdminTool;
 import io.kelta.mcp.tool.Schemas;
 import io.kelta.mcp.tool.ToolHints;
 import io.kelta.mcp.tool.UserTool;
-import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
@@ -47,7 +47,7 @@ public class GetCollectionSchemaTool implements UserTool, AdminTool {
 
         return SyncToolSpecification.builder()
                 .tool(tool)
-                .callHandler((exchange, request) -> {
+                .callHandler((context, request) -> {
                     Map<String, Object> args = request.arguments();
                     Object cv = args == null ? null : args.get("collection");
                     if (cv == null || cv.toString().isBlank()) {

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/GetFlowRunTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/GetFlowRunTool.java
@@ -5,7 +5,7 @@ import io.kelta.mcp.error.McpErrorMapper;
 import io.kelta.mcp.tool.Schemas;
 import io.kelta.mcp.tool.ToolHints;
 import io.kelta.mcp.tool.UserTool;
-import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
@@ -43,7 +43,7 @@ public class GetFlowRunTool implements UserTool {
 
         return SyncToolSpecification.builder()
                 .tool(tool)
-                .callHandler((exchange, request) -> {
+                .callHandler((context, request) -> {
                     Map<String, Object> args = request.arguments();
                     if (args == null) args = Map.of();
                     Object id = args.get("executionId");

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/GetRecordTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/GetRecordTool.java
@@ -5,7 +5,7 @@ import io.kelta.mcp.error.McpErrorMapper;
 import io.kelta.mcp.tool.Schemas;
 import io.kelta.mcp.tool.ToolHints;
 import io.kelta.mcp.tool.UserTool;
-import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
@@ -45,7 +45,7 @@ public class GetRecordTool implements UserTool {
 
         return SyncToolSpecification.builder()
                 .tool(tool)
-                .callHandler((exchange, request) -> {
+                .callHandler((context, request) -> {
                     Map<String, Object> args = request.arguments();
                     if (args == null) args = Map.of();
                     Object cv = args.get("collection");

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/ListApprovalsTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/ListApprovalsTool.java
@@ -5,7 +5,7 @@ import io.kelta.mcp.error.McpErrorMapper;
 import io.kelta.mcp.tool.Schemas;
 import io.kelta.mcp.tool.ToolHints;
 import io.kelta.mcp.tool.UserTool;
-import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
 import org.springframework.stereotype.Component;
 
@@ -43,7 +43,7 @@ public class ListApprovalsTool implements UserTool {
 
         return SyncToolSpecification.builder()
                 .tool(tool)
-                .callHandler((exchange, request) -> {
+                .callHandler((context, request) -> {
                     Map<String, Object> args = request.arguments();
                     if (args == null) args = Map.of();
                     String status = String.valueOf(args.getOrDefault("status", "pending"));

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/ListCollectionsTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/ListCollectionsTool.java
@@ -6,7 +6,7 @@ import io.kelta.mcp.tool.AdminTool;
 import io.kelta.mcp.tool.Schemas;
 import io.kelta.mcp.tool.ToolHints;
 import io.kelta.mcp.tool.UserTool;
-import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
 import org.springframework.stereotype.Component;
 
@@ -40,7 +40,7 @@ public class ListCollectionsTool implements UserTool, AdminTool {
 
         return SyncToolSpecification.builder()
                 .tool(tool)
-                .callHandler((exchange, request) -> {
+                .callHandler((context, request) -> {
                     boolean includeSystem = readBool(request.arguments(), "includeSystem", true);
                     String path = "/api/collections";
                     if (!includeSystem) {

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/QueryCollectionTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/QueryCollectionTool.java
@@ -5,7 +5,7 @@ import io.kelta.mcp.error.McpErrorMapper;
 import io.kelta.mcp.tool.Schemas;
 import io.kelta.mcp.tool.ToolHints;
 import io.kelta.mcp.tool.UserTool;
-import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
@@ -115,7 +115,7 @@ public class QueryCollectionTool implements UserTool {
 
         return SyncToolSpecification.builder()
                 .tool(tool)
-                .callHandler((exchange, request) -> {
+                .callHandler((context, request) -> {
                     Map<String, Object> args = request.arguments();
                     if (args == null) args = Map.of();
                     Object cv = args.get("collection");

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/SearchTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/SearchTool.java
@@ -5,7 +5,7 @@ import io.kelta.mcp.error.McpErrorMapper;
 import io.kelta.mcp.tool.Schemas;
 import io.kelta.mcp.tool.ToolHints;
 import io.kelta.mcp.tool.UserTool;
-import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
@@ -42,7 +42,7 @@ public class SearchTool implements UserTool {
 
         return SyncToolSpecification.builder()
                 .tool(tool)
-                .callHandler((exchange, request) -> {
+                .callHandler((context, request) -> {
                     Map<String, Object> args = request.arguments();
                     if (args == null) args = Map.of();
                     Object q = args.get("query");

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/SubmitForApprovalTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/SubmitForApprovalTool.java
@@ -5,7 +5,7 @@ import io.kelta.mcp.error.McpErrorMapper;
 import io.kelta.mcp.tool.Schemas;
 import io.kelta.mcp.tool.ToolHints;
 import io.kelta.mcp.tool.UserTool;
-import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
@@ -43,7 +43,7 @@ public class SubmitForApprovalTool implements UserTool {
 
         return SyncToolSpecification.builder()
                 .tool(tool)
-                .callHandler((exchange, request) -> {
+                .callHandler((context, request) -> {
                     Map<String, Object> args = request.arguments();
                     if (args == null) args = Map.of();
                     Object cId = args.get("collectionId");

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/UpdateRecordTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/UpdateRecordTool.java
@@ -5,7 +5,7 @@ import io.kelta.mcp.error.McpErrorMapper;
 import io.kelta.mcp.tool.Schemas;
 import io.kelta.mcp.tool.ToolHints;
 import io.kelta.mcp.tool.UserTool;
-import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
@@ -46,7 +46,7 @@ public class UpdateRecordTool implements UserTool {
 
         return SyncToolSpecification.builder()
                 .tool(tool)
-                .callHandler((exchange, request) -> {
+                .callHandler((context, request) -> {
                     Map<String, Object> args = request.arguments();
                     if (args == null) args = Map.of();
                     Object cv = args.get("collection");

--- a/kelta-mcp/src/main/java/io/kelta/mcp/transport/HttpServletStatelessServerTransportProvider.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/transport/HttpServletStatelessServerTransportProvider.java
@@ -1,0 +1,189 @@
+package io.kelta.mcp.transport;
+
+import io.modelcontextprotocol.common.McpTransportContext;
+import io.modelcontextprotocol.json.McpJsonMapper;
+import io.modelcontextprotocol.json.jackson3.JacksonMcpJsonMapper;
+import io.modelcontextprotocol.server.McpStatelessServerHandler;
+import io.modelcontextprotocol.server.McpTransportContextExtractor;
+import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.spec.McpStatelessServerTransport;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Mono;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+/**
+ * HTTP adapter for {@link McpStatelessServerTransport} — turns one inbound
+ * POST into one JSON-RPC request/response (or a fire-and-forget notification),
+ * with no per-session state.
+ *
+ * <p>Why stateless: the SDK's
+ * {@code HttpServletStreamableServerTransportProvider} keeps a per-pod
+ * {@code ConcurrentHashMap<sessionId, McpStreamableServerSession>}. Pod
+ * restarts wipe that map, and the next request from a connected client
+ * arrives carrying a stale {@code Mcp-Session-Id} — the SDK then returns
+ * {@code -32603 Session not found}, {@code mcp-remote 0.1.x} surfaces it as
+ * a fatal error, and the client tools start failing until the user manually
+ * restarts the MCP host. Painful with frequent deploys.
+ *
+ * <p>The kelta MCP surface doesn't actually need streaming: every tool is a
+ * synchronous request/response, and we don't broadcast {@code listChanged}
+ * notifications or use resource subscriptions. So we drop the streamable
+ * transport in favour of the SDK's built-in stateless mode
+ * ({@link McpStatelessServerTransport} +
+ * {@link io.modelcontextprotocol.server.McpStatelessSyncServer}) and provide
+ * this tiny HTTP adapter — the SDK ships one for stdio but not for
+ * Servlet-based HTTP. Each request carries everything it needs (PAT in
+ * {@code Authorization}, tenant slug in the URL path), so pod restarts are
+ * invisible to the client by construction.
+ *
+ * <p>The class is not a {@code HttpServlet}; it just exposes
+ * {@link #service(HttpServletRequest, HttpServletResponse)} so that
+ * {@code KeltaMcpController} can dispatch to it by type, the same way it
+ * called {@code transport.service(...)} on the previous streamable
+ * transport.
+ *
+ * <h2>Wire format</h2>
+ * <ul>
+ *   <li>{@code POST} with a JSON-RPC request body → blocks on the SDK
+ *       handler, writes a {@code 200 OK} JSON-RPC response.</li>
+ *   <li>{@code POST} with a JSON-RPC notification body (no {@code id}) →
+ *       fires the handler, returns {@code 204 No Content}.</li>
+ *   <li>{@code GET} (used by the streamable transport for SSE) and
+ *       {@code DELETE} (session close) → {@code 405 Method Not Allowed},
+ *       since stateless mode has nothing to stream and no session to
+ *       close.</li>
+ * </ul>
+ *
+ * <p>JSON-RPC batches (an array body) are not supported — {@code mcp-remote}
+ * sends individual messages and the protocol marks batch as optional. A
+ * batch yields {@code 400 Bad Request} with a clear error.
+ */
+public class HttpServletStatelessServerTransportProvider implements McpStatelessServerTransport {
+
+    private static final Logger log = LoggerFactory.getLogger(
+            HttpServletStatelessServerTransportProvider.class);
+    private static final String APPLICATION_JSON = "application/json";
+
+    private final McpJsonMapper jsonMapper;
+    private final McpTransportContextExtractor<HttpServletRequest> contextExtractor;
+    private volatile McpStatelessServerHandler handler;
+
+    public HttpServletStatelessServerTransportProvider(
+            McpTransportContextExtractor<HttpServletRequest> contextExtractor) {
+        this.jsonMapper = new JacksonMcpJsonMapper(JsonMapper.builder().build());
+        this.contextExtractor = contextExtractor != null
+                ? contextExtractor
+                : (req) -> McpTransportContext.EMPTY;
+    }
+
+    @Override
+    public void setMcpHandler(McpStatelessServerHandler handler) {
+        this.handler = handler;
+    }
+
+    @Override
+    public Mono<Void> closeGracefully() {
+        return Mono.empty();
+    }
+
+    /**
+     * Servlet-side dispatch. Reads the request body as a JSON-RPC message,
+     * routes to the SDK handler, and writes the response.
+     *
+     * <p>Exceptions thrown by the handler are mapped to JSON-RPC error
+     * responses or HTTP error statuses — they never propagate out of this
+     * method.
+     */
+    public void service(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        if (handler == null) {
+            // McpServer.sync(transport).build() registers the handler; if we
+            // haven't been built yet, the transport isn't usable.
+            resp.sendError(HttpServletResponse.SC_SERVICE_UNAVAILABLE,
+                    "MCP handler not bound");
+            return;
+        }
+
+        String method = req.getMethod();
+        if (!"POST".equalsIgnoreCase(method)) {
+            // Stateless mode has no SSE channel and no session lifecycle, so
+            // GET / DELETE have nothing meaningful to do. Return 405 with an
+            // Allow header so well-behaved clients don't keep retrying.
+            resp.setHeader("Allow", "POST");
+            resp.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED,
+                    method + " not supported by stateless MCP transport");
+            return;
+        }
+
+        byte[] body = req.getInputStream().readAllBytes();
+        if (body.length == 0) {
+            resp.sendError(HttpServletResponse.SC_BAD_REQUEST, "Empty request body");
+            return;
+        }
+
+        // Parse polymorphically. JSON-RPC requests have an `id`, notifications
+        // don't. We could deserialize directly to the sealed JSONRPCMessage
+        // interface, but going through a Map<?,?> avoids any reliance on the
+        // SDK's polymorphic-deserialization wiring.
+        Object parsed;
+        try {
+            parsed = jsonMapper.readValue(body, Object.class);
+        } catch (IOException e) {
+            log.warn("Malformed JSON-RPC body", e);
+            resp.sendError(HttpServletResponse.SC_BAD_REQUEST, "Malformed JSON");
+            return;
+        }
+
+        if (parsed instanceof java.util.List<?>) {
+            resp.sendError(HttpServletResponse.SC_BAD_REQUEST,
+                    "JSON-RPC batch requests are not supported by this transport");
+            return;
+        }
+        if (!(parsed instanceof Map<?, ?> raw)) {
+            resp.sendError(HttpServletResponse.SC_BAD_REQUEST,
+                    "JSON-RPC payload must be an object");
+            return;
+        }
+
+        McpTransportContext context = contextExtractor.extract(req);
+
+        try {
+            if (raw.containsKey("id") && raw.get("id") != null) {
+                McpSchema.JSONRPCRequest request = jsonMapper.convertValue(
+                        raw, McpSchema.JSONRPCRequest.class);
+                McpSchema.JSONRPCResponse response = handler.handleRequest(context, request)
+                        .block();
+                writeJsonResponse(resp, response);
+            } else {
+                McpSchema.JSONRPCNotification notification = jsonMapper.convertValue(
+                        raw, McpSchema.JSONRPCNotification.class);
+                handler.handleNotification(context, notification).block();
+                resp.setStatus(HttpServletResponse.SC_NO_CONTENT);
+            }
+        } catch (RuntimeException e) {
+            // The SDK handler should produce a JSONRPCResponse with an error
+            // payload rather than throw; if anything escapes, surface it as a
+            // 500 with a redacted message rather than leak a stack trace.
+            log.error("Unhandled exception while dispatching MCP request", e);
+            resp.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
+                    "Internal MCP server error");
+        }
+    }
+
+    private void writeJsonResponse(HttpServletResponse resp, Object payload) throws IOException {
+        String json = jsonMapper.writeValueAsString(payload);
+        resp.setStatus(HttpServletResponse.SC_OK);
+        resp.setContentType(APPLICATION_JSON + ";charset=" + StandardCharsets.UTF_8.name());
+        resp.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        try (PrintWriter writer = resp.getWriter()) {
+            writer.write(json);
+        }
+    }
+}

--- a/kelta-mcp/src/main/java/io/kelta/mcp/transport/KeltaMcpController.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/transport/KeltaMcpController.java
@@ -1,7 +1,6 @@
 package io.kelta.mcp.transport;
 
 import io.kelta.mcp.auth.KeltaTransportContextExtractor;
-import io.modelcontextprotocol.server.transport.HttpServletStreamableServerTransportProvider;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -12,35 +11,32 @@ import org.springframework.web.bind.annotation.RestController;
 
 /**
  * Spring MVC controller that dispatches MCP requests at
- * {@code /{tenantSlug}/mcp/(user|admin)} to the matching SDK transport
- * servlet, leaving the slug in the URL end-to-end.
+ * {@code /{tenantSlug}/mcp/(user|admin)} to the matching stateless
+ * transport, leaving the slug in the URL end-to-end.
  *
  * <p>The slug is just a Spring {@code @PathVariable} — Spring extracts
  * it, we stamp it onto the request as an attribute (read by
  * {@link KeltaTransportContextExtractor} when the SDK builds its
- * transport context), and we hand the request straight to the SDK
- * transport via {@code HttpServlet.service}. The SDK's {@code
- * mcpEndpoint} validation uses {@code requestUri.endsWith(mcpEndpoint)}
- * so the slug-prefixed URL matches natively.
+ * transport context), and the request goes straight to the
+ * stateless transport's {@code service()} method.
  *
- * <p>This replaces an earlier strip-and-re-add approach where the
- * filter rewrote {@code /{slug}/mcp/user} to {@code /mcp/user} and
- * forwarded to a slug-less servlet registration. With path variables
- * we don't need to rewrite anything — the slug travels with the
- * request all the way through, and outbound calls re-use the same
- * slug verbatim.
+ * <p>Stateless mode (see {@link HttpServletStatelessServerTransportProvider})
+ * means there's no per-pod session state to lose on restart. The
+ * controller still accepts {@code GET} and {@code DELETE} so misbehaving
+ * clients get a clean {@code 405 Method Not Allowed} from the transport
+ * instead of a Spring 404.
  */
 @RestController
 public class KeltaMcpController {
 
-    private final HttpServletStreamableServerTransportProvider userTransport;
-    private final HttpServletStreamableServerTransportProvider adminTransport;
+    private final HttpServletStatelessServerTransportProvider userTransport;
+    private final HttpServletStatelessServerTransportProvider adminTransport;
 
     public KeltaMcpController(
             @Qualifier("userTransportProvider")
-            HttpServletStreamableServerTransportProvider userTransport,
+            HttpServletStatelessServerTransportProvider userTransport,
             @Qualifier("adminTransportProvider")
-            HttpServletStreamableServerTransportProvider adminTransport) {
+            HttpServletStatelessServerTransportProvider adminTransport) {
         this.userTransport = userTransport;
         this.adminTransport = adminTransport;
     }
@@ -54,7 +50,7 @@ public class KeltaMcpController {
                           HttpServletRequest request,
                           HttpServletResponse response) throws Exception {
         request.setAttribute(KeltaTransportContextExtractor.SLUG_REQUEST_ATTRIBUTE, tenantSlug);
-        HttpServletStreamableServerTransportProvider transport = "user".equals(profile)
+        HttpServletStatelessServerTransportProvider transport = "user".equals(profile)
                 ? userTransport
                 : adminTransport;
         transport.service(request, response);

--- a/kelta-mcp/src/test/java/io/kelta/mcp/McpApplicationTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/McpApplicationTest.java
@@ -5,7 +5,7 @@ import io.kelta.mcp.resource.UserResourceTemplate;
 import io.kelta.mcp.tool.AdminTool;
 import io.kelta.mcp.tool.UserTool;
 import io.kelta.mcp.transport.KeltaMcpController;
-import io.modelcontextprotocol.server.McpSyncServer;
+import io.modelcontextprotocol.server.McpStatelessSyncServer;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
 import io.modelcontextprotocol.spec.McpSchema.ToolAnnotations;
 import org.junit.jupiter.api.Test;
@@ -33,11 +33,11 @@ class McpApplicationTest {
 
     @Autowired
     @Qualifier("userMcpServer")
-    private McpSyncServer userServer;
+    private McpStatelessSyncServer userServer;
 
     @Autowired
     @Qualifier("adminMcpServer")
-    private McpSyncServer adminServer;
+    private McpStatelessSyncServer adminServer;
 
     @Autowired
     private KeltaMcpController mcpController;

--- a/kelta-mcp/src/test/java/io/kelta/mcp/observe/ObservedToolDecoratorTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/observe/ObservedToolDecoratorTest.java
@@ -2,9 +2,11 @@ package io.kelta.mcp.observe;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.common.McpTransportContext;
+import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.JsonSchema;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
 import org.junit.jupiter.api.Test;
@@ -13,6 +15,7 @@ import org.slf4j.MDC;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiFunction;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -22,25 +25,25 @@ class ObservedToolDecoratorTest {
     private final MeterRegistry registry = new SimpleMeterRegistry();
     private final ObservedToolDecorator decorator = new ObservedToolDecorator(registry);
 
-    private SyncToolSpecification stub(java.util.function.BiFunction<Object, CallToolRequest, CallToolResult> handler) {
+    private SyncToolSpecification stub(BiFunction<McpTransportContext, CallToolRequest, CallToolResult> handler) {
         Tool tool = Tool.builder()
                 .name("stub_tool")
                 .description("test")
-                .inputSchema(new io.modelcontextprotocol.spec.McpSchema.JsonSchema(
-                        "object", Map.of(), List.of(), false, null, null))
+                .inputSchema(new JsonSchema("object", Map.of(), List.of(), false, null, null))
                 .build();
         return SyncToolSpecification.builder()
                 .tool(tool)
-                .callHandler((exchange, req) -> handler.apply(exchange, req))
+                .callHandler(handler)
                 .build();
     }
 
     @Test
     void recordsSuccessTimerAndCounter() {
-        SyncToolSpecification decorated = decorator.decorate(stub((ex, req) ->
+        SyncToolSpecification decorated = decorator.decorate(stub((ctx, req) ->
                 CallToolResult.builder().content(List.of(new TextContent("ok"))).build()), "user");
 
-        decorated.callHandler().apply(null, new CallToolRequest("stub_tool", Map.of(), null));
+        decorated.callHandler().apply(McpTransportContext.EMPTY,
+                new CallToolRequest("stub_tool", Map.of(), null));
 
         assertThat(registry.counter("mcp.tool.calls",
                 "tool", "stub_tool", "profile", "user", "status", "success")
@@ -52,11 +55,12 @@ class ObservedToolDecoratorTest {
 
     @Test
     void taggedAsErrorWhenIsErrorTrue() {
-        SyncToolSpecification decorated = decorator.decorate(stub((ex, req) ->
+        SyncToolSpecification decorated = decorator.decorate(stub((ctx, req) ->
                 CallToolResult.builder().isError(true)
                         .content(List.of(new TextContent("nope"))).build()), "user");
 
-        decorated.callHandler().apply(null, new CallToolRequest("stub_tool", Map.of(), null));
+        decorated.callHandler().apply(McpTransportContext.EMPTY,
+                new CallToolRequest("stub_tool", Map.of(), null));
 
         assertThat(registry.counter("mcp.tool.calls",
                 "tool", "stub_tool", "profile", "user", "status", "error")
@@ -65,12 +69,13 @@ class ObservedToolDecoratorTest {
 
     @Test
     void taggedAsExceptionWhenHandlerThrows() {
-        SyncToolSpecification decorated = decorator.decorate(stub((ex, req) -> {
+        SyncToolSpecification decorated = decorator.decorate(stub((ctx, req) -> {
             throw new RuntimeException("boom");
         }), "admin");
 
         assertThatThrownBy(() ->
-                decorated.callHandler().apply(null, new CallToolRequest("stub_tool", Map.of(), null)))
+                decorated.callHandler().apply(McpTransportContext.EMPTY,
+                        new CallToolRequest("stub_tool", Map.of(), null)))
                 .isInstanceOf(RuntimeException.class);
 
         assertThat(registry.counter("mcp.tool.calls",
@@ -83,13 +88,14 @@ class ObservedToolDecoratorTest {
         AtomicReference<String> seenTool = new AtomicReference<>();
         AtomicReference<String> seenProfile = new AtomicReference<>();
 
-        SyncToolSpecification decorated = decorator.decorate(stub((ex, req) -> {
+        SyncToolSpecification decorated = decorator.decorate(stub((ctx, req) -> {
             seenTool.set(MDC.get("mcpTool"));
             seenProfile.set(MDC.get("mcpProfile"));
             return CallToolResult.builder().content(List.of(new TextContent("ok"))).build();
         }), "user");
 
-        decorated.callHandler().apply(null, new CallToolRequest("stub_tool", Map.of(), null));
+        decorated.callHandler().apply(McpTransportContext.EMPTY,
+                new CallToolRequest("stub_tool", Map.of(), null));
 
         assertThat(seenTool.get()).isEqualTo("stub_tool");
         assertThat(seenProfile.get()).isEqualTo("user");
@@ -99,12 +105,13 @@ class ObservedToolDecoratorTest {
 
     @Test
     void mdcIsClearedEvenWhenHandlerThrows() {
-        SyncToolSpecification decorated = decorator.decorate(stub((ex, req) -> {
+        SyncToolSpecification decorated = decorator.decorate(stub((ctx, req) -> {
             throw new RuntimeException("boom");
         }), "user");
 
         try {
-            decorated.callHandler().apply(null, new CallToolRequest("stub_tool", Map.of(), null));
+            decorated.callHandler().apply(McpTransportContext.EMPTY,
+                    new CallToolRequest("stub_tool", Map.of(), null));
         } catch (RuntimeException ignored) {
         }
 

--- a/kelta-mcp/src/test/java/io/kelta/mcp/observe/PatPropagatingToolDecoratorTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/observe/PatPropagatingToolDecoratorTest.java
@@ -4,9 +4,7 @@ import io.kelta.mcp.auth.KeltaTransportContextExtractor;
 import io.kelta.mcp.auth.RequestPatHolder;
 import io.kelta.mcp.auth.RequestSlugHolder;
 import io.modelcontextprotocol.common.McpTransportContext;
-import io.modelcontextprotocol.server.McpAsyncServerExchange;
-import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
-import io.modelcontextprotocol.server.McpSyncServerExchange;
+import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.JsonSchema;
@@ -17,16 +15,15 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiFunction;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 class PatPropagatingToolDecoratorTest {
 
     private final PatPropagatingToolDecorator decorator = new PatPropagatingToolDecorator();
 
-    private SyncToolSpecification stub(java.util.function.BiFunction<McpSyncServerExchange, CallToolRequest, CallToolResult> handler) {
+    private SyncToolSpecification stub(BiFunction<McpTransportContext, CallToolRequest, CallToolResult> handler) {
         Tool tool = Tool.builder()
                 .name("stub")
                 .description("test")
@@ -34,28 +31,22 @@ class PatPropagatingToolDecoratorTest {
                 .build();
         return SyncToolSpecification.builder()
                 .tool(tool)
-                .callHandler(handler::apply)
+                .callHandler(handler)
                 .build();
-    }
-
-    private McpSyncServerExchange exchangeWithContext(McpTransportContext ctx) {
-        McpAsyncServerExchange asyncExchange = mock(McpAsyncServerExchange.class);
-        when(asyncExchange.transportContext()).thenReturn(ctx);
-        return new McpSyncServerExchange(asyncExchange);
     }
 
     @Test
     void copiesPatFromTransportContextIntoHolderForDurationOfCall() {
         AtomicReference<String> seen = new AtomicReference<>();
-        SyncToolSpecification decorated = decorator.decorate(stub((ex, req) -> {
+        SyncToolSpecification decorated = decorator.decorate(stub((ctx, req) -> {
             seen.set(RequestPatHolder.get());
             return CallToolResult.builder().content(List.of(new TextContent("ok"))).build();
         }));
 
-        McpSyncServerExchange exchange = exchangeWithContext(
-                McpTransportContext.create(Map.of(KeltaTransportContextExtractor.PAT_KEY, "klt_propagated")));
+        McpTransportContext context = McpTransportContext.create(
+                Map.of(KeltaTransportContextExtractor.PAT_KEY, "klt_propagated"));
 
-        decorated.callHandler().apply(exchange, new CallToolRequest("stub", Map.of(), null));
+        decorated.callHandler().apply(context, new CallToolRequest("stub", Map.of(), null));
 
         assertThat(seen.get()).isEqualTo("klt_propagated");
         assertThat(RequestPatHolder.get()).isNull(); // cleared after
@@ -63,15 +54,15 @@ class PatPropagatingToolDecoratorTest {
 
     @Test
     void clearsHolderEvenWhenInnerHandlerThrows() {
-        SyncToolSpecification decorated = decorator.decorate(stub((ex, req) -> {
+        SyncToolSpecification decorated = decorator.decorate(stub((ctx, req) -> {
             throw new RuntimeException("boom");
         }));
 
-        McpSyncServerExchange exchange = exchangeWithContext(
-                McpTransportContext.create(Map.of(KeltaTransportContextExtractor.PAT_KEY, "klt_x")));
+        McpTransportContext context = McpTransportContext.create(
+                Map.of(KeltaTransportContextExtractor.PAT_KEY, "klt_x"));
 
         try {
-            decorated.callHandler().apply(exchange, new CallToolRequest("stub", Map.of(), null));
+            decorated.callHandler().apply(context, new CallToolRequest("stub", Map.of(), null));
         } catch (RuntimeException ignored) {
         }
 
@@ -81,14 +72,13 @@ class PatPropagatingToolDecoratorTest {
     @Test
     void doesNothingWhenContextHasNoPat() {
         AtomicReference<String> seen = new AtomicReference<>();
-        SyncToolSpecification decorated = decorator.decorate(stub((ex, req) -> {
+        SyncToolSpecification decorated = decorator.decorate(stub((ctx, req) -> {
             seen.set(RequestPatHolder.get());
             return CallToolResult.builder().content(List.of(new TextContent("ok"))).build();
         }));
 
-        McpSyncServerExchange exchange = exchangeWithContext(McpTransportContext.EMPTY);
-
-        decorated.callHandler().apply(exchange, new CallToolRequest("stub", Map.of(), null));
+        decorated.callHandler().apply(McpTransportContext.EMPTY,
+                new CallToolRequest("stub", Map.of(), null));
 
         assertThat(seen.get()).isNull();
     }
@@ -97,21 +87,37 @@ class PatPropagatingToolDecoratorTest {
     void copiesTenantSlugFromTransportContextIntoHolder() {
         AtomicReference<String> seenPat = new AtomicReference<>();
         AtomicReference<String> seenSlug = new AtomicReference<>();
-        SyncToolSpecification decorated = decorator.decorate(stub((ex, req) -> {
+        SyncToolSpecification decorated = decorator.decorate(stub((ctx, req) -> {
             seenPat.set(RequestPatHolder.get());
             seenSlug.set(RequestSlugHolder.get());
             return CallToolResult.builder().content(List.of(new TextContent("ok"))).build();
         }));
 
-        McpSyncServerExchange exchange = exchangeWithContext(McpTransportContext.create(Map.of(
+        McpTransportContext context = McpTransportContext.create(Map.of(
                 KeltaTransportContextExtractor.PAT_KEY, "klt_session",
-                KeltaTransportContextExtractor.TENANT_SLUG_KEY, "threadline-clothing")));
+                KeltaTransportContextExtractor.TENANT_SLUG_KEY, "threadline-clothing"));
 
-        decorated.callHandler().apply(exchange, new CallToolRequest("stub", Map.of(), null));
+        decorated.callHandler().apply(context, new CallToolRequest("stub", Map.of(), null));
 
         assertThat(seenPat.get()).isEqualTo("klt_session");
         assertThat(seenSlug.get()).isEqualTo("threadline-clothing");
         assertThat(RequestPatHolder.get()).isNull();
         assertThat(RequestSlugHolder.get()).isNull();
+    }
+
+    @Test
+    void tolerantOfNullContext() {
+        // Defensive contract: if a caller bypasses the SDK and supplies null,
+        // we don't NPE — we just don't populate the holders.
+        AtomicReference<String> seen = new AtomicReference<>();
+        SyncToolSpecification decorated = decorator.decorate(stub((ctx, req) -> {
+            seen.set(RequestPatHolder.get());
+            return CallToolResult.builder().content(List.of(new TextContent("ok"))).build();
+        }));
+
+        decorated.callHandler().apply(null, new CallToolRequest("stub", Map.of(), null));
+
+        assertThat(seen.get()).isNull();
+        assertThat(RequestPatHolder.get()).isNull();
     }
 }

--- a/kelta-mcp/src/test/java/io/kelta/mcp/observe/RateLimitedToolDecoratorTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/observe/RateLimitedToolDecoratorTest.java
@@ -4,7 +4,7 @@ import io.kelta.mcp.auth.RequestPatHolder;
 import io.kelta.mcp.config.McpProperties;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.JsonSchema;
@@ -48,7 +48,7 @@ class RateLimitedToolDecoratorTest {
                 .build();
         return SyncToolSpecification.builder()
                 .tool(tool)
-                .callHandler((ex, req) -> {
+                .callHandler((ctx, req) -> {
                     calls.incrementAndGet();
                     return CallToolResult.builder().content(List.of(new TextContent("ok"))).build();
                 })

--- a/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/GetCollectionSchemaToolTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/GetCollectionSchemaToolTest.java
@@ -5,7 +5,7 @@ import com.github.tomakehurst.wiremock.client.WireMock;
 import io.kelta.mcp.auth.RequestPatHolder;
 import io.kelta.mcp.client.GatewayHttpClient;
 import io.kelta.mcp.config.McpProperties;
-import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;

--- a/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/ListCollectionsToolTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/ListCollectionsToolTest.java
@@ -5,7 +5,7 @@ import com.github.tomakehurst.wiremock.client.WireMock;
 import io.kelta.mcp.auth.RequestPatHolder;
 import io.kelta.mcp.client.GatewayHttpClient;
 import io.kelta.mcp.config.McpProperties;
-import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;

--- a/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/QueryCollectionToolTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/QueryCollectionToolTest.java
@@ -5,7 +5,7 @@ import com.github.tomakehurst.wiremock.client.WireMock;
 import io.kelta.mcp.auth.RequestPatHolder;
 import io.kelta.mcp.client.GatewayHttpClient;
 import io.kelta.mcp.config.McpProperties;
-import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.Tool;

--- a/kelta-mcp/src/test/java/io/kelta/mcp/transport/HttpServletStatelessServerTransportProviderTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/transport/HttpServletStatelessServerTransportProviderTest.java
@@ -1,0 +1,200 @@
+package io.kelta.mcp.transport;
+
+import io.modelcontextprotocol.common.McpTransportContext;
+import io.modelcontextprotocol.server.McpStatelessServerHandler;
+import io.modelcontextprotocol.spec.McpSchema.JSONRPCNotification;
+import io.modelcontextprotocol.spec.McpSchema.JSONRPCRequest;
+import io.modelcontextprotocol.spec.McpSchema.JSONRPCResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import reactor.core.publisher.Mono;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class HttpServletStatelessServerTransportProviderTest {
+
+    private static final String CTX_KEY = "kelta.test.value";
+
+    private HttpServletStatelessServerTransportProvider transport;
+    private AtomicReference<JSONRPCRequest> seenRequest;
+    private AtomicReference<JSONRPCNotification> seenNotification;
+    private AtomicReference<McpTransportContext> seenContext;
+
+    @BeforeEach
+    void setUp() {
+        transport = new HttpServletStatelessServerTransportProvider(req -> {
+            String marker = req.getHeader("X-Test-Marker");
+            return marker == null
+                    ? McpTransportContext.EMPTY
+                    : McpTransportContext.create(Map.of(CTX_KEY, marker));
+        });
+        seenRequest = new AtomicReference<>();
+        seenNotification = new AtomicReference<>();
+        seenContext = new AtomicReference<>();
+        transport.setMcpHandler(new McpStatelessServerHandler() {
+            @Override
+            public Mono<JSONRPCResponse> handleRequest(McpTransportContext context, JSONRPCRequest request) {
+                seenRequest.set(request);
+                seenContext.set(context);
+                return Mono.just(new JSONRPCResponse(
+                        "2.0",
+                        request.id(),
+                        Map.of("ok", true, "echo", request.method()),
+                        null));
+            }
+
+            @Override
+            public Mono<Void> handleNotification(McpTransportContext context, JSONRPCNotification notification) {
+                seenNotification.set(notification);
+                seenContext.set(context);
+                return Mono.empty();
+            }
+        });
+    }
+
+    @Test
+    void postRequestReturnsJsonRpcResponseAndPropagatesContext() throws Exception {
+        MockHttpServletRequest req = new MockHttpServletRequest("POST", "/threadline-clothing/mcp/user");
+        req.addHeader("Content-Type", "application/json");
+        req.addHeader("X-Test-Marker", "from-extractor");
+        req.setContent("""
+                {"jsonrpc":"2.0","id":7,"method":"tools/list","params":{}}""".getBytes());
+        MockHttpServletResponse res = new MockHttpServletResponse();
+
+        transport.service(req, res);
+
+        assertThat(res.getStatus()).isEqualTo(200);
+        assertThat(res.getContentType()).startsWith("application/json");
+        assertThat(res.getContentAsString())
+                .contains("\"id\":7")
+                .contains("\"echo\":\"tools/list\"");
+
+        assertThat(seenRequest.get().method()).isEqualTo("tools/list");
+        assertThat(seenContext.get()).isNotNull();
+        assertThat(seenContext.get().get(CTX_KEY)).isEqualTo("from-extractor");
+    }
+
+    @Test
+    void postNotificationReturns204NoContent() throws Exception {
+        MockHttpServletRequest req = new MockHttpServletRequest("POST", "/threadline-clothing/mcp/user");
+        req.addHeader("Content-Type", "application/json");
+        req.setContent("""
+                {"jsonrpc":"2.0","method":"notifications/initialized"}""".getBytes());
+        MockHttpServletResponse res = new MockHttpServletResponse();
+
+        transport.service(req, res);
+
+        assertThat(res.getStatus()).isEqualTo(204);
+        assertThat(res.getContentAsString()).isEmpty();
+        assertThat(seenNotification.get().method()).isEqualTo("notifications/initialized");
+    }
+
+    @Test
+    void postWithJsonRpcRequestThatHasNullIdIsTreatedAsNotification() throws Exception {
+        // Some clients send id=null for fire-and-forget. We treat that as a
+        // notification rather than dispatching as a request — JSON-RPC 2.0
+        // requires an id on requests, and a null id means "no response
+        // expected".
+        MockHttpServletRequest req = new MockHttpServletRequest("POST", "/threadline-clothing/mcp/user");
+        req.addHeader("Content-Type", "application/json");
+        req.setContent("""
+                {"jsonrpc":"2.0","id":null,"method":"notifications/cancelled"}""".getBytes());
+        MockHttpServletResponse res = new MockHttpServletResponse();
+
+        transport.service(req, res);
+
+        assertThat(res.getStatus()).isEqualTo(204);
+    }
+
+    @Test
+    void getReturns405MethodNotAllowed() throws Exception {
+        MockHttpServletRequest req = new MockHttpServletRequest("GET", "/threadline-clothing/mcp/user");
+        MockHttpServletResponse res = new MockHttpServletResponse();
+
+        transport.service(req, res);
+
+        assertThat(res.getStatus()).isEqualTo(405);
+        assertThat(res.getHeader("Allow")).isEqualTo("POST");
+    }
+
+    @Test
+    void deleteReturns405MethodNotAllowed() throws Exception {
+        MockHttpServletRequest req = new MockHttpServletRequest("DELETE", "/threadline-clothing/mcp/user");
+        MockHttpServletResponse res = new MockHttpServletResponse();
+
+        transport.service(req, res);
+
+        assertThat(res.getStatus()).isEqualTo(405);
+    }
+
+    @Test
+    void emptyBodyReturns400() throws Exception {
+        MockHttpServletRequest req = new MockHttpServletRequest("POST", "/threadline-clothing/mcp/user");
+        req.addHeader("Content-Type", "application/json");
+        req.setContent(new byte[0]);
+        MockHttpServletResponse res = new MockHttpServletResponse();
+
+        transport.service(req, res);
+
+        assertThat(res.getStatus()).isEqualTo(400);
+    }
+
+    @Test
+    void malformedJsonReturns400() throws Exception {
+        MockHttpServletRequest req = new MockHttpServletRequest("POST", "/threadline-clothing/mcp/user");
+        req.addHeader("Content-Type", "application/json");
+        req.setContent("{not json".getBytes());
+        MockHttpServletResponse res = new MockHttpServletResponse();
+
+        transport.service(req, res);
+
+        assertThat(res.getStatus()).isEqualTo(400);
+    }
+
+    @Test
+    void jsonRpcBatchReturns400() throws Exception {
+        // JSON-RPC batches are optional in the protocol; we don't support them
+        // and reject explicitly so callers see a clear error rather than
+        // silently dropping requests.
+        MockHttpServletRequest req = new MockHttpServletRequest("POST", "/threadline-clothing/mcp/user");
+        req.addHeader("Content-Type", "application/json");
+        req.setContent("""
+                [{"jsonrpc":"2.0","id":1,"method":"tools/list"},
+                 {"jsonrpc":"2.0","id":2,"method":"resources/list"}]""".getBytes());
+        MockHttpServletResponse res = new MockHttpServletResponse();
+
+        transport.service(req, res);
+
+        assertThat(res.getStatus()).isEqualTo(400);
+        assertThat(seenRequest.get()).isNull();
+    }
+
+    @Test
+    void serviceBeforeHandlerBoundReturns503() throws Exception {
+        // Before McpServer.sync(transport).build() runs, setMcpHandler hasn't
+        // been called — any request should get 503 rather than NPE.
+        HttpServletStatelessServerTransportProvider unbound =
+                new HttpServletStatelessServerTransportProvider(null);
+        MockHttpServletRequest req = new MockHttpServletRequest("POST", "/threadline-clothing/mcp/user");
+        req.setContent("""
+                {"jsonrpc":"2.0","id":1,"method":"tools/list"}""".getBytes());
+        MockHttpServletResponse res = new MockHttpServletResponse();
+
+        unbound.service(req, res);
+
+        assertThat(res.getStatus()).isEqualTo(503);
+    }
+
+    @Test
+    void closeGracefullyCompletesSynchronously() {
+        // Stateless mode has no streams or session state to drain — the
+        // close-graceful contract is just a Mono<Void> that completes.
+        Void done = transport.closeGracefully().block();
+        assertThat(done).isNull();
+    }
+}


### PR DESCRIPTION
## Summary

Pod restarts (every deploy) used to invalidate every connected MCP client's session — the SDK's `HttpServletStreamableServerTransportProvider` keeps a per-pod `ConcurrentHashMap<sessionId, ...>`, so the next request after a restart arrived with a stale `Mcp-Session-Id` and the server returned `-32603 Session not found`. `mcp-remote` surfaces it as a fatal error and the client tools start failing until the user manually restarts Cursor / Claude Desktop.

This PR replaces that with the SDK's built-in **stateless** server mode (`McpStatelessSyncServer` + `McpStatelessServerTransport`). The SDK only lacked an HttpServlet adapter — this adds one (~150 lines) and rewires the kelta-mcp surface to use it. Every request now carries everything it needs (PAT in `Authorization`, tenant slug in URL); pod restart is invisible to the client by construction.

The alternative — Redis-backed session storage on the existing streamable transport — would have required forking ~26 KB of `HttpServletStreamableServerTransportProvider` (the `sessions` field is `private final`, no extension points) and serializing internal SDK state. Stateless is strictly better for our use case.

## What changes

**New transport (1 file, ~150 lines):**
- `HttpServletStatelessServerTransportProvider` implements `McpStatelessServerTransport` and exposes `service(HttpServletRequest, HttpServletResponse)` so `KeltaMcpController` dispatches by type the same way it called the streamable transport before.
- POST request → 200 + JSON-RPC response. POST notification (no id) → 204. GET / DELETE → 405. Empty body / malformed JSON / JSON-RPC batch → 400. Handler not bound → 503.

**Wiring switched to stateless:**
- `McpServerConfig` builds `McpStatelessSyncServer` instead of `McpSyncServer`.
- `KeltaMcpController` holds `HttpServletStatelessServerTransportProvider` references.

**Spec type swap (mechanical):**
- `UserTool`, `AdminTool`, `UserResource`, `UserResourceTemplate` interfaces — `McpServerFeatures.*Specification` → `McpStatelessServerFeatures.*Specification`.
- 28 tool implementations + 3 resource implementations + 3 decorators (`ObservedToolDecorator`, `RateLimitedToolDecorator`, `PatPropagatingToolDecorator`) — same import swap; handler lambda first arg renamed from `exchange` to `context` (the stateless signature is `BiFunction<McpTransportContext, CallToolRequest, CallToolResult>`; tools ignored the first arg, so the rename is cosmetic).
- `PatPropagatingToolDecorator` simplified — reads PAT/slug directly off the `McpTransportContext` arg instead of going through `exchange.transportContext()`.

## Trade-offs

- No server-initiated SSE notifications (`tools/listChanged`, resource subscriptions). We don't broadcast these today, and with ephemeral pods they were best-effort anyway.
- Resources advertise `capabilities(false, false)` instead of `(false, true)` so clients don't expect listChanged notifications that won't arrive.

## Test plan

- [x] **146/146 unit tests pass** (was 132; +10 new transport tests + 4 misc additions)
- [x] New `HttpServletStatelessServerTransportProviderTest` covers: 200 + JSON-RPC response, 204 notification, null-id-treated-as-notification, 405 GET / DELETE, 400 empty / malformed / batch, 503 unbound handler, `closeGracefully` no-op
- [x] All decorator tests rewritten without `McpSyncServerExchange` mocks
- [x] All 6 tool tests rebuilt with the stateless spec type
- [x] `McpApplicationTest` (Spring Boot context smoke) passes with `McpStatelessSyncServer` autowire
- [ ] **Post-deploy:** initialize from Cursor against `https://emf.rzware.com/threadline-clothing/mcp/user`, then restart the kelta-mcp pod, then immediately call `query_collection` — should succeed without any client-side reconnect

🤖 Generated with [Claude Code](https://claude.com/claude-code)