### PR TITLE
fix(layouts): honor configured displayColumns on related lists

### DIFF
--- a/kelta-ui/app/src/components/LayoutRelatedLists/LayoutRelatedLists.test.tsx
+++ b/kelta-ui/app/src/components/LayoutRelatedLists/LayoutRelatedLists.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest'
+import { parseDisplayColumns } from './parseDisplayColumns'
+
+describe('parseDisplayColumns', () => {
+  it('returns empty array for null/undefined/empty input', () => {
+    expect(parseDisplayColumns(null)).toEqual([])
+    expect(parseDisplayColumns(undefined)).toEqual([])
+    expect(parseDisplayColumns('')).toEqual([])
+    expect(parseDisplayColumns('   ')).toEqual([])
+  })
+
+  it('parses JSON-stringified array (current builder format)', () => {
+    expect(parseDisplayColumns('["productName","quantity","unitPrice"]')).toEqual([
+      'productName',
+      'quantity',
+      'unitPrice',
+    ])
+  })
+
+  it('drops non-string entries from a JSON array', () => {
+    expect(parseDisplayColumns('["a", 1, null, "b"]')).toEqual(['a', 'b'])
+  })
+
+  it('returns empty array for malformed JSON', () => {
+    expect(parseDisplayColumns('[not, valid, json')).toEqual([])
+  })
+
+  it('parses comma-separated legacy format', () => {
+    expect(parseDisplayColumns('productName, quantity ,unitPrice')).toEqual([
+      'productName',
+      'quantity',
+      'unitPrice',
+    ])
+  })
+
+  it('drops empty fragments from comma-separated input', () => {
+    expect(parseDisplayColumns('a,,b, ,c')).toEqual(['a', 'b', 'c'])
+  })
+})

--- a/kelta-ui/app/src/components/LayoutRelatedLists/LayoutRelatedLists.tsx
+++ b/kelta-ui/app/src/components/LayoutRelatedLists/LayoutRelatedLists.tsx
@@ -11,6 +11,14 @@ import { RelatedList } from '@/components/RelatedList'
 import type { LayoutRelatedListDto } from '@/hooks/usePageLayout'
 import { parseDisplayColumns } from './parseDisplayColumns'
 
+/**
+ * Normalize the persisted sort direction into the lower-case form the
+ * RelatedList API uses. Anything unrecognized falls back to ascending.
+ */
+function normalizeSortDirection(raw: string | null | undefined): 'asc' | 'desc' {
+  return raw && raw.trim().toLowerCase() === 'desc' ? 'desc' : 'asc'
+}
+
 export interface LayoutRelatedListsProps {
   /** Related list configurations from the resolved page layout */
   relatedLists: LayoutRelatedListDto[]
@@ -50,6 +58,8 @@ export function LayoutRelatedLists({
           tenantSlug={tenantSlug}
           limit={rl.rowLimit}
           displayColumns={parseDisplayColumns(rl.displayColumns)}
+          sortField={rl.sortField ?? undefined}
+          sortDirection={normalizeSortDirection(rl.sortDirection)}
           includedData={includedData}
         />
       ))}

--- a/kelta-ui/app/src/components/LayoutRelatedLists/LayoutRelatedLists.tsx
+++ b/kelta-ui/app/src/components/LayoutRelatedLists/LayoutRelatedLists.tsx
@@ -9,6 +9,7 @@
 import React, { useMemo } from 'react'
 import { RelatedList } from '@/components/RelatedList'
 import type { LayoutRelatedListDto } from '@/hooks/usePageLayout'
+import { parseDisplayColumns } from './parseDisplayColumns'
 
 export interface LayoutRelatedListsProps {
   /** Related list configurations from the resolved page layout */
@@ -48,6 +49,7 @@ export function LayoutRelatedLists({
           parentRecordId={parentRecordId}
           tenantSlug={tenantSlug}
           limit={rl.rowLimit}
+          displayColumns={parseDisplayColumns(rl.displayColumns)}
           includedData={includedData}
         />
       ))}

--- a/kelta-ui/app/src/components/LayoutRelatedLists/parseDisplayColumns.ts
+++ b/kelta-ui/app/src/components/LayoutRelatedLists/parseDisplayColumns.ts
@@ -1,0 +1,25 @@
+/**
+ * Parse the `displayColumns` value persisted with a related-list layout entry.
+ *
+ * The layout builder stores this as `JSON.stringify(string[])` (JSON-encoded
+ * array of field names). Older or hand-edited rows may use a comma-separated
+ * string. Anything unrecognized is treated as "no override" (empty array),
+ * which causes the renderer to fall back to auto-discovered columns.
+ */
+export function parseDisplayColumns(raw: string | null | undefined): string[] {
+  if (!raw) return []
+  const trimmed = raw.trim()
+  if (!trimmed) return []
+  if (trimmed.startsWith('[')) {
+    try {
+      const parsed = JSON.parse(trimmed)
+      return Array.isArray(parsed) ? parsed.filter((s): s is string => typeof s === 'string') : []
+    } catch {
+      return []
+    }
+  }
+  return trimmed
+    .split(',')
+    .map((c) => c.trim())
+    .filter(Boolean)
+}

--- a/kelta-ui/app/src/components/RelatedList/RelatedList.test.tsx
+++ b/kelta-ui/app/src/components/RelatedList/RelatedList.test.tsx
@@ -242,6 +242,89 @@ describe('RelatedList', () => {
       expect(headers).toEqual(['name', 'email', 'phone', 'title'])
     })
 
+    it('passes sortField as JSON:API sort param (asc default)', async () => {
+      mockSchemaWith(['name'])
+      mockOneRecord({ name: 'Ada' })
+
+      render(
+        <TestWrapper>
+          <RelatedList
+            collectionName="contacts"
+            foreignKeyField="accountId"
+            parentRecordId="rec-123"
+            tenantSlug="test-tenant"
+            displayColumns={['name']}
+            sortField="name"
+          />
+        </TestWrapper>
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText('Ada')).toBeDefined()
+      })
+
+      const recordsCall = mockGet.mock.calls.find(([url]) =>
+        String(url).startsWith('/api/contacts')
+      )
+      expect(recordsCall).toBeDefined()
+      expect(String(recordsCall![0])).toContain('sort=name')
+      expect(String(recordsCall![0])).not.toContain('sort=-name')
+    })
+
+    it('prefixes sort param with - for desc direction', async () => {
+      mockSchemaWith(['name'])
+      mockOneRecord({ name: 'Ada' })
+
+      render(
+        <TestWrapper>
+          <RelatedList
+            collectionName="contacts"
+            foreignKeyField="accountId"
+            parentRecordId="rec-123"
+            tenantSlug="test-tenant"
+            displayColumns={['name']}
+            sortField="name"
+            sortDirection="desc"
+          />
+        </TestWrapper>
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText('Ada')).toBeDefined()
+      })
+
+      const recordsCall = mockGet.mock.calls.find(([url]) =>
+        String(url).startsWith('/api/contacts')
+      )
+      expect(String(recordsCall![0])).toContain('sort=-name')
+    })
+
+    it('omits sort param when sortField is not provided', async () => {
+      mockSchemaWith(['name'])
+      mockOneRecord({ name: 'Ada' })
+
+      render(
+        <TestWrapper>
+          <RelatedList
+            collectionName="contacts"
+            foreignKeyField="accountId"
+            parentRecordId="rec-123"
+            tenantSlug="test-tenant"
+            displayColumns={['name']}
+          />
+        </TestWrapper>
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText('Ada')).toBeDefined()
+      })
+
+      const recordsCall = mockGet.mock.calls.find(([url]) =>
+        String(url).startsWith('/api/contacts')
+      )
+      expect(String(recordsCall![0])).not.toContain('sort=')
+    })
+
     it('silently drops unknown names from displayColumns', async () => {
       mockSchemaWith(['name', 'email'])
       mockOneRecord({ name: 'Ada', email: 'a@x' })

--- a/kelta-ui/app/src/components/RelatedList/RelatedList.test.tsx
+++ b/kelta-ui/app/src/components/RelatedList/RelatedList.test.tsx
@@ -53,6 +53,9 @@ function TestWrapper({ children }: { children: React.ReactNode }) {
 describe('RelatedList', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    // Drop any queued mockResolvedValueOnce values left over from a prior test.
+    // clearAllMocks only clears call history, not the implementation queue.
+    mockGet.mockReset()
   })
 
   it('shows empty state when no related records found', async () => {
@@ -154,6 +157,113 @@ describe('RelatedList', () => {
 
     await waitFor(() => {
       expect(screen.getByText('Team Members')).toBeDefined()
+    })
+  })
+
+  describe('column resolution', () => {
+    function mockSchemaWith(fieldNames: string[]) {
+      // useCollectionSchema fetches `/api/collections/{name}?include=fields` and
+      // expects a JSON:API envelope; field records arrive in the `included` array.
+      mockGet.mockResolvedValueOnce({
+        data: {
+          id: 'col-1',
+          type: 'collections',
+          attributes: { name: 'contacts', displayName: 'Contacts' },
+        },
+        included: fieldNames.map((name, i) => ({
+          id: `f-${i}`,
+          type: 'fields',
+          attributes: {
+            name,
+            displayName: name,
+            type: 'STRING',
+            required: false,
+            active: true,
+            fieldOrder: i,
+          },
+        })),
+      })
+    }
+
+    function mockOneRecord(values: Record<string, unknown>) {
+      mockGet.mockResolvedValueOnce({
+        data: [{ id: 'rec-1', accountId: 'rec-123', ...values }],
+        metadata: { totalCount: 1, currentPage: 1, pageSize: 5, totalPages: 1 },
+      })
+    }
+
+    it('renders only configured displayColumns, in given order', async () => {
+      mockSchemaWith(['name', 'email', 'phone', 'title'])
+      mockOneRecord({ name: 'Ada', email: 'a@x', phone: '555', title: 'Eng' })
+
+      render(
+        <TestWrapper>
+          <RelatedList
+            collectionName="contacts"
+            foreignKeyField="accountId"
+            parentRecordId="rec-123"
+            tenantSlug="test-tenant"
+            displayColumns={['title', 'email']}
+          />
+        </TestWrapper>
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText('Eng')).toBeDefined()
+      })
+
+      const headers = screen.getAllByRole('columnheader').map((el) => el.textContent)
+      expect(headers).toEqual(['title', 'email'])
+      // 'Ada' is the `name` field — not in displayColumns, so should NOT render
+      expect(screen.queryByText('Ada')).toBeNull()
+    })
+
+    it('falls back to first MAX_COLUMNS schema fields when displayColumns is empty', async () => {
+      mockSchemaWith(['name', 'email', 'phone', 'title', 'notes'])
+      mockOneRecord({ name: 'Ada' })
+
+      render(
+        <TestWrapper>
+          <RelatedList
+            collectionName="contacts"
+            foreignKeyField="accountId"
+            parentRecordId="rec-123"
+            tenantSlug="test-tenant"
+            displayColumns={[]}
+          />
+        </TestWrapper>
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText('Ada')).toBeDefined()
+      })
+
+      const headers = screen.getAllByRole('columnheader').map((el) => el.textContent)
+      expect(headers).toEqual(['name', 'email', 'phone', 'title'])
+    })
+
+    it('silently drops unknown names from displayColumns', async () => {
+      mockSchemaWith(['name', 'email'])
+      mockOneRecord({ name: 'Ada', email: 'a@x' })
+
+      render(
+        <TestWrapper>
+          <RelatedList
+            collectionName="contacts"
+            foreignKeyField="accountId"
+            parentRecordId="rec-123"
+            tenantSlug="test-tenant"
+            displayColumns={['ghost', 'name', 'phantom']}
+          />
+        </TestWrapper>
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText('Ada')).toBeDefined()
+      })
+
+      const headers = screen.getAllByRole('columnheader').map((el) => el.textContent)
+      expect(headers).toEqual(['name'])
     })
   })
 

--- a/kelta-ui/app/src/components/RelatedList/RelatedList.tsx
+++ b/kelta-ui/app/src/components/RelatedList/RelatedList.tsx
@@ -79,6 +79,10 @@ export interface RelatedListProps {
    * "first N non-system fields" auto-discovery.
    */
   displayColumns?: string[]
+  /** Optional: field name on the related collection to sort by. */
+  sortField?: string
+  /** Optional: sort direction. Defaults to ascending. */
+  sortDirection?: 'asc' | 'desc' | 'ASC' | 'DESC'
   /**
    * Optional: raw JSON:API response from the parent record request.
    * When provided, related records are extracted from the `included` array
@@ -115,6 +119,8 @@ export function RelatedList({
   label,
   limit = DEFAULT_LIMIT,
   displayColumns,
+  sortField,
+  sortDirection,
   includedData,
 }: RelatedListProps): React.ReactElement {
   const navigate = useNavigate()
@@ -173,8 +179,24 @@ export function RelatedList({
     // resolve this include — return null to trigger the fallback API call.
     if (allOfType.length === 0) return null
     // Filter to records that reference this parent
-    return allOfType.filter((r) => String(r[foreignKeyField]) === parentRecordId)
-  }, [includedData, collectionName, foreignKeyField, parentRecordId])
+    const filtered = allOfType.filter((r) => String(r[foreignKeyField]) === parentRecordId)
+    // Apply layout-configured sort client-side (preloaded data isn't server-sorted).
+    if (sortField) {
+      const desc = sortDirection?.toLowerCase() === 'desc'
+      const sorted = [...filtered].sort((a, b) => {
+        const av = a[sortField]
+        const bv = b[sortField]
+        if (av == null && bv == null) return 0
+        if (av == null) return 1
+        if (bv == null) return -1
+        if (av < bv) return -1
+        if (av > bv) return 1
+        return 0
+      })
+      return desc ? sorted.reverse() : sorted
+    }
+    return filtered
+  }, [includedData, collectionName, foreignKeyField, parentRecordId, sortField, sortDirection])
 
   // Only fetch via API if no pre-loaded data is available
   const hasPreloadedData = preloadedRecords !== null
@@ -189,6 +211,8 @@ export function RelatedList({
     parentRecordId,
     limit,
     include: includeParam,
+    sortField,
+    sortDirection,
     enabled: !schemaLoading && !hasPreloadedData,
   })
 

--- a/kelta-ui/app/src/components/RelatedList/RelatedList.tsx
+++ b/kelta-ui/app/src/components/RelatedList/RelatedList.tsx
@@ -72,6 +72,14 @@ export interface RelatedListProps {
   /** Optional: number of records to show (default: 5) */
   limit?: number
   /**
+   * Optional: ordered list of field names to display as columns. When provided
+   * and non-empty, these names are resolved against the schema and rendered in
+   * the given order, exactly as configured (no system-field/FK filtering, no
+   * MAX_COLUMNS slice). When omitted or empty, falls back to the legacy
+   * "first N non-system fields" auto-discovery.
+   */
+  displayColumns?: string[]
+  /**
    * Optional: raw JSON:API response from the parent record request.
    * When provided, related records are extracted from the `included` array
    * instead of making a separate API call. This eliminates per-related-list
@@ -106,6 +114,7 @@ export function RelatedList({
   tenantSlug,
   label,
   limit = DEFAULT_LIMIT,
+  displayColumns,
   includedData,
 }: RelatedListProps): React.ReactElement {
   const navigate = useNavigate()
@@ -118,15 +127,24 @@ export function RelatedList({
   // Fetch permissions for the related collection
   const { permissions } = useObjectPermissions(collectionName)
 
-  // Determine visible columns (exclude system fields and FK field, limit to MAX_COLUMNS)
+  // Determine visible columns. When `displayColumns` is provided, render exactly
+  // those fields in that order (configured in the page layout). Otherwise fall
+  // back to the legacy auto-discovery: first MAX_COLUMNS non-system, non-id,
+  // non-FK fields.
   const visibleFields = useMemo<FieldDefinition[]>(() => {
     if (!fields.length) return []
+    if (displayColumns && displayColumns.length > 0) {
+      const byName = new Map(fields.map((f) => [f.name, f]))
+      return displayColumns
+        .map((name) => byName.get(name))
+        .filter((f): f is FieldDefinition => Boolean(f))
+    }
     return fields
       .filter((f) => !SYSTEM_FIELDS.has(f.name))
       .filter((f) => f.name !== 'id')
       .filter((f) => f.name !== foreignKeyField)
       .slice(0, MAX_COLUMNS)
-  }, [fields, foreignKeyField])
+  }, [fields, foreignKeyField, displayColumns])
 
   // Identify reference fields among visible columns for include resolution
   const referenceFields = useMemo(

--- a/kelta-ui/app/src/hooks/useRelatedRecords.ts
+++ b/kelta-ui/app/src/hooks/useRelatedRecords.ts
@@ -25,6 +25,10 @@ export interface RelatedRecordsOptions {
   enabled?: boolean
   /** Comma-separated list of collection names to include via JSON:API ?include= */
   include?: string
+  /** Field to sort by on the related collection. Omit for backend default. */
+  sortField?: string
+  /** Sort direction. Defaults to ascending when sortField is set. */
+  sortDirection?: 'asc' | 'desc' | 'ASC' | 'DESC'
 }
 
 export interface UseRelatedRecordsReturn {
@@ -51,7 +55,9 @@ async function fetchRelatedRecords(
   foreignKeyField: string,
   parentRecordId: string,
   limit: number,
-  include?: string
+  include?: string,
+  sortField?: string,
+  sortDirection?: 'asc' | 'desc' | 'ASC' | 'DESC'
 ): Promise<{ paginated: PaginatedResponse; rawResponse: unknown }> {
   const queryParams = new URLSearchParams()
   queryParams.set('page[number]', '1')
@@ -59,6 +65,10 @@ async function fetchRelatedRecords(
   queryParams.set(`filter[${foreignKeyField}][eq]`, parentRecordId)
   if (include) {
     queryParams.set('include', include)
+  }
+  if (sortField) {
+    const desc = sortDirection?.toLowerCase() === 'desc'
+    queryParams.set('sort', desc ? `-${sortField}` : sortField)
   }
 
   const rawResponse = await apiClient.get(`/api/${collectionName}?${queryParams.toString()}`)
@@ -84,6 +94,8 @@ export function useRelatedRecords(options: RelatedRecordsOptions): UseRelatedRec
     limit = 5,
     enabled = true,
     include,
+    sortField,
+    sortDirection,
   } = options
 
   const isEnabled = !!collectionName && !!foreignKeyField && !!parentRecordId && enabled
@@ -94,7 +106,16 @@ export function useRelatedRecords(options: RelatedRecordsOptions): UseRelatedRec
     error,
     refetch,
   } = useQuery({
-    queryKey: ['related-records', collectionName, foreignKeyField, parentRecordId, limit, include],
+    queryKey: [
+      'related-records',
+      collectionName,
+      foreignKeyField,
+      parentRecordId,
+      limit,
+      include,
+      sortField,
+      sortDirection,
+    ],
     queryFn: () =>
       fetchRelatedRecords(
         apiClient,
@@ -102,7 +123,9 @@ export function useRelatedRecords(options: RelatedRecordsOptions): UseRelatedRec
         foreignKeyField!,
         parentRecordId!,
         limit,
-        include
+        include,
+        sortField,
+        sortDirection
       ),
     enabled: isEnabled,
     staleTime: 30 * 1000, // 30 seconds


### PR DESCRIPTION
## Summary

- Order detail page (and any other detail page using a configured page layout) ignored the layout's `displayColumns` and always showed the first 4 schema fields. Reported on the Threadline Clothing **Order** layout, which configures `[Product Name, Quantity, Unit Price, Line Total]` but rendered `[Product, Product Name, SKU, Size]`.
- `LayoutRelatedLists` did not forward `displayColumns` to `RelatedList`, and `RelatedList` had no prop for it. Now it parses the persisted value, forwards it, and `RelatedList` renders exactly the configured columns in order. Auto-discovery fallback is preserved when no layout is configured.

## Root cause

1. Builder saves `JSON.stringify(string[])` to `layout_related_lists.display_columns`.
2. `usePageLayout` loads it into `LayoutRelatedListDto.displayColumns`.
3. `LayoutRelatedLists.tsx` only passed `collectionName`, `foreignKeyField`, `parentRecordId`, `tenantSlug`, `limit`, `includedData` — never `displayColumns`.
4. `RelatedList.tsx` resolved columns as `fields.filter(...).slice(0, MAX_COLUMNS)` — config-blind.

## Changes

- New `parseDisplayColumns(raw)` helper handles JSON-stringified arrays and the legacy comma-separated form.
- `LayoutRelatedLists` parses and forwards `displayColumns` to `RelatedList`.
- `RelatedList` accepts `displayColumns?: string[]`. When non-empty, looks each name up in the schema and renders in that order, dropping unresolved names. When empty/absent, the legacy "first MAX_COLUMNS non-system, non-id, non-FK" fallback is preserved for the auto-discovery branch in `ObjectDetailPage`.
- Vitest coverage:
  - `parseDisplayColumns` — null/empty/JSON/CSV/malformed.
  - `RelatedList` column resolution — configured order honored, fallback when empty, unknown names dropped.

## Out of scope (follow-up)

`sortField` / `sortDirection` from the same Edit Related List modal are persisted but not yet honored — `useRelatedRecords` does not pass `sort` to the API. Tracking separately.

## Test plan

- [x] Unit tests pass (`npm run test:run -- src/components/RelatedList src/components/LayoutRelatedLists` — 13/13)
- [x] Lint clean on touched files
- [x] Typecheck clean on touched files (pre-existing TS errors elsewhere are unrelated)
- [ ] Manual: open `/<tenant>/app/o/orders/<id>` after deploy, confirm Order Items table headers match layout config
- [ ] Manual: edit related-list config (toggle a column on/off), refresh detail, confirm UI reflects change
- [ ] Regression: a collection with no configured layout still renders auto-discovered related lists

🤖 Generated with [Claude Code](https://claude.com/claude-code)