### PR TITLE
feat(autopilot): Phase 3 observability foundations

### DIFF
--- a/.claude/dispatcher/lib/parse-usage.sh
+++ b/.claude/dispatcher/lib/parse-usage.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Parse a worker's claude -p stream-json log into a single per-task cost
+# summary line (JSON), suitable for Promtail/Loki ingestion.
+#
+# Usage:
+#   .claude/dispatcher/lib/parse-usage.sh <jsonl-path> <task-id> <final-state> [<duration-sec>]
+#
+# Output (stdout, single JSON line):
+#   {
+#     "ts": "2026-05-11T...",
+#     "task": "CHORE-...",
+#     "final_state": "MERGED",
+#     "duration_sec": 412,
+#     "input_tokens": <int>,
+#     "cache_creation_tokens": <int>,
+#     "cache_read_tokens": <int>,
+#     "output_tokens": <int>,
+#     "estimated_cost_usd": <float>,
+#     "request_count": <int>
+#   }
+#
+# Cost estimation uses Claude Opus 4.7 list pricing (rough, not authoritative):
+#   - input          $15 / M tokens
+#   - cache creation $18.75 / M tokens (1.25 × input)
+#   - cache read     $1.50 / M tokens (0.10 × input)
+#   - output         $75 / M tokens
+# Override via env: PRICE_INPUT, PRICE_CACHE_CREATION, PRICE_CACHE_READ, PRICE_OUTPUT (per token).
+
+set -uo pipefail
+
+JSONL="${1:-}"
+TASK="${2:-unknown}"
+FINAL_STATE="${3:-unknown}"
+DURATION_SEC="${4:-0}"
+
+[[ -n "$JSONL" && -f "$JSONL" ]] || { echo "Usage: $0 <jsonl> <task-id> <final-state> [<duration-sec>]" >&2; exit 2; }
+command -v jq >/dev/null 2>&1 || { echo "jq required" >&2; exit 2; }
+
+PRICE_INPUT="${PRICE_INPUT:-0.000015}"
+PRICE_CACHE_CREATION="${PRICE_CACHE_CREATION:-0.00001875}"
+PRICE_CACHE_READ="${PRICE_CACHE_READ:-0.0000015}"
+PRICE_OUTPUT="${PRICE_OUTPUT:-0.000075}"
+
+# Sum usage fields across every assistant `message_delta` event with a usage
+# block. Use awk on the jq stream — faster than letting jq do the math for
+# multi-MB logs. Each usage object's totals already accumulate within a
+# single Claude turn; multiple turns concatenate.
+# The log file mixes claude CLI stream-json output with worker.sh's own
+# stderr lines (status messages, log_event records). Pre-filter to JSON
+# lines only, then ask jq for the usage block from anywhere in the object
+# tree (`..` recursive descent — handles both .event.usage from
+# stream_event message_delta and .message.usage from assistant events).
+read_tokens="$(grep -E '^[[:space:]]*\{' "$JSONL" 2>/dev/null \
+  | jq -r '
+      [.. | objects | select(has("usage")) | .usage]
+      | map(select(. != null))
+      | (.[]?
+         | [(.input_tokens // 0),
+            (.cache_creation_input_tokens // 0),
+            (.cache_read_input_tokens // 0),
+            (.output_tokens // 0)]
+         | @tsv)
+    ' 2>/dev/null \
+  | awk '
+      BEGIN { i=0; cc=0; cr=0; o=0; n=0 }
+      NF>=4 { i+=$1; cc+=$2; cr+=$3; o+=$4; n++ }
+      END { printf "%d\t%d\t%d\t%d\t%d\n", i, cc, cr, o, n }
+    ')"
+
+INPUT_TOKENS="$(printf '%s' "$read_tokens" | cut -f1)"
+CACHE_CREATION="$(printf '%s' "$read_tokens" | cut -f2)"
+CACHE_READ="$(printf '%s' "$read_tokens" | cut -f3)"
+OUTPUT_TOKENS="$(printf '%s' "$read_tokens" | cut -f4)"
+REQUEST_COUNT="$(printf '%s' "$read_tokens" | cut -f5)"
+
+COST_USD="$(awk -v i="$INPUT_TOKENS" -v cc="$CACHE_CREATION" -v cr="$CACHE_READ" -v o="$OUTPUT_TOKENS" \
+                -v pi="$PRICE_INPUT" -v pcc="$PRICE_CACHE_CREATION" -v pcr="$PRICE_CACHE_READ" -v po="$PRICE_OUTPUT" \
+                'BEGIN { printf "%.6f", i*pi + cc*pcc + cr*pcr + o*po }')"
+
+TS="$(date -u +%Y-%m-%dT%H:%M:%S.%3NZ 2>/dev/null || date -u +%Y-%m-%dT%H:%M:%SZ)"
+HOST="${HOSTNAME:-$(hostname)}"
+
+jq -nc \
+  --arg ts "$TS" --arg host "$HOST" --arg task "$TASK" --arg state "$FINAL_STATE" \
+  --argjson duration "${DURATION_SEC:-0}" \
+  --argjson it "${INPUT_TOKENS:-0}" \
+  --argjson cct "${CACHE_CREATION:-0}" \
+  --argjson crt "${CACHE_READ:-0}" \
+  --argjson ot "${OUTPUT_TOKENS:-0}" \
+  --argjson reqs "${REQUEST_COUNT:-0}" \
+  --argjson cost "${COST_USD:-0}" '
+  {
+    ts: $ts, host: $host, task: $task, final_state: $state,
+    duration_sec: $duration,
+    input_tokens: $it,
+    cache_creation_tokens: $cct,
+    cache_read_tokens: $crt,
+    output_tokens: $ot,
+    request_count: $reqs,
+    estimated_cost_usd: $cost,
+    component: "cost"
+  }
+'

--- a/.claude/dispatcher/observability/README.md
+++ b/.claude/dispatcher/observability/README.md
@@ -1,0 +1,107 @@
+# EMF Autopilot — Phase 3 Observability
+
+Foundations for shipping dispatcher logs + per-task cost telemetry to the homelab Loki + Grafana, plus a ready-to-import dashboard and alert rules.
+
+Per the plan, deployment was deferred until **2 weeks of real data**. This PR ships the wiring so the deploy is one short ops task when the time comes.
+
+## What lands here
+
+| File | Purpose |
+|---|---|
+| `lib/parse-usage.sh` (in `..`) | Aggregates `claude -p` stream-json into a one-line cost summary per task, written to `/var/log/emf-dispatcher/cost-<task-id>.json` |
+| `worker.sh` integration (in `..`) | Calls parse-usage at the end of every task; injects `duration_sec` into the `task_done` event |
+| `promtail/promtail-config.yml` | Promtail scrape config for `worker-01` (3 jobs: per-task jsonl, cost summaries, dispatcher journal) |
+| `promtail/promtail.service` | systemd unit |
+| `grafana/emf-autopilot-dashboard.json` | Importable dashboard: throughput, cost per task, top 10 expensive, retry rate, recent events |
+| `alerts/emf-autopilot-alerts.yml` | Prometheus/Mimir alert rules: failed-task count, host down, dispatcher flap, CI slow, daily spend, single-task runaway |
+
+## Deploy steps (when ready)
+
+### 1. Expose Loki externally
+
+Loki currently runs as ClusterIP only (`10.152.183.127:3100`). worker-01 lives outside the cluster so it can't reach that. Add a Traefik IngressRoute:
+
+```yaml
+# homelab-argo/observability/loki-ingressroute.yaml
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: loki
+  namespace: observability
+spec:
+  entryPoints: [websecure]
+  routes:
+    - match: Host(`loki.rzware.com`) && PathPrefix(`/loki/api`)
+      kind: Rule
+      services:
+        - name: loki
+          port: 3100
+      middlewares:
+        - name: loki-basic-auth
+  tls:
+    secretName: loki-tls
+```
+
+Add a basic-auth Middleware + Secret (see existing `grafana` IngressRoute for pattern). Add `loki.rzware.com` to ddns-updater.
+
+### 2. Install Promtail on worker-01
+
+```sh
+ssh worker-01
+
+# Binary
+sudo wget -O /tmp/promtail.zip https://github.com/grafana/loki/releases/download/v3.0.0/promtail-linux-amd64.zip
+sudo unzip /tmp/promtail.zip -d /usr/local/bin/
+sudo mv /usr/local/bin/promtail-linux-amd64 /usr/local/bin/promtail
+sudo chmod +x /usr/local/bin/promtail
+
+# Config
+sudo install -d -o root -g root /etc/promtail
+sudo install -d -o promtail -g promtail /var/lib/promtail
+sudo cp ~/GitHub/emf/.claude/dispatcher/observability/promtail/promtail-config.yml /etc/promtail/config.yml
+# Edit /etc/promtail/config.yml: set the right loki url, basic-auth password file
+sudo install -m 600 -o root -g root <(echo 'YOUR_BASIC_AUTH_PASSWORD') /etc/promtail/.loki-password
+
+# systemd
+sudo cp ~/GitHub/emf/.claude/dispatcher/observability/promtail/promtail.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now promtail
+
+# Verify
+journalctl -fu promtail
+```
+
+### 3. Import the Grafana dashboard
+
+In Grafana UI:
+- Dashboards → New → Import
+- Paste `grafana/emf-autopilot-dashboard.json`
+- Pick the Loki datasource
+
+### 4. Wire alerts into Mimir/Prometheus
+
+Place `alerts/emf-autopilot-alerts.yml` next to your other Mimir alert rules, reload the rule loader. **Tune thresholds first** based on the first week of data (`EMFAutopilotDailySpendHigh` defaults to $50/day; adjust).
+
+## Verifying
+
+After deployment, first signal:
+
+```sh
+ssh worker-01
+cat /var/log/emf-dispatcher/cost-*.json | jq -c .
+```
+
+You should see one line per completed task with token counts + estimated cost. Once Promtail is shipping, the dashboard's "Daily $ spend" stat will start populating within a minute.
+
+## Cost estimation accuracy
+
+`parse-usage.sh` uses Claude Opus 4.7 list pricing baked in:
+
+| Tier | Per token |
+|---|---|
+| Input | $0.000015 (= $15/M) |
+| Cache creation | $0.00001875 (= $18.75/M, 1.25× input) |
+| Cache read | $0.0000015 (= $1.50/M, 0.10× input) |
+| Output | $0.000075 (= $75/M) |
+
+Override via env: `PRICE_INPUT`, `PRICE_CACHE_CREATION`, `PRICE_CACHE_READ`, `PRICE_OUTPUT`. For exact accounting, reconcile against the Anthropic console's billing page periodically.

--- a/.claude/dispatcher/observability/alerts/emf-autopilot-alerts.yml
+++ b/.claude/dispatcher/observability/alerts/emf-autopilot-alerts.yml
@@ -1,0 +1,70 @@
+groups:
+  - name: emf-autopilot
+    interval: 1m
+    rules:
+
+      # ---- Volume / health -----------------------------------------------------
+
+      - alert: EMFAutopilotFailedTasksHigh
+        expr: |
+          sum(count_over_time({source="emf-dispatcher", stream_type="task"} |~ "queue_fail" [1d])) > 3
+        for: 5m
+        labels: {severity: warning, component: autopilot}
+        annotations:
+          summary: 'Autopilot failed-task count > 3 in 24h ({{ $value }} so far)'
+          runbook: 'Check emf-queue/failed/ and tail per-task jsonl logs on worker-01.'
+
+      - alert: EMFAutopilotWorkerHostDown
+        expr: |
+          up{instance=~".*worker-01.*"} == 0
+        for: 5m
+        labels: {severity: critical, component: autopilot}
+        annotations:
+          summary: 'worker-01 (craig@192.168.0.232) is unreachable'
+          runbook: 'ssh worker-01; if up, check `systemctl status emf-dispatcher`.'
+
+      - alert: EMFAutopilotDispatcherFlapping
+        expr: |
+          sum(rate({source="emf-dispatcher", stream_type="systemd"} |~ "Started emf-dispatcher" [10m])) > 0.05
+        for: 10m
+        labels: {severity: warning, component: autopilot}
+        annotations:
+          summary: 'emf-dispatcher systemd unit restarting > 0.05 r/s'
+          runbook: '`journalctl -u emf-dispatcher --since "30 min ago"` and look for the crash reason.'
+
+      # ---- CI duration ---------------------------------------------------------
+
+      - alert: EMFAutopilotCIMedianSlow
+        expr: |
+          quantile_over_time(0.5,
+            {source="emf-dispatcher", stream_type="cost"}
+            | json | unwrap duration_sec [1h]
+          ) > 480
+        for: 30m
+        labels: {severity: warning, component: autopilot}
+        annotations:
+          summary: 'Autopilot task median duration > 8 min (currently {{ $value | humanizeDuration }})'
+          runbook: 'Check Github Actions queue depth + runner health on fc17.'
+
+      # ---- Cost ---------------------------------------------------------------
+
+      - alert: EMFAutopilotDailySpendHigh
+        # Threshold should be set after 1 week of baseline data per the plan.
+        # Default: $50/day. Edit before deploying.
+        expr: |
+          sum(sum_over_time({source="emf-dispatcher", stream_type="cost"} | json | unwrap estimated_cost_usd [1d])) > 50
+        for: 10m
+        labels: {severity: warning, component: autopilot}
+        annotations:
+          summary: 'Autopilot daily $ spend > $50 (currently ${{ $value | humanize }})'
+          runbook: 'Check Top 10 most expensive tasks panel; drill into longest-running attempts.'
+
+      - alert: EMFAutopilotSingleTaskSpendHigh
+        # Catches runaway loops where one task burns the budget.
+        expr: |
+          max by (task) (sum_over_time({source="emf-dispatcher", stream_type="cost"} | json | unwrap estimated_cost_usd [1h])) > 10
+        for: 5m
+        labels: {severity: warning, component: autopilot}
+        annotations:
+          summary: 'Single autopilot task ({{ $labels.task }}) > $10 in 1h'
+          runbook: 'tmux attach -r -t emf-worker-{{ $labels.task }} on worker-01 and inspect.'

--- a/.claude/dispatcher/observability/grafana/emf-autopilot-dashboard.json
+++ b/.claude/dispatcher/observability/grafana/emf-autopilot-dashboard.json
@@ -1,0 +1,127 @@
+{
+  "annotations": {"list": []},
+  "editable": true,
+  "graphTooltip": 0,
+  "id": null,
+  "title": "EMF Autopilot",
+  "tags": ["emf", "autopilot", "kelta"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "refresh": "30s",
+  "time": {"from": "now-24h", "to": "now"},
+  "templating": {
+    "list": [
+      {
+        "name": "loki_ds",
+        "type": "datasource",
+        "query": "loki",
+        "current": {"text": "Loki", "value": "Loki"}
+      }
+    ]
+  },
+  "panels": [
+    {
+      "type": "stat",
+      "title": "Tasks merged (last 24h)",
+      "gridPos": {"x": 0, "y": 0, "w": 4, "h": 3},
+      "datasource": {"type": "loki", "uid": "${loki_ds}"},
+      "targets": [{
+        "expr": "count_over_time({source=\"emf-dispatcher\", stream_type=\"task\"} |~ \"task_done\" [24h])",
+        "queryType": "instant"
+      }],
+      "options": {"colorMode": "background", "graphMode": "none"}
+    },
+    {
+      "type": "stat",
+      "title": "Tasks failed (last 24h)",
+      "gridPos": {"x": 4, "y": 0, "w": 4, "h": 3},
+      "datasource": {"type": "loki", "uid": "${loki_ds}"},
+      "targets": [{
+        "expr": "count_over_time({source=\"emf-dispatcher\", stream_type=\"task\"} |~ \"queue_fail\" [24h])",
+        "queryType": "instant"
+      }],
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {"mode": "absolute", "steps": [
+            {"color": "green", "value": null},
+            {"color": "yellow", "value": 1},
+            {"color": "red", "value": 3}
+          ]}
+        }
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Daily $ spend",
+      "gridPos": {"x": 8, "y": 0, "w": 4, "h": 3},
+      "datasource": {"type": "loki", "uid": "${loki_ds}"},
+      "targets": [{
+        "expr": "sum(sum_over_time({source=\"emf-dispatcher\", stream_type=\"cost\"} | json | unwrap estimated_cost_usd [24h]))",
+        "queryType": "instant"
+      }],
+      "fieldConfig": {"defaults": {"unit": "currencyUSD", "decimals": 2}}
+    },
+    {
+      "type": "stat",
+      "title": "Median task duration",
+      "gridPos": {"x": 12, "y": 0, "w": 4, "h": 3},
+      "datasource": {"type": "loki", "uid": "${loki_ds}"},
+      "targets": [{
+        "expr": "quantile_over_time(0.5, {source=\"emf-dispatcher\", stream_type=\"cost\"} | json | unwrap duration_sec [24h])",
+        "queryType": "instant"
+      }],
+      "fieldConfig": {"defaults": {"unit": "s"}}
+    },
+
+    {
+      "type": "timeseries",
+      "title": "PR throughput (merges per hour)",
+      "gridPos": {"x": 0, "y": 3, "w": 12, "h": 7},
+      "datasource": {"type": "loki", "uid": "${loki_ds}"},
+      "targets": [{
+        "expr": "sum(count_over_time({source=\"emf-dispatcher\", stream_type=\"task\"} |~ \"task_done\" [1h]))"
+      }]
+    },
+    {
+      "type": "timeseries",
+      "title": "Cost per merged task ($)",
+      "gridPos": {"x": 12, "y": 3, "w": 12, "h": 7},
+      "datasource": {"type": "loki", "uid": "${loki_ds}"},
+      "targets": [{
+        "expr": "{source=\"emf-dispatcher\", stream_type=\"cost\", final_state=\"MERGED\"} | json | unwrap estimated_cost_usd",
+        "legendFormat": "{{task}}"
+      }]
+    },
+
+    {
+      "type": "table",
+      "title": "Top 10 most expensive tasks (last 7d)",
+      "gridPos": {"x": 0, "y": 10, "w": 12, "h": 8},
+      "datasource": {"type": "loki", "uid": "${loki_ds}"},
+      "targets": [{
+        "expr": "topk(10, sum by (task) (sum_over_time({source=\"emf-dispatcher\", stream_type=\"cost\"} | json | unwrap estimated_cost_usd [7d])))",
+        "queryType": "instant"
+      }]
+    },
+    {
+      "type": "timeseries",
+      "title": "Bug-loop retry rate (releases per hour)",
+      "gridPos": {"x": 12, "y": 10, "w": 12, "h": 8},
+      "datasource": {"type": "loki", "uid": "${loki_ds}"},
+      "targets": [{
+        "expr": "sum(count_over_time({source=\"emf-dispatcher\", stream_type=\"task\"} |~ \"queue_release_orphan\" [1h]))"
+      }]
+    },
+
+    {
+      "type": "logs",
+      "title": "Recent dispatcher events",
+      "gridPos": {"x": 0, "y": 18, "w": 24, "h": 8},
+      "datasource": {"type": "loki", "uid": "${loki_ds}"},
+      "targets": [{
+        "expr": "{source=\"emf-dispatcher\"} |~ \"level.:.\\\"(error|warn|event)\\\"\""
+      }],
+      "options": {"showTime": true, "wrapLogMessage": true}
+    }
+  ]
+}

--- a/.claude/dispatcher/observability/promtail/promtail-config.yml
+++ b/.claude/dispatcher/observability/promtail/promtail-config.yml
@@ -1,0 +1,110 @@
+# Promtail configuration for worker-01 (craig@192.168.0.232).
+# Ships dispatcher logs + per-task cost summaries to the homelab Loki.
+#
+# Install:
+#   1. Add a Loki IngressRoute / external endpoint (see this dir's README)
+#   2. Install Promtail binary:
+#        sudo wget -O /usr/local/bin/promtail \
+#          https://github.com/grafana/loki/releases/download/v3.0.0/promtail-linux-amd64.zip
+#        sudo unzip /usr/local/bin/promtail -d /usr/local/bin/
+#        sudo chmod +x /usr/local/bin/promtail-linux-amd64
+#        sudo mv /usr/local/bin/promtail-linux-amd64 /usr/local/bin/promtail
+#   3. Drop this file at /etc/promtail/config.yml
+#   4. Drop ../systemd/promtail.service into /etc/systemd/system/
+#   5. sudo systemctl daemon-reload && sudo systemctl enable --now promtail
+
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /var/lib/promtail/positions.yaml
+
+clients:
+  # Set this to the externally-reachable Loki push URL. Examples:
+  #   - https://loki.rzware.com/loki/api/v1/push  (after adding an IngressRoute)
+  #   - http://192.168.0.x:NODEPORT/loki/api/v1/push (NodePort fallback)
+  - url: https://loki.rzware.com/loki/api/v1/push
+    # If the ingress requires basic auth (recommended), set credentials:
+    # basic_auth:
+    #   username: promtail
+    #   password_file: /etc/promtail/.loki-password
+    tenant_id: emf-autopilot
+
+scrape_configs:
+  # ---- 1. Per-task worker logs (claude -p stream-json) -----------------------
+  - job_name: emf-worker-task
+    static_configs:
+      - targets: [localhost]
+        labels:
+          host: worker-01
+          source: emf-dispatcher
+          stream_type: task
+          __path__: /var/log/emf-dispatcher/*.jsonl
+    pipeline_stages:
+      # The file matches both per-task <ID>.jsonl AND component logs
+      # (dispatch.jsonl, worker.jsonl, claim.jsonl, cost-<ID>.json).
+      # Extract the task ID from the filename.
+      - regex:
+          source: filename
+          expression: '/(?P<basename>[^/]+)\.(?:jsonl|json)$'
+      - labels:
+          basename:
+      # The per-task files have ID like "CHORE-2026-05-10-0001".
+      # Component logs have basename "dispatch", "worker", "claim".
+      - regex:
+          source: basename
+          expression: '^(?:cost-)?(?P<task>(?:TASK|BUG|CHORE|DOC|SEC)-\d{4}-\d{2}-\d{2}-\d{4})$'
+      - labels:
+          task:
+      # Drop non-JSON lines (claude --verbose status text).
+      - match:
+          selector: '{stream_type="task"}'
+          stages:
+            - drop:
+                expression: '^[^{]'
+
+  # ---- 2. Per-task cost summaries (parse-usage.sh output) --------------------
+  - job_name: emf-worker-cost
+    static_configs:
+      - targets: [localhost]
+        labels:
+          host: worker-01
+          source: emf-dispatcher
+          stream_type: cost
+          __path__: /var/log/emf-dispatcher/cost-*.json
+    pipeline_stages:
+      - json:
+          expressions:
+            task: task
+            final_state: final_state
+            cost: estimated_cost_usd
+      - labels:
+          task:
+          final_state:
+      - metrics:
+          # Counters auto-incremented per scraped line — Prometheus/Mimir
+          # gets per-task cost as a numeric series via Loki's metric
+          # extraction.
+          emf_autopilot_task_cost_usd:
+            type: Histogram
+            description: 'Estimated $ cost per autopilot task (claude API)'
+            source: cost
+            config:
+              buckets: [0.01, 0.10, 0.50, 1.00, 5.00, 10.00, 25.00, 50.00, 100.00]
+
+  # ---- 3. Dispatcher service journal ----------------------------------------
+  - job_name: emf-dispatcher-journal
+    journal:
+      max_age: 24h
+      path: /var/log/journal
+      labels:
+        host: worker-01
+        source: emf-dispatcher
+        stream_type: systemd
+    relabel_configs:
+      - source_labels: ['__journal__systemd_unit']
+        target_label: unit
+      - source_labels: ['__journal__systemd_unit']
+        regex: '^emf-dispatcher\.service$'
+        action: keep

--- a/.claude/dispatcher/observability/promtail/promtail.service
+++ b/.claude/dispatcher/observability/promtail/promtail.service
@@ -1,0 +1,25 @@
+[Unit]
+Description=Promtail (ships emf-dispatcher logs to homelab Loki)
+Documentation=https://github.com/cklinker/emf/blob/main/.claude/dispatcher/observability/README.md
+After=network-online.target emf-dispatcher.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=root
+ExecStart=/usr/local/bin/promtail -config.file=/etc/promtail/config.yml
+Restart=always
+RestartSec=10
+TimeoutStartSec=30
+
+# Promtail needs to read /var/log/emf-dispatcher/* (group-readable as
+# craig:craig per the dispatcher unit) and journald (`journalctl` group
+# membership).
+SupplementaryGroups=craig systemd-journal
+
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=promtail
+
+[Install]
+WantedBy=multi-user.target

--- a/.claude/dispatcher/worker.sh
+++ b/.claude/dispatcher/worker.sh
@@ -57,6 +57,7 @@ trap cleanup_worktree EXIT
 
 # ---- 1. Worktree ------------------------------------------------------------
 
+WORKER_START_TS="$(date +%s)"
 log_event worker_start task="$ID" attempts="$ATTEMPTS" max="$MAX_ATTEMPTS" branch="$BRANCH"
 
 if ! git -C "$EMF_REPO" fetch --quiet origin main; then
@@ -267,11 +268,22 @@ if [[ -z "$final_state" ]]; then
   log_warn "ci poll timed out" minutes="$PR_TIMEOUT_MIN"
 fi
 
-# ---- 7. Archive -------------------------------------------------------------
+# ---- 7. Cost telemetry ------------------------------------------------------
+# Aggregate the claude session's usage events into a one-line JSON summary so
+# Promtail can ship it to Loki for per-task / per-day cost panels.
+WORKER_END_TS="$(date +%s)"
+DURATION_SEC=$(( WORKER_END_TS - WORKER_START_TS ))
+COST_LOG="${EMF_LOG_DIR:-/var/log/emf-dispatcher}/cost-${ID}.json"
+if [[ -x "$SELF_DIR/lib/parse-usage.sh" ]]; then
+  bash "$SELF_DIR/lib/parse-usage.sh" "$JSONL_LOG" "$ID" "$final_state" "$DURATION_SEC" \
+    > "$COST_LOG" 2>/dev/null || log_warn "parse-usage failed"
+fi
+
+# ---- 8. Archive -------------------------------------------------------------
 
 case "$final_state" in
   MERGED)
-    log_event task_done task="$ID" pr="$PR_NUM"
+    log_event task_done task="$ID" pr="$PR_NUM" duration_sec="$DURATION_SEC"
     queue_done "$TASK_FILE" "$PR_NUM"
     ;;
   CHECK_FAIL|CLOSED|TIMEOUT)


### PR DESCRIPTION
## Summary

Lands the foundation for shipping autopilot logs + per-task cost telemetry to the homelab Loki + Grafana. Per the plan, actual deployment is deferred until 2 weeks of real data — this PR makes the deploy a short ops task when ready.

**Live now:**
- \`lib/parse-usage.sh\` — aggregates the claude -p stream-json log into a one-line cost summary per task (token counts × Opus 4.7 list pricing → estimated_cost_usd)
- \`worker.sh\` integration — captures \`WORKER_START_TS\`, computes \`duration_sec\`, calls parse-usage at session end, writes \`/var/log/emf-dispatcher/cost-<task-id>.json\`. \`task_done\` event now also carries \`duration_sec\`

**Foundations (deploy when ready):**
- \`observability/promtail/{promtail-config.yml, promtail.service}\` — three scrape jobs (per-task jsonl, cost summaries, dispatcher journal), tagged with \`task=ID\` for drill-down
- \`observability/grafana/emf-autopilot-dashboard.json\` — importable: 4 stats (merged/failed/spend/duration), throughput timeseries, cost-per-task, top 10 expensive table, retry rate, recent events
- \`observability/alerts/emf-autopilot-alerts.yml\` — 6 rules: failed-tasks-high, worker-host-down, dispatcher-flapping, ci-median-slow, daily-spend-high, single-task-spend-high
- \`observability/README.md\` — full deploy steps including the Loki IngressRoute that's needed (Loki is currently ClusterIP only; worker-01 is outside the cluster)

## Test plan

- [x] \`bash -n\` clean
- [x] parse-usage.sh tested against a real worker log on worker-01: \`{"task":"CHORE-TEST","duration_sec":600,"input_tokens":226,"cache_creation_tokens":403110,"cache_read_tokens":4426857,"output_tokens":16187,"request_count":113,"estimated_cost_usd":15.416013,"component":"cost"}\` — useful immediate signal that a single retry-heavy task burned ~$15
- [ ] After merge: deploy worker.sh to worker-01 (manual: \`ssh worker-01; cd ~/GitHub/emf; git pull\`) — next task will produce a cost-\*.json
- [ ] Defer Promtail / Loki ingress / Grafana / alerts deployment per plan

## Autopilot

- [x] Autopilot-label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)