### PR TITLE
fix(layouts): dedupe React across kelta-ui + components peer deps

### DIFF
--- a/kelta-ui/app/vite.config.ts
+++ b/kelta-ui/app/vite.config.ts
@@ -10,6 +10,14 @@ export default defineConfig({
     alias: {
       '@': path.resolve(__dirname, './src'),
     },
+    // Force a single React instance across the app and the file:-linked
+    // @kelta/components / @kelta/formula workspace packages. Without this,
+    // npm hoists a second react@18 inside packages/components/node_modules
+    // (because that package declares react ^18 as a peer/dev dep) while the
+    // app uses react@19 — calling a hook from the components bundle then
+    // hits a different ReactCurrentDispatcher and throws
+    // "Cannot read properties of null (reading 'useRef')".
+    dedupe: ['react', 'react-dom', 'react/jsx-runtime'],
   },
   server: {
     port: 5174,

--- a/kelta-web/packages/components/package.json
+++ b/kelta-web/packages/components/package.json
@@ -24,10 +24,10 @@
     "@kelta/formula": "^0.0.1",
     "@kelta/sdk": "^0.0.1",
     "@tanstack/react-query": "^5.0.0",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
+    "react": "^18.2.0 || ^19.0.0",
+    "react-dom": "^18.2.0 || ^19.0.0",
     "react-hook-form": "^7.0.0",
-    "react-router-dom": "^6.0.0"
+    "react-router-dom": "^6.0.0 || ^7.0.0"
   },
   "devDependencies": {
     "@tanstack/react-query": "^5.24.1",


### PR DESCRIPTION
## Symptom

\`/{tenant}/app/o/{collection}/{id}/edit\` threw \`Cannot read properties of null (reading useRef)\` from inside the \`@kelta/components\` dist as soon as #816 wired \`useLayoutRules\` into \`ObjectFormBody\`. ErrorBoundary blocked the whole page.

## Root cause

\`npm ls react\` from kelta-ui:

\`\`\`
+-- @kelta/components@0.0.1 -> ./../../kelta-web/packages/components
| `-- react@18.3.1
+-- react@19.2.3
\`\`\`

Two React copies. Components dist imports \`react\` as external; at runtime the resolution picked the nested 18.x while \`ObjectFormBody\` was rendering with the app's 19.x. \`useRef\` from one React instance + \`ReactCurrentDispatcher\` from another = null deref.

## Fix

- \`vite.config.ts\` → \`resolve.dedupe: ['react', 'react-dom', 'react/jsx-runtime']\` so vite forces a single instance regardless of which package's \`node_modules\` first matched.
- \`packages/components/package.json\` → widen peer deps to \`^18.2.0 || ^19.0.0\` (and react-router \`^6 || ^7\`) so npm stops installing the duplicate.

## Test plan

- [ ] After deploy, opening the order_items edit page renders without the ErrorBoundary
- [ ] COMPUTE rule fires when changing Quantity

🤖 Generated with [Claude Code](https://claude.com/claude-code)