### PR TITLE
fix(components,plugin-sdk): replace JSX.Element with ReactElement after React 19 bump

### DIFF
--- a/kelta-web/packages/components/src/FilterBuilder/FilterBuilder.tsx
+++ b/kelta-web/packages/components/src/FilterBuilder/FilterBuilder.tsx
@@ -1,4 +1,5 @@
 import { useCallback } from 'react';
+import type { ReactElement } from 'react';
 import type { FilterExpression } from '@kelta/sdk';
 import type { FilterBuilderProps } from './types';
 import { OPERATORS_BY_TYPE } from './types';
@@ -30,7 +31,7 @@ export function FilterBuilder({
   maxFilters = 10,
   className = '',
   testId = 'kelta-filter-builder',
-}: FilterBuilderProps): JSX.Element {
+}: FilterBuilderProps): ReactElement {
   // Add a new filter
   const addFilter = useCallback(() => {
     if (value.length >= maxFilters || fields.length === 0) return;

--- a/kelta-web/packages/components/src/Layout/PageLayout.tsx
+++ b/kelta-web/packages/components/src/Layout/PageLayout.tsx
@@ -1,3 +1,4 @@
+import type { ReactElement } from 'react';
 import type { PageLayoutProps } from './types';
 
 /**
@@ -26,7 +27,7 @@ export function PageLayout({
   className = '',
   style,
   testId = 'kelta-page-layout',
-}: PageLayoutProps): JSX.Element {
+}: PageLayoutProps): ReactElement {
   return (
     <div className={`kelta-page-layout ${className}`} style={style} data-testid={testId}>
       {header && (

--- a/kelta-web/packages/components/src/Layout/ThreeColumnLayout.tsx
+++ b/kelta-web/packages/components/src/Layout/ThreeColumnLayout.tsx
@@ -1,3 +1,4 @@
+import type { ReactElement } from 'react';
 import type { ThreeColumnLayoutProps } from './types';
 
 /**
@@ -42,7 +43,7 @@ export function ThreeColumnLayout({
   breakpoints = DEFAULT_BREAKPOINTS,
   collapsibleOnMobile = true,
   testId = 'kelta-three-column-layout',
-}: ThreeColumnLayoutProps): JSX.Element {
+}: ThreeColumnLayoutProps): ReactElement {
   const layoutStyle = {
     ...style,
     '--left-width': leftWidth,

--- a/kelta-web/packages/components/src/Layout/TwoColumnLayout.tsx
+++ b/kelta-web/packages/components/src/Layout/TwoColumnLayout.tsx
@@ -1,3 +1,4 @@
+import type { ReactElement } from 'react';
 import type { TwoColumnLayoutProps } from './types';
 
 /**
@@ -40,7 +41,7 @@ export function TwoColumnLayout({
   breakpoints = DEFAULT_BREAKPOINTS,
   collapsibleOnMobile = true,
   testId = 'kelta-two-column-layout',
-}: TwoColumnLayoutProps): JSX.Element {
+}: TwoColumnLayoutProps): ReactElement {
   const layoutStyle = {
     ...style,
     '--sidebar-width': sidebarWidth,

--- a/kelta-web/packages/components/src/ResourceDetail/ResourceDetail.tsx
+++ b/kelta-web/packages/components/src/ResourceDetail/ResourceDetail.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useMemo } from 'react';
+import type { ReactElement } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import type { FieldDefinition, ResourceMetadata } from '@kelta/sdk';
 import { useKeltaClient, useCurrentUser } from '../context/KeltaContext';
@@ -86,7 +87,7 @@ export function ResourceDetail({
   customRenderers = {},
   className = '',
   testId = 'kelta-resource-detail',
-}: ResourceDetailProps): JSX.Element {
+}: ResourceDetailProps): ReactElement {
   const client = useKeltaClient();
   const user = useCurrentUser();
 

--- a/kelta-web/packages/components/src/ResourceDetail/types.ts
+++ b/kelta-web/packages/components/src/ResourceDetail/types.ts
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react';
+import type { ReactElement } from 'react';
 import type { FieldDefinition } from '@kelta/sdk';
 
 /**
@@ -19,7 +20,7 @@ export interface FieldRendererProps {
 /**
  * Field renderer component type (for plugin registry)
  */
-export type FieldRendererComponent = (props: FieldRendererProps) => JSX.Element;
+export type FieldRendererComponent = (props: FieldRendererProps) => ReactElement;
 
 /**
  * Props for ResourceDetail component

--- a/kelta-web/packages/components/src/ResourceForm/ResourceForm.tsx
+++ b/kelta-web/packages/components/src/ResourceForm/ResourceForm.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useCallback } from 'react';
+import type { ReactElement } from 'react';
 import { useForm, Controller } from 'react-hook-form';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { z } from 'zod';
@@ -214,7 +215,7 @@ export function ResourceForm({
   initialValues = {},
   readOnly = false,
   className = '',
-}: ResourceFormProps): JSX.Element {
+}: ResourceFormProps): ReactElement {
   const client = useKeltaClient();
   const user = useCurrentUser();
   const queryClient = useQueryClient();
@@ -520,7 +521,7 @@ interface RenderFieldOptions {
 /**
  * Render a field using custom renderer or default input
  */
-function renderField(field: FieldDefinition, options: RenderFieldOptions): JSX.Element {
+function renderField(field: FieldDefinition, options: RenderFieldOptions): ReactElement {
   const { register, control, readOnly } = options;
 
   // Check for custom field renderer from plugin registry
@@ -556,7 +557,7 @@ function renderDefaultFieldInput(
   field: FieldDefinition,
   register: ReturnType<typeof useForm>['register'],
   readOnly: boolean
-): JSX.Element {
+): ReactElement {
   const baseClassName = `kelta-resource-form__input kelta-resource-form__input--${field.type}`;
   const id = `field-${field.name}`;
 

--- a/kelta-web/packages/components/src/ResourceForm/types.ts
+++ b/kelta-web/packages/components/src/ResourceForm/types.ts
@@ -1,3 +1,4 @@
+import type { ReactElement } from 'react';
 import type { FieldDefinition } from '@kelta/sdk';
 
 /**
@@ -68,4 +69,4 @@ export interface FieldRendererProps {
 /**
  * Field renderer component type
  */
-export type FieldRendererComponent = (props: FieldRendererProps) => JSX.Element;
+export type FieldRendererComponent = (props: FieldRendererProps) => ReactElement;

--- a/kelta-web/packages/plugin-sdk/src/registry/types.ts
+++ b/kelta-web/packages/plugin-sdk/src/registry/types.ts
@@ -1,3 +1,4 @@
+import type { ReactElement } from 'react';
 import type { FieldDefinition, KeltaClient, User } from '@kelta/sdk';
 
 /**
@@ -28,7 +29,7 @@ export interface FieldRendererProps {
 /**
  * Field renderer component type
  */
-export type FieldRendererComponent = (props: FieldRendererProps) => JSX.Element;
+export type FieldRendererComponent = (props: FieldRendererProps) => ReactElement;
 
 /**
  * Props passed to page components
@@ -53,7 +54,7 @@ export interface PageComponentProps {
 /**
  * Page component type
  */
-export type PageComponent = (props: PageComponentProps) => JSX.Element;
+export type PageComponent = (props: PageComponentProps) => ReactElement;
 
 /**
  * Registered page component with route


### PR DESCRIPTION
## Symptom

After PR #818 bumped the kelta-web workspace to React 19, the kelta-ui Docker build (and \`npm run build\` locally) failed in plugin-sdk:

\`\`\`
src/registry/types.ts:31:69 - error TS2503: Cannot find namespace 'JSX'.
[vite:dts] Internal Error: Unable to follow symbol for "JSX"
\`\`\`

## Cause

React 19's \`@types/react\` no longer ships a global \`JSX\` namespace. Every \`JSX.Element\` reference is now a hard error.

## Fix

Replace every remaining \`JSX.Element\` with \`React.ReactElement\` and add the import where needed:

- plugin-sdk: \`registry/types.ts\`
- components: \`FilterBuilder\`, \`Layout/PageLayout\`, \`Layout/ThreeColumnLayout\`, \`Layout/TwoColumnLayout\`, \`ResourceDetail\` (+ types), \`ResourceForm\` (+ types)

## Verification

- \`npm run build\` clean
- \`npm run lint\` 0 errors
- \`npm test\` 842 / 842 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)