### PR TITLE
fix(dispatcher): prune_orphans respects in-flight PRs + hook allows --force-with-lease

### DIFF
--- a/.claude/dispatcher/dispatch.sh
+++ b/.claude/dispatcher/dispatch.sh
@@ -43,7 +43,7 @@ active_sessions() {
 }
 
 prune_orphans() {
-  local active dead_count=0 owner sess
+  local active dead_count=0 owner sess pr id pr_state
   active="$(active_sessions)"
   shopt -s nullglob
   for f in "$EMF_QUEUE_REPO"/in-progress/*.md; do
@@ -53,11 +53,39 @@ prune_orphans() {
       continue
     fi
     sess="$TMUX_PREFIX-$(basename "$f" .md)"
-    if ! grep -qx "$sess" <<<"$active"; then
-      log_warn "orphan detected, releasing" file="$f" session="$sess"
-      queue_release_orphan "$f" || true
-      dead_count=$((dead_count + 1))
+    grep -qx "$sess" <<<"$active" && continue   # tmux session alive — not orphan
+
+    # Tmux session gone, but the worker may have completed its push and
+    # the PR may still be in flight (waiting on CI / auto-merge). Don't
+    # release in that case — releasing would re-spawn a new worker that
+    # races against the existing PR.
+    pr="$(queue_get_field "$f" pr)"
+    if [[ -n "$pr" && "$pr" != "null" ]]; then
+      pr_state="$(gh pr view "$pr" -R cklinker/emf --json state --jq '.state' 2>/dev/null || echo UNKNOWN)"
+      id="$(basename "$f" .md)"
+      case "$pr_state" in
+        OPEN)
+          # PR still open: leave the task in in-progress until the PR
+          # merges or closes, then mark accordingly.
+          continue
+          ;;
+        MERGED)
+          log_info "tmux gone but PR merged; archiving" task="$id" pr="$pr"
+          queue_done "$f" "$pr" || true
+          continue
+          ;;
+        CLOSED)
+          log_warn "tmux gone and PR closed; releasing for retry" task="$id" pr="$pr"
+          ;;
+        *)
+          log_warn "tmux gone, PR state $pr_state; releasing for retry" task="$id" pr="$pr"
+          ;;
+      esac
     fi
+
+    log_warn "orphan detected, releasing" file="$f" session="$sess"
+    queue_release_orphan "$f" || true
+    dead_count=$((dead_count + 1))
   done
   shopt -u nullglob
   (( dead_count > 0 )) && log_info "released $dead_count orphan(s)"

--- a/.claude/hooks/guard-bash.sh
+++ b/.claude/hooks/guard-bash.sh
@@ -37,9 +37,13 @@ block() {
   exit 2
 }
 
-# Direct push/force-push to main
-if [[ "$cmd_scan" =~ git[[:space:]]+push[[:space:]]+(--force|-f|origin[[:space:]]+main\b) ]]; then
-  block "no force-push or direct push to main"
+# Direct push to main, or unsafe force-push.
+# --force-with-lease and --force-if-includes are the safe forms (only succeed
+# if remote ref matches the expected commit) — allow those.
+if [[ "$cmd_scan" =~ git[[:space:]]+push[[:space:]]+([^[:space:]]+[[:space:]]+)*--force([[:space:]]|$) ]] \
+   || [[ "$cmd_scan" =~ git[[:space:]]+push[[:space:]]+([^[:space:]]+[[:space:]]+)*-f([[:space:]]|$) ]] \
+   || [[ "$cmd_scan" =~ git[[:space:]]+push[[:space:]]+origin[[:space:]]+main\b ]]; then
+  block "no unsafe force-push or direct push to main (use --force-with-lease for force-push)"
 fi
 
 # Hook bypass flags


### PR DESCRIPTION
## Summary

Two related fixes from Track C smoke debugging.

### 1. \`prune_orphans\` must not release tasks with an open PR

When a worker's poll loop hits the 30 min PR timeout (e.g. force-push confused it; auto-merge was queued but slow), the worker's trap exits the tmux session. The next \`prune_orphans\` tick saw the session gone and released the task back to \`approved/\`, which the dispatcher then re-spawned — creating a duplicate worker that re-did all the work and opened a second PR.

New logic when tmux session is missing:
- Read \`pr\` field from frontmatter
- If PR state \`OPEN\`: leave task in \`in-progress/\` (PR is in flight)
- If PR state \`MERGED\`: archive task to \`done/\`
- If PR state \`CLOSED\`: release for retry (legitimate failure)
- Other (UNKNOWN, gh error): release for retry (conservative)

### 2. \`guard-bash.sh\` allows \`--force-with-lease\`

Hook blocked all force-pushes including the safe \`--force-with-lease\` form. Used during manual conflict resolution of stuck PRs. \`--force-with-lease\` only succeeds if the remote ref matches the expected commit, so it cannot silently overwrite work. Bare \`--force\` and \`-f\` remain blocked.

## Test plan

- [x] \`bash -n\` clean
- [ ] After merge: deploy to worker-01, restart dispatcher, confirm no respawn loop on a manually-rebased PR

## Autopilot

- [x] Autopilot-label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)