### PR TITLE
fix(runtime): page through all child records during include resolution

### DIFF
--- a/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/router/DynamicCollectionRouter.java
+++ b/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/router/DynamicCollectionRouter.java
@@ -1441,7 +1441,18 @@ public class DynamicCollectionRouter {
     /**
      * Queries child records from a collection using an IN filter on the given
      * reference field.
+     *
+     * <p>Pages through every matching record so JSON:API include resolution
+     * stays complete. The previous single-page (1×1000) cap silently truncated
+     * include results — e.g. on the bulk
+     * {@code GET /api/collections?include=fields} call, ~92 collections × 10-20
+     * fields each can exceed 1000 included rows. The truncated set still
+     * returns 200, but newly-added fields tail-end of the list disappear from
+     * the SPA's collection store, so layout placements that reference them
+     * silently drop on render.
      */
+    private static final int INCLUDE_PAGE_SIZE = 1000;
+
     private List<Map<String, Object>> queryChildRecords(
             CollectionDefinition childDef,
             String refField,
@@ -1451,23 +1462,34 @@ public class DynamicCollectionRouter {
         List<FilterCondition> filters = new ArrayList<>();
         filters.add(new FilterCondition(refField, FilterOperator.IN, parentIds));
 
-        QueryRequest childQuery = new QueryRequest(
-                new Pagination(1, 1000),
-                List.of(),
-                List.of(),
-                filters
-        );
-
-        childQuery = injectTenantFilter(childQuery, childDef, request);
-
+        List<Map<String, Object>> aggregated = new ArrayList<>();
         try {
-            QueryResult childResult = queryEngine.executeQuery(childDef, childQuery);
-            return childResult.data();
+            int page = 1;
+            while (true) {
+                QueryRequest childQuery = new QueryRequest(
+                        new Pagination(page, INCLUDE_PAGE_SIZE),
+                        List.of(),
+                        List.of(),
+                        filters
+                );
+                childQuery = injectTenantFilter(childQuery, childDef, request);
+                QueryResult childResult = queryEngine.executeQuery(childDef, childQuery);
+                List<Map<String, Object>> data = childResult.data();
+                if (data.isEmpty()) {
+                    break;
+                }
+                aggregated.addAll(data);
+                if (data.size() < INCLUDE_PAGE_SIZE) {
+                    break;
+                }
+                page++;
+            }
         } catch (Exception e) {
             logger.warn("Failed to query child records for '{}': {}", childDef.name(),
                     e.getMessage());
             return List.of();
         }
+        return aggregated;
     }
 
 }

--- a/kelta-ui/app/src/context/CollectionStoreContext.tsx
+++ b/kelta-ui/app/src/context/CollectionStoreContext.tsx
@@ -190,17 +190,37 @@ export function CollectionStoreProvider({
   const { isAuthenticated } = useAuth()
   const queryClient = useQueryClient()
 
-  // Single API call to load all collections with their fields.
-  // Only runs when the user is authenticated — prevents 401 loops on the login page.
+  // Page through every collection + included fields. Earlier this was a
+  // single page=1 size=1000 call, which silently truncated when total
+  // collections × fields exceeded the cap and made newly-added fields
+  // (e.g. a fresh rollup_summary) invisible to the cache. Backend list
+  // responses include metadata.totalPages — keep fetching until exhausted.
   const { data: schemas = [], isLoading } = useQuery({
     queryKey: ['collection-store'],
     queryFn: async () => {
-      const raw = await apiClient.get('/api/collections?page[size]=1000&include=fields')
-      const parsed = parseCollectionsResponse(raw)
+      const PAGE_SIZE = 500
+      const allData: RawResource[] = []
+      const allIncluded: RawResource[] = []
+      let page = 1
+      while (true) {
+        const raw = (await apiClient.get(
+          `/api/collections?page[size]=${PAGE_SIZE}&page[number]=${page}&include=fields`
+        )) as {
+          data?: RawResource[]
+          included?: RawResource[]
+          metadata?: { totalPages?: number }
+        }
+        if (Array.isArray(raw.data)) allData.push(...raw.data)
+        if (Array.isArray(raw.included)) allIncluded.push(...raw.included)
+        const totalPages = raw.metadata?.totalPages ?? 1
+        if (page >= totalPages || !Array.isArray(raw.data) || raw.data.length < PAGE_SIZE) break
+        page++
+      }
 
-      // Pre-populate the React Query cache with individual collection-schema entries.
-      // This way, any component using useCollectionSchema(name) will find cached data
-      // and won't make an additional API call.
+      const parsed = parseCollectionsResponse({ data: allData, included: allIncluded })
+
+      // Pre-populate the React Query cache with individual collection-schema entries
+      // so useCollectionSchema(name) finds cached data without a second fetch.
       for (const schema of parsed) {
         queryClient.setQueryData(['collection-schema', schema.name], schema)
       }


### PR DESCRIPTION
## Summary
Removes silent truncation in JSON:API include resolution + the SPA bulk loader. Both sides now stream every record / page, no caps.

- **Backend**: `queryChildRecords` now loops `page=1..N` until the result set drains (page < page_size or empty). No max-page cap. Used by every `?include=...` resolution path.
- **Frontend**: `CollectionStoreProvider` pages through `/api/collections?include=fields` until `metadata.totalPages` is exhausted (or short page returned). Was a single `page[size]=1000` call, capped silently.

## Why
Browser probe revealed:
\`{ totalIncludedFields: 1000, ordersFieldCount: 18, rollupPresent: false }\`

92 collections × 10–20 fields each crossed the 1000 cap; new fields at the tail (e.g. `computed_total`) were dropped from the included[] array. Direct `GET /api/collections/orders?include=fields` returned 19, but the SPA primed its store from the bulk endpoint — 18-field schema, layout placement for the rollup field failed `schemaFieldsById.get()`, DetailSection silently dropped the row.

Tenants with hundreds of collections + thousands of fields will exceed any fixed cap. Pagination loops handle unbounded sets.

## Test plan
- [x] `mvn -pl runtime/runtime-core test` — 1165 pass
- [x] `tsc --noEmit` clean
- [ ] After deploy: hard-reload the order detail page; "Computed Total" renders 211.98

🤖 Generated with [Claude Code](https://claude.com/claude-code)