### PR TITLE
fix(layouts): honor sortField/sortDirection on related lists

### DIFF
--- a/kelta-ui/app/src/components/LayoutRelatedLists/LayoutRelatedLists.tsx
+++ b/kelta-ui/app/src/components/LayoutRelatedLists/LayoutRelatedLists.tsx
@@ -11,6 +11,14 @@ import { RelatedList } from '@/components/RelatedList'
 import type { LayoutRelatedListDto } from '@/hooks/usePageLayout'
 import { parseDisplayColumns } from './parseDisplayColumns'
 
+/**
+ * Normalize the persisted sort direction into the lower-case form the
+ * RelatedList API uses. Anything unrecognized falls back to ascending.
+ */
+function normalizeSortDirection(raw: string | null | undefined): 'asc' | 'desc' {
+  return raw && raw.trim().toLowerCase() === 'desc' ? 'desc' : 'asc'
+}
+
 export interface LayoutRelatedListsProps {
   /** Related list configurations from the resolved page layout */
   relatedLists: LayoutRelatedListDto[]
@@ -50,6 +58,8 @@ export function LayoutRelatedLists({
           tenantSlug={tenantSlug}
           limit={rl.rowLimit}
           displayColumns={parseDisplayColumns(rl.displayColumns)}
+          sortField={rl.sortField ?? undefined}
+          sortDirection={normalizeSortDirection(rl.sortDirection)}
           includedData={includedData}
         />
       ))}

--- a/kelta-ui/app/src/components/RelatedList/RelatedList.test.tsx
+++ b/kelta-ui/app/src/components/RelatedList/RelatedList.test.tsx
@@ -242,6 +242,89 @@ describe('RelatedList', () => {
       expect(headers).toEqual(['name', 'email', 'phone', 'title'])
     })
 
+    it('passes sortField as JSON:API sort param (asc default)', async () => {
+      mockSchemaWith(['name'])
+      mockOneRecord({ name: 'Ada' })
+
+      render(
+        <TestWrapper>
+          <RelatedList
+            collectionName="contacts"
+            foreignKeyField="accountId"
+            parentRecordId="rec-123"
+            tenantSlug="test-tenant"
+            displayColumns={['name']}
+            sortField="name"
+          />
+        </TestWrapper>
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText('Ada')).toBeDefined()
+      })
+
+      const recordsCall = mockGet.mock.calls.find(([url]) =>
+        String(url).startsWith('/api/contacts')
+      )
+      expect(recordsCall).toBeDefined()
+      expect(String(recordsCall![0])).toContain('sort=name')
+      expect(String(recordsCall![0])).not.toContain('sort=-name')
+    })
+
+    it('prefixes sort param with - for desc direction', async () => {
+      mockSchemaWith(['name'])
+      mockOneRecord({ name: 'Ada' })
+
+      render(
+        <TestWrapper>
+          <RelatedList
+            collectionName="contacts"
+            foreignKeyField="accountId"
+            parentRecordId="rec-123"
+            tenantSlug="test-tenant"
+            displayColumns={['name']}
+            sortField="name"
+            sortDirection="desc"
+          />
+        </TestWrapper>
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText('Ada')).toBeDefined()
+      })
+
+      const recordsCall = mockGet.mock.calls.find(([url]) =>
+        String(url).startsWith('/api/contacts')
+      )
+      expect(String(recordsCall![0])).toContain('sort=-name')
+    })
+
+    it('omits sort param when sortField is not provided', async () => {
+      mockSchemaWith(['name'])
+      mockOneRecord({ name: 'Ada' })
+
+      render(
+        <TestWrapper>
+          <RelatedList
+            collectionName="contacts"
+            foreignKeyField="accountId"
+            parentRecordId="rec-123"
+            tenantSlug="test-tenant"
+            displayColumns={['name']}
+          />
+        </TestWrapper>
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText('Ada')).toBeDefined()
+      })
+
+      const recordsCall = mockGet.mock.calls.find(([url]) =>
+        String(url).startsWith('/api/contacts')
+      )
+      expect(String(recordsCall![0])).not.toContain('sort=')
+    })
+
     it('silently drops unknown names from displayColumns', async () => {
       mockSchemaWith(['name', 'email'])
       mockOneRecord({ name: 'Ada', email: 'a@x' })

--- a/kelta-ui/app/src/components/RelatedList/RelatedList.tsx
+++ b/kelta-ui/app/src/components/RelatedList/RelatedList.tsx
@@ -79,6 +79,10 @@ export interface RelatedListProps {
    * "first N non-system fields" auto-discovery.
    */
   displayColumns?: string[]
+  /** Optional: field name on the related collection to sort by. */
+  sortField?: string
+  /** Optional: sort direction. Defaults to ascending. */
+  sortDirection?: 'asc' | 'desc' | 'ASC' | 'DESC'
   /**
    * Optional: raw JSON:API response from the parent record request.
    * When provided, related records are extracted from the `included` array
@@ -115,6 +119,8 @@ export function RelatedList({
   label,
   limit = DEFAULT_LIMIT,
   displayColumns,
+  sortField,
+  sortDirection,
   includedData,
 }: RelatedListProps): React.ReactElement {
   const navigate = useNavigate()
@@ -173,8 +179,24 @@ export function RelatedList({
     // resolve this include — return null to trigger the fallback API call.
     if (allOfType.length === 0) return null
     // Filter to records that reference this parent
-    return allOfType.filter((r) => String(r[foreignKeyField]) === parentRecordId)
-  }, [includedData, collectionName, foreignKeyField, parentRecordId])
+    const filtered = allOfType.filter((r) => String(r[foreignKeyField]) === parentRecordId)
+    // Apply layout-configured sort client-side (preloaded data isn't server-sorted).
+    if (sortField) {
+      const desc = sortDirection?.toLowerCase() === 'desc'
+      const sorted = [...filtered].sort((a, b) => {
+        const av = a[sortField]
+        const bv = b[sortField]
+        if (av == null && bv == null) return 0
+        if (av == null) return 1
+        if (bv == null) return -1
+        if (av < bv) return -1
+        if (av > bv) return 1
+        return 0
+      })
+      return desc ? sorted.reverse() : sorted
+    }
+    return filtered
+  }, [includedData, collectionName, foreignKeyField, parentRecordId, sortField, sortDirection])
 
   // Only fetch via API if no pre-loaded data is available
   const hasPreloadedData = preloadedRecords !== null
@@ -189,6 +211,8 @@ export function RelatedList({
     parentRecordId,
     limit,
     include: includeParam,
+    sortField,
+    sortDirection,
     enabled: !schemaLoading && !hasPreloadedData,
   })
 

--- a/kelta-ui/app/src/hooks/useRelatedRecords.ts
+++ b/kelta-ui/app/src/hooks/useRelatedRecords.ts
@@ -25,6 +25,10 @@ export interface RelatedRecordsOptions {
   enabled?: boolean
   /** Comma-separated list of collection names to include via JSON:API ?include= */
   include?: string
+  /** Field to sort by on the related collection. Omit for backend default. */
+  sortField?: string
+  /** Sort direction. Defaults to ascending when sortField is set. */
+  sortDirection?: 'asc' | 'desc' | 'ASC' | 'DESC'
 }
 
 export interface UseRelatedRecordsReturn {
@@ -51,7 +55,9 @@ async function fetchRelatedRecords(
   foreignKeyField: string,
   parentRecordId: string,
   limit: number,
-  include?: string
+  include?: string,
+  sortField?: string,
+  sortDirection?: 'asc' | 'desc' | 'ASC' | 'DESC'
 ): Promise<{ paginated: PaginatedResponse; rawResponse: unknown }> {
   const queryParams = new URLSearchParams()
   queryParams.set('page[number]', '1')
@@ -59,6 +65,10 @@ async function fetchRelatedRecords(
   queryParams.set(`filter[${foreignKeyField}][eq]`, parentRecordId)
   if (include) {
     queryParams.set('include', include)
+  }
+  if (sortField) {
+    const desc = sortDirection?.toLowerCase() === 'desc'
+    queryParams.set('sort', desc ? `-${sortField}` : sortField)
   }
 
   const rawResponse = await apiClient.get(`/api/${collectionName}?${queryParams.toString()}`)
@@ -84,6 +94,8 @@ export function useRelatedRecords(options: RelatedRecordsOptions): UseRelatedRec
     limit = 5,
     enabled = true,
     include,
+    sortField,
+    sortDirection,
   } = options
 
   const isEnabled = !!collectionName && !!foreignKeyField && !!parentRecordId && enabled
@@ -94,7 +106,16 @@ export function useRelatedRecords(options: RelatedRecordsOptions): UseRelatedRec
     error,
     refetch,
   } = useQuery({
-    queryKey: ['related-records', collectionName, foreignKeyField, parentRecordId, limit, include],
+    queryKey: [
+      'related-records',
+      collectionName,
+      foreignKeyField,
+      parentRecordId,
+      limit,
+      include,
+      sortField,
+      sortDirection,
+    ],
     queryFn: () =>
       fetchRelatedRecords(
         apiClient,
@@ -102,7 +123,9 @@ export function useRelatedRecords(options: RelatedRecordsOptions): UseRelatedRec
         foreignKeyField!,
         parentRecordId!,
         limit,
-        include
+        include,
+        sortField,
+        sortDirection
       ),
     enabled: isEnabled,
     staleTime: 30 * 1000, // 30 seconds


### PR DESCRIPTION
## Summary

Companion to [emf#806](https://github.com/cklinker/emf/pull/806). The Edit Related List modal persists `sortField` and `sortDirection`, but `useRelatedRecords` never built a JSON:API `sort` param — the configured sort was silently ignored.

- Forward `sortField` / `sortDirection` from `LayoutRelatedLists` → `RelatedList` → `useRelatedRecords`.
- Encode as `sort=<field>` for ascending, `sort=-<field>` for descending (matches `useCollectionRecords` convention).
- Apply the same sort client-side on the preloaded `includedData` path so behavior is consistent whether the related list is server-fetched or extracted from the parent's `?include=` response.
- Tests cover asc default, desc prefix, and absent-sort omission.

## Stacked on emf#806

Base branch is `fix/related-list-display-columns`. Re-target to `main` once that PR merges.

## Test plan

- [x] Unit tests pass (16/16 across RelatedList + LayoutRelatedLists)
- [x] Lint clean on touched files
- [x] Typecheck clean on touched files
- [ ] Manual: configure related list with sortField=`productName`, direction=`desc`, refresh detail page, confirm rows reverse-alphabetical
- [ ] Manual: switch direction to `asc`, refresh, confirm rows alphabetical

🤖 Generated with [Claude Code](https://claude.com/claude-code)