### PR TITLE
fix(flow): compute QUERY_RECORDS aggregations via storage adapter

### DIFF
--- a/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/query/AggregationSpec.java
+++ b/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/query/AggregationSpec.java
@@ -1,0 +1,38 @@
+package io.kelta.runtime.query;
+
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Specification for a single aggregation to compute over a query result set.
+ *
+ * <p>Used by {@link QueryEngine#aggregate(io.kelta.runtime.model.CollectionDefinition, java.util.List, java.util.List)}
+ * to describe SQL aggregate functions (e.g. {@code SUM(total_amount) AS total_spent}).
+ *
+ * @param function aggregate function: COUNT, SUM, MIN, MAX, AVG (uppercase)
+ * @param field    column to aggregate; required for SUM/MIN/MAX/AVG, ignored for COUNT
+ * @param alias    output key in the result map; must be a valid SQL identifier
+ */
+public record AggregationSpec(String function, String field, String alias) {
+
+    private static final Set<String> VALID_FUNCTIONS = Set.of("COUNT", "SUM", "MIN", "MAX", "AVG");
+
+    public AggregationSpec {
+        Objects.requireNonNull(function, "function cannot be null");
+        Objects.requireNonNull(alias, "alias cannot be null");
+        function = function.toUpperCase();
+        if (!VALID_FUNCTIONS.contains(function)) {
+            throw new IllegalArgumentException(
+                "Invalid aggregate function '" + function + "'; must be one of " + VALID_FUNCTIONS);
+        }
+        if (alias.isBlank()) {
+            throw new IllegalArgumentException("alias cannot be blank");
+        }
+        if (!"COUNT".equals(function)) {
+            if (field == null || field.isBlank()) {
+                throw new IllegalArgumentException(
+                    "field is required for aggregate function " + function);
+            }
+        }
+    }
+}

--- a/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/query/DefaultQueryEngine.java
+++ b/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/query/DefaultQueryEngine.java
@@ -183,6 +183,28 @@ public class DefaultQueryEngine implements QueryEngine {
     }
     
     @Override
+    public Map<String, Object> aggregate(CollectionDefinition definition,
+                                          List<FilterCondition> filters,
+                                          List<AggregationSpec> specs) {
+        Objects.requireNonNull(definition, "definition cannot be null");
+        if (specs == null || specs.isEmpty()) {
+            return Map.of();
+        }
+
+        if (filters != null) {
+            validateFilterFields(definition, filters);
+        }
+        for (AggregationSpec spec : specs) {
+            if (spec.field() != null && !isValidField(definition, spec.field())) {
+                throw new InvalidQueryException(spec.field(),
+                    "Aggregation field does not exist in collection '" + definition.name() + "'");
+            }
+        }
+
+        return storageAdapter.aggregate(definition, filters == null ? List.of() : filters, specs);
+    }
+
+    @Override
     public Optional<Map<String, Object>> getById(CollectionDefinition definition, String id) {
         Objects.requireNonNull(definition, "definition cannot be null");
         Objects.requireNonNull(id, "id cannot be null");

--- a/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/query/QueryEngine.java
+++ b/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/query/QueryEngine.java
@@ -2,6 +2,7 @@ package io.kelta.runtime.query;
 
 import io.kelta.runtime.model.CollectionDefinition;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -55,6 +56,23 @@ public interface QueryEngine {
      * @throws io.kelta.runtime.storage.StorageException if the query fails
      */
     QueryResult executeQuery(CollectionDefinition definition, QueryRequest request);
+
+    /**
+     * Computes one or more aggregate values over the records matching {@code filters}.
+     *
+     * <p>Validates each spec's {@code field} against the collection definition before
+     * delegating to the storage adapter. The returned map is keyed by spec alias.
+     *
+     * @param definition the collection definition
+     * @param filters    filter conditions; same semantics as {@code QueryRequest.filters()}
+     * @param specs      aggregations to compute; must be non-empty
+     * @return aggregate values keyed by alias
+     * @throws InvalidQueryException if a spec's field does not exist in the collection
+     * @throws io.kelta.runtime.storage.StorageException if the query fails
+     */
+    Map<String, Object> aggregate(CollectionDefinition definition,
+                                   List<FilterCondition> filters,
+                                   List<AggregationSpec> specs);
     
     /**
      * Gets a single record by its ID.

--- a/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/storage/PhysicalTableStorageAdapter.java
+++ b/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/storage/PhysicalTableStorageAdapter.java
@@ -4,6 +4,7 @@ import io.kelta.runtime.context.TenantContext;
 import io.kelta.runtime.model.CollectionDefinition;
 import io.kelta.runtime.model.FieldDefinition;
 import io.kelta.runtime.model.FieldType;
+import io.kelta.runtime.query.AggregationSpec;
 import io.kelta.runtime.query.FilterCondition;
 import io.kelta.runtime.query.FilterOperator;
 import io.kelta.runtime.query.Pagination;
@@ -298,6 +299,66 @@ public class PhysicalTableStorageAdapter implements StorageAdapter {
         } catch (DataAccessException e) {
             throw new StorageException("Failed to query collection: " + definition.name(), e);
         }
+    }
+
+    @Override
+    public Map<String, Object> aggregate(CollectionDefinition definition,
+                                          List<FilterCondition> filters,
+                                          List<AggregationSpec> specs) {
+        if (specs == null || specs.isEmpty()) {
+            return Map.of();
+        }
+
+        TableRef tableRef = getTableRef(definition);
+        List<Object> params = new ArrayList<>();
+
+        StringBuilder selectList = new StringBuilder();
+        for (int i = 0; i < specs.size(); i++) {
+            AggregationSpec spec = specs.get(i);
+            if (i > 0) selectList.append(", ");
+            String aliasIdent = sanitizeIdentifier(spec.alias());
+            if ("COUNT".equals(spec.function())) {
+                selectList.append("COUNT(*) AS ").append(aliasIdent);
+            } else {
+                String columnName = sanitizeIdentifier(resolveColumnName(definition, spec.field()));
+                selectList.append(spec.function()).append("(").append(columnName).append(") AS ").append(aliasIdent);
+            }
+        }
+
+        StringBuilder sql = new StringBuilder("SELECT ");
+        sql.append(selectList);
+        sql.append(" FROM ").append(tableRef.toSql());
+
+        if (filters != null && !filters.isEmpty()) {
+            sql.append(" WHERE ");
+            sql.append(buildWhereClause(filters, definition, params));
+        }
+
+        try {
+            Map<String, Object> row = jdbcTemplate.queryForMap(sql.toString(), params.toArray());
+            Map<String, Object> caseInsensitive = new HashMap<>();
+            for (Map.Entry<String, Object> e : row.entrySet()) {
+                caseInsensitive.put(e.getKey().toLowerCase(), e.getValue());
+            }
+            Map<String, Object> result = new HashMap<>();
+            for (AggregationSpec spec : specs) {
+                Object value = caseInsensitive.get(spec.alias().toLowerCase());
+                result.put(spec.alias(), normalizeAggregateValue(spec.function(), value));
+            }
+            return result;
+        } catch (DataAccessException e) {
+            throw new StorageException("Failed to aggregate collection: " + definition.name(), e);
+        }
+    }
+
+    private Object normalizeAggregateValue(String function, Object raw) {
+        if ("COUNT".equals(function)) {
+            if (raw == null) return 0L;
+            return raw instanceof Number n ? n.longValue() : Long.parseLong(raw.toString());
+        }
+        if (raw == null) return null;
+        if (raw instanceof Number n) return n.doubleValue();
+        return raw;
     }
 
     @Override

--- a/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/storage/StorageAdapter.java
+++ b/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/storage/StorageAdapter.java
@@ -1,9 +1,12 @@
 package io.kelta.runtime.storage;
 
 import io.kelta.runtime.model.CollectionDefinition;
+import io.kelta.runtime.query.AggregationSpec;
+import io.kelta.runtime.query.FilterCondition;
 import io.kelta.runtime.query.QueryRequest;
 import io.kelta.runtime.query.QueryResult;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -74,6 +77,26 @@ public interface StorageAdapter {
      * @throws StorageException if the query fails
      */
     QueryResult query(CollectionDefinition definition, QueryRequest request);
+
+    /**
+     * Computes one or more aggregate values over a filtered subset of records.
+     *
+     * <p>Builds and executes a single SQL query of the form
+     * {@code SELECT fn1(col1) AS alias1, fn2(col2) AS alias2 FROM <table> WHERE ...},
+     * reusing the same tenant schema resolution, column-name mapping, and type-coercion
+     * rules as {@link #query(CollectionDefinition, QueryRequest)}.
+     *
+     * @param definition the collection definition
+     * @param filters    filter conditions; same semantics as {@code QueryRequest.filters()}
+     * @param specs      aggregations to compute (one per output entry); must be non-empty
+     * @return a map keyed by each spec's alias, with values typed as {@code Long} for
+     *         {@code COUNT} and {@code Double} for {@code SUM}/{@code AVG}/{@code MIN}/{@code MAX}
+     *         on numeric columns; null/zero results are returned as the zero of the expected type
+     * @throws StorageException if the query fails
+     */
+    Map<String, Object> aggregate(CollectionDefinition definition,
+                                   List<FilterCondition> filters,
+                                   List<AggregationSpec> specs);
     
     /**
      * Gets a single record by its ID.

--- a/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/storage/PhysicalTableStorageAdapterTest.java
+++ b/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/storage/PhysicalTableStorageAdapterTest.java
@@ -4,6 +4,7 @@ import io.kelta.runtime.model.CollectionDefinition;
 import io.kelta.runtime.model.FieldDefinition;
 import io.kelta.runtime.model.FieldType;
 import io.kelta.runtime.model.StorageConfig;
+import io.kelta.runtime.query.AggregationSpec;
 import io.kelta.runtime.query.FilterCondition;
 import io.kelta.runtime.query.FilterOperator;
 import io.kelta.runtime.query.Pagination;
@@ -801,6 +802,101 @@ class PhysicalTableStorageAdapterTest {
             
             assertEquals(1, result.data().size()); // Only Banana has a description
             assertEquals("Banana", result.data().get(0).get("NAME"));
+        }
+    }
+
+    @Nested
+    @DisplayName("Aggregate Tests")
+    class AggregateTests {
+
+        @BeforeEach
+        void initTableAndData() {
+            adapter.initializeCollection(testCollection);
+            insertRow("1", "Apple",      1.99, 100, true,  "SKU001");
+            insertRow("2", "Banana",     0.99, 200, true,  "SKU002");
+            insertRow("3", "Cherry",     3.99,  50, false, "SKU003");
+            insertRow("4", "Date",       5.99,  30, true,  "SKU004");
+            insertRow("5", "Elderberry", 7.99,  10, false, "SKU005");
+        }
+
+        private void insertRow(String id, String name, double price, int quantity,
+                               boolean active, String sku) {
+            Map<String, Object> data = new HashMap<>();
+            data.put("id", id);
+            data.put("name", name);
+            data.put("price", price);
+            data.put("quantity", quantity);
+            data.put("active", active);
+            data.put("sku", sku);
+            data.put("createdAt", Instant.now());
+            data.put("updatedAt", Instant.now());
+            adapter.create(testCollection, data);
+        }
+
+        @Test
+        @DisplayName("SUM + COUNT with no filters covers all rows")
+        void sumAndCountAll() {
+            Map<String, Object> result = adapter.aggregate(
+                testCollection,
+                List.of(),
+                List.of(
+                    new AggregationSpec("SUM", "price", "total_price"),
+                    new AggregationSpec("COUNT", null, "total_count")
+                )
+            );
+
+            assertEquals(20.95, ((Number) result.get("total_price")).doubleValue(), 0.001);
+            assertEquals(5L, result.get("total_count"));
+        }
+
+        @Test
+        @DisplayName("Aggregations honour filter conditions")
+        void aggregationsRespectFilters() {
+            Map<String, Object> result = adapter.aggregate(
+                testCollection,
+                List.of(new FilterCondition("active", FilterOperator.EQ, true)),
+                List.of(
+                    new AggregationSpec("SUM", "quantity", "total_qty"),
+                    new AggregationSpec("COUNT", null, "active_count")
+                )
+            );
+
+            assertEquals(330.0, ((Number) result.get("total_qty")).doubleValue(), 0.001);
+            assertEquals(3L, result.get("active_count"));
+        }
+
+        @Test
+        @DisplayName("Empty match returns zero COUNT and null SUM normalised")
+        void emptyMatchYieldsZeros() {
+            Map<String, Object> result = adapter.aggregate(
+                testCollection,
+                List.of(new FilterCondition("name", FilterOperator.EQ, "no-such-fruit")),
+                List.of(
+                    new AggregationSpec("SUM", "price", "total"),
+                    new AggregationSpec("COUNT", null, "count")
+                )
+            );
+
+            assertEquals(0L, result.get("count"));
+            assertNull(result.get("total"));
+        }
+
+        @Test
+        @DisplayName("MIN, MAX, AVG produce expected scalars")
+        void minMaxAvg() {
+            Map<String, Object> result = adapter.aggregate(
+                testCollection,
+                List.of(),
+                List.of(
+                    new AggregationSpec("MIN", "price", "min_price"),
+                    new AggregationSpec("MAX", "price", "max_price"),
+                    new AggregationSpec("AVG", "price", "avg_price")
+                )
+            );
+
+            assertEquals(0.99, ((Number) result.get("min_price")).doubleValue(), 0.001);
+            assertEquals(7.99, ((Number) result.get("max_price")).doubleValue(), 0.001);
+            assertEquals(4.19, ((Number) result.get("avg_price")).doubleValue(), 0.001);
         }
     }
 }

--- a/kelta-platform/runtime/runtime-module-core/src/main/java/io/kelta/runtime/module/core/CoreActionsModule.java
+++ b/kelta-platform/runtime/runtime-module-core/src/main/java/io/kelta/runtime/module/core/CoreActionsModule.java
@@ -67,16 +67,8 @@ public class CoreActionsModule implements KeltaModule {
         handlers.add(new DeleteRecordActionHandler(objectMapper, collectionRegistry));
 
         // Query handler — queries records with optional aggregations
-        var rollupService = context.getExtension(
-            io.kelta.runtime.service.RollupSummaryService.class);
-        if (rollupService != null) {
-            handlers.add(new QueryRecordsActionHandler(
-                objectMapper, collectionRegistry, queryEngine, rollupService));
-        } else {
-            // Register without aggregation support — queries still work
-            handlers.add(new QueryRecordsActionHandler(
-                objectMapper, collectionRegistry, queryEngine, null));
-        }
+        handlers.add(new QueryRecordsActionHandler(
+            objectMapper, collectionRegistry, queryEngine));
 
         // Handler needing FormulaEvaluator + ActionHandlerRegistry
         handlers.add(new DecisionActionHandler(

--- a/kelta-platform/runtime/runtime-module-core/src/main/java/io/kelta/runtime/module/core/handlers/QueryRecordsActionHandler.java
+++ b/kelta-platform/runtime/runtime-module-core/src/main/java/io/kelta/runtime/module/core/handlers/QueryRecordsActionHandler.java
@@ -3,7 +3,6 @@ package io.kelta.runtime.module.core.handlers;
 import io.kelta.runtime.model.CollectionDefinition;
 import io.kelta.runtime.query.*;
 import io.kelta.runtime.registry.CollectionRegistry;
-import io.kelta.runtime.service.RollupSummaryService;
 import io.kelta.runtime.workflow.ActionContext;
 import io.kelta.runtime.workflow.ActionHandler;
 import io.kelta.runtime.workflow.ActionResult;
@@ -52,16 +51,13 @@ public class QueryRecordsActionHandler implements ActionHandler {
     private final ObjectMapper objectMapper;
     private final CollectionRegistry collectionRegistry;
     private final QueryEngine queryEngine;
-    private final RollupSummaryService rollupSummaryService;
 
     public QueryRecordsActionHandler(ObjectMapper objectMapper,
                                      CollectionRegistry collectionRegistry,
-                                     QueryEngine queryEngine,
-                                     RollupSummaryService rollupSummaryService) {
+                                     QueryEngine queryEngine) {
         this.objectMapper = objectMapper;
         this.collectionRegistry = collectionRegistry;
         this.queryEngine = queryEngine;
-        this.rollupSummaryService = rollupSummaryService;
     }
 
     @Override
@@ -75,7 +71,6 @@ public class QueryRecordsActionHandler implements ActionHandler {
             Map<String, Object> config = objectMapper.readValue(
                 context.actionConfigJson(), new TypeReference<>() {});
 
-            // 1. Resolve collection
             String targetCollectionName = (String) config.get("targetCollectionName");
             if (targetCollectionName == null || targetCollectionName.isBlank()) {
                 return ActionResult.failure("targetCollectionName is required");
@@ -86,42 +81,31 @@ public class QueryRecordsActionHandler implements ActionHandler {
                 return ActionResult.failure("Collection not found: " + targetCollectionName);
             }
 
-            // 2. Build filters
             List<FilterCondition> filters = buildFilters(config);
-
-            // 3. Build sorting
             List<SortField> sorting = buildSorting(config);
 
-            // 4. Build pagination
             int pageSize = config.containsKey("pageSize")
                 ? ((Number) config.get("pageSize")).intValue()
                 : 200;
             Pagination pagination = new Pagination(1, pageSize);
 
-            // 5. Execute query
             QueryRequest request = new QueryRequest(pagination, sorting, List.of(), filters);
             QueryResult queryResult = queryEngine.executeQuery(targetCollection, request);
 
-            // 6. Build output
             Map<String, Object> output = new LinkedHashMap<>();
             output.put("records", queryResult.data());
             output.put("totalCount", queryResult.metadata().totalCount());
 
-            // 7. Compute aggregations if requested
-            @SuppressWarnings("unchecked")
-            List<Map<String, Object>> aggregations =
-                (List<Map<String, Object>>) config.get("aggregations");
-
-            if (aggregations != null && !aggregations.isEmpty()
-                    && rollupSummaryService != null) {
-                Map<String, Object> aggResults = computeAggregations(
-                    targetCollection, filters, aggregations);
+            List<AggregationSpec> aggregationSpecs = buildAggregationSpecs(config);
+            if (!aggregationSpecs.isEmpty()) {
+                Map<String, Object> aggResults = queryEngine.aggregate(
+                    targetCollection, filters, aggregationSpecs);
                 output.put("aggregations", aggResults);
             }
 
             log.info("Query records: collection={}, filters={}, records={}, aggregations={}",
                 targetCollectionName, filters.size(), queryResult.data().size(),
-                aggregations != null ? aggregations.size() : 0);
+                aggregationSpecs.size());
 
             return ActionResult.success(output);
         } catch (Exception e) {
@@ -139,6 +123,7 @@ public class QueryRecordsActionHandler implements ActionHandler {
             if (config.get("targetCollectionName") == null) {
                 throw new IllegalArgumentException("Config must contain 'targetCollectionName'");
             }
+            buildAggregationSpecs(config);
         } catch (IllegalArgumentException e) {
             throw e;
         } catch (Exception e) {
@@ -204,70 +189,21 @@ public class QueryRecordsActionHandler implements ActionHandler {
         return sorting;
     }
 
-    private Map<String, Object> computeAggregations(
-            CollectionDefinition collection,
-            List<FilterCondition> filters,
-            List<Map<String, Object>> aggregations) {
-
-        Map<String, Object> results = new LinkedHashMap<>();
-        String tableName = collection.storageConfig().tableName();
-
-        // For aggregations, we need a filter field and value to pass to RollupSummaryService.
-        // If we have filters, use the first one as the grouping constraint.
-        // If no filters, compute against all records (use a dummy always-true condition).
-        String filterField = null;
-        String filterValue = null;
-        Map<String, Object> additionalFilter = null;
-
-        if (!filters.isEmpty()) {
-            FilterCondition primaryFilter = filters.get(0);
-            filterField = primaryFilter.fieldName();
-            filterValue = primaryFilter.value() != null ? primaryFilter.value().toString() : null;
-
-            // Any additional filters beyond the first one
-            if (filters.size() > 1) {
-                additionalFilter = new LinkedHashMap<>();
-                for (int i = 1; i < filters.size(); i++) {
-                    FilterCondition fc = filters.get(i);
-                    additionalFilter.put(fc.fieldName(),
-                        fc.value() != null ? fc.value().toString() : null);
-                }
-            }
+    @SuppressWarnings("unchecked")
+    private List<AggregationSpec> buildAggregationSpecs(Map<String, Object> config) {
+        List<Map<String, Object>> raw =
+            (List<Map<String, Object>>) config.get("aggregations");
+        if (raw == null || raw.isEmpty()) {
+            return List.of();
         }
 
-        for (Map<String, Object> agg : aggregations) {
+        List<AggregationSpec> specs = new ArrayList<>(raw.size());
+        for (Map<String, Object> agg : raw) {
             String function = (String) agg.get("function");
             String field = (String) agg.get("field");
             String alias = (String) agg.get("alias");
-
-            if (function == null || alias == null) continue;
-
-            try {
-                Object value;
-                if (filterField != null && filterValue != null) {
-                    value = rollupSummaryService.compute(
-                        tableName, filterField, filterValue,
-                        function.toUpperCase(), field, additionalFilter);
-                } else {
-                    // No filter — compute aggregate over all records using a sentinel
-                    // Use tenant_id or a similar always-present field if available
-                    // For now, we'll fall back to 0 for count and null for others
-                    value = function.equalsIgnoreCase("COUNT") ? 0L : null;
-                }
-
-                // Ensure numeric types are consistent
-                if (value == null) {
-                    value = function.equalsIgnoreCase("COUNT") ? 0L : 0.0;
-                }
-
-                results.put(alias, value);
-            } catch (Exception e) {
-                log.warn("Failed to compute aggregation {} for alias '{}': {}",
-                    function, alias, e.getMessage());
-                results.put(alias, function.equalsIgnoreCase("COUNT") ? 0L : 0.0);
-            }
+            specs.add(new AggregationSpec(function, field, alias));
         }
-
-        return results;
+        return specs;
     }
 }

--- a/kelta-platform/runtime/runtime-module-core/src/test/java/io/kelta/runtime/module/core/handlers/QueryRecordsActionHandlerTest.java
+++ b/kelta-platform/runtime/runtime-module-core/src/test/java/io/kelta/runtime/module/core/handlers/QueryRecordsActionHandlerTest.java
@@ -1,0 +1,162 @@
+package io.kelta.runtime.module.core.handlers;
+
+import io.kelta.runtime.model.CollectionDefinition;
+import io.kelta.runtime.query.AggregationSpec;
+import io.kelta.runtime.query.FilterCondition;
+import io.kelta.runtime.query.Pagination;
+import io.kelta.runtime.query.PaginationMetadata;
+import io.kelta.runtime.query.QueryEngine;
+import io.kelta.runtime.query.QueryRequest;
+import io.kelta.runtime.query.QueryResult;
+import io.kelta.runtime.registry.CollectionRegistry;
+import io.kelta.runtime.workflow.ActionContext;
+import io.kelta.runtime.workflow.ActionResult;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import tools.jackson.databind.ObjectMapper;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@DisplayName("QueryRecordsActionHandler")
+class QueryRecordsActionHandlerTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final CollectionRegistry registry = mock(CollectionRegistry.class);
+    private final QueryEngine queryEngine = mock(QueryEngine.class);
+    private final QueryRecordsActionHandler handler =
+        new QueryRecordsActionHandler(objectMapper, registry, queryEngine);
+
+    private static ActionContext context(String configJson) {
+        return ActionContext.builder()
+            .tenantId("t1").collectionId("c1").collectionName("orders").recordId("r1")
+            .data(Map.of())
+            .actionConfigJson(configJson).workflowRuleId("wf1").executionLogId("log1")
+            .build();
+    }
+
+    private static QueryResult queryResultWith(List<Map<String, Object>> rows, long total) {
+        return new QueryResult(rows, new PaginationMetadata(total, 1, 200, (int) Math.ceil(total / 200.0)));
+    }
+
+    @Test
+    @DisplayName("Should have correct action type key")
+    void key() {
+        assertEquals("QUERY_RECORDS", handler.getActionTypeKey());
+    }
+
+    @Test
+    @DisplayName("Filtered SUM + COUNT returns engine results")
+    void filteredAggregation() {
+        CollectionDefinition collDef = mock(CollectionDefinition.class);
+        when(registry.get("orders")).thenReturn(collDef);
+        when(queryEngine.executeQuery(eq(collDef), any(QueryRequest.class)))
+            .thenReturn(queryResultWith(List.of(Map.of("id", "o1", "total_amount", 161.98)), 1));
+        when(queryEngine.aggregate(eq(collDef), any(), any()))
+            .thenReturn(Map.of("total_spent", 161.98, "total_orders", 1L));
+
+        String config = """
+            {
+              "targetCollectionName": "orders",
+              "filters": [{"field": "customer", "operator": "eq", "value": "cust-1"}],
+              "aggregations": [
+                {"function": "SUM", "field": "total_amount", "alias": "total_spent"},
+                {"function": "COUNT", "alias": "total_orders"}
+              ]
+            }
+            """;
+
+        ActionResult result = handler.execute(context(config));
+        assertTrue(result.successful());
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> aggs = (Map<String, Object>) result.outputData().get("aggregations");
+        assertEquals(161.98, aggs.get("total_spent"));
+        assertEquals(1L, aggs.get("total_orders"));
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<FilterCondition>> filterCap = ArgumentCaptor.forClass(List.class);
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<AggregationSpec>> specCap = ArgumentCaptor.forClass(List.class);
+        verify(queryEngine).aggregate(eq(collDef), filterCap.capture(), specCap.capture());
+
+        assertEquals(1, filterCap.getValue().size());
+        assertEquals("customer", filterCap.getValue().get(0).fieldName());
+        assertEquals(2, specCap.getValue().size());
+        assertEquals("SUM", specCap.getValue().get(0).function());
+        assertEquals("COUNT", specCap.getValue().get(1).function());
+    }
+
+    @Test
+    @DisplayName("Empty filters still aggregate via QueryEngine")
+    void emptyFilterAggregation() {
+        CollectionDefinition collDef = mock(CollectionDefinition.class);
+        when(registry.get("orders")).thenReturn(collDef);
+        when(queryEngine.executeQuery(eq(collDef), any(QueryRequest.class)))
+            .thenReturn(queryResultWith(List.of(), 5));
+        when(queryEngine.aggregate(eq(collDef), eq(List.of()), any()))
+            .thenReturn(Map.of("count", 5L));
+
+        String config = """
+            {
+              "targetCollectionName": "orders",
+              "aggregations": [{"function": "COUNT", "alias": "count"}]
+            }
+            """;
+
+        ActionResult result = handler.execute(context(config));
+        assertTrue(result.successful());
+        @SuppressWarnings("unchecked")
+        Map<String, Object> aggs = (Map<String, Object>) result.outputData().get("aggregations");
+        assertEquals(5L, aggs.get("count"));
+        verify(queryEngine).aggregate(eq(collDef), eq(List.of()), any());
+    }
+
+    @Test
+    @DisplayName("Skips aggregations block when none configured")
+    void noAggregationsConfigured() {
+        CollectionDefinition collDef = mock(CollectionDefinition.class);
+        when(registry.get("orders")).thenReturn(collDef);
+        when(queryEngine.executeQuery(eq(collDef), any(QueryRequest.class)))
+            .thenReturn(queryResultWith(List.of(), 0));
+
+        String config = "{\"targetCollectionName\": \"orders\"}";
+        ActionResult result = handler.execute(context(config));
+        assertTrue(result.successful());
+        assertFalse(result.outputData().containsKey("aggregations"));
+    }
+
+    @Test
+    @DisplayName("validate rejects SUM without field")
+    void validateRejectsSumWithoutField() {
+        String config = """
+            {"targetCollectionName": "orders",
+             "aggregations": [{"function": "SUM", "alias": "x"}]}
+            """;
+        IllegalArgumentException ex = assertThrows(
+            IllegalArgumentException.class, () -> handler.validate(config));
+        assertNotNull(ex.getMessage());
+    }
+
+    @Test
+    @DisplayName("validate rejects unknown aggregate function")
+    void validateRejectsUnknownFunction() {
+        String config = """
+            {"targetCollectionName": "orders",
+             "aggregations": [{"function": "MEDIAN", "field": "x", "alias": "m"}]}
+            """;
+        assertThrows(IllegalArgumentException.class, () -> handler.validate(config));
+    }
+}


### PR DESCRIPTION
## Summary
- Flow `QUERY_RECORDS` step returned `aggregations: { total_spent: 0, total_orders: 0 }` for any tenant collection. Root cause: handler delegated to `RollupSummaryService` which (a) ignored schema-per-tenant table resolution (`FROM orders` instead of `<tenant>.orders`) and (b) skipped `TypeCoercionService`, so `customer = <uuid>` failed at the SQL layer. The exception was swallowed by the handler's catch block, returning 0.
- Added `aggregate()` to `StorageAdapter` / `PhysicalTableStorageAdapter` and `QueryEngine` / `DefaultQueryEngine`, reusing existing `getTableRef()` + `buildWhereClause()` so aggregations honour the same tenant schema, column-name mapping, and type coercion as regular queries.
- `QueryRecordsActionHandler` now builds `AggregationSpec` records and calls `queryEngine.aggregate()` directly; the rollup-shaped fallback that hard-coded zeros is gone. `RollupSummaryService` is untouched and still used by `ROLLUP_SUMMARY` field computation.

## Test plan
- [x] `mvn -pl runtime/runtime-core,runtime/runtime-module-core -am test` — 1078 + 65 tests, 0 failures
- [x] `/verify` — runtime build + gateway (427) + worker (1070) + kelta-web lint/typecheck/format/tests all green
- [x] New `QueryRecordsActionHandlerTest` (6 cases): filtered SUM+COUNT, empty filters, no aggregations configured, SUM-without-field rejection, unknown function rejection
- [x] New `PhysicalTableStorageAdapterTest$AggregateTests` (4 cases) on H2: SUM+COUNT all rows, filter-respecting aggregation, empty match (COUNT=0, SUM=null), MIN/MAX/AVG
- [ ] Manual: trigger flow `f477fe36-03a0-4d9c-b706-a07109d521f6`, confirm `customers.total_spent` / `total_orders` reflect order SUM/COUNT instead of 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)