### PR TITLE
fix(docker): build @kelta/components in kelta-ui image

### DIFF
--- a/kelta-ui/Dockerfile
+++ b/kelta-ui/Dockerfile
@@ -18,9 +18,13 @@ COPY kelta-web/packages/plugin-sdk/package.json ./kelta-web/packages/plugin-sdk/
 WORKDIR /app/kelta-web
 RUN npm install
 
-# Copy kelta-web source and build SDK + plugin-sdk
+# Copy kelta-web source and build SDK + plugin-sdk + components
+# (components must be built before kelta-ui since kelta-ui imports from
+# `@kelta/components` and the package's main/module fields point to dist/)
 COPY kelta-web/packages ./packages
-RUN npm run build --workspace=packages/sdk && npm run build --workspace=packages/plugin-sdk
+RUN npm run build --workspace=packages/sdk \
+ && npm run build --workspace=packages/plugin-sdk \
+ && npm run build --workspace=packages/components
 
 # Copy kelta-ui package files
 WORKDIR /app/kelta-ui/app


### PR DESCRIPTION
## Summary
- Deploy after #809 failed: vite reported "Failed to resolve entry for package @kelta/components" because the kelta-ui Dockerfile only built packages/sdk and packages/plugin-sdk. #809 added the first real runtime import from @kelta/components, exposing the gap.
- Build packages/components alongside the other workspaces so its dist exists when vite resolves the file: dependency.

## Test plan
- [ ] CI Build and Deploy succeeds on this branch