### PR TITLE
fix(system-collections): proper relationship metadata for field picker

### DIFF
--- a/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/model/system/SystemCollectionDefinitions.java
+++ b/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/model/system/SystemCollectionDefinitions.java
@@ -182,6 +182,8 @@ public final class SystemCollectionDefinitions {
         return systemBuilder("users", "Users", "platform_user")
             .displayFieldName("email")
             .addImmutableField("tenantId")
+            .addField(FieldDefinition.lookup("tenantId", "tenants", "Tenant")
+                .withColumnName("tenant_id"))
             .addField(FieldDefinition.requiredString("email", 320))
             .addField(FieldDefinition.string("username", 100))
             .addField(FieldDefinition.string("firstName", 100).withColumnName("first_name"))

--- a/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/model/system/SystemCollectionSeeder.java
+++ b/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/model/system/SystemCollectionSeeder.java
@@ -56,12 +56,15 @@ public class SystemCollectionSeeder {
     private static final String INSERT_FIELD = """
             INSERT INTO field (id, collection_id, name, display_name, type, required,
                                unique_constraint, indexed, default_value, constraints,
-                               field_type_config, reference_target, relationship_type,
-                               relationship_name, cascade_delete, field_order, active,
-                               column_name, immutable, track_history,
+                               field_type_config, reference_target, reference_collection_id,
+                               relationship_type, relationship_name, cascade_delete,
+                               field_order, active, column_name, immutable, track_history,
                                auto_number_sequence_name, created_at, updated_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?::jsonb, ?::jsonb, ?::jsonb, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?::jsonb, ?::jsonb, ?::jsonb, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """;
+
+    private static final String SELECT_COLLECTION_ID_BY_NAME =
+            "SELECT id FROM collection WHERE name = ? AND tenant_id = ?";
 
     private final JdbcTemplate jdbcTemplate;
     private final ObjectMapper objectMapper;
@@ -94,8 +97,34 @@ public class SystemCollectionSeeder {
             }
         }
 
+        // Forward-referenced relationships (e.g. fields seeded before their
+        // target collection was inserted) leave `reference_collection_id` null
+        // on insert. Resolve them all in one pass once every collection has
+        // been written.
+        backfillReferenceCollectionIds();
+
         log.info("System collection seeding complete: {} created, {} updated, {} unchanged",
                 created, updated, unchanged);
+    }
+
+    private static final String BACKFILL_REFERENCE_COLLECTION_ID = """
+            UPDATE field
+            SET reference_collection_id = c.id
+            FROM collection c
+            WHERE field.reference_target = c.name
+              AND field.reference_collection_id IS NULL
+              AND field.reference_target IS NOT NULL
+            """;
+
+    private void backfillReferenceCollectionIds() {
+        try {
+            int rows = jdbcTemplate.update(BACKFILL_REFERENCE_COLLECTION_ID);
+            if (rows > 0) {
+                log.info("Backfilled reference_collection_id on {} field row(s)", rows);
+            }
+        } catch (Exception e) {
+            log.warn("Failed to backfill reference_collection_id: {}", e.getMessage());
+        }
     }
 
     /**
@@ -214,11 +243,13 @@ public class SystemCollectionSeeder {
 
         // Reference config
         String referenceTarget = null;
+        String referenceCollectionId = null;
         String relationshipType = null;
         String relationshipName = null;
         boolean cascadeDelete = false;
         if (fieldDef.referenceConfig() != null) {
             referenceTarget = fieldDef.referenceConfig().targetCollection();
+            referenceCollectionId = lookupCollectionIdByName(referenceTarget);
             relationshipType = fieldDef.referenceConfig().relationshipType();
             relationshipName = fieldDef.referenceConfig().relationshipName();
             cascadeDelete = fieldDef.referenceConfig().cascadeDelete();
@@ -237,6 +268,7 @@ public class SystemCollectionSeeder {
                 constraintsJson,
                 fieldTypeConfigJson,
                 referenceTarget,
+                referenceCollectionId,
                 relationshipType,
                 relationshipName,
                 cascadeDelete,
@@ -248,6 +280,33 @@ public class SystemCollectionSeeder {
                 null,   // auto_number_sequence_name
                 now,
                 now);
+    }
+
+    /**
+     * Looks up the UUID of a system collection by name.
+     *
+     * <p>Used at field-insert time to populate the {@code reference_collection_id}
+     * column alongside {@code reference_target}. Returns {@code null} if the
+     * target collection has not yet been seeded — in that case a follow-up
+     * pass populates the column (see V69 migration for the pattern). System
+     * collections are seeded in {@link SystemCollectionDefinitions#all()}
+     * order, so a forward declaration that references a not-yet-seeded
+     * collection will leave this null until the next reconciliation pass.
+     */
+    private String lookupCollectionIdByName(String collectionName) {
+        if (collectionName == null || collectionName.isBlank()) {
+            return null;
+        }
+        try {
+            List<String> rows = jdbcTemplate.queryForList(
+                    SELECT_COLLECTION_ID_BY_NAME, String.class,
+                    collectionName, SYSTEM_TENANT_ID);
+            return rows.isEmpty() ? null : rows.get(0);
+        } catch (Exception e) {
+            log.debug("Could not resolve reference_collection_id for '{}': {}",
+                    collectionName, e.getMessage());
+            return null;
+        }
     }
 
     /**
@@ -277,9 +336,9 @@ public class SystemCollectionSeeder {
             case ENCRYPTED -> "string";
             case EXTERNAL_ID -> "string";
             case GEOLOCATION -> "number";
-            case REFERENCE -> "string";
-            case LOOKUP -> "string";
-            case MASTER_DETAIL -> "string";
+            case REFERENCE -> "reference";
+            case LOOKUP -> "lookup";
+            case MASTER_DETAIL -> "master_detail";
             case FORMULA -> "string";
             case ROLLUP_SUMMARY -> "string";
         };

--- a/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/model/system/SystemCollectionSeederTest.java
+++ b/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/model/system/SystemCollectionSeederTest.java
@@ -66,11 +66,18 @@ class SystemCollectionSeederTest {
             assertThat(SystemCollectionSeeder.mapFieldType(FieldType.RICH_TEXT)).isEqualTo("string");
             assertThat(SystemCollectionSeeder.mapFieldType(FieldType.ENCRYPTED)).isEqualTo("string");
             assertThat(SystemCollectionSeeder.mapFieldType(FieldType.EXTERNAL_ID)).isEqualTo("string");
-            assertThat(SystemCollectionSeeder.mapFieldType(FieldType.REFERENCE)).isEqualTo("string");
-            assertThat(SystemCollectionSeeder.mapFieldType(FieldType.LOOKUP)).isEqualTo("string");
-            assertThat(SystemCollectionSeeder.mapFieldType(FieldType.MASTER_DETAIL)).isEqualTo("string");
             assertThat(SystemCollectionSeeder.mapFieldType(FieldType.FORMULA)).isEqualTo("string");
             assertThat(SystemCollectionSeeder.mapFieldType(FieldType.ROLLUP_SUMMARY)).isEqualTo("string");
+        }
+
+        @Test
+        void shouldMapRelationshipTypesToTheirOwnNames() {
+            // Relationship fields are stored with their proper logical type so the
+            // frontend picker can recognize them as drillable. Reverse mapping in
+            // CollectionLifecycleManager.reverseMapFieldType() consumes these.
+            assertThat(SystemCollectionSeeder.mapFieldType(FieldType.REFERENCE)).isEqualTo("reference");
+            assertThat(SystemCollectionSeeder.mapFieldType(FieldType.LOOKUP)).isEqualTo("lookup");
+            assertThat(SystemCollectionSeeder.mapFieldType(FieldType.MASTER_DETAIL)).isEqualTo("master_detail");
         }
 
         @Test
@@ -251,7 +258,7 @@ class SystemCollectionSeederTest {
                     contains("INSERT INTO field"),
                     any(), any(), any(), any(), any(), any(), any(), any(),
                     any(), any(), any(), any(), any(), any(), any(), any(),
-                    any(), any(), any(), any(), any(), any(), any());
+                    any(), any(), any(), any(), any(), any(), any(), any());
         }
     }
 
@@ -285,7 +292,7 @@ class SystemCollectionSeederTest {
             verify(jdbcTemplate, never()).update(contains("INSERT INTO field"),
                     any(), any(), any(), any(), any(), any(), any(), any(),
                     any(), any(), any(), any(), any(), any(), any(), any(),
-                    any(), any(), any(), any(), any(), any(), any());
+                    any(), any(), any(), any(), any(), any(), any(), any());
         }
 
         @Test
@@ -312,7 +319,7 @@ class SystemCollectionSeederTest {
             verify(jdbcTemplate, times(missingCount)).update(contains("INSERT INTO field"),
                     any(), any(), any(), any(), any(), any(), any(), any(),
                     any(), any(), any(), any(), any(), any(), any(), any(),
-                    any(), any(), any(), any(), any(), any(), any());
+                    any(), any(), any(), any(), any(), any(), any(), any());
         }
 
         @Test
@@ -418,10 +425,13 @@ class SystemCollectionSeederTest {
                 // args[11] = reference_target
                 if ("profiles".equals(args[11])) {
                     foundReferenceField = true;
-                    // args[12] = relationship_type should be "LOOKUP"
-                    assertThat(args[12]).isEqualTo("LOOKUP");
-                    // args[13] = relationship_name should be "Profile"
-                    assertThat(args[13]).isEqualTo("Profile");
+                    // args[12] = reference_collection_id (null in this mocked test —
+                    // no real `collection` rows exist, so the lookup returns null)
+                    assertThat(args[12]).isNull();
+                    // args[13] = relationship_type should be "LOOKUP"
+                    assertThat(args[13]).isEqualTo("LOOKUP");
+                    // args[14] = relationship_name should be "Profile"
+                    assertThat(args[14]).isEqualTo("Profile");
                     break;
                 }
             }
@@ -446,10 +456,11 @@ class SystemCollectionSeederTest {
 
             boolean foundMappedField = false;
             for (Object[] args : captor.getAllValues()) {
-                // args[2] = name, args[17] = column_name
+                // args[2] = name, args[18] = column_name (shifted +1 by new
+                // reference_collection_id column at index 12)
                 if ("firstName".equals(args[2])) {
                     foundMappedField = true;
-                    assertThat(args[17]).isEqualTo("first_name");
+                    assertThat(args[18]).isEqualTo("first_name");
                     break;
                 }
             }

--- a/kelta-ui/app/src/components/FieldExpressionPicker/FieldsTab.tsx
+++ b/kelta-ui/app/src/components/FieldExpressionPicker/FieldsTab.tsx
@@ -26,15 +26,11 @@ const CHILD_REL_SEPARATOR = '__'
 /**
  * Resolves the target collection for an outgoing relationship.
  *
- * Three sources, in order of confidence:
- * 1. `referenceCollectionId` — the proper UUID set on user-defined collections.
- * 2. `referenceTarget` — the target collection *name* set on system collection
- *    LOOKUP/MASTER_DETAIL fields (which never get a UUID).
- * 3. Name-based heuristic — for plain-string FK fields like `tenantId` on
- *    system collections that have no relationship metadata at all, strip the
- *    `Id`/`_id` suffix and look for a collection whose name matches the stem
- *    or its plural. This catches the very common case where a field is
- *    structurally a foreign key but the schema didn't bother to declare it.
+ * Two sources, in order of confidence:
+ * 1. `referenceCollectionId` — the proper UUID. Set on user-defined fields and
+ *    on system fields seeded after the relationship-metadata fix landed.
+ * 2. `referenceTarget` — the target collection *name*. Defensive fallback for
+ *    legacy rows where the UUID hasn't been backfilled.
  *
  * Returns `undefined` when no candidate target collection can be found.
  */
@@ -50,22 +46,6 @@ function resolveTargetCollection(
   if (field.referenceTarget) {
     const byName = store.getCollectionByName(field.referenceTarget)
     if (byName) return byName
-  }
-  const stem = stripIdSuffix(field.name)
-  if (!stem) return undefined
-  return (
-    store.getCollectionByName(stem) ??
-    store.getCollectionByName(`${stem}s`) ??
-    store.getCollectionByName(`${stem}es`) ??
-    store.collections.find((c) => c.name.toLowerCase() === stem.toLowerCase())
-  )
-}
-
-function stripIdSuffix(name: string): string | undefined {
-  if (name.endsWith('_id') && name.length > 3) return name.slice(0, -3)
-  if (name.endsWith('Id') && name.length > 2) {
-    const stem = name.slice(0, -2)
-    return stem.charAt(0).toLowerCase() + stem.slice(1)
   }
   return undefined
 }


### PR DESCRIPTION
## Summary

The previous fix worked around system collections by adding a name-suffix heuristic in the picker. This replaces that with the proper backend fix the user asked for: system collections now emit correct relationship metadata, so the picker doesn't need any special-casing.

Three root causes addressed:

1. \`SystemCollectionSeeder.mapFieldType\` collapsed \`REFERENCE\` / \`LOOKUP\` / \`MASTER_DETAIL\` all to \`"string"\`. The frontend's type normalisation expected \`"reference"\` / \`"lookup"\` / \`"master_detail"\`, so it never recognised system FKs as relationships. Mapping now emits the proper logical type for each.
2. The \`INSERT INTO field\` statement wrote \`reference_target\` (name) but not \`reference_collection_id\` (UUID). The frontend's collection-store keys off the UUID. Now populated at insert time, with a post-pass backfill that handles forward references and reuses the same SQL as the historical V69 migration.
3. \`tenantId\` on \`users\` was only declared via \`addImmutableField(\"tenantId\")\` — a flag, not a field — so it was invisible in the schema. Now declared with \`FieldDefinition.lookup(\"tenantId\", \"tenants\", \"Tenant\")\` so users can drill from a User to their Tenant in the picker.

Frontend cleanup: drop the name-suffix heuristic from [FieldsTab.tsx](kelta-ui/app/src/components/FieldExpressionPicker/FieldsTab.tsx) introduced in #802. Keep the \`referenceTarget\` fallback as defensive cover for legacy rows.

## Test plan

- [x] All 33 \`SystemCollectionSeederTest\` cases pass (positional assertions updated for the new column, plus a new test asserting relationship types map to themselves).
- [x] Full runtime-core suite: 1074 tests, all green.
- [x] Worker round-trip tests for \`reverseMapFieldType\` pass.
- [x] Frontend lint, typecheck, and 16 unit tests pass.
- [ ] Manual: after deploy, open an email template related to \`Users\`, confirm \`tenantId\` appears with the cascade chevron and drilling shows the Tenants collection's fields. Also verify \`profileId\` and \`managerId\` now show as relationships rather than plain strings.

## Migration impact

Existing system-collection field rows will retain their old type strings (\`"string"\`) until reseeded — but the post-pass backfill only touches \`reference_collection_id\`, which is harmless on already-correct rows. On any environment where the seeder runs (boot or admin-triggered reseed), system fields will get rewritten to their proper types on the next insert/sync. For environments that already have system rows with \`type=\"string\"\` and need them updated in place, a separate one-shot migration would be needed — flag if that's required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)