### PR TITLE
chore(field-renderer): drop Sigma icon from rollup_summary cell

### DIFF
--- a/kelta-ui/app/src/components/FieldRenderer/FieldRenderer.tsx
+++ b/kelta-ui/app/src/components/FieldRenderer/FieldRenderer.tsx
@@ -19,7 +19,6 @@ import {
   Lock,
   Hash,
   Calculator,
-  Sigma,
   Check,
   X,
   Copy,
@@ -399,12 +398,7 @@ export function FieldRenderer({
     }
 
     case 'rollup_summary': {
-      return (
-        <span className={cn('inline-flex items-center gap-1 font-mono tabular-nums', className)}>
-          <Sigma className="h-3.5 w-3.5 text-muted-foreground" aria-hidden="true" />
-          {formatNumber(value)}
-        </span>
-      )
+      return <span className={cn('font-mono tabular-nums', className)}>{formatNumber(value)}</span>
     }
 
     case 'geolocation': {


### PR DESCRIPTION
Removes the Σ icon prefix from rollup_summary value rendering. Matches sibling numeric types (number/currency/percent) which render bare values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)