### PR TITLE
fix(verify): include runtime-messaging-nats in build list

### DIFF
--- a/.claude/commands/verify.md
+++ b/.claude/commands/verify.md
@@ -4,7 +4,7 @@ Run these steps in order, stopping on any failure:
 
 ## Step 1: Build runtime modules (dependency for gateway and worker)
 ```bash
-mvn clean install -DskipTests -f kelta-platform/pom.xml -pl runtime/runtime-core,runtime/runtime-events,runtime/runtime-jsonapi,runtime/runtime-module-core,runtime/runtime-module-integration,runtime/runtime-module-schema -am -B
+mvn clean install -DskipTests -f kelta-platform/pom.xml -pl runtime/runtime-core,runtime/runtime-events,runtime/runtime-messaging-nats,runtime/runtime-jsonapi,runtime/runtime-module-core,runtime/runtime-module-integration,runtime/runtime-module-schema -am -B
 ```
 
 ## Step 2: Run gateway tests

--- a/.claude/commands/verify.sh
+++ b/.claude/commands/verify.sh
@@ -16,7 +16,7 @@ fail() { echo "FAILED: $1" >&2; exit 1; }
 step "1/5 build runtime modules"
 mvn clean install -DskipTests \
   -f kelta-platform/pom.xml \
-  -pl runtime/runtime-core,runtime/runtime-events,runtime/runtime-jsonapi,runtime/runtime-module-core,runtime/runtime-module-integration,runtime/runtime-module-schema \
+  -pl runtime/runtime-core,runtime/runtime-events,runtime/runtime-messaging-nats,runtime/runtime-jsonapi,runtime/runtime-module-core,runtime/runtime-module-integration,runtime/runtime-module-schema \
   -am -B \
   || fail "runtime build"
 


### PR DESCRIPTION
## Summary

\`/verify\` (both \`.claude/commands/verify.sh\` and \`.claude/commands/verify.md\`) listed only 6 of 7 runtime modules in the \`-pl\` filter. \`kelta-gateway\` depends on \`io.kelta:runtime-messaging-nats:jar:1.0.0-SNAPSHOT\`, so the gateway test step fails on a clean \`.m2\` cache:

\`\`\`
[ERROR] Failed to execute goal on project kelta-gateway: Could not resolve dependencies
        for project io.kelta:kelta-gateway:jar:1.0.0-SNAPSHOT:
        Could not find artifact io.kelta:runtime-messaging-nats:jar:1.0.0-SNAPSHOT
\`\`\`

\`ci.yml\`'s \`test-java\` job already had the correct 7-module list — only the local-callable command was stale. Caught by the first autopilot worker smoke task (\`CHORE-2026-05-10-0001\`) on \`worker-01\`.

## Test plan

- [x] verify.sh and verify.md both updated with \`runtime-messaging-nats\` in the \`-pl\` list (matching ci.yml)
- [ ] After merge: re-run the smoke task; expect step 1 (runtime build) and step 2 (gateway tests) to both pass

## Docs touched

- N/A — no behavior change beyond restoring parity with CI

## Migration

- N/A

## Autopilot

- [x] **Autopilot-label this one.** Trivial 2-line fix; auto-merge on green is fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)