### PR TITLE
feat(autopilot): Phase 1 dispatcher + worker scripts

### DIFF
--- a/.claude/dispatcher/README.md
+++ b/.claude/dispatcher/README.md
@@ -1,0 +1,98 @@
+# EMF autopilot dispatcher
+
+Phase 1 of the autonomous feature lifecycle planned in [`~/.claude/plans/i-want-to-maximize-sleepy-karp.md`](../../). Runs on `worker-01` (Linux, `craig@192.168.0.232`) as a systemd service. Mac side runs `status.sh` via launchd for visibility.
+
+## Pieces
+
+| File | Role |
+|---|---|
+| `dispatch.sh` | Outer loop on worker-01: pull queue, prune dead workers, claim + spawn up to `MAX_PARALLEL` |
+| `worker.sh` | Per-task: worktree → `claude -p` with worker-prompt → `/verify` → push → `gh pr create` → poll CI → archive |
+| `claim.sh` | Atomic claim of the next eligible task from `approved/` |
+| `worker-prompt.md` | System prompt appended to every `claude -p` worker session |
+| `lib/queue.sh` | Frontmatter rw, atomic claim, push-with-retry, eligibility filter |
+| `lib/log.sh` | Structured JSON logging to stderr + `$EMF_LOG_DIR/<component>.jsonl` |
+| `status.sh` | One-screen queue summary; safe on either machine |
+| `systemd/emf-dispatcher.service` | systemd unit for `worker-01` |
+| `launchd/com.cklinker.emf-status.plist` | every-1-min status refresh on Mac |
+
+## Install on worker-01
+
+```sh
+ssh worker-01
+
+# 1. Pull the latest emf + emf-queue
+cd ~/GitHub/emf       && git pull
+cd ~/GitHub/emf-queue && git pull
+
+# 2. Prepare runtime dirs
+sudo install -d -o craig -g craig /var/lib/emf-wt /var/log/emf-dispatcher
+
+# 3. Install + enable the systemd unit
+sudo cp ~/GitHub/emf/.claude/dispatcher/systemd/emf-dispatcher.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now emf-dispatcher.service
+
+# 4. Watch it run
+journalctl -fu emf-dispatcher -o cat
+```
+
+## Install on Mac
+
+```sh
+cp ~/GitHub/emf/.claude/dispatcher/launchd/com.cklinker.emf-status.plist \
+   ~/Library/LaunchAgents/
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.cklinker.emf-status.plist
+
+# Verify
+cat /tmp/emf-status.txt   # refreshes every minute
+
+# Add an SSH config entry for worker-01 if not already
+cat >> ~/.ssh/config <<'EOF'
+Host worker-01
+  HostName 192.168.0.232
+  User craig
+EOF
+```
+
+## Live debugging
+
+```sh
+ssh worker-01
+
+# List active workers
+tmux ls
+
+# Attach to one (read-only — Ctrl+b d to detach)
+tmux attach -r -t emf-worker-TASK-2026-05-10-0001
+
+# Tail dispatcher log
+journalctl -fu emf-dispatcher -o cat
+
+# Tail per-task log
+tail -f /var/log/emf-dispatcher/TASK-2026-05-10-0001.jsonl | jq -c .
+```
+
+## Safety knobs
+
+- `MAX_PARALLEL=3` (env on systemd unit) — set to `0` to drain without claiming new work
+- `systemctl stop emf-dispatcher` — stops claiming; in-flight workers in tmux finish naturally
+- Move a task back: `cd ~/GitHub/emf-queue && git mv in-progress/TASK-X.md approved/TASK-X.md && git commit -m "manual release" && git push`
+- Pause everything: rename `approved/` to `approved.paused/` (the dispatcher's eligibility query returns nothing)
+
+## Failure modes + recovery
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Task stuck in `in-progress/` | tmux session died | Dispatcher prunes within one tick; manual: `queue_release_orphan` or `git mv in-progress/X.md approved/X.md` |
+| Two workers grabbed same task | Push race | Won't happen with `queue_push_with_retry` (commit + push, rebase on reject) |
+| PR opens but CI never runs | No runners online | `gh api /repos/cklinker/emf/actions/runners` — should show 12 idle on fc17 |
+| Migration collision | Two `needs_migration: true` tasks raced | Dispatcher's eligibility filter blocks if `_active-migration` exists; manual: `rm` the marker after manual fix |
+| Worker burns retries | Buggy task brief | Move to `failed/`, rewrite the brief in `inbox/`, re-promote via planner |
+
+## What this does NOT do (Phase 2+)
+
+- Planner: turn free-form `inbox/` briefs into structured `ready/` tasks
+- Plan-file linter: enforce frontmatter schema
+- Token-spend telemetry: per-task Anthropic cost rollup
+- Grafana dashboard

--- a/.claude/dispatcher/claim.sh
+++ b/.claude/dispatcher/claim.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Claim the next eligible task from emf-queue/approved/. Echoes the new
+# in-progress path on success (e.g. /home/craig/GitHub/emf-queue/in-progress/TASK-X.md).
+# Exits non-zero with no output if nothing claimable.
+#
+# Used by dispatch.sh in a loop. Standalone-callable for testing.
+#
+# Usage:
+#   .claude/dispatcher/claim.sh [--owner NAME]
+
+set -uo pipefail
+
+SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "$SELF_DIR/lib/log.sh"
+. "$SELF_DIR/lib/queue.sh"
+
+EMF_LOG_COMPONENT="claim"
+log_init "claim"
+
+OWNER="${HOSTNAME:-$(hostname)}"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --owner) OWNER="$2"; shift 2 ;;
+    -h|--help) sed -n '2,12p' "$0"; exit 0 ;;
+    *) echo "Unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+queue_pull >/dev/null 2>&1 || {
+  log_error "queue_pull failed"
+  exit 1
+}
+
+while IFS= read -r src; do
+  [[ -z "$src" ]] && continue
+  base="$(basename "$src")"
+  id="${base%.md}"
+
+  EMF_LOG_TASK_ID="$id"
+  log_event task_claim_attempt task="$id" file="$src"
+
+  dest="$(queue_claim "$src" "$OWNER")"
+  rc=$?
+  if (( rc == 0 )) && [[ -n "$dest" ]]; then
+    log_event task_claimed task="$id" owner="$OWNER" path="$dest"
+    echo "$dest"
+    exit 0
+  fi
+  log_warn "claim failed (rc=$rc), trying next" task="$id"
+done < <(queue_eligible_tasks)
+
+log_event no_eligible_tasks
+exit 1

--- a/.claude/dispatcher/dispatch.sh
+++ b/.claude/dispatcher/dispatch.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Dispatcher loop. Runs as a systemd service on worker-01.
+#
+# Each tick:
+#   1. Pull emf-queue + emf to latest
+#   2. Prune in-progress entries whose tmux worker died (release as orphan)
+#   3. Count active tmux sessions matching emf-worker-*
+#   4. While count < MAX_PARALLEL and there's an eligible task: claim + spawn
+#   5. Sleep TICK_SECONDS
+#
+# Workers run inside detached tmux sessions so the Mac side can attach for
+# live debugging without fighting with this loop.
+#
+# Env (override via systemd unit Environment= or shell):
+#   MAX_PARALLEL    default 3
+#   TICK_SECONDS    default 30
+#   EMF_REPO        default ~/GitHub/emf
+#   EMF_QUEUE_REPO  default ~/GitHub/emf-queue
+#   TMUX_PREFIX     default emf-worker
+
+set -uo pipefail
+
+SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "$SELF_DIR/lib/log.sh"
+. "$SELF_DIR/lib/queue.sh"
+
+MAX_PARALLEL="${MAX_PARALLEL:-3}"
+TICK_SECONDS="${TICK_SECONDS:-30}"
+EMF_REPO="${EMF_REPO:-$HOME/GitHub/emf}"
+EMF_QUEUE_REPO="${EMF_QUEUE_REPO:-$HOME/GitHub/emf-queue}"
+TMUX_PREFIX="${TMUX_PREFIX:-emf-worker}"
+
+EMF_LOG_COMPONENT="dispatch"
+log_init "dispatch"
+
+if ! command -v tmux >/dev/null 2>&1; then
+  log_error "tmux not found on PATH"
+  exit 2
+fi
+
+active_sessions() {
+  tmux ls 2>/dev/null | awk -F: -v p="$TMUX_PREFIX" '$1 ~ "^"p"-" {print $1}' | sort
+}
+
+prune_orphans() {
+  local active dead_count=0 owner sess
+  active="$(active_sessions)"
+  shopt -s nullglob
+  for f in "$EMF_QUEUE_REPO"/in-progress/*.md; do
+    owner="$(queue_get_field "$f" owner)"
+    if [[ "$owner" != "${HOSTNAME:-$(hostname)}" ]]; then
+      # Owned by another machine — leave it alone.
+      continue
+    fi
+    sess="$TMUX_PREFIX-$(basename "$f" .md)"
+    if ! grep -qx "$sess" <<<"$active"; then
+      log_warn "orphan detected, releasing" file="$f" session="$sess"
+      queue_release_orphan "$f" || true
+      dead_count=$((dead_count + 1))
+    fi
+  done
+  shopt -u nullglob
+  (( dead_count > 0 )) && log_info "released $dead_count orphan(s)"
+}
+
+spawn_worker() {
+  local task_file="$1"
+  local id sess
+  id="$(basename "$task_file" .md)"
+  sess="$TMUX_PREFIX-$id"
+
+  log_event spawn task="$id" session="$sess"
+  tmux new-session -d -s "$sess" \
+    "EMF_REPO='$EMF_REPO' EMF_QUEUE_REPO='$EMF_QUEUE_REPO' bash '$SELF_DIR/worker.sh' '$task_file'; sleep 5"
+}
+
+main_loop() {
+  log_event dispatch_start max_parallel="$MAX_PARALLEL" tick="$TICK_SECONDS"
+  while :; do
+    if ! git -C "$EMF_QUEUE_REPO" pull --rebase --autostash >/dev/null 2>&1; then
+      log_warn "queue pull failed; will retry next tick"
+    fi
+    if ! git -C "$EMF_REPO" pull --rebase --autostash main >/dev/null 2>&1; then
+      # Not fatal — workers fetch independently.
+      :
+    fi
+
+    prune_orphans
+
+    local active_count
+    active_count="$(active_sessions | wc -l | tr -d ' ')"
+
+    while (( active_count < MAX_PARALLEL )); do
+      local claimed
+      claimed="$("$SELF_DIR/claim.sh" --owner "${HOSTNAME:-$(hostname)}" 2>/dev/null)"
+      if [[ -z "$claimed" || ! -f "$claimed" ]]; then
+        break
+      fi
+      spawn_worker "$claimed"
+      active_count=$((active_count + 1))
+    done
+
+    sleep "$TICK_SECONDS"
+  done
+}
+
+main_loop

--- a/.claude/dispatcher/launchd/com.cklinker.emf-status.plist
+++ b/.claude/dispatcher/launchd/com.cklinker.emf-status.plist
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.cklinker.emf-status</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>-lc</string>
+    <string>/Users/craigklinker/GitHub/emf/.claude/dispatcher/status.sh > /tmp/emf-status.txt 2>&1</string>
+  </array>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>EMF_QUEUE_REPO</key>
+    <string>/Users/craigklinker/GitHub/emf-queue</string>
+    <key>WORKER_HOST</key>
+    <string>worker-01</string>
+    <key>PATH</key>
+    <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+  </dict>
+
+  <key>StartInterval</key>
+  <integer>60</integer>
+
+  <key>RunAtLoad</key>
+  <true/>
+
+  <key>StandardOutPath</key>
+  <string>/tmp/emf-status.launchd.log</string>
+  <key>StandardErrorPath</key>
+  <string>/tmp/emf-status.launchd.log</string>
+</dict>
+</plist>

--- a/.claude/dispatcher/lib/log.sh
+++ b/.claude/dispatcher/lib/log.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Structured logging for the dispatcher + workers. Emits one JSON object per
+# line so Promtail/Loki can ingest cleanly.
+#
+# Usage from another script:
+#   . .claude/dispatcher/lib/log.sh
+#   log_init dispatch       # sets EMF_LOG_COMPONENT for all subsequent calls
+#   log_info "starting loop" foo=bar count=3
+#   log_error "claim failed" task=$id reason="$msg"
+#   log_event task_claimed task=$id worker=$host
+#
+# Output sinks:
+#   - stderr (always; lets you tail in tmux)
+#   - $EMF_LOG_DIR/<component>.jsonl if EMF_LOG_DIR is set (default /var/log/emf-dispatcher)
+
+EMF_LOG_DIR="${EMF_LOG_DIR:-/var/log/emf-dispatcher}"
+EMF_LOG_COMPONENT="${EMF_LOG_COMPONENT:-uninit}"
+EMF_LOG_TASK_ID="${EMF_LOG_TASK_ID:-}"
+
+log_init() {
+  EMF_LOG_COMPONENT="$1"
+  if [[ -n "${EMF_LOG_DIR:-}" ]]; then
+    mkdir -p "$EMF_LOG_DIR" 2>/dev/null || EMF_LOG_DIR=""
+  fi
+}
+
+# Internal: emit one JSON line. Args: level, message, then key=value pairs.
+_log_emit() {
+  local level="$1"; shift
+  local msg="$1"; shift
+  local ts host pid line
+  ts="$(date -u +%Y-%m-%dT%H:%M:%S.%3NZ 2>/dev/null || date -u +%Y-%m-%dT%H:%M:%SZ)"
+  host="${HOSTNAME:-$(hostname)}"
+  pid=$$
+
+  # Build key=value pairs into JSON kv. Falls back gracefully if jq is missing.
+  if command -v jq >/dev/null 2>&1; then
+    local kv_args=()
+    local k v
+    for arg in "$@"; do
+      k="${arg%%=*}"; v="${arg#*=}"
+      kv_args+=(--arg "$k" "$v")
+    done
+    line="$(jq -nc \
+      --arg ts "$ts" --arg host "$host" --arg pid "$pid" \
+      --arg level "$level" --arg msg "$msg" \
+      --arg component "$EMF_LOG_COMPONENT" --arg task "$EMF_LOG_TASK_ID" \
+      "${kv_args[@]}" '
+        ($ARGS.named | with_entries(select(.value != ""))) +
+        {ts: $ts, host: $host, pid: ($pid|tonumber), level: $level,
+         msg: $msg, component: $component, task: $task}
+      ')"
+  else
+    # No jq: best-effort plain text.
+    line="$ts $level [$EMF_LOG_COMPONENT${EMF_LOG_TASK_ID:+/$EMF_LOG_TASK_ID}] $msg $*"
+  fi
+
+  printf '%s\n' "$line" >&2
+  if [[ -n "$EMF_LOG_DIR" && -d "$EMF_LOG_DIR" ]]; then
+    printf '%s\n' "$line" >> "$EMF_LOG_DIR/${EMF_LOG_COMPONENT}.jsonl" 2>/dev/null || true
+  fi
+}
+
+log_info()  { _log_emit info  "$@"; }
+log_warn()  { _log_emit warn  "$@"; }
+log_error() { _log_emit error "$@"; }
+log_event() {
+  # log_event <event_name> [k=v ...]
+  local event="$1"; shift
+  _log_emit event "$event" "$@"
+}

--- a/.claude/dispatcher/lib/queue.sh
+++ b/.claude/dispatcher/lib/queue.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+# Queue manipulation primitives for the dispatcher and workers.
+# All functions assume EMF_QUEUE_REPO points at a git working tree with the
+# six lifecycle dirs (inbox/ready/approved/in-progress/done/failed).
+#
+# Source this file from another script:
+#   . .claude/dispatcher/lib/queue.sh
+#
+# Functions:
+#   queue_pull                    — git pull --rebase --autostash
+#   queue_push_with_retry MSG     — commit (msg) and push, retry on race
+#   queue_get_field FILE FIELD    — read scalar frontmatter field
+#   queue_set_field FILE FIELD VAL— upsert scalar frontmatter field
+#   queue_eligible_tasks          — list approved/*.md eligible to claim
+#   queue_claim FILE              — atomic mv approved → in-progress
+#   queue_done FILE PR_NUM        — atomic mv in-progress → done
+#   queue_fail FILE REASON        — atomic mv in-progress → failed
+#   queue_release_orphan FILE     — mv in-progress → approved (worker died)
+
+EMF_QUEUE_REPO="${EMF_QUEUE_REPO:-$HOME/GitHub/emf-queue}"
+
+# ---- Internal helpers --------------------------------------------------------
+
+_q() { git -C "$EMF_QUEUE_REPO" "$@"; }
+
+_q_in_progress_count_by_owner() {
+  local owner="$1"
+  local n=0 f
+  for f in "$EMF_QUEUE_REPO"/in-progress/*.md; do
+    [[ -e "$f" ]] || continue
+    [[ "$(queue_get_field "$f" owner)" == "$owner" ]] && n=$((n+1))
+  done
+  echo "$n"
+}
+
+# ---- Public API --------------------------------------------------------------
+
+queue_pull() {
+  _q pull --rebase --autostash 2>&1 || return 1
+}
+
+queue_push_with_retry() {
+  local msg="$1"
+  local tries=0
+  while (( tries < 3 )); do
+    _q add -A
+    if _q diff --cached --quiet; then
+      return 0   # nothing to commit
+    fi
+    _q commit -m "$msg" >/dev/null 2>&1 || return 2
+    if _q push 2>/dev/null; then
+      return 0
+    fi
+    tries=$((tries+1))
+    _q pull --rebase --autostash >/dev/null 2>&1 || return 3
+  done
+  return 4
+}
+
+# Read a scalar frontmatter field: 'foo: bar' → echoes 'bar'.
+queue_get_field() {
+  local file="$1" field="$2"
+  awk -v f="$field" '
+    BEGIN{in_fm=0}
+    /^---[[:space:]]*$/{ in_fm = (in_fm ? 0 : 1); next }
+    in_fm && $0 ~ "^"f":[[:space:]]" {
+      sub("^"f":[[:space:]]*", "")
+      sub(/^"/, ""); sub(/"$/, "")
+      sub(/^'\''/, ""); sub(/'\''$/, "")
+      print; exit
+    }
+  ' "$file"
+}
+
+# Upsert a scalar frontmatter field. Inserts before the closing '---' if
+# the field doesn't exist.
+queue_set_field() {
+  local file="$1" field="$2" val="$3"
+  if grep -q "^${field}:" "$file" 2>/dev/null; then
+    sed -i.bak -E "s|^${field}:.*|${field}: ${val}|" "$file" && rm -f "${file}.bak"
+  else
+    awk -v line="${field}: ${val}" '
+      BEGIN{seen=0; inserted=0}
+      /^---[[:space:]]*$/{
+        if (seen==0){ print; seen=1; next }
+        if (seen==1 && !inserted){ print line; inserted=1 }
+      }
+      {print}
+    ' "$file" > "$file.tmp" && mv "$file.tmp" "$file"
+  fi
+}
+
+# List approved tasks in claim order. Filters:
+#   - status: approved
+#   - depends_on: every dep id must be in done/
+#   - parallel_safe: false → only if no other in-progress task exists
+#   - needs_migration: true → only if _active-migration marker absent
+# Sort: priority asc, then created_at asc.
+queue_eligible_tasks() {
+  local active_in_progress=0
+  active_in_progress=$(ls "$EMF_QUEUE_REPO"/in-progress/*.md 2>/dev/null | wc -l | tr -d ' ')
+  local migration_locked="false"
+  [[ -f "$EMF_QUEUE_REPO/_active-migration" ]] && migration_locked="true"
+
+  local tmp
+  tmp="$(mktemp -t qeligible.XXXX)"
+  local f
+  for f in "$EMF_QUEUE_REPO"/approved/*.md; do
+    [[ -e "$f" ]] || continue
+    local id pri created par_safe needs_mig deps eligible=1
+    id="$(queue_get_field "$f" id)"
+    pri="$(queue_get_field "$f" priority)"; pri="${pri:-5}"
+    created="$(queue_get_field "$f" created_at)"
+    par_safe="$(queue_get_field "$f" parallel_safe)"
+    needs_mig="$(queue_get_field "$f" needs_migration)"
+    deps="$(queue_get_field "$f" depends_on)"
+
+    # Migration lock
+    if [[ "$needs_mig" == "true" && "$migration_locked" == "true" ]]; then
+      eligible=0
+    fi
+    # Parallel-safe check: if any other in-progress task exists and this one
+    # isn't parallel_safe, skip.
+    if [[ "$par_safe" == "false" && "$active_in_progress" -gt 0 ]]; then
+      eligible=0
+    fi
+    # Dependency check: every id in depends_on must be in done/.
+    if [[ -n "$deps" && "$deps" != "[]" ]]; then
+      local d_ids
+      d_ids="$(printf '%s\n' "$deps" | tr -d '[]" ' | tr ',' '\n')"
+      local d
+      for d in $d_ids; do
+        [[ -z "$d" ]] && continue
+        if [[ ! -f "$EMF_QUEUE_REPO/done/$d.md" ]]; then
+          eligible=0; break
+        fi
+      done
+    fi
+    if (( eligible == 1 )); then
+      printf '%s\t%s\t%s\n' "$pri" "$created" "$f" >> "$tmp"
+    fi
+  done
+
+  sort -k1,1n -k2,2 "$tmp" | cut -f3
+  rm -f "$tmp"
+}
+
+# Atomic claim. Echoes the new in-progress path, or empty + nonzero exit on race.
+queue_claim() {
+  local src="$1"
+  local owner="${2:-${HOSTNAME:-$(hostname)}}"
+  local base id dest branch attempts
+  base="$(basename "$src")"
+  id="${base%.md}"
+  dest="$EMF_QUEUE_REPO/in-progress/$base"
+  branch="autopilot/$id"
+  attempts="$(queue_get_field "$src" attempts)"; attempts="${attempts:-0}"
+
+  queue_pull >/dev/null 2>&1 || return 1
+  if [[ ! -f "$src" ]]; then
+    return 2   # someone else claimed it during pull
+  fi
+
+  _q mv "approved/$base" "in-progress/$base"
+  queue_set_field "$dest" status "in_progress"
+  queue_set_field "$dest" owner "$owner"
+  queue_set_field "$dest" branch "$branch"
+  queue_set_field "$dest" attempts "$((attempts + 1))"
+
+  if queue_push_with_retry "claim $id by $owner (attempt $((attempts + 1)))"; then
+    echo "$dest"
+    return 0
+  fi
+  return 3
+}
+
+queue_done() {
+  local src="$1" pr="$2"
+  local base id dest
+  base="$(basename "$src")"
+  id="${base%.md}"
+  dest="$EMF_QUEUE_REPO/done/$base"
+
+  _q mv "in-progress/$base" "done/$base"
+  queue_set_field "$dest" status "done"
+  [[ -n "$pr" ]] && queue_set_field "$dest" pr "$pr"
+
+  # If this task held the migration lock, release it.
+  local needs_mig
+  needs_mig="$(queue_get_field "$dest" needs_migration)"
+  if [[ "$needs_mig" == "true" && -f "$EMF_QUEUE_REPO/_active-migration" ]]; then
+    _q rm -f "_active-migration" >/dev/null 2>&1
+  fi
+
+  queue_push_with_retry "done $id (pr #$pr)"
+}
+
+queue_fail() {
+  local src="$1" reason="$2"
+  local base id dest
+  base="$(basename "$src")"
+  id="${base%.md}"
+  dest="$EMF_QUEUE_REPO/failed/$base"
+
+  _q mv "in-progress/$base" "failed/$base"
+  queue_set_field "$dest" status "failed"
+  queue_set_field "$dest" fail_reason "${reason//$'\n'/ }"
+
+  # Release migration lock if held.
+  local needs_mig
+  needs_mig="$(queue_get_field "$dest" needs_migration)"
+  if [[ "$needs_mig" == "true" && -f "$EMF_QUEUE_REPO/_active-migration" ]]; then
+    _q rm -f "_active-migration" >/dev/null 2>&1
+  fi
+
+  queue_push_with_retry "fail $id: ${reason:0:80}"
+}
+
+queue_release_orphan() {
+  local src="$1"
+  local base id
+  base="$(basename "$src")"
+  id="${base%.md}"
+  _q mv "in-progress/$base" "approved/$base" 2>/dev/null
+  queue_set_field "$EMF_QUEUE_REPO/approved/$base" status "approved"
+  queue_set_field "$EMF_QUEUE_REPO/approved/$base" owner "null"
+  queue_push_with_retry "release orphan $id (worker died)"
+}

--- a/.claude/dispatcher/status.sh
+++ b/.claude/dispatcher/status.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Print a one-screen summary of the autopilot queue + worker state.
+# Safe to run on either machine. On the Mac, optionally SSHes to worker-01
+# to fetch tmux session list.
+#
+# Usage:
+#   .claude/dispatcher/status.sh            # default: pull queue, print table
+#   .claude/dispatcher/status.sh --no-pull  # skip git pull (faster, may be stale)
+#
+# Mac launchd plist (com.cklinker.emf-status.plist) runs this every minute.
+
+set -uo pipefail
+
+SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "$SELF_DIR/lib/queue.sh"
+
+EMF_QUEUE_REPO="${EMF_QUEUE_REPO:-$HOME/GitHub/emf-queue}"
+WORKER_HOST="${WORKER_HOST:-worker-01}"
+DO_PULL=1
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --no-pull) DO_PULL=0; shift ;;
+    -h|--help) sed -n '2,12p' "$0"; exit 0 ;;
+    *) echo "Unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+if (( DO_PULL )); then
+  git -C "$EMF_QUEUE_REPO" pull --rebase --autostash >/dev/null 2>&1 || true
+fi
+
+count() { ls -1 "$EMF_QUEUE_REPO/$1"/*.md 2>/dev/null | wc -l | tr -d ' '; }
+
+I=$(count inbox)
+R=$(count ready)
+A=$(count approved)
+IP=$(count in-progress)
+D=$(count done)
+F=$(count failed)
+
+migration_lock="—"
+[[ -f "$EMF_QUEUE_REPO/_active-migration" ]] && migration_lock="HELD"
+
+# Workers (only meaningful from the Mac; on worker-01 itself, just `tmux ls`).
+workers=""
+if command -v tmux >/dev/null 2>&1 && tmux ls 2>/dev/null | grep -q '^emf-worker-'; then
+  workers="$(tmux ls 2>/dev/null | awk -F: '$1 ~ /^emf-worker-/ {print $1}')"
+elif command -v ssh >/dev/null 2>&1 && [[ "$WORKER_HOST" != "$(hostname)" ]]; then
+  workers="$(ssh -o ConnectTimeout=3 -o BatchMode=yes "$WORKER_HOST" \
+    "tmux ls 2>/dev/null | awk -F: '\$1 ~ /^emf-worker-/ {print \$1}'" 2>/dev/null || true)"
+fi
+worker_count="$(printf '%s\n' "$workers" | grep -c emf-worker- || true)"
+
+# Recently merged (last 5).
+recent_done="$(ls -1t "$EMF_QUEUE_REPO/done"/*.md 2>/dev/null | head -5 | xargs -n1 basename 2>/dev/null | sed 's/\.md$//')"
+
+cat <<EOF
+─── EMF autopilot status ───  $(date '+%Y-%m-%d %H:%M:%S')
+
+Queue:
+  inbox:       $I
+  ready:       $R   (planner output, awaiting your review)
+  approved:    $A
+  in-progress: $IP
+  done:        $D
+  failed:      $F   $( (( F > 0 )) && echo '⚠ triage needed' )
+
+Locks:
+  migration:   $migration_lock
+
+Workers ($worker_count active on $WORKER_HOST):
+${workers:-  (none)}
+
+Recently merged:
+${recent_done:-  (none)}
+EOF

--- a/.claude/dispatcher/systemd/emf-dispatcher.service
+++ b/.claude/dispatcher/systemd/emf-dispatcher.service
@@ -1,0 +1,43 @@
+[Unit]
+Description=EMF autopilot dispatcher (worker-01)
+Documentation=https://github.com/cklinker/emf/blob/main/.claude/dispatcher/README.md
+After=network-online.target docker.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=craig
+Group=craig
+WorkingDirectory=/home/craig/GitHub/emf
+ExecStart=/bin/bash /home/craig/GitHub/emf/.claude/dispatcher/dispatch.sh
+
+# --- Environment ---
+Environment=MAX_PARALLEL=3
+Environment=TICK_SECONDS=30
+Environment=EMF_REPO=/home/craig/GitHub/emf
+Environment=EMF_QUEUE_REPO=/home/craig/GitHub/emf-queue
+Environment=EMF_WT_ROOT=/var/lib/emf-wt
+Environment=EMF_LOG_DIR=/var/log/emf-dispatcher
+Environment=ANTHROPIC_LOG=info
+# Make sure tmux + claude + gh + node + java are on PATH for non-login shells.
+Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+# --- Restart + safety ---
+Restart=always
+RestartSec=10
+TimeoutStartSec=60
+TimeoutStopSec=30
+KillMode=mixed
+KillSignal=SIGTERM
+
+# --- Logging ---
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=emf-dispatcher
+
+# --- Resource hints (workers run in tmux outside this cgroup) ---
+MemoryAccounting=yes
+CPUAccounting=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/.claude/dispatcher/worker-prompt.md
+++ b/.claude/dispatcher/worker-prompt.md
@@ -1,0 +1,50 @@
+You are an autopilot worker for the Kelta Platform. You run inside a dedicated git worktree on the Linux box `worker-01` (craig@192.168.0.232). Your job is to take ONE task from the queue, implement it correctly, and stop. The shell wrapper around you handles git push, PR creation, CI watching, and queue archival — those are NOT your responsibility.
+
+# Your task
+
+Your task file is at `$EMF_TASK_FILE`. Read it first. The frontmatter tells you:
+- `id` — stable task identifier (e.g. `TASK-2026-05-10-0001`)
+- `type` — `feature` | `bug` | `chore` | `doc` | `security`
+- `source_plan` — optional path to a detailed plan in `~/.claude/plans/`
+- `parallel_safe` — if `false`, you must avoid touching shared registries / config caches
+- `needs_migration` — if `true`, you MUST run the migration claim before writing any `V<N>__*.sql` file (see below)
+- `needs_doc_update` — list of `.claude/docs/*.md` files you must touch
+- `branch` — the git branch your worktree is already on (`autopilot/<id>`)
+
+The body of the task file is a free-text brief. If a `source_plan` is set, read it — the brief is just a pointer.
+
+# Hard rules
+
+1. **Stay in the current worktree.** You're at `/var/lib/emf-wt/<id>` on a feature branch. Don't `cd` out, don't `git checkout`, don't `git push` (the wrapper handles push). One commit per logical step is fine.
+2. **Run `bash .claude/commands/verify.sh` before signaling done.** It builds runtime + tests gateway + tests worker + lints/tests kelta-web + (conditionally) kelta-ui. Must exit 0.
+3. **For `type: feature` you must add at least one test** — a `*Test.java` for backend, a `*.test.ts` / `*.test.tsx` for frontend, plus an `e2e-tests/**/*.spec.ts` if the change is user-visible. The `require-tests.sh` Stop hook enforces this.
+4. **For migrations**: if `needs_migration: true`, run `bash scripts/migration-claim.sh --task-file "$EMF_TASK_FILE"` BEFORE writing the migration file. It returns the next free `V<N>` and stamps the claim into your task file. Use that exact `V<N>` in the filename. Don't pick your own number.
+5. **Update docs as required.** If `needs_doc_update` lists `architecture.md`, you must edit `.claude/docs/architecture.md`. The `pre-pr-gate.sh` hook will block if you don't.
+6. **Append one line to `.claude/CHANGELOG.md`** describing the change. Format: `- YYYY-MM-DD <type>(<scope>): <one-line summary> (<task-id>)`.
+7. **Never push to main.** Never use `--no-verify`. Never `git reset --hard`. The `guard-bash.sh` hook will block these. If you hit a build error, fix the root cause; don't bypass the gate.
+8. **Code style**: follow existing patterns in the codebase. Check [CLAUDE.md](../../CLAUDE.md) and [.claude/docs/conventions.md](../../.claude/docs/conventions.md). No unnecessary abstractions, no comments explaining what well-named code already says.
+
+# Workflow
+
+1. Read `$EMF_TASK_FILE` end-to-end. If `source_plan` is set, read it.
+2. Search the codebase for existing patterns related to the task (use the Explore agent if scope is uncertain).
+3. Make the changes. Small, focused commits inside the worktree are fine.
+4. Add tests (for `feature` and most `bug` tasks). Run them locally as you go (`mvn -pl <module> test` or `cd kelta-ui/app && npm run test:run`).
+5. If you add a migration, claim it first via `migration-claim.sh`.
+6. Update `.claude/docs/*.md` for any required changes.
+7. Append the changelog line.
+8. Run `bash .claude/commands/verify.sh`. If it fails, iterate. Up to `max_attempts` per the task.
+9. Stop. The wrapper takes over from here (push + PR + watch + archive).
+
+# What the wrapper does after you stop
+
+- `git push -u origin <branch>`
+- `gh pr create --label autopilot --fill` (the auto-merge workflow squash-merges on green CI)
+- Polls `gh pr checks` until conclusion (timeout 30 min)
+- On success: marks the task done in the queue, removes the worktree
+- On CI failure: re-launches you with the failure context appended to the task brief, up to `max_attempts`
+- On `max_attempts` exhausted: moves the task to `failed/` with the diagnostic
+
+# When you can't make progress
+
+If after honest effort you can't complete the task (ambiguous brief, blocked on missing infra, the task is wrong about how something works), STOP and write a `BLOCKED.md` file in the worktree root explaining what's needed. The wrapper will pick that up, mark the task `failed`, and write the contents into the failure record. Don't half-implement and stop; that wastes the next attempt.

--- a/.claude/dispatcher/worker.sh
+++ b/.claude/dispatcher/worker.sh
@@ -1,0 +1,238 @@
+#!/usr/bin/env bash
+# Per-task worker. Runs ONE task end-to-end:
+#   1. Create worktree at $EMF_WT_ROOT/<task-id> on a fresh branch off origin/main
+#   2. Invoke `claude -p` with the worker-prompt, passing the task brief
+#   3. Run /verify (defensive — the worker also runs it inside the session)
+#   4. Push branch, open PR with autopilot label
+#   5. Poll `gh pr checks` until conclusion
+#   6. On success: queue_done; on retryable failure: re-loop up to max_attempts
+#   7. On exhausted retries: queue_fail; always: remove the worktree
+#
+# Designed to run inside a tmux session named emf-worker-<task-id> so the
+# Mac side can attach for live debugging.
+#
+# Usage:
+#   .claude/dispatcher/worker.sh <task-file>
+#
+# Env:
+#   EMF_REPO        path to the EMF main repo (default ~/GitHub/emf)
+#   EMF_QUEUE_REPO  path to emf-queue (default ~/GitHub/emf-queue)
+#   EMF_WT_ROOT     worktree root (default /var/lib/emf-wt)
+#   CLAUDE_BIN      claude CLI path (default 'claude' from PATH)
+#   PR_TIMEOUT_MIN  how long to wait for CI (default 30)
+
+set -uo pipefail
+
+SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "$SELF_DIR/lib/log.sh"
+. "$SELF_DIR/lib/queue.sh"
+
+EMF_REPO="${EMF_REPO:-$HOME/GitHub/emf}"
+EMF_QUEUE_REPO="${EMF_QUEUE_REPO:-$HOME/GitHub/emf-queue}"
+EMF_WT_ROOT="${EMF_WT_ROOT:-/var/lib/emf-wt}"
+CLAUDE_BIN="${CLAUDE_BIN:-claude}"
+PR_TIMEOUT_MIN="${PR_TIMEOUT_MIN:-30}"
+
+TASK_FILE="${1:-}"
+[[ -n "$TASK_FILE" && -f "$TASK_FILE" ]] || { echo "Usage: $0 <task-file>" >&2; exit 2; }
+
+EMF_LOG_COMPONENT="worker"
+log_init "worker"
+ID="$(basename "$TASK_FILE" .md)"
+EMF_LOG_TASK_ID="$ID"
+
+BRANCH="$(queue_get_field "$TASK_FILE" branch)"
+[[ -z "$BRANCH" ]] && BRANCH="autopilot/$ID"
+WT="$EMF_WT_ROOT/$ID"
+ATTEMPTS="$(queue_get_field "$TASK_FILE" attempts)"; ATTEMPTS="${ATTEMPTS:-1}"
+MAX_ATTEMPTS="$(queue_get_field "$TASK_FILE" max_attempts)"; MAX_ATTEMPTS="${MAX_ATTEMPTS:-3}"
+
+cleanup_worktree() {
+  if [[ -d "$WT" ]]; then
+    log_info "removing worktree" path="$WT"
+    git -C "$EMF_REPO" worktree remove --force "$WT" 2>/dev/null || rm -rf "$WT"
+  fi
+}
+trap cleanup_worktree EXIT
+
+# ---- 1. Worktree ------------------------------------------------------------
+
+log_event worker_start task="$ID" attempts="$ATTEMPTS" max="$MAX_ATTEMPTS" branch="$BRANCH"
+
+if ! git -C "$EMF_REPO" fetch --quiet origin main; then
+  log_error "git fetch failed"
+  queue_fail "$TASK_FILE" "git fetch origin main failed"
+  exit 1
+fi
+
+mkdir -p "$EMF_WT_ROOT"
+if [[ -d "$WT" ]]; then
+  log_warn "stale worktree exists, removing" path="$WT"
+  git -C "$EMF_REPO" worktree remove --force "$WT" 2>/dev/null || rm -rf "$WT"
+fi
+
+if ! git -C "$EMF_REPO" worktree add "$WT" -b "$BRANCH" origin/main 2>&1; then
+  log_error "worktree add failed"
+  queue_fail "$TASK_FILE" "worktree add failed"
+  exit 1
+fi
+log_info "worktree created" path="$WT"
+
+# ---- 2. Claude session ------------------------------------------------------
+
+WORKER_PROMPT="$WT/.claude/dispatcher/worker-prompt.md"
+[[ -f "$WORKER_PROMPT" ]] || { log_error "worker-prompt missing" path="$WORKER_PROMPT"; queue_fail "$TASK_FILE" "worker-prompt.md missing in worktree"; exit 1; }
+
+USER_PROMPT="$(cat <<EOF
+Begin task ${ID}.
+
+Task file (already read by you via \$EMF_TASK_FILE = ${TASK_FILE}):
+
+\`\`\`
+$(cat "$TASK_FILE")
+\`\`\`
+
+Work in the current directory ($WT). Stop only when /verify is green and you have followed all hard rules in the worker-prompt. Do not push or open a PR — the wrapper does that.
+EOF
+)"
+
+cd "$WT" || { log_error "cd to worktree failed"; queue_fail "$TASK_FILE" "cd worktree failed"; exit 1; }
+
+JSONL_LOG="${EMF_LOG_DIR:-/var/log/emf-dispatcher}/${ID}.jsonl"
+mkdir -p "$(dirname "$JSONL_LOG")" 2>/dev/null || true
+
+log_event claude_start task="$ID" log="$JSONL_LOG"
+EMF_TASK_FILE="$TASK_FILE" \
+  "$CLAUDE_BIN" \
+    -p "$USER_PROMPT" \
+    --append-system-prompt "$(cat "$WORKER_PROMPT")" \
+    --output-format stream-json \
+    --include-partial-messages \
+    --verbose \
+    --dangerously-skip-permissions \
+  >> "$JSONL_LOG" 2>&1
+CLAUDE_RC=$?
+log_event claude_end task="$ID" rc="$CLAUDE_RC"
+
+# ---- 3. Self-blocked check --------------------------------------------------
+
+if [[ -f "$WT/BLOCKED.md" ]]; then
+  reason="$(cat "$WT/BLOCKED.md")"
+  log_warn "worker self-blocked" reason="${reason:0:100}"
+  queue_fail "$TASK_FILE" "BLOCKED: ${reason:0:200}"
+  exit 0
+fi
+
+# ---- 4. Defensive /verify ---------------------------------------------------
+
+log_event verify_start task="$ID"
+if ! bash "$WT/.claude/commands/verify.sh" >> "$JSONL_LOG" 2>&1; then
+  log_error "/verify failed after claude session"
+  if (( ATTEMPTS < MAX_ATTEMPTS )); then
+    log_info "will retry on next dispatch cycle (queue_release_orphan)" attempts="$ATTEMPTS" max="$MAX_ATTEMPTS"
+    queue_release_orphan "$TASK_FILE"
+  else
+    queue_fail "$TASK_FILE" "/verify failed after $MAX_ATTEMPTS attempts"
+  fi
+  exit 1
+fi
+log_event verify_end task="$ID"
+
+# ---- 5. Push + PR -----------------------------------------------------------
+
+# If nothing changed, the worker did nothing useful. Treat as failure.
+if git -C "$WT" diff --quiet origin/main && [[ -z "$(git -C "$WT" status --porcelain)" ]]; then
+  log_error "no changes after worker session"
+  if (( ATTEMPTS < MAX_ATTEMPTS )); then
+    queue_release_orphan "$TASK_FILE"
+  else
+    queue_fail "$TASK_FILE" "worker produced no diff after $MAX_ATTEMPTS attempts"
+  fi
+  exit 1
+fi
+
+# Stage anything left unstaged + create a final commit if needed.
+git -C "$WT" add -A
+if ! git -C "$WT" diff --cached --quiet; then
+  git -C "$WT" commit -m "autopilot: $ID — final commit by worker.sh" >/dev/null
+fi
+
+if ! git -C "$WT" push -u origin "$BRANCH" 2>&1; then
+  log_error "git push failed"
+  queue_fail "$TASK_FILE" "git push origin $BRANCH failed"
+  exit 1
+fi
+log_event branch_pushed task="$ID" branch="$BRANCH"
+
+PR_URL="$(gh pr create --label autopilot --fill --head "$BRANCH" 2>&1 | tail -1)"
+if [[ "$PR_URL" != https://github.com/* ]]; then
+  log_error "gh pr create failed" output="$PR_URL"
+  queue_fail "$TASK_FILE" "gh pr create failed: ${PR_URL:0:120}"
+  exit 1
+fi
+PR_NUM="${PR_URL##*/}"
+log_event pr_opened task="$ID" pr="$PR_NUM" url="$PR_URL"
+queue_set_field "$TASK_FILE" pr "$PR_NUM"
+
+# ---- 6. Poll CI -------------------------------------------------------------
+
+deadline=$(( $(date +%s) + PR_TIMEOUT_MIN * 60 ))
+poll_interval=30
+final_state=""
+
+while (( $(date +%s) < deadline )); do
+  raw="$(gh pr view "$PR_NUM" --json state,mergedAt,statusCheckRollup 2>/dev/null)"
+  state="$(printf '%s' "$raw" | jq -r '.state // "UNKNOWN"')"
+  merged_at="$(printf '%s' "$raw" | jq -r '.mergedAt // ""')"
+
+  if [[ "$state" == "MERGED" || -n "$merged_at" ]]; then
+    final_state="MERGED"; break
+  fi
+  if [[ "$state" == "CLOSED" ]]; then
+    final_state="CLOSED"; break
+  fi
+
+  failures="$(printf '%s' "$raw" | jq -r '
+    [.statusCheckRollup[]?
+     | select((.conclusion // .state // "") | ascii_downcase
+              | IN("failure","failed","cancelled","timed_out","action_required","startup_failure"))
+     | (.name // .context // "?")
+    ] | join(",")
+  ')"
+  if [[ -n "$failures" && "$failures" != "" ]]; then
+    final_state="CHECK_FAIL"
+    log_warn "ci checks failed" failures="$failures"
+    break
+  fi
+
+  sleep "$poll_interval"
+done
+
+if [[ -z "$final_state" ]]; then
+  final_state="TIMEOUT"
+  log_warn "ci poll timed out" minutes="$PR_TIMEOUT_MIN"
+fi
+
+# ---- 7. Archive -------------------------------------------------------------
+
+case "$final_state" in
+  MERGED)
+    log_event task_done task="$ID" pr="$PR_NUM"
+    queue_done "$TASK_FILE" "$PR_NUM"
+    ;;
+  CHECK_FAIL|CLOSED|TIMEOUT)
+    if (( ATTEMPTS < MAX_ATTEMPTS )); then
+      log_info "releasing for retry" final_state="$final_state" attempts="$ATTEMPTS" max="$MAX_ATTEMPTS"
+      # Close the PR so the next attempt opens a fresh one.
+      gh pr close "$PR_NUM" --comment "autopilot retry: closing to relaunch on attempt $((ATTEMPTS + 1))" >/dev/null 2>&1 || true
+      git -C "$EMF_REPO" push origin --delete "$BRANCH" >/dev/null 2>&1 || true
+      queue_release_orphan "$TASK_FILE"
+    else
+      log_error "exhausted retries" final_state="$final_state" attempts="$ATTEMPTS"
+      queue_fail "$TASK_FILE" "$final_state after $MAX_ATTEMPTS attempts (pr #$PR_NUM)"
+    fi
+    ;;
+  *)
+    queue_fail "$TASK_FILE" "unexpected final state: $final_state"
+    ;;
+esac


### PR DESCRIPTION
## Summary

Phase 1 of [the autopilot plan](https://github.com/cklinker/emf/blob/main/.claude/plans/). Builds on the Phase 0 scaffolding ([#834](https://github.com/cklinker/emf/pull/834)) — composes hooks, migration claim, rollback, and auto-merge into a running system on \`worker-01\`.

- **\`dispatch.sh\`** — outer loop, runs as systemd unit \`emf-dispatcher.service\`. \`MAX_PARALLEL=3\`. Spawns workers in detached tmux sessions for live SSH-attach debugging.
- **\`worker.sh\`** — per-task: worktree → \`claude -p\` with worker-prompt → \`/verify\` → push → autopilot PR → poll CI → archive.
- **\`claim.sh\`** — atomic claim respecting \`parallel_safe\`, \`depends_on\`, and the migration lock.
- **\`worker-prompt.md\`** — system prompt for every worker session. Hard rules enforced by the Phase 0 hooks.
- **\`lib/queue.sh\`** + **\`lib/log.sh\`** — primitives.
- **\`systemd/emf-dispatcher.service\`** + **\`launchd/com.cklinker.emf-status.plist\`** — boot scripts for both machines.
- **\`status.sh\`** — one-screen queue summary.
- **\`README.md\`** — install + live-debug + recovery.

## Test plan

- [x] \`bash -n\` syntax check on all 7 scripts: clean
- [x] \`queue_get_field\` / \`queue_set_field\` round-trip on a temp queue: frontmatter mutates correctly
- [x] \`status.sh\` against the live \`emf-queue\` post Phase 0 merge: prints zeros across all dirs
- [ ] After merge: install systemd unit on worker-01, enable, watch \`journalctl -fu emf-dispatcher\` start the loop
- [ ] After merge: install launchd plist on Mac, verify \`/tmp/emf-status.txt\` refreshes every 60 s
- [ ] After merge: hand-write 1 trivial task in \`emf-queue/approved/\`, watch the loop claim it within 30 s, watch the worker complete + auto-merge a PR

## Docs touched

- [x] \`.claude/dispatcher/README.md\` — install + ops + recovery (new file)
- [ ] \`.claude/docs/architecture.md\` — autopilot loop is new; doc update lands when the planner ships in Phase 2 (so the architecture doc covers the full system at once, not in pieces)

## Migration

- N/A

## Autopilot

- [ ] **Do NOT autopilot-label this PR.** Hand review — these scripts will run unattended on \`worker-01\`.

## Risk

Low until I install the systemd unit. The scripts can sit in main without doing anything (nothing invokes them). Bring-up is a separate manual step.

## Follow-ups

- Phase 2: planner agent on Mac + plan-file linter
- Phase 3: token-spend telemetry from stream-json + Grafana dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)