### PR TITLE
fix(collections): invalidate schema caches on field mutations

### DIFF
--- a/kelta-ui/app/src/pages/CollectionDetailPage/CollectionDetailPage.tsx
+++ b/kelta-ui/app/src/pages/CollectionDetailPage/CollectionDetailPage.tsx
@@ -368,13 +368,27 @@ export function CollectionDetailPage({
     },
   })
 
+  // Invalidate every cache that holds a snapshot of this collection's fields:
+  // the admin page query, the bulk store that primes useCollectionSchema, and
+  // the per-collection schema entry that end-user pages consume. Without all
+  // three, end-user sessions silently render stale layouts when an admin adds
+  // a field — the layout placement falls through to a missing schema field
+  // and is dropped without warning.
+  const invalidateCollectionCaches = () => {
+    queryClient.invalidateQueries({ queryKey: ['collection', collectionId] })
+    queryClient.invalidateQueries({ queryKey: ['collection-store'] })
+    if (collection?.name) {
+      queryClient.invalidateQueries({ queryKey: ['collection-schema', collection.name] })
+    }
+  }
+
   // Add field mutation
   const addFieldMutation = useMutation({
     mutationFn: async (fieldData: Omit<FieldEditorDefinition, 'id' | 'order'>) => {
       await apiClient.postResource(`/api/fields`, { ...fieldData, collectionId })
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['collection', collectionId] })
+      invalidateCollectionCaches()
       showToast(t('success.created', { item: t('collections.field') }), 'success')
       setFieldEditorOpen(false)
       setEditingField(undefined)
@@ -396,7 +410,7 @@ export function CollectionDetailPage({
       await apiClient.putResource(`/api/fields/${fieldId}`, fieldData)
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['collection', collectionId] })
+      invalidateCollectionCaches()
       showToast(t('success.updated', { item: t('collections.field') }), 'success')
       setFieldEditorOpen(false)
       setEditingField(undefined)
@@ -863,6 +877,7 @@ export function CollectionDetailPage({
     },
     onSuccess: () => {
       refetchCollection()
+      invalidateCollectionCaches()
       setLocalFieldOrder(null)
     },
     onError: () => {


### PR DESCRIPTION
## Summary
- Adds invalidation of `['collection-store']` and `['collection-schema', collection.name]` to add/edit/reorder field mutations on the admin Collection Detail page.
- Fixes a class of \"new field invisible until refresh / 5 min\" bugs in the end-user app — most recently visible as a new `rollup_summary` field appearing in the layout designer but not on the record detail view.

## Root cause
[CollectionStoreContext.tsx:198](kelta-ui/app/src/context/CollectionStoreContext.tsx:198) bulk-loads all collections at app start with `staleTime: 5min` and primes the `['collection-schema', name]` cache via `setQueryData`. [useCollectionSchema](kelta-ui/app/src/hooks/useCollectionSchema.ts) honors that cache (`enabled: !cachedData`), so end-user sessions keep returning the pre-mutation field list. When a layout placement references a field that isn't in the cached schema, [LayoutFieldSections.mapPlacementsToFields](kelta-ui/app/src/components/LayoutFieldSections/LayoutFieldSections.tsx:66) drops it silently.

The admin page's field mutations were only invalidating `['collection', collectionId]` (its own page query), missing the two caches the end-user reads.

## Test plan
- [x] `tsc --noEmit` and `eslint` clean
- [ ] Manual: add a field on the admin Collection Detail page → end-user record detail page reflects it without a hard reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)