### PR TITLE
fix(docker): build @kelta/formula in kelta-ui image

### DIFF
--- a/kelta-ui/Dockerfile
+++ b/kelta-ui/Dockerfile
@@ -13,16 +13,18 @@ COPY kelta-web/package.json kelta-web/package-lock.json* kelta-web/tsconfig.json
 COPY kelta-web/packages/sdk/package.json ./kelta-web/packages/sdk/
 COPY kelta-web/packages/components/package.json ./kelta-web/packages/components/
 COPY kelta-web/packages/plugin-sdk/package.json ./kelta-web/packages/plugin-sdk/
+COPY kelta-web/packages/formula/package.json ./kelta-web/packages/formula/
 
 # Install kelta-web dependencies
 WORKDIR /app/kelta-web
 RUN npm install
 
-# Copy kelta-web source and build SDK + plugin-sdk + components
-# (components must be built before kelta-ui since kelta-ui imports from
-# `@kelta/components` and the package's main/module fields point to dist/)
+# Copy kelta-web source and build formula + sdk + plugin-sdk + components.
+# Build order matters: components imports @kelta/formula and @kelta/sdk via
+# package main/module fields (point to dist/), so those must build first.
 COPY kelta-web/packages ./packages
-RUN npm run build --workspace=packages/sdk \
+RUN npm run build --workspace=packages/formula \
+ && npm run build --workspace=packages/sdk \
  && npm run build --workspace=packages/plugin-sdk \
  && npm run build --workspace=packages/components
 


### PR DESCRIPTION
## Summary

The kelta-ui Dockerfile only copies and builds \`packages/sdk\`, \`packages/plugin-sdk\`, and \`packages/components\`. PR #811 introduces a new workspace package \`@kelta/formula\` that \`@kelta/components\` depends on, so \`npm install\` in the kelta-ui stage fails with E404 trying to fetch \`@kelta/formula\` from the public registry.

Adds the formula package alongside the existing three:
- copies \`packages/formula/package.json\` before \`npm install\`
- builds it first in the workspace build chain (components depends on it)

This fix is split out so it can land independently and unblock the rebuilt image, even before #811 merges.

## Test plan

- [ ] CI \`Build & Push ui\` passes on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)