### PR TITLE
feat(dispatcher): idempotent launchd installer for Mac autopilot agents

### DIFF
--- a/.claude/dispatcher/README.md
+++ b/.claude/dispatcher/README.md
@@ -14,7 +14,9 @@ Phase 1 of the autonomous feature lifecycle planned in [`~/.claude/plans/i-want-
 | `lib/log.sh` | Structured JSON logging to stderr + `$EMF_LOG_DIR/<component>.jsonl` |
 | `status.sh` | One-screen queue summary; safe on either machine |
 | `systemd/emf-dispatcher.service` | systemd unit for `worker-01` |
+| `launchd/com.cklinker.emf-planner.plist` | every-10-min planner run on Mac |
 | `launchd/com.cklinker.emf-status.plist` | every-1-min status refresh on Mac |
+| `launchd/install-launchd.sh` | idempotent installer for both agents |
 
 ## Install on worker-01
 
@@ -40,12 +42,14 @@ journalctl -fu emf-dispatcher -o cat
 ## Install on Mac
 
 ```sh
-cp ~/GitHub/emf/.claude/dispatcher/launchd/com.cklinker.emf-status.plist \
-   ~/Library/LaunchAgents/
-launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.cklinker.emf-status.plist
+# Installs both plists, reloads launchd, verifies registration. Idempotent —
+# re-run any time a plist changes. A plain `cp` is NOT enough; launchd holds
+# the old definition until it is booted out + bootstrapped.
+bash ~/GitHub/emf/.claude/dispatcher/launchd/install-launchd.sh
 
 # Verify
-cat /tmp/emf-status.txt   # refreshes every minute
+cat /tmp/emf-status.txt          # refreshes every minute
+tail -f /tmp/emf-planner.launchd.log
 
 # Add an SSH config entry for worker-01 if not already
 cat >> ~/.ssh/config <<'EOF'

--- a/.claude/dispatcher/launchd/install-launchd.sh
+++ b/.claude/dispatcher/launchd/install-launchd.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Install (or refresh) the Mac launchd agents for the EMF autopilot.
+#
+# Idempotent — safe to re-run any time the plists change. Copies the plists
+# from this dir to ~/Library/LaunchAgents/, then bootout + bootstrap each one
+# so launchd picks up the new copy (a plain `cp` is not enough — the running
+# launchd keeps the old definition until it is reloaded).
+#
+# Usage:
+#   bash ~/GitHub/emf/.claude/dispatcher/launchd/install-launchd.sh
+#
+# No sudo required — gui/$(id -u) is the per-user domain.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TARGET_DIR="$HOME/Library/LaunchAgents"
+UID_NUM="$(id -u)"
+DOMAIN="gui/$UID_NUM"
+
+AGENTS=(
+  "com.cklinker.emf-planner"
+  "com.cklinker.emf-status"
+)
+
+install -d "$TARGET_DIR"
+
+for label in "${AGENTS[@]}"; do
+  src="$SCRIPT_DIR/${label}.plist"
+  dst="$TARGET_DIR/${label}.plist"
+
+  if [[ ! -f "$src" ]]; then
+    echo "[install-launchd] missing source plist: $src" >&2
+    exit 1
+  fi
+
+  echo "[install-launchd] copying $label.plist"
+  install -m 644 "$src" "$dst"
+
+  echo "[install-launchd] reloading $label"
+  launchctl bootout "$DOMAIN" "$dst" 2>/dev/null || true
+  launchctl bootstrap "$DOMAIN" "$dst"
+done
+
+echo
+echo "[install-launchd] launchctl list (emf agents):"
+launchctl list | grep emf || true
+
+# Verify every agent is registered. `launchctl list` prints PID + status +
+# label, one per line. Missing = bootstrap silently failed.
+missing=0
+for label in "${AGENTS[@]}"; do
+  if ! launchctl list | awk '{print $3}' | grep -qx "$label"; then
+    echo "[install-launchd] ERROR: $label not registered" >&2
+    missing=1
+  fi
+done
+
+if [[ $missing -ne 0 ]]; then
+  exit 1
+fi
+
+echo
+echo "[install-launchd] done. Tail logs:"
+echo "  tail -f /tmp/emf-planner.launchd.log"
+echo "  tail -f /tmp/emf-status.launchd.log"
+echo "  cat /tmp/emf-status.txt"


### PR DESCRIPTION
## Summary

- Add `.claude/dispatcher/launchd/install-launchd.sh` — copies both autopilot plists into `~/Library/LaunchAgents/`, then `bootout` + `bootstrap` each in `gui/$UID` so launchd actually picks up the new definition.
- Verifies registration via `launchctl list | grep emf` and exits non-zero if any agent is missing.
- Idempotent: safe to re-run any time a plist changes.
- README Mac install section now points at the script instead of a single-plist `cp`.

## Why

Plain `cp` is not enough — the running launchd keeps the old definition until each agent is booted out + bootstrapped. PR #847 fixed the planner plist's `PATH` but the live launchd ran with the stale `PATH` for hours, exiting `rc=127` silently on every cron tick.

Same shape as `.claude/dispatcher/observability/install-promtail.sh`.

## Test plan

- [ ] `bash .claude/dispatcher/launchd/install-launchd.sh` on the Mac
- [ ] `launchctl list | grep emf` shows both `com.cklinker.emf-planner` and `com.cklinker.emf-status`
- [ ] `/tmp/emf-status.txt` updates within a minute
- [ ] `/tmp/emf-planner.launchd.log` shows next planner tick with the repo's current `PATH`
- [ ] Edit a plist (e.g. bump `StartInterval`), re-run the script, confirm the new interval takes effect without a logout

🤖 Generated with [Claude Code](https://claude.com/claude-code)