### PR TITLE
fix(layouts): add created_by/updated_by audit columns to layout_rule

### DIFF
--- a/kelta-worker/src/main/resources/db/migration/V130__add_layout_rules.sql
+++ b/kelta-worker/src/main/resources/db/migration/V130__add_layout_rules.sql
@@ -18,6 +18,8 @@ CREATE TABLE IF NOT EXISTS layout_rule (
     sort_order      INTEGER      NOT NULL DEFAULT 0,
     created_at      TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
     updated_at      TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    created_by      VARCHAR(255),
+    updated_by      VARCHAR(255),
     CONSTRAINT uq_layout_rule_name UNIQUE (tenant_id, layout_id, name),
     CONSTRAINT chk_layout_rule_kind CHECK (kind IN ('COMPUTE','VALIDATE','DEFAULT','TRANSFORM'))
 );

--- a/kelta-worker/src/main/resources/db/migration/V131__add_audit_users_to_layout_rule.sql
+++ b/kelta-worker/src/main/resources/db/migration/V131__add_audit_users_to_layout_rule.sql
@@ -1,0 +1,12 @@
+-- V131: Add created_by/updated_by audit columns to layout_rule
+--
+-- PhysicalTableStorageAdapter unconditionally inserts/selects
+-- id, created_at, updated_at, created_by, updated_by for every collection
+-- (see V68). V130 created layout_rule without created_by/updated_by, which
+-- caused INSERTs to fail with "column does not exist" for any DB that ran
+-- V130 before this fix landed. Use IF NOT EXISTS so fresh installs from the
+-- patched V130 are no-ops.
+
+ALTER TABLE layout_rule
+    ADD COLUMN IF NOT EXISTS created_by VARCHAR(255),
+    ADD COLUMN IF NOT EXISTS updated_by VARCHAR(255);


### PR DESCRIPTION
## Summary

PR #811 created \`layout_rule\` without \`created_by\`/\`updated_by\` columns. \`PhysicalTableStorageAdapter\` unconditionally INSERTs/SELECTs both for every collection (per V68's audit-column convention), so \`POST /api/layout-rules\` 500s with \`column "created_by" does not exist\`.

- Patches V130 for fresh installs.
- Adds V131 to \`ALTER\` already-migrated DBs. \`ADD COLUMN IF NOT EXISTS\` makes both safe to re-run.

## Test plan

- [ ] After deploy + Flyway runs V131, \`POST /api/layout-rules\` returns 201

🤖 Generated with [Claude Code](https://claude.com/claude-code)