### PR TITLE
fix(layouts): await rule list refetch and surface errors in RulesEditor

### DIFF
--- a/kelta-ui/app/src/pages/PageLayoutsPage/RulesEditor.tsx
+++ b/kelta-ui/app/src/pages/PageLayoutsPage/RulesEditor.tsx
@@ -194,16 +194,25 @@ export function RulesEditor({ layoutId, layoutName, fieldNames, onClose }: Rules
       }
       return apiClient.post('/api/layout-rules', envelope)
     },
-    onSuccess: () => {
-      qc.invalidateQueries({ queryKey: ['layout-rules', layoutId] })
+    // Await the refetch before clearing the draft so the side panel reflects
+    // the new rule before the editor pane goes back to the empty state.
+    onSuccess: async () => {
+      await qc.invalidateQueries({ queryKey: ['layout-rules', layoutId] })
+      await qc.refetchQueries({ queryKey: ['layout-rules', layoutId] })
       setDraft(null)
     },
   })
 
   const deleteMutation = useMutation({
     mutationFn: async (id: string) => apiClient.delete(`/api/layout-rules/${id}`),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ['layout-rules', layoutId] }),
+    onSuccess: async () => {
+      await qc.invalidateQueries({ queryKey: ['layout-rules', layoutId] })
+      await qc.refetchQueries({ queryKey: ['layout-rules', layoutId] })
+    },
   })
+
+  const saveError = saveMutation.error as Error | null
+  const deleteError = deleteMutation.error as Error | null
 
   const formulaError = useMemo(
     () => (draft ? syntaxError(draft.formula) : null),
@@ -360,6 +369,16 @@ export function RulesEditor({ layoutId, layoutName, fieldNames, onClose }: Rules
                 formulaError={formulaError}
                 cycleError={cycleError}
               />
+            )}
+
+            {(saveError || deleteError) && (
+              <div
+                className="mt-4 rounded border border-destructive bg-destructive/10 p-2 text-xs text-destructive"
+                role="alert"
+                data-testid="rules-editor-server-error"
+              >
+                {(saveError ?? deleteError)?.message ?? 'Operation failed'}
+              </div>
             )}
 
             {draft && (


### PR DESCRIPTION
## Summary

After saving a new rule the side panel showed the prior list because \`invalidateQueries\` returned a Promise that was never awaited; \`setDraft(null)\` then ran before the refetch settled. Mutation errors were also silently swallowed.

## Fix

- Await \`invalidateQueries\` + \`refetchQueries\` before clearing the draft
- Render save/delete error message inline (testid \`rules-editor-server-error\`)
- Apply same pattern to delete

## Test plan

- [x] \`vitest run RulesEditor.test.tsx\` — 5/5 pass
- [ ] Manual: create a rule, observe new entry in side panel before editor pane resets

🤖 Generated with [Claude Code](https://claude.com/claude-code)