### PR TITLE
fix(runtime): qualify rollup table with tenant schema

### DIFF
--- a/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/query/DefaultQueryEngine.java
+++ b/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/query/DefaultQueryEngine.java
@@ -15,6 +15,7 @@ import io.kelta.runtime.formula.FormulaEvaluator;
 import io.kelta.runtime.registry.CollectionRegistry;
 import io.kelta.runtime.storage.PhysicalTableStorageAdapter;
 import io.kelta.runtime.storage.StorageAdapter;
+import io.kelta.runtime.storage.TableRef;
 import io.kelta.runtime.validation.CustomValidationRuleEngine;
 import io.kelta.runtime.validation.OperationType;
 import io.kelta.runtime.validation.TypeCoercionService;
@@ -796,13 +797,16 @@ public class DefaultQueryEngine implements QueryEngine {
             return null;
         }
 
-        String childTable = resolveTableName(childDef);
+        TableRef childTable = resolveTableRef(childDef);
         String fkColumn = resolveColumnName(childDef, foreignKeyField);
         String aggColumn = aggregateField == null ? null : resolveColumnName(childDef, aggregateField);
 
         try {
-            return rollupSummaryService.compute(childTable, fkColumn, parentId.toString(),
+            Object value = rollupSummaryService.compute(childTable, fkColumn, parentId.toString(),
                     aggregateFunction, aggColumn, filter);
+            logger.debug("Rollup '{}' = {} ({} on {}.{})", field.name(), value,
+                    aggregateFunction, childTable.toSql(), aggColumn != null ? aggColumn : "*");
+            return value;
         } catch (RuntimeException e) {
             logger.warn("Rollup compute failed for field '{}' on collection '{}': {}",
                     field.name(), childDef.name(), e.getMessage());
@@ -810,11 +814,24 @@ public class DefaultQueryEngine implements QueryEngine {
         }
     }
 
-    private String resolveTableName(CollectionDefinition def) {
-        if (def.storageConfig() != null && def.storageConfig().tableName() != null) {
-            return def.storageConfig().tableName();
+    /**
+     * Resolves the schema-qualified table reference for a child collection,
+     * mirroring {@link io.kelta.runtime.storage.PhysicalTableStorageAdapter}'s
+     * tenant-schema rules. Tenant collections route to the current tenant's
+     * schema; system collections stay in the public schema.
+     */
+    private TableRef resolveTableRef(CollectionDefinition def) {
+        String tableName = def.storageConfig() != null && def.storageConfig().tableName() != null
+                ? def.storageConfig().tableName()
+                : def.name();
+        if (def.systemCollection()) {
+            return TableRef.publicSchema(tableName);
         }
-        return def.name();
+        String tenantSlug = io.kelta.runtime.context.TenantContext.getSlug();
+        if (tenantSlug != null && !tenantSlug.isBlank()) {
+            return TableRef.tenantSchema(tenantSlug, tableName);
+        }
+        return TableRef.publicSchema(tableName);
     }
 
     private String resolveColumnName(CollectionDefinition def, String fieldName) {

--- a/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/service/RollupSummaryService.java
+++ b/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/service/RollupSummaryService.java
@@ -1,5 +1,6 @@
 package io.kelta.runtime.service;
 
+import io.kelta.runtime.storage.TableRef;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
 
@@ -23,35 +24,39 @@ public class RollupSummaryService {
     /**
      * Computes rollup summary values for a parent record.
      *
-     * @param childTableName    the child collection's table name
-     * @param foreignKeyField   the FK field on the child table pointing to parent
+     * <p>Schema-per-tenant aware: the caller passes a {@link TableRef} that
+     * resolves to the child collection's tenant-qualified table (or the
+     * public schema for system collections).
+     *
+     * @param childTable        schema-qualified reference to the child table
+     * @param foreignKeyColumn  FK column on the child table pointing at the parent
      * @param parentRecordId    the parent record's ID
      * @param aggregateFunction COUNT, SUM, MIN, MAX, or AVG
-     * @param aggregateField    the field to aggregate (null for COUNT)
-     * @param filter            optional filter criteria for child records
-     * @return the computed value
+     * @param aggregateColumn   the column to aggregate (null for COUNT)
+     * @param filter            optional equality filter applied to child rows
+     * @return the computed value, or null when JDBC returns null
      */
-    public Object compute(String childTableName, String foreignKeyField,
+    public Object compute(TableRef childTable, String foreignKeyColumn,
                           String parentRecordId, String aggregateFunction,
-                          String aggregateField, Map<String, Object> filter) {
+                          String aggregateColumn, Map<String, Object> filter) {
         StringBuilder sql = new StringBuilder("SELECT ");
         sql.append(switch (aggregateFunction) {
             case "COUNT" -> "COUNT(*)";
-            case "SUM" -> "SUM(" + sanitize(aggregateField) + ")";
-            case "MIN" -> "MIN(" + sanitize(aggregateField) + ")";
-            case "MAX" -> "MAX(" + sanitize(aggregateField) + ")";
-            case "AVG" -> "AVG(" + sanitize(aggregateField) + ")";
+            case "SUM" -> "SUM(" + sanitizeColumn(aggregateColumn) + ")";
+            case "MIN" -> "MIN(" + sanitizeColumn(aggregateColumn) + ")";
+            case "MAX" -> "MAX(" + sanitizeColumn(aggregateColumn) + ")";
+            case "AVG" -> "AVG(" + sanitizeColumn(aggregateColumn) + ")";
             default -> throw new IllegalArgumentException("Unknown aggregate function: " + aggregateFunction);
         });
-        sql.append(" FROM ").append(sanitize(childTableName));
-        sql.append(" WHERE ").append(sanitize(foreignKeyField)).append(" = ?");
+        sql.append(" FROM ").append(childTable.toSql());
+        sql.append(" WHERE ").append(sanitizeColumn(foreignKeyColumn)).append(" = ?");
 
         List<Object> params = new ArrayList<>();
         params.add(parentRecordId);
 
         if (filter != null && !filter.isEmpty()) {
             for (Map.Entry<String, Object> entry : filter.entrySet()) {
-                sql.append(" AND ").append(sanitize(entry.getKey())).append(" = ?");
+                sql.append(" AND ").append(sanitizeColumn(entry.getKey())).append(" = ?");
                 params.add(entry.getValue());
             }
         }
@@ -59,7 +64,7 @@ public class RollupSummaryService {
         return jdbcTemplate.queryForObject(sql.toString(), Object.class, params.toArray());
     }
 
-    private String sanitize(String identifier) {
+    private String sanitizeColumn(String identifier) {
         if (identifier == null || !identifier.matches("^[a-zA-Z_][a-zA-Z0-9_]*$")) {
             throw new IllegalArgumentException("Invalid identifier: " + identifier);
         }

--- a/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/query/RollupSummaryComputeTest.java
+++ b/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/query/RollupSummaryComputeTest.java
@@ -7,6 +7,7 @@ import io.kelta.runtime.model.FieldType;
 import io.kelta.runtime.registry.CollectionRegistry;
 import io.kelta.runtime.service.RollupSummaryService;
 import io.kelta.runtime.storage.StorageAdapter;
+import io.kelta.runtime.storage.TableRef;
 import io.kelta.runtime.validation.ValidationEngine;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -83,9 +84,9 @@ class RollupSummaryComputeTest {
         doReturn(new QueryResult(List.of(row1, row2), new PaginationMetadata(2, 1, 50, 1)))
                 .when(storageAdapter).query(eq(orders), any(QueryRequest.class));
         when(collectionRegistry.get("orderLines")).thenReturn(orderLines());
-        doReturn(12.0).when(rollupSummaryService).compute(eq("orderLines"), eq("order_id"), eq("o1"),
+        doReturn(12.0).when(rollupSummaryService).compute(eq(TableRef.publicSchema("orderLines")), eq("order_id"), eq("o1"),
                 eq("SUM"), eq("amount"), any());
-        doReturn(7.0).when(rollupSummaryService).compute(eq("orderLines"), eq("order_id"), eq("o2"),
+        doReturn(7.0).when(rollupSummaryService).compute(eq(TableRef.publicSchema("orderLines")), eq("order_id"), eq("o2"),
                 eq("SUM"), eq("amount"), any());
 
         QueryResult result = queryEngine.executeQuery(orders, QueryRequest.defaults());
@@ -106,7 +107,7 @@ class RollupSummaryComputeTest {
         doReturn(new QueryResult(List.of(row), new PaginationMetadata(1, 1, 50, 1)))
                 .when(storageAdapter).query(eq(orders), any(QueryRequest.class));
         when(collectionRegistry.get("orderLines")).thenReturn(orderLines());
-        doReturn(3L).when(rollupSummaryService).compute(eq("orderLines"), eq("order_id"), eq("o1"),
+        doReturn(3L).when(rollupSummaryService).compute(eq(TableRef.publicSchema("orderLines")), eq("order_id"), eq("o1"),
                 eq("COUNT"), any(), any());
 
         QueryResult result = queryEngine.executeQuery(orders, QueryRequest.defaults());


### PR DESCRIPTION
## Summary
- `RollupSummaryService.compute` now accepts a `TableRef` and uses `toSql()` to render a schema-qualified table identifier.
- `DefaultQueryEngine.resolveTableRef` mirrors `PhysicalTableStorageAdapter.getTableRef` — public schema for system collections, tenant slug schema otherwise.
- Restores the rollup_summary value on parent record GETs in tenant-isolated deployments.

## Why
Tenant collections live in per-tenant Postgres schemas (e.g. `\"threadline-clothing\".order_items`). The previous compute emitted unqualified `FROM order_items`, which either resolved to the public schema (returning null) or threw `relation does not exist` — caught by the surrounding try/catch and silently returned null. The parent record's rollup field came back empty in API responses, so the layout placement rendered no value.

## Test plan
- [x] `mvn -pl runtime/runtime-core test -Dtest=RollupSummaryComputeTest` — 4 pass
- [x] `mvn -pl runtime/runtime-core,runtime/runtime-module-core,runtime/runtime-module-schema test` — full module suite passes
- [ ] After deploy: GET `/api/orders/{id}` returns `computed_total = SUM(line_total)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)