### PR TITLE
fix(worker): unwrap PGobject when loading fieldTypeConfig

### DIFF
--- a/kelta-worker/src/main/java/io/kelta/worker/service/CollectionLifecycleManager.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/service/CollectionLifecycleManager.java
@@ -516,22 +516,36 @@ public class CollectionLifecycleManager {
                 }
             }
 
-            // Parse fieldTypeConfig JSON
+            // Parse fieldTypeConfig JSON. PostgreSQL returns JSONB columns as
+            // org.postgresql.util.PGobject through the standard JDBC API; .toString()
+            // yields the raw JSON. Earlier branches covered the String / Map cases
+            // but missed PGobject, so newly-loaded rollup_summary fields surfaced
+            // with a null fieldTypeConfig and silently skipped compute.
             Map<String, Object> parsedFieldTypeConfig = null;
             Object fieldTypeConfigObj = row.get("field_type_config");
+            String ftcJson = null;
             if (fieldTypeConfigObj instanceof String ftcStr && !ftcStr.isBlank()) {
+                ftcJson = ftcStr;
+            } else if (fieldTypeConfigObj instanceof Map) {
+                @SuppressWarnings("unchecked")
+                Map<String, Object> configMap = (Map<String, Object>) fieldTypeConfigObj;
+                parsedFieldTypeConfig = configMap;
+            } else if (fieldTypeConfigObj != null
+                    && "org.postgresql.util.PGobject".equals(fieldTypeConfigObj.getClass().getName())) {
+                String raw = fieldTypeConfigObj.toString();
+                if (raw != null && !raw.isBlank()) {
+                    ftcJson = raw;
+                }
+            }
+            if (ftcJson != null) {
                 try {
-                    parsedFieldTypeConfig = objectMapper.readValue(ftcStr,
+                    parsedFieldTypeConfig = objectMapper.readValue(ftcJson,
                             objectMapper.getTypeFactory().constructMapType(
                                     HashMap.class, String.class, Object.class));
                 } catch (Exception ex) {
                     log.warn("Failed to parse fieldTypeConfig for field '{}': {}",
                             fieldName, ex.getMessage());
                 }
-            } else if (fieldTypeConfigObj instanceof Map) {
-                @SuppressWarnings("unchecked")
-                Map<String, Object> configMap = (Map<String, Object>) fieldTypeConfigObj;
-                parsedFieldTypeConfig = configMap;
             }
 
             FieldDefinition fieldDef = new FieldDefinition(


### PR DESCRIPTION
## Summary
- `CollectionLifecycleManager.loadFieldsFromDb` now handles \`org.postgresql.util.PGobject\` — the actual type the JDBC driver returns for JSONB columns.
- Restores the rollup_summary value pipeline. The fieldTypeConfig was loaded as null on every worker startup, so \`DefaultQueryEngine.computeRollupValue\` short-circuited at the \`cfg == null\` guard before any logging fired.

## Why
PostgreSQL JSONB columns surface through standard JDBC as \`PGobject\`, not String and not Map. The previous parser only handled the latter two and silently dropped the config. Stack:

\`row.get(\"field_type_config\") instanceof PGobject → ftc=null → FieldDefinition.fieldTypeConfig()=null\`
\`DefaultQueryEngine.computeRollupValue: if (cfg == null) return null; // silent\`
\`response: no computed_total attribute\`

## Test plan
- [x] Local compile passes
- [ ] After deploy: GET \`/api/orders/{id}\` returns \`computed_total = SUM(line_total)\` (211.98 for ORD-100003)
- [ ] Worker logs emit the new INFO traces from PR #826 confirming compute reached

🤖 Generated with [Claude Code](https://claude.com/claude-code)