### PR TITLE
fix(layouts): pass post-mutation values into rule engine to fix stale eval

### DIFF
--- a/kelta-ui/app/src/pages/ResourceFormPage/ResourceFormPage.tsx
+++ b/kelta-ui/app/src/pages/ResourceFormPage/ResourceFormPage.tsx
@@ -11,7 +11,7 @@
  * - 12.4: Use custom field renderers when registered, fall back to defaults
  */
 
-import React, { useState, useCallback, useMemo } from 'react'
+import React, { useState, useCallback, useMemo, useRef } from 'react'
 import { useParams, useNavigate, useSearchParams, Link } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { cn } from '@/lib/utils'
@@ -963,33 +963,37 @@ export function ResourceFormPage({
   /**
    * Handle field value change
    */
+  // Mirror formData in a ref so handleFieldChange can compute the post-mutation
+  // values map and pass it straight into the engine, bypassing the
+  // useState/useRef async-update race that would otherwise have the engine
+  // evaluate against stale values.
+  const formDataRef = useRef(formData)
+  formDataRef.current = formData
+
   const handleFieldChange = useCallback(
     (fieldName: string, value: unknown) => {
-      setFormData((prev) => ({
-        ...prev,
-        [fieldName]: value,
-      }))
+      const next = { ...formDataRef.current, [fieldName]: value }
+      formDataRef.current = next
+      setFormData(next)
 
       // Clear error when field is modified
       if (formErrors[fieldName]) {
         setFormErrors((prev) => {
-          const next = { ...prev }
-          delete next[fieldName]
-          return next
+          const errNext = { ...prev }
+          delete errNext[fieldName]
+          return errNext
         })
       }
 
-      // Drive the layout-rules engine: cascade computes/validations triggered
-      // by this field. The engine writes back via setFieldValue (above), so
-      // dependent fields update in the same render cycle.
-      ruleEngine.onFieldChange(fieldName)
+      // Drive the layout-rules engine with the freshly computed values map.
+      ruleEngine.onFieldChange(fieldName, next)
     },
     [formErrors, ruleEngine]
   )
 
   const handleFieldBlur = useCallback(
     (fieldName: string) => {
-      ruleEngine.onFieldBlur(fieldName)
+      ruleEngine.onFieldBlur(fieldName, formDataRef.current)
     },
     [ruleEngine],
   )

--- a/kelta-ui/app/src/pages/app/ObjectFormPage/ObjectFormPage.tsx
+++ b/kelta-ui/app/src/pages/app/ObjectFormPage/ObjectFormPage.tsx
@@ -16,7 +16,7 @@
  * - Loading states
  */
 
-import React, { useState, useCallback, useMemo } from 'react'
+import React, { useState, useCallback, useMemo, useRef } from 'react'
 import { useNavigate, useParams, useSearchParams, Link } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
 import { Save, X, Loader2, AlertCircle } from 'lucide-react'
@@ -501,23 +501,29 @@ function ObjectFormBody({
 
   const pageTitle = isNew ? `New ${collectionLabel}` : `Edit ${collectionLabel}`
 
-  // Handle field change
+  // Handle field change. Use a functional ref of the latest values so we can
+  // pass the post-mutation map directly to the engine — without that, the
+  // engine reads stale values because setFormData is async and useLayoutRules'
+  // valuesRef only refreshes on the next render.
+  const formDataRef = useRef(formData)
+  formDataRef.current = formData
   const handleFieldChange = useCallback(
     (name: string, value: unknown) => {
-      setFormData((prev) => ({ ...prev, [name]: value }))
+      const next = { ...formDataRef.current, [name]: value }
+      formDataRef.current = next
+      setFormData(next)
       // Clear server-side error for this field when user modifies it
       setFormErrors((prev) => {
         if (prev[name]) {
-          const next = { ...prev }
-          delete next[name]
-          return next
+          const errNext = { ...prev }
+          delete errNext[name]
+          return errNext
         }
         return prev
       })
-      // Drive the layout-rules engine: cascade computes/validations triggered
-      // by this field. The engine writes back via setFieldValue (above), so
-      // dependent fields update in the same render cycle.
-      ruleEngine.onFieldChange(name)
+      // Drive the engine with the freshly computed values map so cascaded
+      // computes/validations see the new value immediately.
+      ruleEngine.onFieldChange(name, next)
     },
     [ruleEngine]
   )

--- a/kelta-web/packages/components/src/FilterBuilder/FilterBuilder.tsx
+++ b/kelta-web/packages/components/src/FilterBuilder/FilterBuilder.tsx
@@ -1,4 +1,5 @@
 import { useCallback } from 'react';
+import type { ReactElement } from 'react';
 import type { FilterExpression } from '@kelta/sdk';
 import type { FilterBuilderProps } from './types';
 import { OPERATORS_BY_TYPE } from './types';
@@ -30,7 +31,7 @@ export function FilterBuilder({
   maxFilters = 10,
   className = '',
   testId = 'kelta-filter-builder',
-}: FilterBuilderProps): JSX.Element {
+}: FilterBuilderProps): ReactElement {
   // Add a new filter
   const addFilter = useCallback(() => {
     if (value.length >= maxFilters || fields.length === 0) return;

--- a/kelta-web/packages/components/src/Layout/PageLayout.tsx
+++ b/kelta-web/packages/components/src/Layout/PageLayout.tsx
@@ -1,3 +1,4 @@
+import type { ReactElement } from 'react';
 import type { PageLayoutProps } from './types';
 
 /**
@@ -26,7 +27,7 @@ export function PageLayout({
   className = '',
   style,
   testId = 'kelta-page-layout',
-}: PageLayoutProps): JSX.Element {
+}: PageLayoutProps): ReactElement {
   return (
     <div className={`kelta-page-layout ${className}`} style={style} data-testid={testId}>
       {header && (

--- a/kelta-web/packages/components/src/Layout/ThreeColumnLayout.tsx
+++ b/kelta-web/packages/components/src/Layout/ThreeColumnLayout.tsx
@@ -1,3 +1,4 @@
+import type { ReactElement } from 'react';
 import type { ThreeColumnLayoutProps } from './types';
 
 /**
@@ -42,7 +43,7 @@ export function ThreeColumnLayout({
   breakpoints = DEFAULT_BREAKPOINTS,
   collapsibleOnMobile = true,
   testId = 'kelta-three-column-layout',
-}: ThreeColumnLayoutProps): JSX.Element {
+}: ThreeColumnLayoutProps): ReactElement {
   const layoutStyle = {
     ...style,
     '--left-width': leftWidth,

--- a/kelta-web/packages/components/src/Layout/TwoColumnLayout.tsx
+++ b/kelta-web/packages/components/src/Layout/TwoColumnLayout.tsx
@@ -1,3 +1,4 @@
+import type { ReactElement } from 'react';
 import type { TwoColumnLayoutProps } from './types';
 
 /**
@@ -40,7 +41,7 @@ export function TwoColumnLayout({
   breakpoints = DEFAULT_BREAKPOINTS,
   collapsibleOnMobile = true,
   testId = 'kelta-two-column-layout',
-}: TwoColumnLayoutProps): JSX.Element {
+}: TwoColumnLayoutProps): ReactElement {
   const layoutStyle = {
     ...style,
     '--sidebar-width': sidebarWidth,

--- a/kelta-web/packages/components/src/LayoutRenderer/clientRules/useLayoutRules.ts
+++ b/kelta-web/packages/components/src/LayoutRenderer/clientRules/useLayoutRules.ts
@@ -26,10 +26,19 @@ export interface UseLayoutRulesResult {
   diagnostics: RuleEngineDiagnostic[];
   /** Whether a field is a compute target (render as read-only with ƒ adornment). */
   isComputed: (field: string) => boolean;
-  /** Run one onChange tick — call from your form's field-change handler. */
-  onFieldChange: (field: string) => void;
+  /**
+   * Run one onChange tick — call from your form's field-change handler.
+   *
+   * Pass the post-mutation values map as the second argument to bypass the
+   * stale-closure / async-setState race: with plain useState, calling
+   * `setFormData(prev => ({...prev, name: value}))` does NOT make the new
+   * value visible to the engine until React re-renders and our `values`
+   * prop updates. Supply `nextValues` so the engine sees the fresh value
+   * immediately.
+   */
+  onFieldChange: (field: string, nextValues?: Record<string, unknown>) => void;
   /** Run one onBlur tick — call from your input onBlur handler. */
-  onFieldBlur: (field: string) => void;
+  onFieldBlur: (field: string, nextValues?: Record<string, unknown>) => void;
   /** Run before-save checks. Block submission when blocked === true. */
   runBeforeSave: () => BeforeSaveResult;
 }
@@ -92,14 +101,19 @@ export function useLayoutRules(opts: UseLayoutRulesOptions): UseLayoutRulesResul
   }, [engine, binding]);
 
   const onFieldChange = useCallback(
-    (field: string) => {
+    (field: string, nextValues?: Record<string, unknown>) => {
+      // Override the ref with caller-supplied fresh values BEFORE the engine
+      // reads them. Avoids the React useState/useRef race where the engine
+      // would otherwise read pre-change values.
+      if (nextValues) valuesRef.current = nextValues;
       engine?.onFieldChange(field, binding);
     },
     [engine, binding]
   );
 
   const onFieldBlur = useCallback(
-    (field: string) => {
+    (field: string, nextValues?: Record<string, unknown>) => {
+      if (nextValues) valuesRef.current = nextValues;
       engine?.onFieldBlur(field, binding);
     },
     [engine, binding]

--- a/kelta-web/packages/components/src/ResourceDetail/ResourceDetail.tsx
+++ b/kelta-web/packages/components/src/ResourceDetail/ResourceDetail.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useMemo } from 'react';
+import type { ReactElement } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import type { FieldDefinition, ResourceMetadata } from '@kelta/sdk';
 import { useKeltaClient, useCurrentUser } from '../context/KeltaContext';
@@ -86,7 +87,7 @@ export function ResourceDetail({
   customRenderers = {},
   className = '',
   testId = 'kelta-resource-detail',
-}: ResourceDetailProps): JSX.Element {
+}: ResourceDetailProps): ReactElement {
   const client = useKeltaClient();
   const user = useCurrentUser();
 

--- a/kelta-web/packages/components/src/ResourceDetail/types.ts
+++ b/kelta-web/packages/components/src/ResourceDetail/types.ts
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react';
+import type { ReactElement } from 'react';
 import type { FieldDefinition } from '@kelta/sdk';
 
 /**
@@ -19,7 +20,7 @@ export interface FieldRendererProps {
 /**
  * Field renderer component type (for plugin registry)
  */
-export type FieldRendererComponent = (props: FieldRendererProps) => JSX.Element;
+export type FieldRendererComponent = (props: FieldRendererProps) => ReactElement;
 
 /**
  * Props for ResourceDetail component

--- a/kelta-web/packages/components/src/ResourceForm/ResourceForm.tsx
+++ b/kelta-web/packages/components/src/ResourceForm/ResourceForm.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useCallback } from 'react';
+import type { ReactElement } from 'react';
 import { useForm, Controller } from 'react-hook-form';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { z } from 'zod';
@@ -214,7 +215,7 @@ export function ResourceForm({
   initialValues = {},
   readOnly = false,
   className = '',
-}: ResourceFormProps): JSX.Element {
+}: ResourceFormProps): ReactElement {
   const client = useKeltaClient();
   const user = useCurrentUser();
   const queryClient = useQueryClient();
@@ -520,7 +521,7 @@ interface RenderFieldOptions {
 /**
  * Render a field using custom renderer or default input
  */
-function renderField(field: FieldDefinition, options: RenderFieldOptions): JSX.Element {
+function renderField(field: FieldDefinition, options: RenderFieldOptions): ReactElement {
   const { register, control, readOnly } = options;
 
   // Check for custom field renderer from plugin registry
@@ -556,7 +557,7 @@ function renderDefaultFieldInput(
   field: FieldDefinition,
   register: ReturnType<typeof useForm>['register'],
   readOnly: boolean
-): JSX.Element {
+): ReactElement {
   const baseClassName = `kelta-resource-form__input kelta-resource-form__input--${field.type}`;
   const id = `field-${field.name}`;
 

--- a/kelta-web/packages/components/src/ResourceForm/types.ts
+++ b/kelta-web/packages/components/src/ResourceForm/types.ts
@@ -1,3 +1,4 @@
+import type { ReactElement } from 'react';
 import type { FieldDefinition } from '@kelta/sdk';
 
 /**
@@ -68,4 +69,4 @@ export interface FieldRendererProps {
 /**
  * Field renderer component type
  */
-export type FieldRendererComponent = (props: FieldRendererProps) => JSX.Element;
+export type FieldRendererComponent = (props: FieldRendererProps) => ReactElement;

--- a/kelta-web/packages/plugin-sdk/src/registry/types.ts
+++ b/kelta-web/packages/plugin-sdk/src/registry/types.ts
@@ -1,3 +1,4 @@
+import type { ReactElement } from 'react';
 import type { FieldDefinition, KeltaClient, User } from '@kelta/sdk';
 
 /**
@@ -28,7 +29,7 @@ export interface FieldRendererProps {
 /**
  * Field renderer component type
  */
-export type FieldRendererComponent = (props: FieldRendererProps) => JSX.Element;
+export type FieldRendererComponent = (props: FieldRendererProps) => ReactElement;
 
 /**
  * Props passed to page components
@@ -53,7 +54,7 @@ export interface PageComponentProps {
 /**
  * Page component type
  */
-export type PageComponent = (props: PageComponentProps) => JSX.Element;
+export type PageComponent = (props: PageComponentProps) => ReactElement;
 
 /**
  * Registered page component with route


### PR DESCRIPTION
## Symptom

Changing Quantity from 1 → 2 left \`line_total\` at the value computed for quantity=1. Returning to the field and editing again applied the rule against the previous value — the form was always one tick behind.

## Cause

\`handleFieldChange\` queued setFormData (async) and then called \`ruleEngine.onFieldChange\` synchronously. \`useLayoutRules\` mirrored \`values\` into a ref only on re-render, so the engine's \`getValues()\` returned the pre-change state.

## Fix

- \`useLayoutRules\`: extend \`onFieldChange\` / \`onFieldBlur\` to accept an optional \`nextValues\` map. When supplied, the hook overrides \`valuesRef.current\` before the engine reads it.
- \`ObjectFormPage\` + \`ResourceFormPage\`: keep a \`formDataRef\`, compute the post-mutation map locally, and hand it to both \`setFormData\` and \`ruleEngine.onFieldChange(name, next)\`. Engine now evaluates against the new value in the same JS tick.

## Verification

- \`@kelta/components\` clientRules: 34 / 34 tests pass
- \`RulesEditor\` smoke: 5 / 5 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)