### PR TITLE
doc(architecture): document the autopilot loop

### DIFF
--- a/.claude/CHANGELOG.md
+++ b/.claude/CHANGELOG.md
@@ -9,3 +9,4 @@ This file tracks merged autopilot work. Entries are appended by autopilot worker
 ## 2026-05-11
 
 - 2026-05-11 chore(repo): add .editorconfig with project-wide indentation rules (CHORE-2026-05-10-0004)
+- 2026-05-11 doc(architecture): document the autopilot loop — topology, queue lifecycle, label gate, migration lock, bug ingress (DOC-2026-05-10-0001)

--- a/.claude/docs/architecture.md
+++ b/.claude/docs/architecture.md
@@ -155,3 +155,13 @@ kubectl describe pod -n kelta <pod-name>
 - **Metrics**: Spring Boot OpenTelemetry starter → Mimir (production) / OTLP HTTP (local dev)
 - **Auth**: JWT validation at gateway, Cerbos for fine-grained authorization
 - **Multi-tenancy**: TenantContext (ThreadLocal), per-tenant PostgreSQL schemas, tenant-aware NATS events
+
+## Autopilot loop
+
+Two-machine pipeline that turns task briefs into merged PRs without human keystrokes. The **MacBook Pro** runs the planner agent (briefs → structured tasks) and the cockpit (`.claude/dispatcher/status.sh` refreshed every minute by launchd). **`worker-01`** (`craig@192.168.0.232`) runs the dispatcher (`.claude/dispatcher/dispatch.sh` under systemd) which claims work and spawns up to `MAX_PARALLEL` `claude -p` workers, each in its own `/var/lib/emf-wt/<id>` worktree + tmux session.
+
+Tasks flow through [`emf-queue`](../../../emf-queue/README.md): `inbox/` (user briefs + auto-filed bugs) → `ready/` (planner-emitted) → `approved/` (user review) → `in-progress/` (atomic claim) → `done/` (merged) or `failed/` (retries exhausted).
+
+Auto-merge is gated by the `autopilot` PR label: [`.github/workflows/auto-merge.yml`](../../.github/workflows/auto-merge.yml) enables squash auto-merge only when that label is present. Migrations are serialized by an `_active-migration` marker file at the `emf-queue` root — the dispatcher's eligibility filter refuses to claim a second `needs_migration: true` task while it exists. E2E failures auto-file `inbox/BUG-<run-id>.md` via `.github/workflows/post-deploy-validate.yml`; those bug tasks carry `auto_promote: true` and skip user review.
+
+See [`.claude/dispatcher/README.md`](../dispatcher/README.md) for ops, install, and recovery.


### PR DESCRIPTION
Add a top-level "Autopilot loop" section to .claude/docs/architecture.md
covering the two-machine topology, queue lifecycle, autopilot label
auto-merge gate, migration lock marker, and E2E bug auto-ingress.
Defers ops detail to .claude/dispatcher/README.md.

Task: DOC-2026-05-10-0001

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
