### PR TITLE
chore(kelta-web): bump all workspace packages to React 19 + react-router 7

### DIFF
--- a/kelta-web/package.json
+++ b/kelta-web/package.json
@@ -21,11 +21,11 @@
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.4.2",
-    "@testing-library/react": "^14.2.1",
+    "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.5.2",
     "@types/node": "^20.11.24",
-    "@types/react": "^18.2.61",
-    "@types/react-dom": "^18.2.19",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
     "@typescript-eslint/eslint-plugin": "^7.1.0",
     "@typescript-eslint/parser": "^7.1.0",
     "@vitejs/plugin-react": "^4.2.1",
@@ -47,10 +47,10 @@
     "@hookform/resolvers": "^3.3.4",
     "@tanstack/react-query": "^5.24.1",
     "axios": "^1.6.7",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0",
     "react-hook-form": "^7.51.0",
-    "react-router-dom": "^6.22.2",
+    "react-router-dom": "^7.0.0",
     "zod": "^3.22.4"
   },
   "engines": {

--- a/kelta-web/packages/components/package.json
+++ b/kelta-web/packages/components/package.json
@@ -24,17 +24,17 @@
     "@kelta/formula": "^0.0.1",
     "@kelta/sdk": "^0.0.1",
     "@tanstack/react-query": "^5.0.0",
-    "react": "^18.2.0 || ^19.0.0",
-    "react-dom": "^18.2.0 || ^19.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
     "react-hook-form": "^7.0.0",
-    "react-router-dom": "^6.0.0 || ^7.0.0"
+    "react-router-dom": "^7.0.0"
   },
   "devDependencies": {
     "@tanstack/react-query": "^5.24.1",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0",
     "react-hook-form": "^7.51.0",
-    "react-router-dom": "^6.22.2"
+    "react-router-dom": "^7.0.0"
   },
   "keywords": [
     "kelta",

--- a/kelta-web/packages/components/src/LayoutRenderer/LayoutRenderer.tsx
+++ b/kelta-web/packages/components/src/LayoutRenderer/LayoutRenderer.tsx
@@ -7,7 +7,7 @@
  */
 
 import { useState, useMemo, useCallback } from 'react';
-import type { ReactNode } from 'react';
+import type { ReactNode, ReactElement } from 'react';
 import type {
   FieldDefinition,
   LayoutSection,
@@ -173,7 +173,7 @@ function FieldCell({
   requiredOnLayout,
   onChange,
   customRenderers,
-}: FieldCellProps): JSX.Element | null {
+}: FieldCellProps): ReactElement | null {
   const fieldName = field?.name ?? '';
 
   const handleChange = useCallback(
@@ -236,7 +236,7 @@ function SectionRenderer({
   onChange,
   customRenderers,
   fieldMap,
-}: SectionRendererProps): JSX.Element | null {
+}: SectionRendererProps): ReactElement | null {
   const [collapsed, setCollapsed] = useState(section.collapsed);
 
   // Sort and filter visible fields
@@ -387,7 +387,7 @@ function TabGroupRenderer({
   onChange,
   customRenderers,
   fieldMap,
-}: TabGroupRendererProps): JSX.Element {
+}: TabGroupRendererProps): ReactElement {
   const [activeTab, setActiveTab] = useState(0);
 
   const visibleSections = useMemo(
@@ -437,7 +437,7 @@ interface RelatedListRendererProps {
   relatedList: LayoutRelatedList;
 }
 
-function RelatedListRenderer({ relatedList }: RelatedListRendererProps): JSX.Element {
+function RelatedListRenderer({ relatedList }: RelatedListRendererProps): ReactElement {
   const columns = relatedList.displayColumns
     ? relatedList.displayColumns.split(',').map((c) => c.trim())
     : [];
@@ -494,7 +494,7 @@ export function LayoutRenderer({
   customRenderers,
   className = '',
   testId = 'kelta-layout-renderer',
-}: LayoutRendererProps): JSX.Element {
+}: LayoutRendererProps): ReactElement {
   // Build field lookup maps
   const fieldMap = useMemo(() => {
     const map = new Map<string, FieldDefinition>();

--- a/kelta-web/packages/components/src/Navigation/Navigation.tsx
+++ b/kelta-web/packages/components/src/Navigation/Navigation.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback, useRef, KeyboardEvent } from 'react';
+import type { ReactElement } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import type { NavigationProps, MenuItem } from './types';
 
@@ -40,7 +41,7 @@ export function Navigation({
   collapsible = false,
   className = '',
   testId = 'kelta-navigation',
-}: NavigationProps): JSX.Element {
+}: NavigationProps): ReactElement {
   const navigate = useNavigate();
   const location = useLocation();
   const [expandedItems, setExpandedItems] = useState<Set<string>>(new Set());
@@ -127,7 +128,7 @@ export function Navigation({
       }
 
       if (item.path) {
-        navigate(item.path);
+        void navigate(item.path);
       }
     },
     [navigate, toggleExpanded]
@@ -198,7 +199,7 @@ export function Navigation({
   );
 
   // Render a menu item
-  const renderItem = (item: MenuItem, depth: number = 0, visibleItems: MenuItem[]): JSX.Element => {
+  const renderItem = (item: MenuItem, depth: number = 0, visibleItems: MenuItem[]): ReactElement => {
     const hasChildren = item.children && item.children.length > 0;
     const isExpanded = expandedItems.has(item.id);
     const active = isActive(item.path) || hasActiveChild(item);

--- a/kelta-web/packages/components/src/Navigation/Navigation.tsx
+++ b/kelta-web/packages/components/src/Navigation/Navigation.tsx
@@ -199,7 +199,11 @@ export function Navigation({
   );
 
   // Render a menu item
-  const renderItem = (item: MenuItem, depth: number = 0, visibleItems: MenuItem[]): ReactElement => {
+  const renderItem = (
+    item: MenuItem,
+    depth: number = 0,
+    visibleItems: MenuItem[]
+  ): ReactElement => {
     const hasChildren = item.children && item.children.length > 0;
     const isExpanded = expandedItems.has(item.id);
     const active = isActive(item.path) || hasActiveChild(item);

--- a/kelta-web/packages/plugin-sdk/package.json
+++ b/kelta-web/packages/plugin-sdk/package.json
@@ -22,12 +22,12 @@
   },
   "peerDependencies": {
     "@kelta/sdk": "^0.0.1",
-    "react": "^18.2.0",
-    "react-router-dom": "^6.0.0"
+    "react": "^19.0.0",
+    "react-router-dom": "^7.0.0"
   },
   "devDependencies": {
-    "react": "^18.2.0",
-    "react-router-dom": "^6.22.2"
+    "react": "^19.2.0",
+    "react-router-dom": "^7.0.0"
   },
   "keywords": [
     "kelta",


### PR DESCRIPTION
## Summary

Aligns the kelta-web workspace with kelta-ui (already on React 19 + react-router 7). Pre-bump, the file:-linked packages declared peer deps on React ^18.2.0, which caused npm to install a duplicate \`react@18\` inside \`packages/components/node_modules\` — that duplicate broke hooks at runtime with \`Cannot read properties of null reading useRef\` (#817 worked around it; this PR removes the underlying cause).

## Changes

| Package | Before | After |
|---|---|---|
| **kelta-web** (root) | react ^18.2.0 / react-dom ^18.2.0 / react-router-dom ^6.22.2 / @types/react* 18 / @testing-library/react ^14.2.1 | react ^19.2.0 / react-dom ^19.2.0 / react-router-dom ^7.0.0 / @types/react* 19 / @testing-library/react ^16.3.0 |
| **plugin-sdk** | peer+dev react ^18.2.0 / react-router-dom ^6 | peer+dev react ^19 / react-router-dom ^7 |
| **components** | peer+dev react ^18 \|\| ^19 (temporary) | peer+dev react ^19, react-router-dom ^7 |

## Verification

- \`npm ls react\` resolves to a single \`19.2.6\` across the workspace
- \`npm run build\` clean
- \`npm test\` 842 / 842 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)