### PR TITLE
fix(layouts): handle array-form displayColumns from JSONB

### DIFF
--- a/kelta-ui/app/src/components/LayoutRelatedLists/LayoutRelatedLists.test.tsx
+++ b/kelta-ui/app/src/components/LayoutRelatedLists/LayoutRelatedLists.test.tsx
@@ -9,6 +9,20 @@ describe('parseDisplayColumns', () => {
     expect(parseDisplayColumns('   ')).toEqual([])
   })
 
+  it('returns array input as-is when JSONB deserializes to a real array', () => {
+    expect(parseDisplayColumns(['productName', 'quantity'])).toEqual(['productName', 'quantity'])
+  })
+
+  it('drops non-string entries from a real array input', () => {
+    // Cast to bypass TS — we are deliberately testing runtime resilience.
+    expect(parseDisplayColumns(['a', 1, null, 'b'] as unknown)).toEqual(['a', 'b'])
+  })
+
+  it('returns empty array when input is neither string nor array', () => {
+    expect(parseDisplayColumns(42 as unknown)).toEqual([])
+    expect(parseDisplayColumns({ foo: 'bar' } as unknown)).toEqual([])
+  })
+
   it('parses JSON-stringified array (current builder format)', () => {
     expect(parseDisplayColumns('["productName","quantity","unitPrice"]')).toEqual([
       'productName',

--- a/kelta-ui/app/src/components/LayoutRelatedLists/parseDisplayColumns.ts
+++ b/kelta-ui/app/src/components/LayoutRelatedLists/parseDisplayColumns.ts
@@ -1,13 +1,20 @@
 /**
  * Parse the `displayColumns` value persisted with a related-list layout entry.
  *
- * The layout builder stores this as `JSON.stringify(string[])` (JSON-encoded
- * array of field names). Older or hand-edited rows may use a comma-separated
- * string. Anything unrecognized is treated as "no override" (empty array),
- * which causes the renderer to fall back to auto-discovered columns.
+ * The backend column is JSONB. Depending on serialization, the value can arrive
+ * as a real `string[]`, as a JSON-stringified array, or as a comma-separated
+ * legacy string. Anything unrecognized becomes `[]`, which causes the renderer
+ * to fall back to auto-discovered columns.
  */
-export function parseDisplayColumns(raw: string | null | undefined): string[] {
-  if (!raw) return []
+export function parseDisplayColumns(raw: unknown): string[] {
+  if (raw == null) return []
+
+  if (Array.isArray(raw)) {
+    return raw.filter((s): s is string => typeof s === 'string')
+  }
+
+  if (typeof raw !== 'string') return []
+
   const trimmed = raw.trim()
   if (!trimmed) return []
   if (trimmed.startsWith('[')) {

--- a/kelta-ui/app/src/hooks/usePageLayout.ts
+++ b/kelta-ui/app/src/hooks/usePageLayout.ts
@@ -51,7 +51,11 @@ export interface LayoutRelatedListDto {
   relatedCollectionName: string
   relationshipFieldId: string
   relationshipFieldName: string
-  displayColumns: string
+  /**
+   * JSONB-backed; can arrive as a real `string[]` or as a JSON-stringified
+   * array. Use `parseDisplayColumns()` to normalize before reading.
+   */
+  displayColumns: string | string[]
   sortField: string | null
   sortDirection: string
   rowLimit: number


### PR DESCRIPTION
## Summary

Order detail page crashed with `e.trim is not a function` after [emf#806](https://github.com/cklinker/emf/pull/806). The backend column is JSONB and round-trips as a real `string[]`, not the stringified form `parseDisplayColumns` assumed.

- `parseDisplayColumns` now accepts `unknown`. Real arrays pass through (non-string entries filtered). String branches (JSON-stringified array, comma-separated legacy) unchanged. Anything else → `[]`.
- `LayoutRelatedListDto.displayColumns` typed as `string | string[]` to match reality.
- 3 new Vitest cases (real array, mixed-type array, non-string non-array input).

## Test plan

- [x] Unit tests pass (19/19 across RelatedList + LayoutRelatedLists)
- [x] Lint + typecheck clean on touched files
- [ ] Manual: reload Order detail page, confirm no crash, columns render per layout config

🤖 Generated with [Claude Code](https://claude.com/claude-code)