### PR TITLE
feat(fields): rollup_summary configuration end-to-end

### DIFF
--- a/e2e-tests/helpers/data-factory.ts
+++ b/e2e-tests/helpers/data-factory.ts
@@ -170,6 +170,8 @@ export class DataFactory {
       displayName: string;
       type: string;
       required?: boolean;
+      referenceTarget?: string;
+      fieldTypeConfig?: Record<string, unknown>;
     },
   ): Promise<JsonApiResource> {
     const result = await this.request(
@@ -220,6 +222,17 @@ export class DataFactory {
     throw new Error(
       `createRecord for '${collectionName}' failed after ${MAX_RETRIES} retries`,
     );
+  }
+
+  async getRecord(
+    collectionName: string,
+    id: string,
+  ): Promise<JsonApiResource> {
+    const result = await this.request(
+      "GET",
+      `/api/${collectionName}/${id}`,
+    );
+    return result.data as JsonApiResource;
   }
 
   /**

--- a/e2e-tests/tests/journeys/rollup-summary-journey.spec.ts
+++ b/e2e-tests/tests/journeys/rollup-summary-journey.spec.ts
@@ -1,0 +1,107 @@
+import { test, expect } from "../../fixtures";
+
+/**
+ * Rollup Summary end-to-end coverage:
+ * - Configure a ROLLUP_SUMMARY field on a parent collection via the
+ *   admin/fields API with fieldTypeConfig (childCollection, foreignKeyField,
+ *   aggregateFunction, aggregateField).
+ * - Insert child records and confirm the parent GET returns the aggregated
+ *   value computed by RollupSummaryService through DefaultQueryEngine.
+ *
+ * Validates the new wiring end-to-end: UI submits these config keys, backend
+ * reads them and invokes the SQL aggregate.
+ */
+test.describe("Rollup Summary Journey", () => {
+  test("computes SUM rollup over child records", async ({ dataFactory }) => {
+    const parent = await dataFactory.createCollection({
+      displayName: `Rollup Parent ${Date.now()}`,
+    });
+    const parentName = parent.attributes.name as string;
+
+    const child = await dataFactory.createCollection({
+      displayName: `Rollup Child ${Date.now()}`,
+    });
+    const childName = child.attributes.name as string;
+
+    await dataFactory.addField(child.id, {
+      name: "amount",
+      displayName: "Amount",
+      type: "number",
+    });
+    await dataFactory.addField(child.id, {
+      name: "parentRef",
+      displayName: "Parent",
+      type: "master_detail",
+      referenceTarget: parentName,
+    });
+
+    await dataFactory.addField(parent.id, {
+      name: "totalAmount",
+      displayName: "Total Amount",
+      type: "rollup_summary",
+      fieldTypeConfig: {
+        childCollection: childName,
+        foreignKeyField: "parentRef",
+        aggregateFunction: "SUM",
+        aggregateField: "amount",
+      },
+    });
+
+    await dataFactory.waitForStorageReady(parentName);
+    await dataFactory.waitForStorageReady(childName);
+
+    const parentRecord = await dataFactory.createRecord(parentName, {});
+    await dataFactory.createRecord(childName, {
+      amount: 5,
+      parentRef: parentRecord.id,
+    });
+    await dataFactory.createRecord(childName, {
+      amount: 7,
+      parentRef: parentRecord.id,
+    });
+
+    const fetched = await dataFactory.getRecord(parentName, parentRecord.id);
+    expect(Number(fetched.attributes.totalAmount)).toBe(12);
+  });
+
+  test("COUNT rollup ignores aggregateField", async ({ dataFactory }) => {
+    const parent = await dataFactory.createCollection({
+      displayName: `Rollup Count Parent ${Date.now()}`,
+    });
+    const parentName = parent.attributes.name as string;
+
+    const child = await dataFactory.createCollection({
+      displayName: `Rollup Count Child ${Date.now()}`,
+    });
+    const childName = child.attributes.name as string;
+
+    await dataFactory.addField(child.id, {
+      name: "parentRef",
+      displayName: "Parent",
+      type: "master_detail",
+      referenceTarget: parentName,
+    });
+
+    await dataFactory.addField(parent.id, {
+      name: "lineCount",
+      displayName: "Line Count",
+      type: "rollup_summary",
+      fieldTypeConfig: {
+        childCollection: childName,
+        foreignKeyField: "parentRef",
+        aggregateFunction: "COUNT",
+      },
+    });
+
+    await dataFactory.waitForStorageReady(parentName);
+    await dataFactory.waitForStorageReady(childName);
+
+    const parentRecord = await dataFactory.createRecord(parentName, {});
+    await dataFactory.createRecord(childName, { parentRef: parentRecord.id });
+    await dataFactory.createRecord(childName, { parentRef: parentRecord.id });
+    await dataFactory.createRecord(childName, { parentRef: parentRecord.id });
+
+    const fetched = await dataFactory.getRecord(parentName, parentRecord.id);
+    expect(Number(fetched.attributes.lineCount)).toBe(3);
+  });
+});

--- a/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/config/KeltaRuntimeAutoConfiguration.java
+++ b/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/config/KeltaRuntimeAutoConfiguration.java
@@ -6,6 +6,7 @@ import io.kelta.runtime.credential.CredentialTypeRegistry;
 import io.kelta.runtime.events.RecordEventPublisher;
 import io.kelta.runtime.query.DefaultQueryEngine;
 import io.kelta.runtime.query.QueryEngine;
+import io.kelta.runtime.service.RollupSummaryService;
 import io.kelta.runtime.registry.CollectionRegistry;
 import io.kelta.runtime.registry.ConcurrentCollectionRegistry;
 import io.kelta.runtime.router.DynamicCollectionRouter;
@@ -130,10 +131,12 @@ public class KeltaRuntimeAutoConfiguration {
                                     ValidationEngine validationEngine,
                                     @Autowired(required = false) CustomValidationRuleEngine customValidationRuleEngine,
                                     @Autowired(required = false) RecordEventPublisher recordEventPublisher,
-                                    @Autowired(required = false) BeforeSaveHookRegistry beforeSaveHookRegistry) {
+                                    @Autowired(required = false) BeforeSaveHookRegistry beforeSaveHookRegistry,
+                                    @Autowired(required = false) RollupSummaryService rollupSummaryService,
+                                    CollectionRegistry collectionRegistry) {
         return new DefaultQueryEngine(storageAdapter, validationEngine,
-                null, null, null, null, customValidationRuleEngine, recordEventPublisher,
-                beforeSaveHookRegistry);
+                null, null, null, rollupSummaryService, customValidationRuleEngine, recordEventPublisher,
+                beforeSaveHookRegistry, collectionRegistry);
     }
 
     /**

--- a/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/query/DefaultQueryEngine.java
+++ b/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/query/DefaultQueryEngine.java
@@ -12,6 +12,8 @@ import io.kelta.runtime.service.AutoNumberService;
 import io.kelta.runtime.service.FieldEncryptionService;
 import io.kelta.runtime.service.RollupSummaryService;
 import io.kelta.runtime.formula.FormulaEvaluator;
+import io.kelta.runtime.registry.CollectionRegistry;
+import io.kelta.runtime.storage.PhysicalTableStorageAdapter;
 import io.kelta.runtime.storage.StorageAdapter;
 import io.kelta.runtime.validation.CustomValidationRuleEngine;
 import io.kelta.runtime.validation.OperationType;
@@ -65,6 +67,7 @@ public class DefaultQueryEngine implements QueryEngine {
     private final CustomValidationRuleEngine customValidationRuleEngine;
     private final RecordEventPublisher recordEventPublisher;
     private final BeforeSaveHookRegistry beforeSaveHookRegistry;
+    private final CollectionRegistry collectionRegistry;
 
     /**
      * Creates a new DefaultQueryEngine with all services including workflow engine.
@@ -85,6 +88,22 @@ public class DefaultQueryEngine implements QueryEngine {
                               CustomValidationRuleEngine customValidationRuleEngine,
                               RecordEventPublisher recordEventPublisher,
                               BeforeSaveHookRegistry beforeSaveHookRegistry) {
+        this(storageAdapter, validationEngine, encryptionService, autoNumberService,
+             formulaEvaluator, rollupSummaryService, customValidationRuleEngine,
+             recordEventPublisher, beforeSaveHookRegistry, null);
+    }
+
+    /**
+     * Creates a new DefaultQueryEngine with all services including the collection
+     * registry needed for ROLLUP_SUMMARY child-table resolution.
+     */
+    public DefaultQueryEngine(StorageAdapter storageAdapter, ValidationEngine validationEngine,
+                              FieldEncryptionService encryptionService, AutoNumberService autoNumberService,
+                              FormulaEvaluator formulaEvaluator, RollupSummaryService rollupSummaryService,
+                              CustomValidationRuleEngine customValidationRuleEngine,
+                              RecordEventPublisher recordEventPublisher,
+                              BeforeSaveHookRegistry beforeSaveHookRegistry,
+                              CollectionRegistry collectionRegistry) {
         this.storageAdapter = Objects.requireNonNull(storageAdapter, "storageAdapter cannot be null");
         this.validationEngine = validationEngine;
         this.encryptionService = encryptionService;
@@ -94,6 +113,7 @@ public class DefaultQueryEngine implements QueryEngine {
         this.customValidationRuleEngine = customValidationRuleEngine;
         this.recordEventPublisher = recordEventPublisher;
         this.beforeSaveHookRegistry = beforeSaveHookRegistry;
+        this.collectionRegistry = collectionRegistry;
     }
 
     /**
@@ -727,17 +747,80 @@ public class DefaultQueryEngine implements QueryEngine {
     private void computeVirtualFields(CollectionDefinition definition, List<Map<String, Object>> records) {
         for (Map<String, Object> record : records) {
             for (FieldDefinition field : definition.fields()) {
-                // TODO: FORMULA and ROLLUP_SUMMARY require field-type-specific config
-                // (expression, childTable, etc.) which is not yet available on FieldDefinition.
-                // These will be wired once FieldDefinition carries a config map.
                 if (field.type() == FieldType.FORMULA && formulaEvaluator != null) {
-                    // Formula expression would come from field config; skip until available
+                    // FORMULA wiring tracked separately; same fieldTypeConfig path will host
+                    // the expression once the formula DSL stabilizes.
                     logger.debug("Skipping formula field '{}' — config not available on FieldDefinition", field.name());
                 } else if (field.type() == FieldType.ROLLUP_SUMMARY && rollupSummaryService != null) {
-                    // Rollup config would come from field config; skip until available
-                    logger.debug("Skipping rollup field '{}' — config not available on FieldDefinition", field.name());
+                    // TODO(perf): batch rollup compute via GROUP BY parent_fk when
+                    // result sets get large; current impl is one query per record.
+                    Object computed = computeRollupValue(field, record);
+                    if (computed != null) {
+                        record.put(field.name(), computed);
+                    }
                 }
             }
         }
+    }
+
+    /**
+     * Resolves a single ROLLUP_SUMMARY field value for one parent record by
+     * delegating to {@link RollupSummaryService}. Returns null when the field
+     * config is incomplete or the child collection cannot be resolved.
+     */
+    private Object computeRollupValue(FieldDefinition field, Map<String, Object> record) {
+        Map<String, Object> cfg = field.fieldTypeConfig();
+        if (cfg == null || collectionRegistry == null) {
+            return null;
+        }
+        String childCollection = (String) cfg.get("childCollection");
+        String foreignKeyField = (String) cfg.get("foreignKeyField");
+        String aggregateFunction = (String) cfg.get("aggregateFunction");
+        String aggregateField = (String) cfg.get("aggregateField");
+        @SuppressWarnings("unchecked")
+        Map<String, Object> filter = (Map<String, Object>) cfg.get("filter");
+        if (childCollection == null || foreignKeyField == null || aggregateFunction == null) {
+            logger.debug("Rollup field '{}' has incomplete config; skipping", field.name());
+            return null;
+        }
+
+        CollectionDefinition childDef = collectionRegistry.get(childCollection);
+        if (childDef == null) {
+            logger.debug("Rollup field '{}' references unknown child collection '{}'",
+                    field.name(), childCollection);
+            return null;
+        }
+
+        Object parentId = record.get("id");
+        if (parentId == null) {
+            return null;
+        }
+
+        String childTable = resolveTableName(childDef);
+        String fkColumn = resolveColumnName(childDef, foreignKeyField);
+        String aggColumn = aggregateField == null ? null : resolveColumnName(childDef, aggregateField);
+
+        try {
+            return rollupSummaryService.compute(childTable, fkColumn, parentId.toString(),
+                    aggregateFunction, aggColumn, filter);
+        } catch (RuntimeException e) {
+            logger.warn("Rollup compute failed for field '{}' on collection '{}': {}",
+                    field.name(), childDef.name(), e.getMessage());
+            return null;
+        }
+    }
+
+    private String resolveTableName(CollectionDefinition def) {
+        if (def.storageConfig() != null && def.storageConfig().tableName() != null) {
+            return def.storageConfig().tableName();
+        }
+        return def.name();
+    }
+
+    private String resolveColumnName(CollectionDefinition def, String fieldName) {
+        if (def.systemCollection()) {
+            return fieldName;
+        }
+        return PhysicalTableStorageAdapter.toSnakeCase(fieldName);
     }
 }

--- a/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/router/DynamicCollectionRouter.java
+++ b/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/router/DynamicCollectionRouter.java
@@ -217,9 +217,15 @@ public class DynamicCollectionRouter {
                 return ResponseEntity.notFound().build();
             }
 
-            // Check system collection cache for get-by-id
+            // Parse JSON:API ?include= up front so cache lookup can match the put guard:
+            // the cache only ever stores no-include responses, so include-bearing requests
+            // must skip the lookup or they'd receive a stale parent without included children.
+            List<String> includeNames = parseIncludeParam(params);
+
+            // Check system collection cache for get-by-id (no-include requests only)
             String tenantId = request.getHeader("X-Tenant-ID");
-            if (definition.systemCollection() && systemCollectionCache != null) {
+            if (definition.systemCollection() && systemCollectionCache != null
+                    && includeNames.isEmpty()) {
                 Optional<Map<String, Object>> cached = systemCollectionCache.getByIdResponse(
                         tenantId, collectionName, id);
                 if (cached.isPresent()) {
@@ -242,7 +248,6 @@ public class DynamicCollectionRouter {
             Map<String, Object> response = toJsonApiResponse(record.get(), collectionName, definition);
 
             // Resolve JSON:API ?include= parameter for inverse (has-many) relationships
-            List<String> includeNames = parseIncludeParam(params);
             if (!includeNames.isEmpty()) {
                 List<Map<String, Object>> included = resolveIncludes(
                         includeNames, List.of(record.get()), collectionName, definition, request);

--- a/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/storage/PhysicalTableStorageAdapter.java
+++ b/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/storage/PhysicalTableStorageAdapter.java
@@ -666,7 +666,7 @@ public class PhysicalTableStorageAdapter implements StorageAdapter {
      * @param camelCase the camelCase string
      * @return the snake_case equivalent
      */
-    static String toSnakeCase(String camelCase) {
+    public static String toSnakeCase(String camelCase) {
         if (camelCase == null || camelCase.isBlank()) {
             return camelCase;
         }

--- a/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/query/RollupSummaryComputeTest.java
+++ b/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/query/RollupSummaryComputeTest.java
@@ -1,0 +1,148 @@
+package io.kelta.runtime.query;
+
+import io.kelta.runtime.model.CollectionDefinition;
+import io.kelta.runtime.model.CollectionDefinitionBuilder;
+import io.kelta.runtime.model.FieldDefinitionBuilder;
+import io.kelta.runtime.model.FieldType;
+import io.kelta.runtime.registry.CollectionRegistry;
+import io.kelta.runtime.service.RollupSummaryService;
+import io.kelta.runtime.storage.StorageAdapter;
+import io.kelta.runtime.validation.ValidationEngine;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Verifies that DefaultQueryEngine reads ROLLUP_SUMMARY field config and
+ * delegates to RollupSummaryService at query time.
+ */
+class RollupSummaryComputeTest {
+
+    private StorageAdapter storageAdapter;
+    private RollupSummaryService rollupSummaryService;
+    private CollectionRegistry collectionRegistry;
+    private DefaultQueryEngine queryEngine;
+
+    @BeforeEach
+    void setUp() {
+        storageAdapter = mock(StorageAdapter.class);
+        rollupSummaryService = mock(RollupSummaryService.class);
+        collectionRegistry = mock(CollectionRegistry.class);
+        queryEngine = new DefaultQueryEngine(
+                storageAdapter, mock(ValidationEngine.class),
+                null, null, null, rollupSummaryService,
+                null, null, null, collectionRegistry);
+    }
+
+    private CollectionDefinition orderLines() {
+        return new CollectionDefinitionBuilder()
+                .name("orderLines")
+                .displayName("Order Lines")
+                .addField(new FieldDefinitionBuilder().name("amount").type(FieldType.DOUBLE).nullable(false).build())
+                .build();
+    }
+
+    private CollectionDefinition ordersWithRollup(Map<String, Object> rollupCfg) {
+        return new CollectionDefinitionBuilder()
+                .name("orders")
+                .displayName("Orders")
+                .addField(new FieldDefinitionBuilder().name("id").type(FieldType.STRING).nullable(false).build())
+                .addField(new FieldDefinitionBuilder()
+                        .name("totalAmount")
+                        .type(FieldType.ROLLUP_SUMMARY)
+                        .fieldTypeConfig(rollupCfg)
+                        .build())
+                .build();
+    }
+
+    @Test
+    void computesSumRollupForEachReturnedRecord() {
+        Map<String, Object> cfg = Map.of(
+                "childCollection", "orderLines",
+                "foreignKeyField", "orderId",
+                "aggregateFunction", "SUM",
+                "aggregateField", "amount");
+        CollectionDefinition orders = ordersWithRollup(cfg);
+
+        Map<String, Object> row1 = new HashMap<>(Map.of("id", "o1"));
+        Map<String, Object> row2 = new HashMap<>(Map.of("id", "o2"));
+        doReturn(new QueryResult(List.of(row1, row2), new PaginationMetadata(2, 1, 50, 1)))
+                .when(storageAdapter).query(eq(orders), any(QueryRequest.class));
+        when(collectionRegistry.get("orderLines")).thenReturn(orderLines());
+        doReturn(12.0).when(rollupSummaryService).compute(eq("orderLines"), eq("order_id"), eq("o1"),
+                eq("SUM"), eq("amount"), any());
+        doReturn(7.0).when(rollupSummaryService).compute(eq("orderLines"), eq("order_id"), eq("o2"),
+                eq("SUM"), eq("amount"), any());
+
+        QueryResult result = queryEngine.executeQuery(orders, QueryRequest.defaults());
+
+        assertEquals(12.0, result.data().get(0).get("totalAmount"));
+        assertEquals(7.0, result.data().get(1).get("totalAmount"));
+    }
+
+    @Test
+    void countRollupOmitsAggregateField() {
+        Map<String, Object> cfg = Map.of(
+                "childCollection", "orderLines",
+                "foreignKeyField", "orderId",
+                "aggregateFunction", "COUNT");
+        CollectionDefinition orders = ordersWithRollup(cfg);
+
+        Map<String, Object> row = new HashMap<>(Map.of("id", "o1"));
+        doReturn(new QueryResult(List.of(row), new PaginationMetadata(1, 1, 50, 1)))
+                .when(storageAdapter).query(eq(orders), any(QueryRequest.class));
+        when(collectionRegistry.get("orderLines")).thenReturn(orderLines());
+        doReturn(3L).when(rollupSummaryService).compute(eq("orderLines"), eq("order_id"), eq("o1"),
+                eq("COUNT"), any(), any());
+
+        QueryResult result = queryEngine.executeQuery(orders, QueryRequest.defaults());
+
+        assertEquals(3L, result.data().get(0).get("totalAmount"));
+    }
+
+    @Test
+    void skipsWhenChildCollectionUnknown() {
+        Map<String, Object> cfg = Map.of(
+                "childCollection", "missing",
+                "foreignKeyField", "orderId",
+                "aggregateFunction", "COUNT");
+        CollectionDefinition orders = ordersWithRollup(cfg);
+        Map<String, Object> row = new HashMap<>(Map.of("id", "o1"));
+        doReturn(new QueryResult(List.of(row), new PaginationMetadata(1, 1, 50, 1)))
+                .when(storageAdapter).query(eq(orders), any(QueryRequest.class));
+        when(collectionRegistry.get("missing")).thenReturn(null);
+
+        QueryResult result = queryEngine.executeQuery(orders, QueryRequest.defaults());
+
+        assertNull(result.data().get(0).get("totalAmount"));
+        verify(rollupSummaryService, never()).compute(any(), any(), any(), any(), any(), any());
+    }
+
+    @Test
+    void skipsWhenFieldTypeConfigMissingRequiredKeys() {
+        Map<String, Object> partialCfg = Map.of("childCollection", "orderLines"); // no FK or fn
+        CollectionDefinition orders = ordersWithRollup(partialCfg);
+        Map<String, Object> row = new HashMap<>(Map.of("id", "o1"));
+        doReturn(new QueryResult(List.of(row), new PaginationMetadata(1, 1, 50, 1)))
+                .when(storageAdapter).query(eq(orders), any(QueryRequest.class));
+
+        QueryResult result = queryEngine.executeQuery(orders, QueryRequest.defaults());
+
+        assertNull(result.data().get(0).get("totalAmount"));
+        verify(rollupSummaryService, never()).compute(any(), any(), any(), any(), any(), any());
+    }
+}

--- a/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/router/DynamicCollectionRouterCacheTest.java
+++ b/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/router/DynamicCollectionRouterCacheTest.java
@@ -210,6 +210,51 @@ class DynamicCollectionRouterCacheTest {
             // Verify the response was cached
             verify(cache).putByIdResponse(eq("tenant-1"), eq("collections"), eq("abc"), any());
         }
+
+        @Test
+        @DisplayName("Should NOT consult cache when include parameter is present")
+        void get_skipsCacheLookup_whenIncludePresent() throws Exception {
+            // Regression: a cached no-include response must not shadow include-bearing
+            // requests, otherwise newly created child rows are invisible until TTL.
+            CollectionDefinition def = buildSystemCollection("collections");
+            when(registry.get("collections")).thenReturn(def);
+
+            // Cache has a stale no-include response — should be ignored
+            Map<String, Object> stale = Map.of(
+                    "data", Map.of("type", "collections", "id", "abc", "attributes", Map.of("name", "Products"))
+            );
+            when(cache.getByIdResponse("tenant-1", "collections", "abc"))
+                    .thenReturn(Optional.of(stale));
+
+            Map<String, Object> record = Map.of("id", "abc", "name", "Products");
+            when(queryEngine.getById(def, "abc")).thenReturn(Optional.of(record));
+
+            mockMvc.perform(get("/api/collections/abc")
+                            .param("include", "fields")
+                            .header("X-Tenant-ID", "tenant-1"))
+                    .andExpect(status().isOk());
+
+            // Cache lookup must be skipped — fresh DB read instead
+            verify(cache, never()).getByIdResponse(any(), any(), any());
+            verify(queryEngine).getById(def, "abc");
+        }
+
+        @Test
+        @DisplayName("Should NOT cache response when include parameter is present")
+        void get_doesNotCache_whenIncludePresent() throws Exception {
+            CollectionDefinition def = buildSystemCollection("collections");
+            when(registry.get("collections")).thenReturn(def);
+
+            Map<String, Object> record = Map.of("id", "abc", "name", "Products");
+            when(queryEngine.getById(def, "abc")).thenReturn(Optional.of(record));
+
+            mockMvc.perform(get("/api/collections/abc")
+                            .param("include", "fields")
+                            .header("X-Tenant-ID", "tenant-1"))
+                    .andExpect(status().isOk());
+
+            verify(cache, never()).putByIdResponse(any(), any(), any(), any());
+        }
     }
 
     @Nested

--- a/kelta-ui/app/src/components/FieldEditor/FieldEditor.test.tsx
+++ b/kelta-ui/app/src/components/FieldEditor/FieldEditor.test.tsx
@@ -927,4 +927,155 @@ describe('FieldEditor Integration', () => {
       expect(onSave).toHaveBeenCalled()
     })
   })
+
+  describe('Rollup Summary configuration', () => {
+    const defaultProps = {
+      collectionId: 'col-123',
+      onSave: vi.fn().mockResolvedValue(undefined),
+      onCancel: vi.fn(),
+    }
+    const childFields = [
+      { name: 'orderId', displayName: 'Order', type: 'master_detail' as const, referenceTarget: 'orders' },
+      { name: 'amount', displayName: 'Amount', type: 'number' as const },
+      { name: 'placedAt', displayName: 'Placed At', type: 'datetime' as const },
+      { name: 'note', displayName: 'Note', type: 'string' as const },
+    ]
+
+    function renderRollupForm(opts?: { fetcher?: ReturnType<typeof vi.fn> }) {
+      const fetcher = opts?.fetcher ?? vi.fn().mockResolvedValue(childFields)
+      const onSave = vi.fn().mockResolvedValue(undefined)
+      const utils = renderWithProviders(
+        <FieldEditor
+          {...defaultProps}
+          collectionName="orders"
+          collections={mockCollections}
+          fetchCollectionFields={fetcher}
+          onSave={onSave}
+        />
+      )
+      return { ...utils, fetcher, onSave }
+    }
+
+    it('renders no rollup config block by default', () => {
+      renderRollupForm()
+      expect(screen.queryByTestId('rollup-config')).not.toBeInTheDocument()
+    })
+
+    it('reveals rollup config inputs when rollup_summary is selected', async () => {
+      const user = userEvent.setup()
+      renderRollupForm()
+      await user.selectOptions(screen.getByTestId('field-type-select'), 'rollup_summary')
+
+      expect(screen.getByTestId('rollup-config')).toBeInTheDocument()
+      expect(screen.getByTestId('field-rollup-child-select')).toBeInTheDocument()
+      expect(screen.getByTestId('field-rollup-fn-select')).toBeInTheDocument()
+    })
+
+    it('builds fieldTypeConfig on submit including aggregateField for SUM', async () => {
+      const user = userEvent.setup()
+      const { onSave, fetcher } = renderRollupForm()
+
+      await user.type(screen.getByTestId('field-name-input'), 'total_amount')
+      await user.selectOptions(screen.getByTestId('field-type-select'), 'rollup_summary')
+      await user.selectOptions(screen.getByTestId('field-rollup-child-select'), 'products')
+      await waitFor(() => expect(fetcher).toHaveBeenCalledWith('products'))
+
+      await user.selectOptions(screen.getByTestId('field-rollup-fk-select'), 'orderId')
+      await user.selectOptions(screen.getByTestId('field-rollup-fn-select'), 'SUM')
+      await user.selectOptions(screen.getByTestId('field-rollup-field-select'), 'amount')
+
+      await user.click(screen.getByTestId('field-editor-submit'))
+
+      await waitFor(() => expect(onSave).toHaveBeenCalled())
+      const submitted = onSave.mock.calls[0][0]
+      expect(submitted.type).toBe('rollup_summary')
+      expect(submitted.fieldTypeConfig).toEqual({
+        childCollection: 'products',
+        foreignKeyField: 'orderId',
+        aggregateFunction: 'SUM',
+        aggregateField: 'amount',
+      })
+    })
+
+    it('omits aggregateField for COUNT and skips the field selector', async () => {
+      const user = userEvent.setup()
+      const { onSave } = renderRollupForm()
+
+      await user.type(screen.getByTestId('field-name-input'), 'line_count')
+      await user.selectOptions(screen.getByTestId('field-type-select'), 'rollup_summary')
+      await user.selectOptions(screen.getByTestId('field-rollup-child-select'), 'products')
+      await waitFor(() =>
+        expect(screen.getByTestId('field-rollup-fk-select')).not.toBeDisabled()
+      )
+      await user.selectOptions(screen.getByTestId('field-rollup-fk-select'), 'orderId')
+      await user.selectOptions(screen.getByTestId('field-rollup-fn-select'), 'COUNT')
+
+      expect(screen.queryByTestId('field-rollup-field-select')).not.toBeInTheDocument()
+
+      await user.click(screen.getByTestId('field-editor-submit'))
+      await waitFor(() => expect(onSave).toHaveBeenCalled())
+      expect(onSave.mock.calls[0][0].fieldTypeConfig).toEqual({
+        childCollection: 'products',
+        foreignKeyField: 'orderId',
+        aggregateFunction: 'COUNT',
+      })
+    })
+
+    it('blocks submit when child collection is missing', async () => {
+      const user = userEvent.setup()
+      const { onSave } = renderRollupForm()
+
+      await user.type(screen.getByTestId('field-name-input'), 'total')
+      await user.selectOptions(screen.getByTestId('field-type-select'), 'rollup_summary')
+      await user.click(screen.getByTestId('field-editor-submit'))
+
+      await new Promise((r) => setTimeout(r, 50))
+      expect(onSave).not.toHaveBeenCalled()
+    })
+
+    it('pre-populates rollup config from existing fieldTypeConfig in edit mode', () => {
+      const existing: FieldDefinition = {
+        id: 'rollup-1',
+        name: 'total_amount',
+        type: 'rollup_summary',
+        required: false,
+        unique: false,
+        indexed: false,
+        order: 0,
+        fieldTypeConfig: {
+          childCollection: 'products',
+          foreignKeyField: 'orderId',
+          aggregateFunction: 'AVG',
+          aggregateField: 'amount',
+        },
+      }
+      renderRollupForm()
+      renderWithProviders(
+        <FieldEditor
+          {...defaultProps}
+          collectionName="orders"
+          collections={mockCollections}
+          fetchCollectionFields={vi.fn().mockResolvedValue(childFields)}
+          field={existing}
+        />
+      )
+
+      const editorNodes = screen.getAllByTestId('rollup-config')
+      expect(editorNodes.length).toBeGreaterThan(0)
+      expect(screen.getAllByTestId('field-rollup-child-select')[0]).toHaveValue('products')
+      expect(screen.getAllByTestId('field-rollup-fn-select')[0]).toHaveValue('AVG')
+    })
+
+    it('renders the warning sigil rather than literal "u26A0" on errors', async () => {
+      const user = userEvent.setup()
+      renderRollupForm()
+      await user.click(screen.getByTestId('field-editor-submit'))
+
+      await waitFor(() => expect(screen.getByTestId('field-name-error')).toBeInTheDocument())
+      const styles = window.getComputedStyle(screen.getByTestId('field-name-error'), '::before')
+      // jsdom returns the raw declared value; ensure we never carry the
+      // literal "u26A0" escape that would render as text.
+      expect(styles.content || '').not.toContain('u26A0')
+    })
+  })
 })

--- a/kelta-ui/app/src/components/FieldEditor/FieldEditor.tsx
+++ b/kelta-ui/app/src/components/FieldEditor/FieldEditor.tsx
@@ -25,7 +25,7 @@
  * - Accessible with keyboard navigation and ARIA attributes
  */
 
-import React, { useEffect, useCallback, useMemo } from 'react'
+import React, { useEffect, useCallback, useMemo, useState } from 'react'
 import { useForm, useFieldArray, Controller } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
@@ -115,17 +115,43 @@ export interface PicklistSummary {
 }
 
 /**
+ * Aggregate function options for rollup_summary fields.
+ */
+export type RollupAggregateFunction = 'COUNT' | 'SUM' | 'AVG' | 'MIN' | 'MAX'
+
+/**
+ * Minimal field info exposed to the rollup config picker.
+ */
+export interface RollupChildField {
+  name: string
+  displayName?: string
+  type: FieldType
+  referenceTarget?: string
+}
+
+/**
+ * Async loader used by the rollup config block to fetch child collection
+ * fields once the user picks a child collection. Page-level concern; the
+ * component falls back to an empty list when not provided.
+ */
+export type FetchCollectionFields = (collectionName: string) => Promise<RollupChildField[]>
+
+/**
  * Props for the FieldEditor component
  */
 export interface FieldEditorProps {
   /** Collection ID for context */
   collectionId: string
+  /** Parent collection name (required when configuring rollup_summary fields) */
+  collectionName?: string
   /** Existing field for edit mode */
   field?: FieldDefinition
   /** Available collections for reference field dropdown */
   collections?: CollectionSummary[]
   /** Available global picklists for picklist field dropdown */
   picklists?: PicklistSummary[]
+  /** Loader for child collection fields (used by rollup_summary config) */
+  fetchCollectionFields?: FetchCollectionFields
   /** Callback when form is submitted */
   onSave: (field: FieldDefinition) => Promise<void>
   /** Callback when form is cancelled */
@@ -255,6 +281,10 @@ export const fieldEditorSchema = z
     currencyCode: z.string().max(3).optional().or(z.literal('')),
     currencyPrecision: z.coerce.number().min(0).max(6).optional(),
     globalPicklistId: z.string().optional().or(z.literal('')),
+    rollupChildCollection: z.string().optional().or(z.literal('')),
+    rollupForeignKey: z.string().optional().or(z.literal('')),
+    rollupFunction: z.enum(['COUNT', 'SUM', 'AVG', 'MIN', 'MAX']).optional(),
+    rollupField: z.string().optional().or(z.literal('')),
     description: z.string().max(500, 'validation.descriptionTooLong').optional().or(z.literal('')),
     trackHistory: z.boolean(),
     searchable: z.boolean(),
@@ -284,6 +314,47 @@ export const fieldEditorSchema = z
     {
       message: 'validation.picklistRequired',
       path: ['globalPicklistId'],
+    }
+  )
+  .refine(
+    (data) => {
+      if (data.type !== 'rollup_summary') return true
+      return !!data.rollupChildCollection
+    },
+    {
+      message: 'validation.rollupChildCollectionRequired',
+      path: ['rollupChildCollection'],
+    }
+  )
+  .refine(
+    (data) => {
+      if (data.type !== 'rollup_summary') return true
+      return !!data.rollupForeignKey
+    },
+    {
+      message: 'validation.rollupForeignKeyRequired',
+      path: ['rollupForeignKey'],
+    }
+  )
+  .refine(
+    (data) => {
+      if (data.type !== 'rollup_summary') return true
+      return !!data.rollupFunction
+    },
+    {
+      message: 'validation.rollupFunctionRequired',
+      path: ['rollupFunction'],
+    }
+  )
+  .refine(
+    (data) => {
+      if (data.type !== 'rollup_summary') return true
+      if (data.rollupFunction === 'COUNT') return true
+      return !!data.rollupField
+    },
+    {
+      message: 'validation.rollupFieldRequired',
+      path: ['rollupField'],
     }
   )
 
@@ -323,9 +394,11 @@ const errorInputClasses = 'border-destructive focus:border-destructive focus:rin
 export function FieldEditor({
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   collectionId,
+  collectionName,
   field,
   collections = [],
   picklists = [],
+  fetchCollectionFields,
   onSave,
   onCancel,
   isSubmitting = false,
@@ -375,6 +448,10 @@ export function FieldEditor({
       currencyCode: (parsedConfig.currencyCode as string) ?? '',
       currencyPrecision: (parsedConfig.precision as number) ?? 2,
       globalPicklistId: (parsedConfig.globalPicklistId as string) ?? '',
+      rollupChildCollection: (parsedConfig.childCollection as string) ?? '',
+      rollupForeignKey: (parsedConfig.foreignKeyField as string) ?? '',
+      rollupFunction: (parsedConfig.aggregateFunction as RollupAggregateFunction) ?? undefined,
+      rollupField: (parsedConfig.aggregateField as string) ?? '',
       description: field?.description ?? '',
       trackHistory: field?.trackHistory ?? false,
       searchable: field?.searchable ?? false,
@@ -406,11 +483,74 @@ export function FieldEditor({
   // Watch field type to show/hide reference target and validation rules
   // eslint-disable-next-line react-hooks/incompatible-library
   const watchedType = watch('type')
+  const watchedRollupChild = watch('rollupChildCollection')
+  const watchedRollupFn = watch('rollupFunction')
 
   // Get available validation rules for current field type
   const availableValidationRules = useMemo(() => {
     return VALIDATION_RULES_BY_TYPE[watchedType] || []
   }, [watchedType])
+
+  // Child collections eligible as rollup targets: those with a master_detail
+  // field whose referenceTarget is the parent collection. We can't tell from
+  // CollectionSummary alone, so we offer the full collection list and rely on
+  // foreign-key dropdown filtering once a child is picked.
+  const rollupChildOptions = useMemo(() => {
+    return collections.filter((c) => !collectionName || c.name !== collectionName)
+  }, [collections, collectionName])
+
+  // Lazily-loaded fields of the selected child collection. Populates the
+  // foreign-key and aggregate-field dropdowns.
+  const [childFields, setChildFields] = useState<RollupChildField[]>([])
+  const [childFieldsLoading, setChildFieldsLoading] = useState(false)
+
+  useEffect(() => {
+    if (watchedType !== 'rollup_summary' || !watchedRollupChild || !fetchCollectionFields) {
+      setChildFields([])
+      return
+    }
+    let cancelled = false
+    setChildFieldsLoading(true)
+    fetchCollectionFields(watchedRollupChild)
+      .then((fields) => {
+        if (!cancelled) setChildFields(fields)
+      })
+      .catch(() => {
+        if (!cancelled) setChildFields([])
+      })
+      .finally(() => {
+        if (!cancelled) setChildFieldsLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [watchedType, watchedRollupChild, fetchCollectionFields])
+
+  // Foreign-key candidates: master_detail fields on the child pointing back
+  // at the parent collection. When parent name unknown, accept any
+  // master_detail.
+  const rollupForeignKeyOptions = useMemo(() => {
+    return childFields.filter(
+      (f) =>
+        f.type === 'master_detail' &&
+        (!collectionName || !f.referenceTarget || f.referenceTarget === collectionName)
+    )
+  }, [childFields, collectionName])
+
+  // Aggregate-field candidates: numeric for SUM/AVG, numeric/date/datetime
+  // for MIN/MAX, anything for COUNT (the field is unused).
+  const rollupAggregateFieldOptions = useMemo(() => {
+    if (watchedRollupFn === 'COUNT') return []
+    const numericTypes: FieldType[] = ['number', 'currency', 'percent']
+    const orderableTypes: FieldType[] = [...numericTypes, 'date', 'datetime']
+    if (watchedRollupFn === 'SUM' || watchedRollupFn === 'AVG') {
+      return childFields.filter((f) => numericTypes.includes(f.type))
+    }
+    if (watchedRollupFn === 'MIN' || watchedRollupFn === 'MAX') {
+      return childFields.filter((f) => orderableTypes.includes(f.type))
+    }
+    return childFields
+  }, [childFields, watchedRollupFn])
 
   // Reset form when field prop changes (for edit mode)
   useEffect(() => {
@@ -429,6 +569,11 @@ export function FieldEditor({
         currencyCode: (parsedConfig.currencyCode as string) ?? '',
         currencyPrecision: (parsedConfig.precision as number) ?? 2,
         globalPicklistId: (parsedConfig.globalPicklistId as string) ?? '',
+        rollupChildCollection: (parsedConfig.childCollection as string) ?? '',
+        rollupForeignKey: (parsedConfig.foreignKeyField as string) ?? '',
+        rollupFunction:
+          (parsedConfig.aggregateFunction as RollupAggregateFunction) ?? undefined,
+        rollupField: (parsedConfig.aggregateField as string) ?? '',
         description: field.description ?? '',
         trackHistory: field.trackHistory ?? false,
         searchable: field.searchable ?? false,
@@ -510,6 +655,16 @@ export function FieldEditor({
         if (data.globalPicklistId) {
           fieldTypeConfig = { globalPicklistId: data.globalPicklistId }
         }
+      } else if (data.type === 'rollup_summary') {
+        const config: Record<string, unknown> = {
+          childCollection: data.rollupChildCollection,
+          foreignKeyField: data.rollupForeignKey,
+          aggregateFunction: data.rollupFunction,
+        }
+        if (data.rollupFunction !== 'COUNT' && data.rollupField) {
+          config.aggregateField = data.rollupField
+        }
+        fieldTypeConfig = config
       }
 
       const needsReferenceTarget = data.type === 'master_detail'
@@ -619,7 +774,7 @@ export function FieldEditor({
         {errors.name && (
           <span
             id="field-name-error"
-            className="flex items-center gap-1 text-sm text-destructive mt-1 before:content-['\u26A0'] before:text-xs"
+            className="flex items-center gap-1 text-sm text-destructive mt-1 before:content-['⚠'] before:text-xs"
             role="alert"
             data-testid="field-name-error"
           >
@@ -662,7 +817,7 @@ export function FieldEditor({
         {errors.displayName && (
           <span
             id="field-display-name-error"
-            className="flex items-center gap-1 text-sm text-destructive mt-1 before:content-['\u26A0'] before:text-xs"
+            className="flex items-center gap-1 text-sm text-destructive mt-1 before:content-['⚠'] before:text-xs"
             role="alert"
             data-testid="field-display-name-error"
           >
@@ -707,7 +862,7 @@ export function FieldEditor({
         {errors.type && (
           <span
             id="field-type-error"
-            className="flex items-center gap-1 text-sm text-destructive mt-1 before:content-['\u26A0'] before:text-xs"
+            className="flex items-center gap-1 text-sm text-destructive mt-1 before:content-['⚠'] before:text-xs"
             role="alert"
             data-testid="field-type-error"
           >
@@ -752,7 +907,7 @@ export function FieldEditor({
           {errors.referenceTarget && (
             <span
               id="field-reference-target-error"
-              className="flex items-center gap-1 text-sm text-destructive mt-1 before:content-['\u26A0'] before:text-xs"
+              className="flex items-center gap-1 text-sm text-destructive mt-1 before:content-['⚠'] before:text-xs"
               role="alert"
               data-testid="field-reference-target-error"
             >
@@ -799,7 +954,7 @@ export function FieldEditor({
           {errors.globalPicklistId && (
             <span
               id="field-global-picklist-error"
-              className="flex items-center gap-1 text-sm text-destructive mt-1 before:content-['\u26A0'] before:text-xs"
+              className="flex items-center gap-1 text-sm text-destructive mt-1 before:content-['⚠'] before:text-xs"
               role="alert"
               data-testid="field-global-picklist-error"
             >
@@ -892,6 +1047,204 @@ export function FieldEditor({
             data-testid="field-currency-precision-input"
             {...register('currencyPrecision')}
           />
+        </div>
+      )}
+
+      {/* Rollup Summary Config */}
+      {watchedType === 'rollup_summary' && (
+        <div
+          className="flex flex-col gap-4 p-4 bg-secondary border border-border rounded-md"
+          data-testid="rollup-config"
+        >
+          <h4 className="m-0 text-base font-medium text-foreground">
+            {t('fieldEditor.rollup.title')}
+          </h4>
+
+          {/* Child collection */}
+          <div className="flex flex-col gap-1">
+            <label
+              htmlFor="field-rollup-child"
+              className="flex items-center gap-1 text-sm font-medium text-foreground"
+            >
+              {t('fieldEditor.rollup.childCollection')}
+              <span className="text-destructive font-semibold" aria-hidden="true">
+                *
+              </span>
+            </label>
+            <select
+              id="field-rollup-child"
+              className={cn(selectClasses, errors.rollupChildCollection && errorInputClasses)}
+              disabled={isSubmitting}
+              aria-required="true"
+              aria-invalid={!!errors.rollupChildCollection}
+              aria-describedby={
+                errors.rollupChildCollection
+                  ? 'field-rollup-child-error'
+                  : 'field-rollup-child-hint'
+              }
+              data-testid="field-rollup-child-select"
+              {...register('rollupChildCollection')}
+            >
+              <option value="">{t('fieldEditor.selectCollection')}</option>
+              {rollupChildOptions.map((collection) => (
+                <option key={collection.id} value={collection.name}>
+                  {collection.displayName || collection.name}
+                </option>
+              ))}
+            </select>
+            {errors.rollupChildCollection && (
+              <span
+                id="field-rollup-child-error"
+                className="flex items-center gap-1 text-sm text-destructive mt-1 before:content-['⚠'] before:text-xs"
+                role="alert"
+                data-testid="field-rollup-child-error"
+              >
+                {getErrorMessage(errors.rollupChildCollection.message)}
+              </span>
+            )}
+            <span id="field-rollup-child-hint" className="text-xs text-muted-foreground mt-1">
+              {t('fieldEditor.rollup.childCollectionHint')}
+            </span>
+          </div>
+
+          {/* Foreign key field */}
+          <div className="flex flex-col gap-1">
+            <label
+              htmlFor="field-rollup-fk"
+              className="flex items-center gap-1 text-sm font-medium text-foreground"
+            >
+              {t('fieldEditor.rollup.foreignKey')}
+              <span className="text-destructive font-semibold" aria-hidden="true">
+                *
+              </span>
+            </label>
+            <select
+              id="field-rollup-fk"
+              className={cn(selectClasses, errors.rollupForeignKey && errorInputClasses)}
+              disabled={isSubmitting || !watchedRollupChild || childFieldsLoading}
+              aria-required="true"
+              aria-invalid={!!errors.rollupForeignKey}
+              aria-describedby={
+                errors.rollupForeignKey ? 'field-rollup-fk-error' : 'field-rollup-fk-hint'
+              }
+              data-testid="field-rollup-fk-select"
+              {...register('rollupForeignKey')}
+            >
+              <option value="">
+                {childFieldsLoading
+                  ? t('common.loading')
+                  : t('fieldEditor.rollup.selectForeignKey')}
+              </option>
+              {rollupForeignKeyOptions.map((f) => (
+                <option key={f.name} value={f.name}>
+                  {f.displayName || f.name}
+                </option>
+              ))}
+            </select>
+            {errors.rollupForeignKey && (
+              <span
+                id="field-rollup-fk-error"
+                className="flex items-center gap-1 text-sm text-destructive mt-1 before:content-['⚠'] before:text-xs"
+                role="alert"
+                data-testid="field-rollup-fk-error"
+              >
+                {getErrorMessage(errors.rollupForeignKey.message)}
+              </span>
+            )}
+            <span id="field-rollup-fk-hint" className="text-xs text-muted-foreground mt-1">
+              {t('fieldEditor.rollup.foreignKeyHint')}
+            </span>
+          </div>
+
+          {/* Aggregate function */}
+          <div className="flex flex-col gap-1">
+            <label
+              htmlFor="field-rollup-fn"
+              className="flex items-center gap-1 text-sm font-medium text-foreground"
+            >
+              {t('fieldEditor.rollup.function')}
+              <span className="text-destructive font-semibold" aria-hidden="true">
+                *
+              </span>
+            </label>
+            <select
+              id="field-rollup-fn"
+              className={cn(selectClasses, errors.rollupFunction && errorInputClasses)}
+              disabled={isSubmitting}
+              aria-required="true"
+              aria-invalid={!!errors.rollupFunction}
+              aria-describedby={errors.rollupFunction ? 'field-rollup-fn-error' : undefined}
+              data-testid="field-rollup-fn-select"
+              {...register('rollupFunction')}
+            >
+              <option value="">{t('fieldEditor.rollup.selectFunction')}</option>
+              <option value="COUNT">{t('fieldEditor.rollup.fn.count')}</option>
+              <option value="SUM">{t('fieldEditor.rollup.fn.sum')}</option>
+              <option value="AVG">{t('fieldEditor.rollup.fn.avg')}</option>
+              <option value="MIN">{t('fieldEditor.rollup.fn.min')}</option>
+              <option value="MAX">{t('fieldEditor.rollup.fn.max')}</option>
+            </select>
+            {errors.rollupFunction && (
+              <span
+                id="field-rollup-fn-error"
+                className="flex items-center gap-1 text-sm text-destructive mt-1 before:content-['⚠'] before:text-xs"
+                role="alert"
+                data-testid="field-rollup-fn-error"
+              >
+                {getErrorMessage(errors.rollupFunction.message)}
+              </span>
+            )}
+          </div>
+
+          {/* Aggregate field (not used for COUNT) */}
+          {watchedRollupFn && watchedRollupFn !== 'COUNT' && (
+            <div className="flex flex-col gap-1">
+              <label
+                htmlFor="field-rollup-field"
+                className="flex items-center gap-1 text-sm font-medium text-foreground"
+              >
+                {t('fieldEditor.rollup.field')}
+                <span className="text-destructive font-semibold" aria-hidden="true">
+                  *
+                </span>
+              </label>
+              <select
+                id="field-rollup-field"
+                className={cn(selectClasses, errors.rollupField && errorInputClasses)}
+                disabled={isSubmitting || !watchedRollupChild || childFieldsLoading}
+                aria-required="true"
+                aria-invalid={!!errors.rollupField}
+                aria-describedby={
+                  errors.rollupField ? 'field-rollup-field-error' : 'field-rollup-field-hint'
+                }
+                data-testid="field-rollup-field-select"
+                {...register('rollupField')}
+              >
+                <option value="">{t('fieldEditor.rollup.selectField')}</option>
+                {rollupAggregateFieldOptions.map((f) => (
+                  <option key={f.name} value={f.name}>
+                    {f.displayName || f.name}
+                  </option>
+                ))}
+              </select>
+              {errors.rollupField && (
+                <span
+                  id="field-rollup-field-error"
+                  className="flex items-center gap-1 text-sm text-destructive mt-1 before:content-['⚠'] before:text-xs"
+                  role="alert"
+                  data-testid="field-rollup-field-error"
+                >
+                  {getErrorMessage(errors.rollupField.message)}
+                </span>
+              )}
+              <span
+                id="field-rollup-field-hint"
+                className="text-xs text-muted-foreground mt-1"
+              >
+                {t('fieldEditor.rollup.fieldHint')}
+              </span>
+            </div>
+          )}
         </div>
       )}
 
@@ -993,7 +1346,7 @@ export function FieldEditor({
         {errors.description && (
           <span
             id="field-description-error"
-            className="flex items-center gap-1 text-sm text-destructive mt-1 before:content-['\u26A0'] before:text-xs"
+            className="flex items-center gap-1 text-sm text-destructive mt-1 before:content-['⚠'] before:text-xs"
             role="alert"
             data-testid="field-description-error"
           >

--- a/kelta-ui/app/src/components/FieldEditor/index.ts
+++ b/kelta-ui/app/src/components/FieldEditor/index.ts
@@ -19,5 +19,8 @@ export type {
   ValidationRuleType,
   CollectionSummary,
   PicklistSummary,
+  RollupAggregateFunction,
+  RollupChildField,
+  FetchCollectionFields,
 } from './FieldEditor'
 export { default } from './FieldEditor'

--- a/kelta-ui/app/src/i18n/translations/en.json
+++ b/kelta-ui/app/src/i18n/translations/en.json
@@ -1195,6 +1195,26 @@
     "descriptionPlaceholder": "Enter a description for this field...",
     "trackHistory": "Track History",
     "searchable": "Searchable",
+    "rollup": {
+      "title": "Rollup Summary Configuration",
+      "childCollection": "Child Collection",
+      "childCollectionHint": "Collection containing the records to aggregate.",
+      "foreignKey": "Foreign Key Field",
+      "foreignKeyHint": "Master-detail field on the child collection that points back to this collection.",
+      "selectForeignKey": "Select a foreign key field...",
+      "function": "Aggregate Function",
+      "selectFunction": "Select a function...",
+      "fn": {
+        "count": "COUNT — number of child records",
+        "sum": "SUM — total of a numeric field",
+        "avg": "AVG — average of a numeric field",
+        "min": "MIN — minimum value",
+        "max": "MAX — maximum value"
+      },
+      "field": "Aggregate Field",
+      "fieldHint": "Field on the child collection to aggregate. Numeric for SUM/AVG; numeric or date for MIN/MAX.",
+      "selectField": "Select a field..."
+    },
     "validation": {
       "nameRequired": "Field name is required",
       "nameTooLong": "Field name must be 50 characters or less",
@@ -1203,6 +1223,10 @@
       "typeRequired": "Field type is required",
       "referenceTargetRequired": "Target collection is required for reference fields",
       "picklistRequired": "A global picklist is required for picklist fields",
+      "rollupChildCollectionRequired": "Child collection is required for rollup fields",
+      "rollupForeignKeyRequired": "Foreign key field is required for rollup fields",
+      "rollupFunctionRequired": "Aggregate function is required for rollup fields",
+      "rollupFieldRequired": "Aggregate field is required for SUM, AVG, MIN, and MAX",
       "descriptionTooLong": "Description must be 500 characters or less"
     }
   },

--- a/kelta-ui/app/src/pages/CollectionDetailPage/CollectionDetailPage.tsx
+++ b/kelta-ui/app/src/pages/CollectionDetailPage/CollectionDetailPage.tsx
@@ -22,6 +22,7 @@ import { useToast, ConfirmDialog, LoadingSpinner, ErrorMessage } from '../../com
 import {
   FieldEditor,
   type FieldDefinition as FieldEditorDefinition,
+  type RollupChildField,
 } from '../../components/FieldEditor'
 import { ValidationRuleEditor } from '../../components/ValidationRuleEditor'
 import { RecordTypeEditor } from '../../components/RecordTypeEditor'
@@ -315,6 +316,30 @@ export function CollectionDetailPage({
 
   // Fetch all collections for reference field dropdown
   const { summaries: allCollectionSummaries } = useCollectionSummaries()
+
+  // Loader for child collection fields, used by the rollup_summary config UI
+  // in the FieldEditor. Fetches fresh on each invocation; cheap enough since
+  // it's only called when the user actively configures a rollup field.
+  const fetchChildCollectionFields = useCallback(
+    async (childCollectionName: string): Promise<RollupChildField[]> => {
+      const raw = await apiClient.get<{
+        included?: { type: string; id: string; attributes: Record<string, unknown> }[]
+      }>(`/api/collections/${encodeURIComponent(childCollectionName)}?include=fields`)
+      if (!raw.included) return []
+      return raw.included
+        .filter((r) => r.type === 'fields')
+        .map((r) => {
+          const attrs = r.attributes as Record<string, unknown>
+          return {
+            name: attrs.name as string,
+            displayName: (attrs.displayName as string | undefined) ?? undefined,
+            type: normalizeFieldType((attrs.type as string) ?? 'string'),
+            referenceTarget: (attrs.referenceTarget as string | undefined) ?? undefined,
+          }
+        })
+    },
+    [apiClient]
+  )
 
   // Fetch global picklists for picklist field dropdown
   const { data: globalPicklists = [] } = useQuery({
@@ -2202,6 +2227,7 @@ export function CollectionDetailPage({
           >
             <FieldEditor
               collectionId={collectionId}
+              collectionName={collection?.name}
               field={editingField}
               collections={allCollectionSummaries.map((c) => ({
                 id: c.id,
@@ -2212,6 +2238,7 @@ export function CollectionDetailPage({
                 id: p.id,
                 name: p.name,
               }))}
+              fetchCollectionFields={fetchChildCollectionFields}
               onSave={handleFieldSave}
               onCancel={handleFieldCancel}
               isSubmitting={addFieldMutation.isPending || updateFieldMutation.isPending}

--- a/kelta-ui/app/src/pages/ResourceFormPage/ResourceFormPage.tsx
+++ b/kelta-ui/app/src/pages/ResourceFormPage/ResourceFormPage.tsx
@@ -11,7 +11,7 @@
  * - 12.4: Use custom field renderers when registered, fall back to defaults
  */
 
-import React, { useState, useCallback, useMemo } from 'react'
+import React, { useState, useCallback, useMemo, useRef } from 'react'
 import { useParams, useNavigate, useSearchParams, Link } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { cn } from '@/lib/utils'
@@ -963,33 +963,37 @@ export function ResourceFormPage({
   /**
    * Handle field value change
    */
+  // Mirror formData in a ref so handleFieldChange can compute the post-mutation
+  // values map and pass it straight into the engine, bypassing the
+  // useState/useRef async-update race that would otherwise have the engine
+  // evaluate against stale values.
+  const formDataRef = useRef(formData)
+  formDataRef.current = formData
+
   const handleFieldChange = useCallback(
     (fieldName: string, value: unknown) => {
-      setFormData((prev) => ({
-        ...prev,
-        [fieldName]: value,
-      }))
+      const next = { ...formDataRef.current, [fieldName]: value }
+      formDataRef.current = next
+      setFormData(next)
 
       // Clear error when field is modified
       if (formErrors[fieldName]) {
         setFormErrors((prev) => {
-          const next = { ...prev }
-          delete next[fieldName]
-          return next
+          const errNext = { ...prev }
+          delete errNext[fieldName]
+          return errNext
         })
       }
 
-      // Drive the layout-rules engine: cascade computes/validations triggered
-      // by this field. The engine writes back via setFieldValue (above), so
-      // dependent fields update in the same render cycle.
-      ruleEngine.onFieldChange(fieldName)
+      // Drive the layout-rules engine with the freshly computed values map.
+      ruleEngine.onFieldChange(fieldName, next)
     },
     [formErrors, ruleEngine]
   )
 
   const handleFieldBlur = useCallback(
     (fieldName: string) => {
-      ruleEngine.onFieldBlur(fieldName)
+      ruleEngine.onFieldBlur(fieldName, formDataRef.current)
     },
     [ruleEngine],
   )

--- a/kelta-ui/app/src/pages/app/ObjectFormPage/ObjectFormPage.tsx
+++ b/kelta-ui/app/src/pages/app/ObjectFormPage/ObjectFormPage.tsx
@@ -16,7 +16,7 @@
  * - Loading states
  */
 
-import React, { useState, useCallback, useMemo } from 'react'
+import React, { useState, useCallback, useMemo, useRef } from 'react'
 import { useNavigate, useParams, useSearchParams, Link } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
 import { Save, X, Loader2, AlertCircle } from 'lucide-react'
@@ -501,23 +501,29 @@ function ObjectFormBody({
 
   const pageTitle = isNew ? `New ${collectionLabel}` : `Edit ${collectionLabel}`
 
-  // Handle field change
+  // Handle field change. Use a functional ref of the latest values so we can
+  // pass the post-mutation map directly to the engine — without that, the
+  // engine reads stale values because setFormData is async and useLayoutRules'
+  // valuesRef only refreshes on the next render.
+  const formDataRef = useRef(formData)
+  formDataRef.current = formData
   const handleFieldChange = useCallback(
     (name: string, value: unknown) => {
-      setFormData((prev) => ({ ...prev, [name]: value }))
+      const next = { ...formDataRef.current, [name]: value }
+      formDataRef.current = next
+      setFormData(next)
       // Clear server-side error for this field when user modifies it
       setFormErrors((prev) => {
         if (prev[name]) {
-          const next = { ...prev }
-          delete next[name]
-          return next
+          const errNext = { ...prev }
+          delete errNext[name]
+          return errNext
         }
         return prev
       })
-      // Drive the layout-rules engine: cascade computes/validations triggered
-      // by this field. The engine writes back via setFieldValue (above), so
-      // dependent fields update in the same render cycle.
-      ruleEngine.onFieldChange(name)
+      // Drive the engine with the freshly computed values map so cascaded
+      // computes/validations see the new value immediately.
+      ruleEngine.onFieldChange(name, next)
     },
     [ruleEngine]
   )

--- a/kelta-web/packages/components/src/FilterBuilder/FilterBuilder.tsx
+++ b/kelta-web/packages/components/src/FilterBuilder/FilterBuilder.tsx
@@ -1,4 +1,5 @@
 import { useCallback } from 'react';
+import type { ReactElement } from 'react';
 import type { FilterExpression } from '@kelta/sdk';
 import type { FilterBuilderProps } from './types';
 import { OPERATORS_BY_TYPE } from './types';
@@ -30,7 +31,7 @@ export function FilterBuilder({
   maxFilters = 10,
   className = '',
   testId = 'kelta-filter-builder',
-}: FilterBuilderProps): JSX.Element {
+}: FilterBuilderProps): ReactElement {
   // Add a new filter
   const addFilter = useCallback(() => {
     if (value.length >= maxFilters || fields.length === 0) return;

--- a/kelta-web/packages/components/src/Layout/PageLayout.tsx
+++ b/kelta-web/packages/components/src/Layout/PageLayout.tsx
@@ -1,3 +1,4 @@
+import type { ReactElement } from 'react';
 import type { PageLayoutProps } from './types';
 
 /**
@@ -26,7 +27,7 @@ export function PageLayout({
   className = '',
   style,
   testId = 'kelta-page-layout',
-}: PageLayoutProps): JSX.Element {
+}: PageLayoutProps): ReactElement {
   return (
     <div className={`kelta-page-layout ${className}`} style={style} data-testid={testId}>
       {header && (

--- a/kelta-web/packages/components/src/Layout/ThreeColumnLayout.tsx
+++ b/kelta-web/packages/components/src/Layout/ThreeColumnLayout.tsx
@@ -1,3 +1,4 @@
+import type { ReactElement } from 'react';
 import type { ThreeColumnLayoutProps } from './types';
 
 /**
@@ -42,7 +43,7 @@ export function ThreeColumnLayout({
   breakpoints = DEFAULT_BREAKPOINTS,
   collapsibleOnMobile = true,
   testId = 'kelta-three-column-layout',
-}: ThreeColumnLayoutProps): JSX.Element {
+}: ThreeColumnLayoutProps): ReactElement {
   const layoutStyle = {
     ...style,
     '--left-width': leftWidth,

--- a/kelta-web/packages/components/src/Layout/TwoColumnLayout.tsx
+++ b/kelta-web/packages/components/src/Layout/TwoColumnLayout.tsx
@@ -1,3 +1,4 @@
+import type { ReactElement } from 'react';
 import type { TwoColumnLayoutProps } from './types';
 
 /**
@@ -40,7 +41,7 @@ export function TwoColumnLayout({
   breakpoints = DEFAULT_BREAKPOINTS,
   collapsibleOnMobile = true,
   testId = 'kelta-two-column-layout',
-}: TwoColumnLayoutProps): JSX.Element {
+}: TwoColumnLayoutProps): ReactElement {
   const layoutStyle = {
     ...style,
     '--sidebar-width': sidebarWidth,

--- a/kelta-web/packages/components/src/LayoutRenderer/clientRules/useLayoutRules.ts
+++ b/kelta-web/packages/components/src/LayoutRenderer/clientRules/useLayoutRules.ts
@@ -26,10 +26,19 @@ export interface UseLayoutRulesResult {
   diagnostics: RuleEngineDiagnostic[];
   /** Whether a field is a compute target (render as read-only with ƒ adornment). */
   isComputed: (field: string) => boolean;
-  /** Run one onChange tick — call from your form's field-change handler. */
-  onFieldChange: (field: string) => void;
+  /**
+   * Run one onChange tick — call from your form's field-change handler.
+   *
+   * Pass the post-mutation values map as the second argument to bypass the
+   * stale-closure / async-setState race: with plain useState, calling
+   * `setFormData(prev => ({...prev, name: value}))` does NOT make the new
+   * value visible to the engine until React re-renders and our `values`
+   * prop updates. Supply `nextValues` so the engine sees the fresh value
+   * immediately.
+   */
+  onFieldChange: (field: string, nextValues?: Record<string, unknown>) => void;
   /** Run one onBlur tick — call from your input onBlur handler. */
-  onFieldBlur: (field: string) => void;
+  onFieldBlur: (field: string, nextValues?: Record<string, unknown>) => void;
   /** Run before-save checks. Block submission when blocked === true. */
   runBeforeSave: () => BeforeSaveResult;
 }
@@ -92,14 +101,19 @@ export function useLayoutRules(opts: UseLayoutRulesOptions): UseLayoutRulesResul
   }, [engine, binding]);
 
   const onFieldChange = useCallback(
-    (field: string) => {
+    (field: string, nextValues?: Record<string, unknown>) => {
+      // Override the ref with caller-supplied fresh values BEFORE the engine
+      // reads them. Avoids the React useState/useRef race where the engine
+      // would otherwise read pre-change values.
+      if (nextValues) valuesRef.current = nextValues;
       engine?.onFieldChange(field, binding);
     },
     [engine, binding]
   );
 
   const onFieldBlur = useCallback(
-    (field: string) => {
+    (field: string, nextValues?: Record<string, unknown>) => {
+      if (nextValues) valuesRef.current = nextValues;
       engine?.onFieldBlur(field, binding);
     },
     [engine, binding]

--- a/kelta-web/packages/components/src/ResourceDetail/ResourceDetail.tsx
+++ b/kelta-web/packages/components/src/ResourceDetail/ResourceDetail.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useMemo } from 'react';
+import type { ReactElement } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import type { FieldDefinition, ResourceMetadata } from '@kelta/sdk';
 import { useKeltaClient, useCurrentUser } from '../context/KeltaContext';
@@ -86,7 +87,7 @@ export function ResourceDetail({
   customRenderers = {},
   className = '',
   testId = 'kelta-resource-detail',
-}: ResourceDetailProps): JSX.Element {
+}: ResourceDetailProps): ReactElement {
   const client = useKeltaClient();
   const user = useCurrentUser();
 

--- a/kelta-web/packages/components/src/ResourceDetail/types.ts
+++ b/kelta-web/packages/components/src/ResourceDetail/types.ts
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react';
+import type { ReactElement } from 'react';
 import type { FieldDefinition } from '@kelta/sdk';
 
 /**
@@ -19,7 +20,7 @@ export interface FieldRendererProps {
 /**
  * Field renderer component type (for plugin registry)
  */
-export type FieldRendererComponent = (props: FieldRendererProps) => JSX.Element;
+export type FieldRendererComponent = (props: FieldRendererProps) => ReactElement;
 
 /**
  * Props for ResourceDetail component

--- a/kelta-web/packages/components/src/ResourceForm/ResourceForm.tsx
+++ b/kelta-web/packages/components/src/ResourceForm/ResourceForm.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useCallback } from 'react';
+import type { ReactElement } from 'react';
 import { useForm, Controller } from 'react-hook-form';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { z } from 'zod';
@@ -214,7 +215,7 @@ export function ResourceForm({
   initialValues = {},
   readOnly = false,
   className = '',
-}: ResourceFormProps): JSX.Element {
+}: ResourceFormProps): ReactElement {
   const client = useKeltaClient();
   const user = useCurrentUser();
   const queryClient = useQueryClient();
@@ -520,7 +521,7 @@ interface RenderFieldOptions {
 /**
  * Render a field using custom renderer or default input
  */
-function renderField(field: FieldDefinition, options: RenderFieldOptions): JSX.Element {
+function renderField(field: FieldDefinition, options: RenderFieldOptions): ReactElement {
   const { register, control, readOnly } = options;
 
   // Check for custom field renderer from plugin registry
@@ -556,7 +557,7 @@ function renderDefaultFieldInput(
   field: FieldDefinition,
   register: ReturnType<typeof useForm>['register'],
   readOnly: boolean
-): JSX.Element {
+): ReactElement {
   const baseClassName = `kelta-resource-form__input kelta-resource-form__input--${field.type}`;
   const id = `field-${field.name}`;
 

--- a/kelta-web/packages/components/src/ResourceForm/types.ts
+++ b/kelta-web/packages/components/src/ResourceForm/types.ts
@@ -1,3 +1,4 @@
+import type { ReactElement } from 'react';
 import type { FieldDefinition } from '@kelta/sdk';
 
 /**
@@ -68,4 +69,4 @@ export interface FieldRendererProps {
 /**
  * Field renderer component type
  */
-export type FieldRendererComponent = (props: FieldRendererProps) => JSX.Element;
+export type FieldRendererComponent = (props: FieldRendererProps) => ReactElement;

--- a/kelta-web/packages/plugin-sdk/src/registry/types.ts
+++ b/kelta-web/packages/plugin-sdk/src/registry/types.ts
@@ -1,3 +1,4 @@
+import type { ReactElement } from 'react';
 import type { FieldDefinition, KeltaClient, User } from '@kelta/sdk';
 
 /**
@@ -28,7 +29,7 @@ export interface FieldRendererProps {
 /**
  * Field renderer component type
  */
-export type FieldRendererComponent = (props: FieldRendererProps) => JSX.Element;
+export type FieldRendererComponent = (props: FieldRendererProps) => ReactElement;
 
 /**
  * Props passed to page components
@@ -53,7 +54,7 @@ export interface PageComponentProps {
 /**
  * Page component type
  */
-export type PageComponent = (props: PageComponentProps) => JSX.Element;
+export type PageComponent = (props: PageComponentProps) => ReactElement;
 
 /**
  * Registered page component with route


### PR DESCRIPTION
## Summary
- FieldEditor now exposes child collection / FK field / aggregate function / aggregate field inputs when `rollup_summary` is selected; submit packs them into `fieldTypeConfig` (`childCollection`, `foreignKeyField`, `aggregateFunction`, `aggregateField`).
- DefaultQueryEngine reads that config and delegates to the existing `RollupSummaryService` per record at query time. Auto-config wires the service + `CollectionRegistry` into the bean. `PhysicalTableStorageAdapter.toSnakeCase` is now `public` for cross-package column-name resolution.
- Bundled fix: the inline error sigil was written as `before:content-['⚠']` in Tailwind arbitrary values, which CSS does not unescape. Replaced with the literal `⚠` across all six error spans (and the four new rollup error spans).

## Test plan
- [x] `kelta-ui/app` — vitest run of `FieldEditor.test.tsx` (74 tests, 7 new for rollup), `tsc --noEmit`, `eslint` clean
- [x] `runtime-core` — `mvn test` 1165 tests pass; new `RollupSummaryComputeTest` (4 tests) covers SUM, COUNT, missing-child, missing-config
- [x] `e2e-tests` — added `rollup-summary-journey.spec.ts` with SUM-over-child and COUNT scenarios using the data factory; runs against the deployed stack in CI
- [ ] Manual: create parent + child collections, configure a rollup field via the Add Field dialog, insert a few child records, GET the parent and verify the aggregated value

## Out of scope
- Filter criteria UI (`fieldTypeConfig.filter` is read by the engine but not yet exposed in the form)
- Batched aggregate query for large result sets — flagged with a `TODO(perf)` near the per-record compute

🤖 Generated with [Claude Code](https://claude.com/claude-code)