### PR TITLE
feat(layouts): LIST editor + per-layout assignment rules

### DIFF
--- a/kelta-ui/app/src/components/FilterBuilder/FilterBuilder.tsx
+++ b/kelta-ui/app/src/components/FilterBuilder/FilterBuilder.tsx
@@ -1,0 +1,222 @@
+/**
+ * FilterBuilder
+ *
+ * Visual editor for a LayoutFilter expression: an AND/OR group of
+ * { field, op, value } clauses. Used to build the LIST-layout default filter
+ * and the layout-assignment condition. Stores no state of its own — fully
+ * controlled by the parent.
+ */
+
+import React, { useCallback, useMemo } from 'react'
+import { Plus, Trash2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+
+export type FilterOperator =
+  | 'equals'
+  | 'not_equals'
+  | 'contains'
+  | 'starts_with'
+  | 'ends_with'
+  | 'gt'
+  | 'lt'
+  | 'gte'
+  | 'lte'
+  | 'is_null'
+  | 'is_not_null'
+
+export interface FilterClause {
+  field: string
+  op: FilterOperator
+  value?: unknown
+}
+
+export interface FilterExpression {
+  logic: 'AND' | 'OR'
+  filters: FilterClause[]
+}
+
+export interface FieldOption {
+  name: string
+  displayName: string
+  /** Optional field UUID — carried by callers that need it but unused by the filter UI. */
+  id?: string
+}
+
+const OPERATOR_LABELS: Record<FilterOperator, string> = {
+  equals: 'equals',
+  not_equals: 'not equals',
+  contains: 'contains',
+  starts_with: 'starts with',
+  ends_with: 'ends with',
+  gt: '>',
+  lt: '<',
+  gte: '>=',
+  lte: '<=',
+  is_null: 'is empty',
+  is_not_null: 'is not empty',
+}
+
+const OPERATORS = Object.keys(OPERATOR_LABELS) as FilterOperator[]
+
+function opTakesValue(op: FilterOperator): boolean {
+  return op !== 'is_null' && op !== 'is_not_null'
+}
+
+export interface FilterBuilderProps {
+  value: FilterExpression | null
+  onChange: (next: FilterExpression | null) => void
+  fields: FieldOption[]
+  /** Optional id prefix to namespace input ids. */
+  idPrefix?: string
+}
+
+export function FilterBuilder({
+  value,
+  onChange,
+  fields,
+  idPrefix = 'filter',
+}: FilterBuilderProps): React.ReactElement {
+  const expr: FilterExpression = useMemo(() => value ?? { logic: 'AND', filters: [] }, [value])
+
+  const emit = useCallback(
+    (next: FilterExpression) => {
+      if (next.filters.length === 0) {
+        onChange(null)
+      } else {
+        onChange(next)
+      }
+    },
+    [onChange]
+  )
+
+  const addClause = useCallback(() => {
+    const defaultField = fields[0]?.name ?? ''
+    emit({
+      ...expr,
+      filters: [...expr.filters, { field: defaultField, op: 'equals', value: '' }],
+    })
+  }, [emit, expr, fields])
+
+  const removeClause = useCallback(
+    (index: number) => {
+      emit({ ...expr, filters: expr.filters.filter((_, i) => i !== index) })
+    },
+    [emit, expr]
+  )
+
+  const updateClause = useCallback(
+    (index: number, patch: Partial<FilterClause>) => {
+      emit({
+        ...expr,
+        filters: expr.filters.map((c, i) => (i === index ? { ...c, ...patch } : c)),
+      })
+    },
+    [emit, expr]
+  )
+
+  const setLogic = useCallback((logic: 'AND' | 'OR') => emit({ ...expr, logic }), [emit, expr])
+
+  return (
+    <div className="flex flex-col gap-2" data-testid="filter-builder">
+      {expr.filters.length > 1 && (
+        <div className="flex items-center gap-2 text-sm">
+          <span className="text-muted-foreground">Match</span>
+          <Select value={expr.logic} onValueChange={(v) => setLogic(v as 'AND' | 'OR')}>
+            <SelectTrigger className="h-8 w-20" data-testid={`${idPrefix}-logic`}>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="AND">ALL</SelectItem>
+              <SelectItem value="OR">ANY</SelectItem>
+            </SelectContent>
+          </Select>
+          <span className="text-muted-foreground">of the following</span>
+        </div>
+      )}
+
+      {expr.filters.map((clause, i) => (
+        <div
+          key={i}
+          className="flex flex-wrap items-center gap-2"
+          data-testid={`${idPrefix}-clause-${i}`}
+        >
+          <Select value={clause.field} onValueChange={(v) => updateClause(i, { field: v })}>
+            <SelectTrigger className="h-8 w-48" data-testid={`${idPrefix}-field-${i}`}>
+              <SelectValue placeholder="Field" />
+            </SelectTrigger>
+            <SelectContent>
+              {fields.map((f) => (
+                <SelectItem key={f.name} value={f.name}>
+                  {f.displayName}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+
+          <Select
+            value={clause.op}
+            onValueChange={(v) =>
+              updateClause(i, {
+                op: v as FilterOperator,
+                value: opTakesValue(v as FilterOperator) ? (clause.value ?? '') : undefined,
+              })
+            }
+          >
+            <SelectTrigger className="h-8 w-36" data-testid={`${idPrefix}-op-${i}`}>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {OPERATORS.map((op) => (
+                <SelectItem key={op} value={op}>
+                  {OPERATOR_LABELS[op]}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+
+          {opTakesValue(clause.op) && (
+            <Input
+              className="h-8 w-48"
+              value={typeof clause.value === 'string' ? clause.value : String(clause.value ?? '')}
+              onChange={(e) => updateClause(i, { value: e.target.value })}
+              data-testid={`${idPrefix}-value-${i}`}
+            />
+          )}
+
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            aria-label="Remove filter"
+            onClick={() => removeClause(i)}
+            data-testid={`${idPrefix}-remove-${i}`}
+          >
+            <Trash2 className="h-4 w-4" />
+          </Button>
+        </div>
+      ))}
+
+      <div>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={addClause}
+          disabled={fields.length === 0}
+          data-testid={`${idPrefix}-add`}
+        >
+          <Plus className="mr-1 h-4 w-4" />
+          Add filter
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/kelta-ui/app/src/components/FilterBuilder/__tests__/FilterBuilder.test.tsx
+++ b/kelta-ui/app/src/components/FilterBuilder/__tests__/FilterBuilder.test.tsx
@@ -1,0 +1,115 @@
+import React from 'react'
+import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi } from 'vitest'
+import { FilterBuilder, type FilterExpression } from '../FilterBuilder'
+
+const fields = [
+  { name: 'status', displayName: 'Status' },
+  { name: 'industry', displayName: 'Industry' },
+]
+
+function Harness({
+  initial,
+  onChange,
+}: {
+  initial: FilterExpression | null
+  onChange: (next: FilterExpression | null) => void
+}) {
+  const [value, setValue] = React.useState<FilterExpression | null>(initial)
+  return (
+    <FilterBuilder
+      value={value}
+      onChange={(next) => {
+        setValue(next)
+        onChange(next)
+      }}
+      fields={fields}
+    />
+  )
+}
+
+describe('FilterBuilder', () => {
+  it('renders only the Add button when value is null', () => {
+    render(<Harness initial={null} onChange={vi.fn()} />)
+    expect(screen.getByTestId('filter-add')).toBeInTheDocument()
+    expect(screen.queryByTestId('filter-clause-0')).toBeNull()
+  })
+
+  it('emits a new clause when Add is clicked', async () => {
+    const onChange = vi.fn()
+    render(<Harness initial={null} onChange={onChange} />)
+    await userEvent.click(screen.getByTestId('filter-add'))
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        logic: 'AND',
+        filters: [expect.objectContaining({ field: 'status', op: 'equals', value: '' })],
+      })
+    )
+  })
+
+  it('hides the value input for is_null / is_not_null operators', () => {
+    render(
+      <Harness
+        initial={{ logic: 'AND', filters: [{ field: 'status', op: 'is_null' }] }}
+        onChange={vi.fn()}
+      />
+    )
+    const clause = screen.getByTestId('filter-clause-0')
+    expect(within(clause).queryByTestId('filter-value-0')).toBeNull()
+  })
+
+  it('hides logic selector with a single clause', () => {
+    render(
+      <Harness
+        initial={{ logic: 'AND', filters: [{ field: 'status', op: 'equals', value: 'a' }] }}
+        onChange={vi.fn()}
+      />
+    )
+    expect(screen.queryByTestId('filter-logic')).toBeNull()
+  })
+
+  it('shows logic selector with multiple clauses', () => {
+    render(
+      <Harness
+        initial={{
+          logic: 'AND',
+          filters: [
+            { field: 'status', op: 'equals', value: 'a' },
+            { field: 'industry', op: 'equals', value: 'b' },
+          ],
+        }}
+        onChange={vi.fn()}
+      />
+    )
+    expect(screen.getByTestId('filter-logic')).toBeInTheDocument()
+  })
+
+  it('emits null when the last clause is removed', async () => {
+    const onChange = vi.fn()
+    render(
+      <Harness
+        initial={{ logic: 'AND', filters: [{ field: 'status', op: 'equals', value: 'a' }] }}
+        onChange={onChange}
+      />
+    )
+    await userEvent.click(screen.getByTestId('filter-remove-0'))
+    expect(onChange).toHaveBeenLastCalledWith(null)
+  })
+
+  it('updates clause value via the input', async () => {
+    const onChange = vi.fn()
+    render(
+      <Harness
+        initial={{ logic: 'AND', filters: [{ field: 'status', op: 'equals', value: '' }] }}
+        onChange={onChange}
+      />
+    )
+    await userEvent.type(screen.getByTestId('filter-value-0'), 'Active')
+    expect(onChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        filters: [expect.objectContaining({ value: 'Active' })],
+      })
+    )
+  })
+})

--- a/kelta-ui/app/src/components/FilterBuilder/index.ts
+++ b/kelta-ui/app/src/components/FilterBuilder/index.ts
@@ -1,0 +1,8 @@
+export {
+  FilterBuilder,
+  type FilterBuilderProps,
+  type FilterClause,
+  type FilterExpression,
+  type FilterOperator,
+  type FieldOption,
+} from './FilterBuilder'

--- a/kelta-ui/app/src/pages/PageLayoutsPage/PageLayoutsPage.tsx
+++ b/kelta-ui/app/src/pages/PageLayoutsPage/PageLayoutsPage.tsx
@@ -18,6 +18,9 @@ import { useToast, ConfirmDialog, LoadingSpinner, ErrorMessage } from '../../com
 import { useCollectionSummaries, type CollectionSummary } from '../../hooks/useCollectionSummaries'
 import { cn } from '@/lib/utils'
 import { RulesEditor } from './RulesEditor'
+import { AssignmentRulesEditor } from './components/AssignmentRulesEditor'
+import { LayoutEditorList } from './components/LayoutEditorList'
+import type { FilterExpression } from '@/components/FilterBuilder'
 
 import {
   LayoutEditorProvider,
@@ -74,6 +77,10 @@ interface PageLayoutDetail {
   isDefault: boolean
   sections: ApiSection[]
   relatedLists: ApiRelatedList[]
+  defaultFilter?: FilterExpression | null
+  defaultSortField?: string | null
+  defaultSortDirection?: 'ASC' | 'DESC' | null
+  defaultRowLimit?: number | null
   createdAt: string
   updatedAt: string
 }
@@ -942,6 +949,59 @@ function LayoutEditorViewInner({ layoutId, onBack }: LayoutEditorViewProps): Rea
     )
   }
 
+  if (layoutDetail?.layoutType === 'LIST' && !collectionDetail) {
+    return (
+      <div className="flex h-screen items-center justify-center">
+        <LoadingSpinner size="large" label="Loading layout..." />
+      </div>
+    )
+  }
+
+  if (layoutDetail?.layoutType === 'LIST' && collectionDetail) {
+    const firstSection = layoutDetail.sections[0]
+    const fieldMap = new Map(collectionDetail.fields.map((f) => [f.id, f]))
+    const initialColumns = (firstSection?.fields ?? [])
+      .slice()
+      .sort((a, b) => (a.sortOrder ?? 0) - (b.sortOrder ?? 0))
+      .map((fp) => {
+        const field = fieldMap.get(fp.fieldId)
+        return {
+          id: fp.id,
+          serverId: fp.id,
+          fieldId: fp.fieldId,
+          fieldName: field?.name,
+          fieldDisplayName: field?.displayName ?? field?.name,
+          fieldType: field?.type,
+          columnSpan: fp.columnSpan ?? 1,
+          labelOverride: fp.labelOverride,
+        }
+      })
+
+    const availableFieldOptions = collectionDetail.fields.map((f) => ({
+      id: f.id,
+      name: f.name,
+      displayName: f.displayName || f.name,
+    }))
+
+    return (
+      <LayoutEditorList
+        initialData={{
+          layoutId: layoutDetail.id,
+          collectionId: layoutDetail.collectionId,
+          layoutName: layoutDetail.name,
+          sectionId: firstSection?.id,
+          initialColumns,
+          defaultFilter: layoutDetail.defaultFilter ?? null,
+          defaultSortField: layoutDetail.defaultSortField ?? undefined,
+          defaultSortDirection: layoutDetail.defaultSortDirection ?? 'ASC',
+          defaultRowLimit: layoutDetail.defaultRowLimit ?? 50,
+        }}
+        availableFields={availableFieldOptions}
+        onBack={handleBack}
+      />
+    )
+  }
+
   return (
     <div className="flex h-screen flex-col overflow-hidden" data-testid="layout-editor">
       <LayoutToolbar
@@ -993,6 +1053,9 @@ export function PageLayoutsPage({
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
   const [layoutToDelete, setLayoutToDelete] = useState<PageLayoutSummary | null>(null)
   const [rulesEditorLayout, setRulesEditorLayout] = useState<PageLayoutSummary | null>(null)
+  const [assignmentEditorLayout, setAssignmentEditorLayout] = useState<PageLayoutSummary | null>(
+    null
+  )
 
   const {
     data: layouts,
@@ -1302,6 +1365,15 @@ export function PageLayoutsPage({
                       </button>
                       <button
                         type="button"
+                        className="cursor-pointer rounded-md border border-border bg-transparent px-4 py-2 text-sm font-medium text-primary transition-all duration-200 hover:border-primary hover:bg-muted focus-visible:outline-2 focus-visible:outline-primary focus-visible:outline-offset-2 max-md:w-full"
+                        onClick={() => setAssignmentEditorLayout(layout)}
+                        aria-label={`Assignments for ${layout.name}`}
+                        data-testid={`assignments-button-${index}`}
+                      >
+                        Assignments
+                      </button>
+                      <button
+                        type="button"
                         className="cursor-pointer rounded-md border border-border bg-transparent px-4 py-2 text-sm font-medium text-destructive transition-all duration-200 hover:border-destructive hover:bg-destructive/10 focus-visible:outline-2 focus-visible:outline-primary focus-visible:outline-offset-2 max-md:w-full"
                         onClick={() => handleDeleteClick(layout)}
                         aria-label={`Delete ${layout.name}`}
@@ -1334,6 +1406,16 @@ export function PageLayoutsPage({
           layoutName={rulesEditorLayout.name}
           fieldNames={[]}
           onClose={() => setRulesEditorLayout(null)}
+        />
+      )}
+
+      {assignmentEditorLayout && (
+        <AssignmentRulesEditor
+          open
+          onClose={() => setAssignmentEditorLayout(null)}
+          layoutId={assignmentEditorLayout.id}
+          layoutName={assignmentEditorLayout.name}
+          collectionId={assignmentEditorLayout.collectionId}
         />
       )}
 

--- a/kelta-ui/app/src/pages/PageLayoutsPage/components/AssignmentRulesEditor.tsx
+++ b/kelta-ui/app/src/pages/PageLayoutsPage/components/AssignmentRulesEditor.tsx
@@ -1,0 +1,351 @@
+/**
+ * AssignmentRulesEditor
+ *
+ * Modal editor for the layout-assignments rows that select which layout to
+ * render for a given record. Each row binds (profile, recordType, condition,
+ * evaluationOrder) to a layout. The runtime resolver walks assignments by
+ * ascending evaluationOrder and applies the first matching one.
+ *
+ * Distinct from the per-layout "Rules" button, which edits per-field
+ * COMPUTE/VALIDATE/DEFAULT/TRANSFORM rules.
+ */
+
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { ArrowDown, ArrowUp, Plus, Trash2 } from 'lucide-react'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { useApi } from '@/context/ApiContext'
+import { useToast } from '@/components/Toast'
+import { FilterBuilder, type FilterExpression, type FieldOption } from '@/components/FilterBuilder'
+
+interface AssignmentRow {
+  /** Editor-local id. `serverId` is set when the row originated from the API. */
+  id: string
+  serverId?: string
+  profileId: string
+  recordTypeId: string
+  condition: FilterExpression | null
+  evaluationOrder: number
+}
+
+interface ServerAssignment {
+  id: string
+  collectionId: string
+  profileId?: string
+  recordTypeId?: string
+  layoutId: string
+  condition?: FilterExpression | null
+  evaluationOrder: number
+}
+
+export interface AssignmentRulesEditorProps {
+  open: boolean
+  onClose: () => void
+  layoutId: string
+  layoutName: string
+  collectionId: string
+  /** If omitted the editor fetches the collection's fields itself. */
+  fields?: FieldOption[]
+}
+
+interface CollectionFieldResource {
+  id: string
+  name: string
+  displayName?: string
+  type?: string
+}
+
+export function AssignmentRulesEditor({
+  open,
+  onClose,
+  layoutId,
+  layoutName,
+  collectionId,
+  fields,
+}: AssignmentRulesEditorProps): React.ReactElement {
+  const { apiClient } = useApi()
+  const { showToast } = useToast()
+  const queryClient = useQueryClient()
+
+  const [rows, setRows] = useState<AssignmentRow[]>([])
+  const [originalServerIds, setOriginalServerIds] = useState<Set<string>>(new Set())
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['layoutAssignments', layoutId],
+    queryFn: () =>
+      apiClient.getList<ServerAssignment>(
+        `/api/layout-assignments?filter[layoutId][eq]=${encodeURIComponent(layoutId)}`
+      ),
+    enabled: open,
+  })
+
+  // Fetch fields for the assignment's collection if the caller didn't pass them.
+  const { data: fetchedFields } = useQuery({
+    queryKey: ['collection-fields', collectionId],
+    queryFn: async () => {
+      type JsonApiResource = {
+        type: string
+        id: string
+        attributes: Record<string, unknown>
+      }
+      const raw = await apiClient.get<{
+        included?: JsonApiResource[]
+      }>(`/api/collections/${collectionId}?include=fields`)
+      return (raw.included ?? [])
+        .filter((r) => r.type === 'fields')
+        .map(
+          (r) =>
+            ({
+              id: r.id,
+              name: r.attributes.name as string,
+              displayName: (r.attributes.displayName as string) || (r.attributes.name as string),
+              type: r.attributes.type as string,
+            }) as CollectionFieldResource
+        )
+    },
+    enabled: open && !fields,
+  })
+
+  const effectiveFields: FieldOption[] = useMemo(() => {
+    if (fields) return fields
+    return (fetchedFields ?? []).map((f) => ({
+      id: f.id,
+      name: f.name,
+      displayName: f.displayName ?? f.name,
+    }))
+  }, [fields, fetchedFields])
+
+  // Reset local edit state when fresh server data arrives; setState-in-effect
+  // is the standard pattern for syncing server data into local editable state.
+  useEffect(() => {
+    if (!data) return
+    const sorted = [...data].sort((a, b) => (a.evaluationOrder ?? 100) - (b.evaluationOrder ?? 100))
+    /* eslint-disable react-hooks/set-state-in-effect */
+    setRows(
+      sorted.map((a) => ({
+        id: crypto.randomUUID(),
+        serverId: a.id,
+        profileId: a.profileId ?? '',
+        recordTypeId: a.recordTypeId ?? '',
+        condition: a.condition ?? null,
+        evaluationOrder: a.evaluationOrder ?? 100,
+      }))
+    )
+    setOriginalServerIds(new Set(sorted.map((a) => a.id)))
+    /* eslint-enable react-hooks/set-state-in-effect */
+  }, [data])
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      const desiredServerIds = new Set(rows.filter((r) => r.serverId).map((r) => r.serverId!))
+      const idsToDelete = Array.from(originalServerIds).filter((id) => !desiredServerIds.has(id))
+      await Promise.all(
+        idsToDelete.map((id) => apiClient.deleteResource(`/api/layout-assignments/${id}`))
+      )
+
+      for (const r of rows) {
+        const payload = {
+          collectionId,
+          layoutId,
+          profileId: r.profileId || null,
+          recordTypeId: r.recordTypeId || null,
+          condition: r.condition ?? null,
+          evaluationOrder: r.evaluationOrder,
+        }
+        if (r.serverId) {
+          await apiClient.putResource(`/api/layout-assignments/${r.serverId}`, payload)
+        } else {
+          await apiClient.postResource('/api/layout-assignments', payload)
+        }
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['layoutAssignments', layoutId] })
+      showToast('Assignments saved', 'success')
+      onClose()
+    },
+    onError: (err: Error) => {
+      showToast(err.message || 'Failed to save assignments', 'error')
+    },
+  })
+
+  const nextOrder = useMemo(() => {
+    const max = rows.reduce((m, r) => Math.max(m, r.evaluationOrder), 0)
+    return max + 10
+  }, [rows])
+
+  const addRow = useCallback(() => {
+    setRows((prev) => [
+      ...prev,
+      {
+        id: crypto.randomUUID(),
+        profileId: '',
+        recordTypeId: '',
+        condition: null,
+        evaluationOrder: nextOrder,
+      },
+    ])
+  }, [nextOrder])
+
+  const updateRow = useCallback((id: string, patch: Partial<AssignmentRow>) => {
+    setRows((prev) => prev.map((r) => (r.id === id ? { ...r, ...patch } : r)))
+  }, [])
+
+  const removeRow = useCallback((id: string) => {
+    setRows((prev) => prev.filter((r) => r.id !== id))
+  }, [])
+
+  const moveRow = useCallback((index: number, dir: -1 | 1) => {
+    setRows((prev) => {
+      const next = [...prev]
+      const target = index + dir
+      if (target < 0 || target >= next.length) return prev
+      ;[next[index], next[target]] = [next[target], next[index]]
+      // Renumber evaluationOrder by 10s so we always have gaps.
+      return next.map((r, i) => ({ ...r, evaluationOrder: (i + 1) * 10 }))
+    })
+  }, [])
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent className="max-w-4xl">
+        <DialogHeader>
+          <DialogTitle>Assignments — {layoutName}</DialogTitle>
+          <DialogDescription>
+            Choose when this layout applies. Runtime walks rules by evaluation order ascending and
+            picks the first one whose profile, record type, and condition all match. Rules without a
+            condition act as fallbacks.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex max-h-[60vh] flex-col gap-3 overflow-y-auto">
+          {isLoading && <p className="text-sm text-muted-foreground">Loading…</p>}
+
+          {!isLoading && rows.length === 0 && (
+            <p className="text-sm text-muted-foreground">
+              No assignment rules. Add one to control when this layout applies.
+            </p>
+          )}
+
+          {rows.map((row, i) => (
+            <div
+              key={row.id}
+              className="flex flex-col gap-2 rounded-md border border-border bg-muted/30 p-3"
+              data-testid={`assignment-row-${i}`}
+            >
+              <div className="flex flex-wrap items-end gap-3">
+                <div className="flex flex-col gap-1">
+                  <Label className="text-xs">Order</Label>
+                  <Input
+                    type="number"
+                    className="h-8 w-20"
+                    value={row.evaluationOrder}
+                    onChange={(e) =>
+                      updateRow(row.id, { evaluationOrder: Number(e.target.value) || 0 })
+                    }
+                    data-testid={`assignment-order-${i}`}
+                  />
+                </div>
+                <div className="flex flex-col gap-1">
+                  <Label className="text-xs">Profile ID</Label>
+                  <Input
+                    className="h-8 w-56"
+                    placeholder="(any)"
+                    value={row.profileId}
+                    onChange={(e) => updateRow(row.id, { profileId: e.target.value })}
+                    data-testid={`assignment-profile-${i}`}
+                  />
+                </div>
+                <div className="flex flex-col gap-1">
+                  <Label className="text-xs">Record type ID</Label>
+                  <Input
+                    className="h-8 w-56"
+                    placeholder="(any)"
+                    value={row.recordTypeId}
+                    onChange={(e) => updateRow(row.id, { recordTypeId: e.target.value })}
+                    data-testid={`assignment-recordtype-${i}`}
+                  />
+                </div>
+                <div className="ml-auto flex gap-1">
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    aria-label="Move up"
+                    disabled={i === 0}
+                    onClick={() => moveRow(i, -1)}
+                  >
+                    <ArrowUp className="h-4 w-4" />
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    aria-label="Move down"
+                    disabled={i === rows.length - 1}
+                    onClick={() => moveRow(i, 1)}
+                  >
+                    <ArrowDown className="h-4 w-4" />
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    aria-label="Remove row"
+                    onClick={() => removeRow(row.id)}
+                    data-testid={`assignment-remove-${i}`}
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
+                </div>
+              </div>
+
+              <div className="flex flex-col gap-1">
+                <Label className="text-xs text-muted-foreground">
+                  Condition (leave empty to act as fallback)
+                </Label>
+                <FilterBuilder
+                  value={row.condition}
+                  onChange={(next) => updateRow(row.id, { condition: next })}
+                  fields={effectiveFields}
+                  idPrefix={`assignment-${i}-cond`}
+                />
+              </div>
+            </div>
+          ))}
+
+          <div>
+            <Button type="button" variant="outline" size="sm" onClick={addRow}>
+              <Plus className="mr-1 h-4 w-4" />
+              Add assignment
+            </Button>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button type="button" variant="ghost" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            onClick={() => mutation.mutate()}
+            disabled={mutation.isPending}
+            data-testid="assignment-save"
+          >
+            {mutation.isPending ? 'Saving…' : 'Save'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/kelta-ui/app/src/pages/PageLayoutsPage/components/LayoutEditorList.tsx
+++ b/kelta-ui/app/src/pages/PageLayoutsPage/components/LayoutEditorList.tsx
@@ -1,0 +1,479 @@
+/**
+ * LayoutEditorList
+ *
+ * Editor for LIST-type page layouts. Renders an ordered, horizontal list of
+ * columns (each backed by a layout-field row) with width and label overrides,
+ * plus a sidebar form for the default filter / sort / row limit that ships
+ * with the layout.
+ *
+ * Self-contained: manages its own local state for columns and defaults and
+ * owns the save mutation. It does not use the section/dropzone-based
+ * LayoutEditorContext used by the DETAIL editor.
+ */
+
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { ArrowLeft, ArrowRight, GripVertical, Plus, Save, Trash2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { useApi } from '@/context/ApiContext'
+import { useToast } from '@/components/Toast'
+import { FilterBuilder, type FilterExpression, type FieldOption } from '@/components/FilterBuilder'
+
+export interface ListColumn {
+  /** Editor-local id. Server-issued id once saved. */
+  id: string
+  /** Field UUID this column renders. */
+  fieldId: string
+  fieldName?: string
+  fieldDisplayName?: string
+  fieldType?: string
+  /** Backend stores this as columnSpan; we treat it as a width unit (1–6). */
+  columnSpan: number
+  labelOverride?: string
+  /** Track which columns came from the server so we know UPDATE vs CREATE. */
+  serverId?: string
+}
+
+export interface LayoutEditorListInitialData {
+  layoutId: string
+  collectionId: string
+  layoutName: string
+  /** The first server section, if any — we collapse LIST layouts to one section. */
+  sectionId?: string
+  initialColumns: ListColumn[]
+  defaultFilter: FilterExpression | null
+  defaultSortField?: string
+  defaultSortDirection: 'ASC' | 'DESC'
+  defaultRowLimit: number
+}
+
+export interface LayoutEditorListProps {
+  initialData: LayoutEditorListInitialData
+  availableFields: FieldOption[]
+  onBack: () => void
+}
+
+const ROW_LIMIT_OPTIONS = [10, 25, 50, 100, 200]
+const WIDTH_OPTIONS = [1, 2, 3, 4, 5, 6]
+
+export function LayoutEditorList({
+  initialData,
+  availableFields,
+  onBack,
+}: LayoutEditorListProps): React.ReactElement {
+  const { apiClient } = useApi()
+  const { showToast } = useToast()
+  const queryClient = useQueryClient()
+
+  const [columns, setColumns] = useState<ListColumn[]>(initialData.initialColumns)
+  const [defaultFilter, setDefaultFilter] = useState<FilterExpression | null>(
+    initialData.defaultFilter
+  )
+  const [defaultSortField, setDefaultSortField] = useState<string>(
+    initialData.defaultSortField ?? ''
+  )
+  const [defaultSortDirection, setDefaultSortDirection] = useState<'ASC' | 'DESC'>(
+    initialData.defaultSortDirection
+  )
+  const [defaultRowLimit, setDefaultRowLimit] = useState<number>(initialData.defaultRowLimit)
+  const [isDirty, setIsDirty] = useState(false)
+
+  // Reset local edit state whenever the parent supplies a fresh server snapshot.
+  // setState-in-effect is the standard pattern for syncing server data into
+  // local editable state; we accept the lint warning here.
+  useEffect(() => {
+    /* eslint-disable react-hooks/set-state-in-effect */
+    setColumns(initialData.initialColumns)
+    setDefaultFilter(initialData.defaultFilter)
+    setDefaultSortField(initialData.defaultSortField ?? '')
+    setDefaultSortDirection(initialData.defaultSortDirection)
+    setDefaultRowLimit(initialData.defaultRowLimit)
+    setIsDirty(false)
+    /* eslint-enable react-hooks/set-state-in-effect */
+  }, [initialData])
+
+  const placedFieldIds = useMemo(() => new Set(columns.map((c) => c.fieldId)), [columns])
+
+  const unplacedFields = useMemo(
+    () => availableFields.filter((f) => !placedFieldIds.has(f.name)),
+    [availableFields, placedFieldIds]
+  )
+
+  const fieldByName = useMemo(() => {
+    const map = new Map<string, FieldOption>()
+    for (const f of availableFields) map.set(f.name, f)
+    return map
+  }, [availableFields])
+
+  const mark = useCallback(() => setIsDirty(true), [])
+
+  const addColumn = useCallback(
+    (fieldName: string) => {
+      const field = fieldByName.get(fieldName)
+      if (!field) return
+      // availableFields tracks by `name`; we still need the underlying field id
+      // for the API. The parent passes id via FieldOption.name === field.name,
+      // but we need .id too — see PageLayoutsPage wiring.
+      const fieldId = field.id ?? fieldName
+      setColumns((prev) => [
+        ...prev,
+        {
+          id: crypto.randomUUID(),
+          fieldId,
+          fieldName: field.name,
+          fieldDisplayName: field.displayName,
+          columnSpan: 1,
+        },
+      ])
+      mark()
+    },
+    [fieldByName, mark]
+  )
+
+  const removeColumn = useCallback(
+    (id: string) => {
+      setColumns((prev) => prev.filter((c) => c.id !== id))
+      mark()
+    },
+    [mark]
+  )
+
+  const updateColumn = useCallback(
+    (id: string, patch: Partial<ListColumn>) => {
+      setColumns((prev) => prev.map((c) => (c.id === id ? { ...c, ...patch } : c)))
+      mark()
+    },
+    [mark]
+  )
+
+  const moveColumn = useCallback(
+    (index: number, direction: -1 | 1) => {
+      setColumns((prev) => {
+        const next = [...prev]
+        const target = index + direction
+        if (target < 0 || target >= next.length) return prev
+        ;[next[index], next[target]] = [next[target], next[index]]
+        return next
+      })
+      mark()
+    },
+    [mark]
+  )
+
+  const saveMutation = useMutation({
+    mutationFn: async () => {
+      const { layoutId, sectionId: initialSectionId } = initialData
+
+      // Step 1: persist parent layout defaults.
+      await apiClient.putResource(`/api/page-layouts/${layoutId}`, {
+        defaultFilter: defaultFilter ?? null,
+        defaultSortField: defaultSortField || null,
+        defaultSortDirection,
+        defaultRowLimit,
+      })
+
+      // Step 2: ensure exactly one section exists ("Columns") and use it.
+      let sectionId = initialSectionId
+      if (!sectionId) {
+        const created = await apiClient.postResource<{ id: string }>('/api/layout-sections', {
+          layoutId,
+          heading: 'Columns',
+          columns: 1,
+          sortOrder: 0,
+          collapsed: false,
+          style: 'DEFAULT',
+          sectionType: 'FIELDS',
+        })
+        sectionId = created.id
+      }
+
+      // Step 3: diff field placements against server.
+      const desiredServerIds = new Set(columns.filter((c) => c.serverId).map((c) => c.serverId!))
+      const originalServerIds = initialData.initialColumns
+        .map((c) => c.serverId)
+        .filter((id): id is string => !!id)
+
+      const idsToDelete = originalServerIds.filter((id) => !desiredServerIds.has(id))
+      await Promise.all(
+        idsToDelete.map((id) => apiClient.deleteResource(`/api/layout-fields/${id}`))
+      )
+
+      // Step 4: create/update each column in order.
+      for (let i = 0; i < columns.length; i++) {
+        const c = columns[i]
+        const payload = {
+          sectionId,
+          fieldId: c.fieldId,
+          columnNumber: 1,
+          columnSpan: c.columnSpan > 1 ? c.columnSpan : null,
+          sortOrder: i,
+          isRequiredOnLayout: false,
+          isReadOnlyOnLayout: false,
+          labelOverride: c.labelOverride || null,
+          helpTextOverride: null,
+          visibilityRule: null,
+        }
+        if (c.serverId) {
+          await apiClient.putResource(`/api/layout-fields/${c.serverId}`, payload)
+        } else {
+          await apiClient.postResource('/api/layout-fields', payload)
+        }
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['pageLayouts'] })
+      queryClient.invalidateQueries({ queryKey: ['pageLayout', initialData.layoutId] })
+      setIsDirty(false)
+      showToast('Layout saved successfully', 'success')
+    },
+    onError: (err: Error) => {
+      showToast(err.message || 'Failed to save layout', 'error')
+    },
+  })
+
+  const handleBack = useCallback(() => {
+    if (isDirty) {
+      const ok = window.confirm('You have unsaved changes. Are you sure you want to leave?')
+      if (!ok) return
+    }
+    onBack()
+  }, [isDirty, onBack])
+
+  return (
+    <div
+      className="flex h-screen flex-col overflow-hidden bg-muted/30"
+      data-testid="layout-editor-list"
+    >
+      <header className="flex items-center justify-between border-b border-border bg-background px-6 py-3">
+        <div className="flex items-center gap-3">
+          <Button variant="ghost" size="sm" onClick={handleBack}>
+            <ArrowLeft className="mr-1 h-4 w-4" />
+            Back
+          </Button>
+          <h2 className="text-lg font-semibold">{initialData.layoutName}</h2>
+          <span className="rounded-md bg-muted px-2 py-0.5 text-xs font-medium uppercase">
+            List
+          </span>
+        </div>
+        <Button
+          onClick={() => saveMutation.mutate()}
+          disabled={!isDirty || saveMutation.isPending}
+          data-testid="save-button"
+        >
+          <Save className="mr-1 h-4 w-4" />
+          {saveMutation.isPending ? 'Saving…' : 'Save'}
+        </Button>
+      </header>
+
+      <div className="grid flex-1 min-h-0 grid-cols-[1fr_360px] gap-4 overflow-hidden p-6">
+        <Card className="flex min-h-0 flex-col overflow-hidden">
+          <CardHeader>
+            <CardTitle>Columns</CardTitle>
+          </CardHeader>
+          <CardContent className="flex flex-1 flex-col gap-3 overflow-y-auto">
+            {columns.length === 0 && (
+              <p className="text-sm text-muted-foreground">
+                No columns yet. Add a field from the panel on the right to get started.
+              </p>
+            )}
+
+            {columns.map((column, i) => (
+              <div
+                key={column.id}
+                className="flex flex-wrap items-center gap-2 rounded-md border border-border bg-background p-3"
+                data-testid={`list-column-${i}`}
+              >
+                <div className="flex items-center text-muted-foreground">
+                  <GripVertical className="h-4 w-4" />
+                </div>
+                <div className="flex min-w-32 flex-1 flex-col">
+                  <span className="text-sm font-medium">
+                    {column.fieldDisplayName ?? column.fieldName ?? column.fieldId}
+                  </span>
+                  {column.fieldType && (
+                    <span className="text-xs text-muted-foreground">{column.fieldType}</span>
+                  )}
+                </div>
+
+                <div className="flex items-center gap-1">
+                  <Label className="text-xs text-muted-foreground" htmlFor={`width-${column.id}`}>
+                    Width
+                  </Label>
+                  <Select
+                    value={String(column.columnSpan)}
+                    onValueChange={(v) => updateColumn(column.id, { columnSpan: Number(v) })}
+                  >
+                    <SelectTrigger className="h-8 w-16" id={`width-${column.id}`}>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {WIDTH_OPTIONS.map((w) => (
+                        <SelectItem key={w} value={String(w)}>
+                          {w}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <Input
+                  className="h-8 w-48"
+                  placeholder="Label override"
+                  value={column.labelOverride ?? ''}
+                  onChange={(e) =>
+                    updateColumn(column.id, { labelOverride: e.target.value || undefined })
+                  }
+                  data-testid={`list-column-label-${i}`}
+                />
+
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  aria-label="Move left"
+                  disabled={i === 0}
+                  onClick={() => moveColumn(i, -1)}
+                >
+                  <ArrowLeft className="h-4 w-4" />
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  aria-label="Move right"
+                  disabled={i === columns.length - 1}
+                  onClick={() => moveColumn(i, 1)}
+                >
+                  <ArrowRight className="h-4 w-4" />
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  aria-label="Remove column"
+                  onClick={() => removeColumn(column.id)}
+                  data-testid={`list-column-remove-${i}`}
+                >
+                  <Trash2 className="h-4 w-4" />
+                </Button>
+              </div>
+            ))}
+
+            {unplacedFields.length > 0 && (
+              <div className="mt-4 border-t border-border pt-3">
+                <Label className="text-xs uppercase text-muted-foreground">Add field</Label>
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {unplacedFields.map((f) => (
+                    <Button
+                      key={f.name}
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      onClick={() => addColumn(f.name)}
+                      data-testid={`add-field-${f.name}`}
+                    >
+                      <Plus className="mr-1 h-3.5 w-3.5" />
+                      {f.displayName}
+                    </Button>
+                  ))}
+                </div>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card className="flex min-h-0 flex-col overflow-hidden">
+          <CardHeader>
+            <CardTitle>Defaults</CardTitle>
+          </CardHeader>
+          <CardContent className="flex flex-1 flex-col gap-4 overflow-y-auto">
+            <div className="flex flex-col gap-1">
+              <Label className="text-sm">Sort by</Label>
+              <div className="flex gap-2">
+                <Select
+                  value={defaultSortField || '__none__'}
+                  onValueChange={(v) => {
+                    setDefaultSortField(v === '__none__' ? '' : v)
+                    mark()
+                  }}
+                >
+                  <SelectTrigger className="h-8 flex-1" data-testid="default-sort-field">
+                    <SelectValue placeholder="No sort" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="__none__">No sort</SelectItem>
+                    {availableFields.map((f) => (
+                      <SelectItem key={f.name} value={f.name}>
+                        {f.displayName}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <Select
+                  value={defaultSortDirection}
+                  onValueChange={(v) => {
+                    setDefaultSortDirection(v as 'ASC' | 'DESC')
+                    mark()
+                  }}
+                >
+                  <SelectTrigger className="h-8 w-24" data-testid="default-sort-direction">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="ASC">Asc</SelectItem>
+                    <SelectItem value="DESC">Desc</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+
+            <div className="flex flex-col gap-1">
+              <Label className="text-sm">Row limit</Label>
+              <Select
+                value={String(defaultRowLimit)}
+                onValueChange={(v) => {
+                  setDefaultRowLimit(Number(v))
+                  mark()
+                }}
+              >
+                <SelectTrigger className="h-8 w-32" data-testid="default-row-limit">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {ROW_LIMIT_OPTIONS.map((n) => (
+                    <SelectItem key={n} value={String(n)}>
+                      {n}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <Label className="text-sm">Default filter</Label>
+              <FilterBuilder
+                value={defaultFilter}
+                onChange={(next) => {
+                  setDefaultFilter(next)
+                  mark()
+                }}
+                fields={availableFields}
+                idPrefix="default-filter"
+              />
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- `LayoutEditorList`: ordered horizontal-column editor for LIST-type page layouts. Per-column width (1–6), label override, plus a side panel for the default filter / sort / row limit that ships with the layout. Branches in `LayoutEditorViewInner` when `layoutType === 'LIST'`; DETAIL/EDIT/MINI continue to use the existing drag-drop editor.
- `AssignmentRulesEditor`: modal opened from a new "Assignments" button on each layout row. Edits `layout-assignments` (profile, recordType, condition, evaluationOrder) so admins can pick which layout applies to which records. Reorder buttons auto-renumber `evaluationOrder` by 10s.
- `FilterBuilder`: shared field/op/value clause builder. Operator vocabulary matches `filterEval` (equals, not_equals, contains, starts_with, ends_with, gt, lt, gte, lte, is_null, is_not_null) so client-side resolution and server-side filter writes agree.
- This is PR 2 of 3. PR3 will migrate admin grids to ObjectDataTable + ColumnPicker + an in-grid FilterBar.

## Test plan
- [x] `npm run typecheck` (kelta-ui) — clean
- [x] FilterBuilder unit tests — 7 passing; covers operator semantics, add/remove, logic toggle, value editing
- [x] Existing PageLayoutsPage + RulesEditor tests still pass (44 total in `src/pages/PageLayoutsPage`, `src/components/FilterBuilder`)
- [ ] Manual smoke: create a LIST-type page layout, add 3 columns with different widths, set a default filter / sort / row limit, save and reload. Open Assignments on a layout, add two rows (one conditional, one fallback), reorder, save, and verify rows persist with the expected `evaluationOrder` values.

## Known pre-existing
- `src/App.test.tsx` fails on `main` (mock for `./pages` missing `CredentialsPage`). Unrelated to this PR — surfaced when running the full kelta-ui suite. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)