### PR TITLE
fix(layouts): revert V130 patch to preserve Flyway checksum

### DIFF
--- a/kelta-worker/src/main/resources/db/migration/V130__add_layout_rules.sql
+++ b/kelta-worker/src/main/resources/db/migration/V130__add_layout_rules.sql
@@ -18,8 +18,6 @@ CREATE TABLE IF NOT EXISTS layout_rule (
     sort_order      INTEGER      NOT NULL DEFAULT 0,
     created_at      TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
     updated_at      TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
-    created_by      VARCHAR(255),
-    updated_by      VARCHAR(255),
     CONSTRAINT uq_layout_rule_name UNIQUE (tenant_id, layout_id, name),
     CONSTRAINT chk_layout_rule_kind CHECK (kind IN ('COMPUTE','VALIDATE','DEFAULT','TRANSFORM'))
 );


### PR DESCRIPTION
## Problem

PR #811 deployed V130 without created_by/updated_by columns. PR #813 patched V130 to add them, which changed Flyway's V130 checksum and broke startup on every DB that already ran V130:

\`\`\`
Migration checksum mismatch for migration version 130
-> Applied to database : 406316891
-> Resolved locally    : -463963438
\`\`\`

(observed in emf-worker-migrate-hzqht).

## Fix

- Revert V130 to its original deployed form.
- V131 (introduced by #813) still ALTERs the table with \`ADD COLUMN IF NOT EXISTS\`, so already-migrated DBs and fresh installs both end up with the audit columns; checksum stability is preserved.

## Test plan

- [ ] After deploy, emf-worker-migrate runs V131 and starts cleanly
- [ ] \`POST /api/layout-rules\` returns 201

🤖 Generated with [Claude Code](https://claude.com/claude-code)