### PR TITLE
feat(autopilot): Phase 2 planner + plan-file linter

### DIFF
--- a/.claude/dispatcher/launchd/com.cklinker.emf-planner.plist
+++ b/.claude/dispatcher/launchd/com.cklinker.emf-planner.plist
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.cklinker.emf-planner</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>-lc</string>
+    <string>/Users/craigklinker/GitHub/emf/.claude/planner/planner.sh</string>
+  </array>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>EMF_REPO</key>
+    <string>/Users/craigklinker/GitHub/emf</string>
+    <key>EMF_QUEUE_REPO</key>
+    <string>/Users/craigklinker/GitHub/emf-queue</string>
+    <key>PATH</key>
+    <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+  </dict>
+
+  <key>StartInterval</key>
+  <integer>600</integer>
+
+  <key>RunAtLoad</key>
+  <false/>
+
+  <key>StandardOutPath</key>
+  <string>/tmp/emf-planner.launchd.log</string>
+  <key>StandardErrorPath</key>
+  <string>/tmp/emf-planner.launchd.log</string>
+</dict>
+</plist>

--- a/.claude/planner/lint-plan.sh
+++ b/.claude/planner/lint-plan.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Validate task-file frontmatter against the JSON Schema in
+# emf-queue/schemas/task-frontmatter.schema.json.
+#
+# Usage:
+#   .claude/planner/lint-plan.sh <task-file.md> [<task-file.md> ...]
+#   .claude/planner/lint-plan.sh --all      # lint every .md in emf-queue/{ready,approved,in-progress,done,failed}
+#
+# Exit:
+#   0 — every file valid
+#   1 — at least one file invalid (errors printed to stderr)
+#   2 — usage error / missing tool
+#
+# Dependencies (all available on Mac + worker-01):
+#   - yq     (mikefarah)
+#   - npx    (ships with Node)  — downloads ajv-cli@5 on first use
+#   - python3 (for frontmatter extraction; stdlib only)
+
+set -uo pipefail
+
+EMF_QUEUE_REPO="${EMF_QUEUE_REPO:-$HOME/GitHub/emf-queue}"
+SCHEMA="${LINT_SCHEMA:-$EMF_QUEUE_REPO/schemas/task-frontmatter.schema.json}"
+
+[[ -f "$SCHEMA" ]] || { echo "Schema not found: $SCHEMA" >&2; exit 2; }
+command -v yq  >/dev/null 2>&1 || { echo "yq not found"  >&2; exit 2; }
+command -v npx >/dev/null 2>&1 || { echo "npx not found" >&2; exit 2; }
+
+# Extract YAML frontmatter (text between the first two '---' delimiter lines).
+extract_fm() {
+  python3 - "$1" <<'PY' 2>/dev/null
+import sys
+path = sys.argv[1]
+with open(path) as f:
+    lines = f.readlines()
+if not lines or lines[0].rstrip() != "---":
+    sys.exit(3)
+buf = []
+for line in lines[1:]:
+    if line.rstrip() == "---":
+        sys.stdout.writelines(buf)
+        sys.exit(0)
+    buf.append(line)
+sys.exit(3)
+PY
+}
+
+# Walk arg list (or --all) into FILES[].
+declare -a FILES=()
+if [[ "${1:-}" == "--all" ]]; then
+  for d in ready approved in-progress done failed; do
+    while IFS= read -r f; do
+      FILES+=("$f")
+    done < <(find "$EMF_QUEUE_REPO/$d" -maxdepth 1 -type f -name '*.md' 2>/dev/null)
+  done
+elif [[ $# -ge 1 ]]; then
+  FILES=("$@")
+else
+  echo "Usage: $0 <file.md>... | --all" >&2
+  exit 2
+fi
+
+(( ${#FILES[@]} == 0 )) && { echo "No task files to lint." >&2; exit 0; }
+
+# Lint each file. Build one bundle of errors so we report all at once.
+bad=0
+tmpdir="$(mktemp -d -t lint-plan.XXXXXX)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+for f in "${FILES[@]}"; do
+  base="$(basename "$f")"
+  fm="$tmpdir/$base.yaml"
+  json="$tmpdir/$base.json"
+  out="$tmpdir/$base.out"
+
+  if ! extract_fm "$f" > "$fm"; then
+    echo "INVALID $base: missing or malformed frontmatter (no '---' fences)" >&2
+    bad=$((bad + 1))
+    continue
+  fi
+
+  if ! yq -o=json '.' "$fm" > "$json" 2>"$out"; then
+    echo "INVALID $base: YAML parse error" >&2
+    sed 's/^/    /' "$out" >&2
+    bad=$((bad + 1))
+    continue
+  fi
+
+  if ! npx --yes ajv-cli@5 validate \
+        --spec=draft2020 --strict=false --all-errors \
+        -s "$SCHEMA" -d "$json" \
+        > "$out" 2>&1; then
+    echo "INVALID $base:" >&2
+    sed 's/^/    /' "$out" >&2
+    bad=$((bad + 1))
+    continue
+  fi
+
+  echo "OK $base"
+done
+
+if (( bad > 0 )); then
+  echo
+  echo "$bad file(s) failed validation." >&2
+  exit 1
+fi
+echo
+echo "All ${#FILES[@]} file(s) valid."

--- a/.claude/planner/planner-prompt.md
+++ b/.claude/planner/planner-prompt.md
@@ -1,0 +1,68 @@
+You are the autopilot **planner** for the Kelta Platform. You run on the user's MacBook Pro every 10 minutes via launchd. Your job: turn free-form briefs in `~/GitHub/emf-queue/inbox/` into structured task files in `~/GitHub/emf-queue/ready/` that the dispatcher on `worker-01` can claim.
+
+You do NOT implement features. You do NOT touch the EMF codebase. You ONLY produce task files.
+
+# What you find in inbox
+
+Two kinds of files:
+
+1. **User briefs** — free-form markdown the user dropped in. Anything from one sentence to a paragraph. May or may not have YAML frontmatter. Examples:
+   - `make-rollup-clickable.md` — "When user clicks a rollup cell, drill down to underlying records"
+   - `fix-flow-rename.md` — "Renaming a flow doesn't update the navigation tree until refresh"
+2. **Auto-filed bug tasks** — already structured (filed by `.github/workflows/build-and-publish-containers.yml` on E2E failure). They have full frontmatter and `auto_promote: true`. Treat these as already valid: validate frontmatter with `lint-plan.sh`, then `git mv` straight to `approved/`.
+
+# Workflow
+
+For each file in `inbox/`:
+
+1. Read the file end-to-end.
+2. If it has full task frontmatter (id, type, etc) AND `auto_promote: true` AND `lint-plan.sh` passes → move it straight to `approved/`. Done.
+3. Otherwise (user brief): plan the work.
+   - Search the EMF codebase for related code. Use the Explore agent if scope is uncertain. Identify the files likely to change.
+   - Decompose into 1–N task files. Each task should be **narrow** (single PR, ideally <2 hours of worker time, 1–3 files touched). The user's existing PR cadence is small focused PRs (~30 PRs/day, <15 min average time-to-merge) — match that.
+   - For each task, write a file at `~/GitHub/emf-queue/ready/<id>.md` with the frontmatter schema in `~/GitHub/emf-queue/schemas/task-frontmatter.schema.json`. Lint each file with `lint-plan.sh` before committing — fix and re-lint until clean.
+   - Move the source brief to `~/GitHub/emf-queue/inbox/_processed/<original>.md` (create the dir if missing). Append a `## Generated tasks` section linking each emitted task by id so there's a paper trail.
+
+4. After processing all inbox files: `git add -A && git commit && git push` once. One commit per planner run, not one per file.
+
+# Frontmatter rules (cheat sheet)
+
+- `id`: `(TASK|BUG|CHORE|DOC|SEC)-YYYY-MM-DD-NNNN`. Today is 2026-05-10. Increment NNNN within the day. Pick the prefix that matches `type`: TASK for `feature`, BUG for `bug`, CHORE for `chore`, DOC for `doc`, SEC for `security`.
+- `type`: one of `feature | bug | chore | doc | security`.
+- `priority`: 1 (urgent) to 5 (low). User briefs default to 3. Bugs default to 2. Security defaults to 1.
+- `parallel_safe`: `true` unless the task touches Flyway migrations, shared registries (auth roles, system collections), or large refactors. When unsure, default `false` — the cost is one fewer parallel worker, the cost of being wrong is two PRs racing on the same code.
+- `needs_migration`: `true` only if a new `kelta-worker/.../db/migration/V<N>__*.sql` file is required. Always implies `parallel_safe: false`.
+- `needs_doc_update`: list of `.claude/docs/*.md` files. Mapping:
+  - new endpoint / entity / data flow → `architecture.md`
+  - new pattern worth codifying → `conventions.md`
+  - new external SDK / dependency → `integrations.md`
+  - new known risk → `concerns.md`
+  - new test pattern → `testing.md`
+- `depends_on`: list of other task ids that must merge before this one starts. Use sparingly — it serializes work. Only set when the second task literally cannot compile without the first.
+- `auto_promote`: leave `false` for tasks you generate from user briefs (the user reviews `ready/` before promoting to `approved/`). Set `true` only when the source was already `auto_promote: true` (bug ingest path).
+- `max_attempts`: 3 unless the task type is `bug` and you suspect it might be hard to reproduce — bump to 5 then.
+
+# Hard rules
+
+- **Never write into `approved/`, `in-progress/`, `done/`, or `failed/`** unless promoting an already-validated `auto_promote: true` bug task. The user owns the `ready/ → approved/` transition for everything else.
+- **Never touch EMF main repo files.** No code, no docs, no migrations. Only emf-queue files.
+- **Never invoke `claude -p`, the dispatcher, or `worker.sh`.** You are upstream of the worker — only emit task files.
+- **Lint before committing.** A task file that fails `lint-plan.sh` will block the dispatcher's claim filter. Fix until clean or DON'T commit it.
+- **No PRs from this session.** No `gh` calls except `gh repo view` for read-only queries.
+- **Be conservative on decomposition.** A brief like "make X clickable" is probably one task, not three. Splitting too aggressively creates dependency-DAG chaos. If in doubt, emit one task with a thorough brief.
+
+# When you can't plan a brief
+
+If a brief is too vague, contradicts the codebase as you understand it, or asks for something explicitly off-limits per `~/.claude/projects/.../memory/MEMORY.md` (e.g. non-OSS deps), DO NOT emit a task. Instead:
+
+- Move the brief to `inbox/_needs_clarification/<original>.md` (create the dir if missing)
+- Append a `## Why I bounced this back` section explaining what's missing or why it can't proceed
+- Continue with other inbox files
+
+The user reads `_needs_clarification/` periodically and either clarifies the brief or drops the idea.
+
+# Stop conditions
+
+- Inbox empty (or only contains files in `_processed/` / `_needs_clarification/`) → stop, exit cleanly
+- After processing all eligible files → commit + push + stop
+- If `lint-plan.sh` returns errors you can't fix → stop, leave the file in `ready/` with a marker so the next run can retry; the lint failure is logged

--- a/.claude/planner/planner.sh
+++ b/.claude/planner/planner.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Planner. Runs every 10 min on the Mac via launchd
+# (~/Library/LaunchAgents/com.cklinker.emf-planner.plist). Reads briefs from
+# emf-queue/inbox/, emits structured tasks into emf-queue/ready/.
+#
+# This is just a thin wrapper around `claude -p` + the system prompt in
+# planner-prompt.md. The Claude session does the heavy lifting (reading briefs,
+# searching the codebase, decomposing into tasks, writing files, linting).
+#
+# Singleton lock: only one planner runs at a time. If the previous run is
+# still going (rare — should be done in <2 min), this one exits silently.
+#
+# Env (override via launchd plist EnvironmentVariables):
+#   EMF_REPO        path to the EMF main repo (default ~/GitHub/emf)
+#   EMF_QUEUE_REPO  path to emf-queue (default ~/GitHub/emf-queue)
+#   CLAUDE_BIN      path to claude CLI (default 'claude' from PATH)
+#   PLANNER_LOG_DIR default ~/Library/Logs/emf-planner
+#   MAX_RUNTIME_SEC default 300 (5 min — kill the session if it overruns)
+
+set -uo pipefail
+
+EMF_REPO="${EMF_REPO:-$HOME/GitHub/emf}"
+EMF_QUEUE_REPO="${EMF_QUEUE_REPO:-$HOME/GitHub/emf-queue}"
+CLAUDE_BIN="${CLAUDE_BIN:-claude}"
+PLANNER_LOG_DIR="${PLANNER_LOG_DIR:-$HOME/Library/Logs/emf-planner}"
+MAX_RUNTIME_SEC="${MAX_RUNTIME_SEC:-300}"
+
+mkdir -p "$PLANNER_LOG_DIR"
+LOG="$PLANNER_LOG_DIR/$(date -u +%Y-%m-%dT%H-%M-%SZ).jsonl"
+LOCK="/tmp/emf-planner.lock"
+
+log() { printf '%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*" >&2; }
+
+# --- Singleton lock ---------------------------------------------------------
+if ! ( set -o noclobber; echo $$ > "$LOCK" ) 2>/dev/null; then
+  prev_pid="$(cat "$LOCK" 2>/dev/null || echo)"
+  if [[ -n "$prev_pid" ]] && kill -0 "$prev_pid" 2>/dev/null; then
+    log "previous planner still running (pid $prev_pid); exiting"
+    exit 0
+  fi
+  log "stale lock (pid $prev_pid not alive); reclaiming"
+  rm -f "$LOCK"
+  echo $$ > "$LOCK"
+fi
+trap 'rm -f "$LOCK"' EXIT
+
+# --- Pull latest queue ------------------------------------------------------
+if ! git -C "$EMF_QUEUE_REPO" pull --rebase --autostash >/dev/null 2>&1; then
+  log "queue pull failed; aborting"
+  exit 1
+fi
+
+# --- Bail if nothing to plan -----------------------------------------------
+shopt -s nullglob
+INBOX_FILES=("$EMF_QUEUE_REPO"/inbox/*.md)
+shopt -u nullglob
+if (( ${#INBOX_FILES[@]} == 0 )); then
+  log "inbox empty; nothing to plan"
+  exit 0
+fi
+log "found ${#INBOX_FILES[@]} inbox file(s); invoking planner session"
+
+# --- Build the user prompt --------------------------------------------------
+USER_PROMPT="$(cat <<EOF
+Process the inbox files in $EMF_QUEUE_REPO/inbox/.
+
+Files to consider:
+$(printf '  - %s\n' "${INBOX_FILES[@]}")
+
+Follow the system prompt rules. Emit tasks to ready/, lint each one, move processed briefs to inbox/_processed/, then commit + push once. Report a one-line summary per file you touched.
+EOF
+)"
+
+# --- Run the planner session -----------------------------------------------
+PROMPT_FILE="$EMF_REPO/.claude/planner/planner-prompt.md"
+[[ -f "$PROMPT_FILE" ]] || { log "missing planner-prompt.md at $PROMPT_FILE"; exit 1; }
+
+cd "$EMF_QUEUE_REPO" || exit 1
+
+timeout --preserve-status "$MAX_RUNTIME_SEC" \
+  "$CLAUDE_BIN" \
+    -p "$USER_PROMPT" \
+    --append-system-prompt "$(cat "$PROMPT_FILE")" \
+    --output-format stream-json \
+    --include-partial-messages \
+    --verbose \
+    --dangerously-skip-permissions \
+  >> "$LOG" 2>&1
+RC=$?
+
+if (( RC == 0 )); then
+  log "planner session ok (log: $LOG)"
+else
+  log "planner session failed (rc=$RC, log: $LOG)"
+fi
+exit "$RC"


### PR DESCRIPTION
## Summary

Phase 2 of the autopilot plan. Closes the loop on the Mac side: free-form briefs in \`emf-queue/inbox/\` → structured tasks in \`emf-queue/ready/\` for user review → \`approved/\` → dispatcher (Phase 1) on \`worker-01\`.

- **\`planner.sh\`** + **launchd plist** — every 10 min, claude -p with planner-prompt.md, processes the inbox in one session, commits + pushes once.
- **\`planner-prompt.md\`** — system prompt. Hard rules: only emit task files, never touch the EMF main repo, lint before commit, conservative decomposition (match the user's small-PR cadence).
- **\`lint-plan.sh\`** — JSON Schema validator using \`yq\` + \`npx ajv-cli@5\`. Supports \`--all\` or specific files. **Already caught a real schema/dispatcher mismatch** during dev → fix lands in [emf-queue#2](https://github.com/cklinker/emf-queue/pull/2).

## Test plan

- [x] \`bash -n\` syntax: clean
- [x] \`./lint-plan.sh --all\` against the live emf-queue: passes after [emf-queue#2](https://github.com/cklinker/emf-queue/pull/2) merges
- [ ] After [emf-queue#2](https://github.com/cklinker/emf-queue/pull/2) merges + this merges + launchd plist installed: drop a one-line brief in \`inbox/\`, wait 10 min, expect a structured task in \`ready/\`

## Docs touched

- [ ] N/A — \`.claude/dispatcher/README.md\` already references "Phase 2 follow-up". A holistic \`.claude/docs/architecture.md\` update lands separately once the full loop is observed in production.

## Migration

- N/A

## Autopilot

- [ ] **Do NOT autopilot-label.** Hand review — adds an unattended Mac-side cron.

## Dependencies

- [emf-queue#2](https://github.com/cklinker/emf-queue/pull/2) — schema fix (the linter caught + drove the fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)