### PR TITLE
chore(autopilot): use task title+type for fallback commit message in worker.sh

### DIFF
--- a/.claude/CHANGELOG.md
+++ b/.claude/CHANGELOG.md
@@ -12,3 +12,4 @@ This file tracks merged autopilot work. Entries are appended by autopilot worker
 - 2026-05-11 doc(architecture): document the autopilot loop — topology, queue lifecycle, label gate, migration lock, bug ingress (DOC-2026-05-10-0001)
 - 2026-05-11 chore(security): add SECURITY.md with vuln reporting policy and autopilot gating note (CHORE-2026-05-10-0002)
 - 2026-05-11 chore(docs): add CONTRIBUTING.md outlining the autopilot workflow (CHORE-2026-05-10-0003)
+- 2026-05-11 chore(autopilot): use task title+type for fallback commit message in worker.sh so `gh pr create --fill` produces a useful PR title (CHORE-2026-05-10-0005)

--- a/.claude/dispatcher/worker.sh
+++ b/.claude/dispatcher/worker.sh
@@ -157,9 +157,25 @@ if git -C "$WT" diff --quiet origin/main && [[ -z "$(git -C "$WT" status --porce
 fi
 
 # Stage anything left unstaged + create a final commit if needed.
+# Use a conventional-commit message built from the task's title + type so
+# that `gh pr create --fill` derives a useful PR title (the title is taken
+# from the first commit on the branch).
 git -C "$WT" add -A
 if ! git -C "$WT" diff --cached --quiet; then
-  git -C "$WT" commit -m "autopilot: $ID — final commit by worker.sh" >/dev/null
+  TASK_TITLE="$(queue_get_field "$TASK_FILE" title)"
+  TASK_TYPE="$(queue_get_field "$TASK_FILE" type)"
+  case "$TASK_TYPE" in
+    feature)        CC_PREFIX="feat"  ;;
+    bug|security)   CC_PREFIX="fix"   ;;
+    doc)            CC_PREFIX="docs"  ;;
+    chore|*)        CC_PREFIX="chore" ;;
+  esac
+  if [[ -n "$TASK_TITLE" ]]; then
+    FALLBACK_MSG="${CC_PREFIX}: ${TASK_TITLE}"
+  else
+    FALLBACK_MSG="${CC_PREFIX}: ${ID} — final commit by worker.sh"
+  fi
+  git -C "$WT" commit -m "$FALLBACK_MSG" >/dev/null
 fi
 
 # Rebase onto latest origin/main BEFORE pushing. Other autopilot workers


### PR DESCRIPTION
When the Claude session ends with uncommitted changes, worker.sh creates a
fallback commit. The previous message ("autopilot: $ID — final commit by
worker.sh") was the first commit on the branch, so `gh pr create --fill`
derived unhelpful PR titles like "autopilot: CHORE-… — final commit by
worker.sh" (e.g. PR #842).

Build the message as `<prefix>: <title>` from the task frontmatter, where
prefix maps feature→feat, bug|security→fix, doc→docs, chore (and unknown)
→chore. `gh pr create --fill` now yields a useful PR title automatically.
