### PR TITLE
feat(scripts/ci): checkout/release helpers for kelta-ci-db pool

### DIFF
--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -1,0 +1,79 @@
+# scripts/ci
+
+Helpers for using the **`kelta-ci-db` PostgreSQL pool** from GitHub Actions
+and other CI contexts. Pool lives in the homelab cluster as 4 PG StatefulSet
+replicas pinned to node `fc17` — see [`homelab-argo/kelta-ci-db/`](https://github.com/cklinker/homelab-argo/tree/main/kelta-ci-db).
+
+## Lifecycle
+
+```
+                          eval "$(checkout-db.sh)"
+                                      │
+   ┌──────────────────────────────────▼────────────────────────────┐
+   │  CI step runs against $CI_DB_JDBC_URL (single PG schema,      │
+   │  isolated from sibling jobs sharing the same instance)        │
+   └──────────────────────────────────┬────────────────────────────┘
+                                      │
+                          release-db.sh  (drops schema, CASCADE)
+```
+
+`checkout-db.sh` picks an instance ordinal (random by default), creates a
+unique schema named `ci_<run-tag>`, and emits `export` lines for sourcing.
+It also writes `/tmp/ci-db-checkout.env` so `release-db.sh` knows what to
+drop later.
+
+## Usage in a workflow
+
+```yaml
+- name: Check out CI DB schema
+  run: |
+    eval "$(scripts/ci/checkout-db.sh)"
+    echo "CI_DB_JDBC_URL=$CI_DB_JDBC_URL" >> $GITHUB_ENV
+    echo "CI_DB_USER=$CI_DB_USER"         >> $GITHUB_ENV
+    echo "CI_DB_PASSWORD=$CI_DB_PASSWORD" >> $GITHUB_ENV
+
+- name: Run integration tests
+  env:
+    SPRING_DATASOURCE_URL: ${{ env.CI_DB_JDBC_URL }}
+    SPRING_DATASOURCE_USERNAME: ${{ env.CI_DB_USER }}
+    SPRING_DATASOURCE_PASSWORD: ${{ env.CI_DB_PASSWORD }}
+  run: mvn verify -f kelta-test-harness/pom.xml -Pintegration-tests -B
+
+- name: Release CI DB schema
+  if: always()
+  run: scripts/ci/release-db.sh
+```
+
+The `if: always()` on release ensures even a failed test cleans up its
+schema. Pool drift is bounded by per-schema cleanup, not per-instance reset.
+
+## Environment overrides
+
+| Var | Default | Purpose |
+|-----|---------|---------|
+| `CI_DB_NAMESPACE` | `kelta-ci-db` | K8s namespace of the pool |
+| `CI_DB_SVC` | `kelta-ci-db` | Headless service name |
+| `CI_DB_USER` | `ci` | PG role |
+| `CI_DB_DATABASE` | `ci` | PG database name |
+| `CI_DB_PASSWORD` | (fetched from secret) | Override to skip `kubectl get secret` |
+| `CI_DB_INSTANCE` | random | Pin to a specific instance ordinal `0..N-1` |
+| `CI_DB_POOL_SIZE` | `4` | Must match the StatefulSet replica count |
+
+## Prerequisites on the runner
+
+- `kubectl` with permission to read the `kelta-ci-db-credentials` secret in
+  the `kelta-ci-db` namespace
+- `psql` (PostgreSQL client)
+- Network reachability to the pool DNS:
+  `kelta-ci-db-N.kelta-ci-db.kelta-ci-db.svc.cluster.local`
+
+The `k8s-runner-integration` pool already has `kubectl` and runs inside the
+cluster, so DNS works directly. For external runners add a sidecar that
+exposes the pool via NodePort or LoadBalancer.
+
+## What's NOT included
+
+- The Java test harness (`kelta-test-harness`) currently uses Testcontainers
+  to boot its own PG. Migrating the harness to read `CI_DB_JDBC_URL` from
+  env (and skip Testcontainers when set) is a follow-up task. The pool is
+  ready; the integration is the next PR.

--- a/scripts/ci/checkout-db.sh
+++ b/scripts/ci/checkout-db.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Check out a throwaway PG schema from the kelta-ci-db pool.
+#
+# Picks one of N pool instances (round-robin via $RANDOM by default; set
+# CI_DB_INSTANCE=N to pin), creates a unique schema, and emits a JDBC URL
+# + matching env vars on stdout for sourcing.
+#
+# Usage (in a CI step):
+#   eval "$(scripts/ci/checkout-db.sh)"
+#   # ... run tests against $CI_DB_JDBC_URL ...
+#   scripts/ci/release-db.sh
+#
+# Env (override defaults):
+#   CI_DB_NAMESPACE   default kelta-ci-db
+#   CI_DB_SVC         default kelta-ci-db (headless service)
+#   CI_DB_USER        default ci         (matches kelta-ci-db secret)
+#   CI_DB_PASSWORD    default fetched from secret if unset
+#   CI_DB_DATABASE    default ci
+#   CI_DB_INSTANCE    pin to instance ordinal 0..N-1 (default: random)
+#   CI_DB_POOL_SIZE   default 4 (matches statefulset replicas)
+#
+# Output (stdout): shell assignments suitable for `eval`. stderr = log.
+#
+# Side effects:
+#   - Creates schema "ci_<run_id>" on the chosen instance
+#   - Writes /tmp/ci-db-checkout.env with the chosen instance + schema for
+#     release-db.sh to consume
+
+set -euo pipefail
+
+CI_DB_NAMESPACE="${CI_DB_NAMESPACE:-kelta-ci-db}"
+CI_DB_SVC="${CI_DB_SVC:-kelta-ci-db}"
+CI_DB_USER="${CI_DB_USER:-ci}"
+CI_DB_DATABASE="${CI_DB_DATABASE:-ci}"
+CI_DB_POOL_SIZE="${CI_DB_POOL_SIZE:-4}"
+
+if [[ -z "${CI_DB_PASSWORD:-}" ]]; then
+  CI_DB_PASSWORD="$(kubectl -n "$CI_DB_NAMESPACE" get secret kelta-ci-db-credentials \
+    -o jsonpath='{.data.POSTGRES_PASSWORD}' | base64 --decode)"
+fi
+
+# Pick instance ordinal.
+if [[ -n "${CI_DB_INSTANCE:-}" ]]; then
+  ord="$CI_DB_INSTANCE"
+else
+  ord=$(( RANDOM % CI_DB_POOL_SIZE ))
+fi
+
+host="${CI_DB_SVC}-${ord}.${CI_DB_SVC}.${CI_DB_NAMESPACE}.svc"
+port=5432
+
+# Unique schema per run. GITHUB_RUN_ID + GITHUB_RUN_ATTEMPT is unique within
+# a workflow; fall back to PID + epoch for local invocation.
+run_tag="${GITHUB_RUN_ID:-$$}_${GITHUB_RUN_ATTEMPT:-$(date +%s)}"
+schema="ci_$(printf '%s' "$run_tag" | tr -c 'A-Za-z0-9_' '_')"
+
+echo "[checkout-db] picked instance=$ord host=$host schema=$schema" >&2
+
+PGPASSWORD="$CI_DB_PASSWORD" psql \
+  -h "$host" -p "$port" -U "$CI_DB_USER" -d "$CI_DB_DATABASE" \
+  -v ON_ERROR_STOP=1 \
+  -c "CREATE SCHEMA IF NOT EXISTS \"$schema\" AUTHORIZATION \"$CI_DB_USER\";" \
+  -c "GRANT ALL ON SCHEMA \"$schema\" TO \"$CI_DB_USER\";" >&2
+
+# Persist the chosen instance + schema for release-db.sh.
+cat > /tmp/ci-db-checkout.env <<EOF
+CI_DB_HOST=$host
+CI_DB_PORT=$port
+CI_DB_USER=$CI_DB_USER
+CI_DB_PASSWORD=$CI_DB_PASSWORD
+CI_DB_DATABASE=$CI_DB_DATABASE
+CI_DB_SCHEMA=$schema
+CI_DB_INSTANCE=$ord
+EOF
+
+# Emit env-var assignments suitable for eval.
+cat <<EOF
+export CI_DB_HOST='$host'
+export CI_DB_PORT='$port'
+export CI_DB_USER='$CI_DB_USER'
+export CI_DB_PASSWORD='$CI_DB_PASSWORD'
+export CI_DB_DATABASE='$CI_DB_DATABASE'
+export CI_DB_SCHEMA='$schema'
+export CI_DB_JDBC_URL='jdbc:postgresql://${host}:${port}/${CI_DB_DATABASE}?currentSchema=${schema}'
+EOF

--- a/scripts/ci/release-db.sh
+++ b/scripts/ci/release-db.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Release the schema claimed by checkout-db.sh.
+#
+# Reads /tmp/ci-db-checkout.env, drops the schema (CASCADE), exits cleanly.
+# Safe to run more than once; missing schema is treated as already released.
+#
+# Usage (in a CI step, typically with `if: always()` so a failed test still
+# releases its schema):
+#   scripts/ci/release-db.sh
+
+set -uo pipefail
+
+ENV_FILE="${CI_DB_ENV_FILE:-/tmp/ci-db-checkout.env}"
+if [[ ! -f "$ENV_FILE" ]]; then
+  echo "[release-db] no $ENV_FILE — checkout never ran or already cleaned up; nothing to do" >&2
+  exit 0
+fi
+
+# shellcheck source=/dev/null
+. "$ENV_FILE"
+
+if [[ -z "${CI_DB_SCHEMA:-}" ]]; then
+  echo "[release-db] $ENV_FILE missing CI_DB_SCHEMA; nothing to do" >&2
+  rm -f "$ENV_FILE"
+  exit 0
+fi
+
+echo "[release-db] dropping schema $CI_DB_SCHEMA on instance ${CI_DB_INSTANCE:-?}" >&2
+PGPASSWORD="$CI_DB_PASSWORD" psql \
+  -h "$CI_DB_HOST" -p "$CI_DB_PORT" -U "$CI_DB_USER" -d "$CI_DB_DATABASE" \
+  -v ON_ERROR_STOP=1 \
+  -c "DROP SCHEMA IF EXISTS \"$CI_DB_SCHEMA\" CASCADE;" >&2 \
+  || echo "[release-db] DROP SCHEMA failed (instance may be down); leaving for next sweep" >&2
+
+rm -f "$ENV_FILE"


### PR DESCRIPTION
## Summary

Companion to [homelab-argo#76](https://github.com/cklinker/homelab-argo/pull/76) (the 4-replica PG pool). Adds two POSIX shell scripts:

- \`scripts/ci/checkout-db.sh\` — picks one of N pool instances (random or pinned via \`\$CI_DB_INSTANCE\`), creates schema \`ci_<run-tag>\`, emits \`export\` lines for \`eval\`
- \`scripts/ci/release-db.sh\` — drops schema CASCADE, idempotent
- \`scripts/ci/README.md\` — usage + env var reference + roadmap note

## Test plan

- [x] \`bash -n\` clean
- [ ] After homelab-argo#76 merges + ArgoCD syncs: \`kubectl exec\` into a runner pod and run \`scripts/ci/checkout-db.sh\` once; expect a schema \`ci_*\` to appear in one of the pool instances
- [ ] Then run \`scripts/ci/release-db.sh\`; expect schema gone

## Out of scope

\`ci.yml\` integration-tests still uses Testcontainers. Migrating \`kelta-test-harness\` to honor \`\$CI_DB_JDBC_URL\` is a follow-up — well-suited for an autopilot task.

## Autopilot

- [x] Autopilot-label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)