### PR TITLE
chore(cache): NATS listeners for domain + feature change events

### DIFF
--- a/.claude/CHANGELOG.md
+++ b/.claude/CHANGELOG.md
@@ -13,3 +13,4 @@ This file tracks merged autopilot work. Entries are appended by autopilot worker
 - 2026-05-11 chore(security): add SECURITY.md with vuln reporting policy and autopilot gating note (CHORE-2026-05-10-0002)
 - 2026-05-11 chore(docs): add CONTRIBUTING.md outlining the autopilot workflow (CHORE-2026-05-10-0003)
 - 2026-05-11 chore(autopilot): use task title+type for fallback commit message in worker.sh so `gh pr create --fill` produces a useful PR title (CHORE-2026-05-10-0005)
+- 2026-05-11 chore(cache): wire NATS listeners for kelta.config.domain.changed.* and kelta.config.feature.changed.* on gateway and worker (CHORE-2026-05-10-0007)

--- a/kelta-gateway/src/main/java/io/kelta/gateway/config/NatsSubscriptionConfig.java
+++ b/kelta-gateway/src/main/java/io/kelta/gateway/config/NatsSubscriptionConfig.java
@@ -2,6 +2,7 @@ package io.kelta.gateway.config;
 
 import io.kelta.gateway.listener.CerbosCacheInvalidationListener;
 import io.kelta.gateway.listener.ConfigEventListener;
+import io.kelta.gateway.listener.CustomDomainCacheInvalidationListener;
 import io.kelta.gateway.listener.RealtimeBridge;
 import io.kelta.gateway.listener.SystemCollectionRouteListener;
 import io.kelta.runtime.event.EventSubscription;
@@ -26,17 +27,20 @@ public class NatsSubscriptionConfig {
     private final SystemCollectionRouteListener systemCollectionRouteListener;
     private final ConfigEventListener configEventListener;
     private final CerbosCacheInvalidationListener cerbosCacheInvalidationListener;
+    private final CustomDomainCacheInvalidationListener customDomainCacheInvalidationListener;
 
     public NatsSubscriptionConfig(NatsSubscriptionManager subscriptionManager,
                                    RealtimeBridge realtimeBridge,
                                    SystemCollectionRouteListener systemCollectionRouteListener,
                                    ConfigEventListener configEventListener,
-                                   CerbosCacheInvalidationListener cerbosCacheInvalidationListener) {
+                                   CerbosCacheInvalidationListener cerbosCacheInvalidationListener,
+                                   CustomDomainCacheInvalidationListener customDomainCacheInvalidationListener) {
         this.subscriptionManager = subscriptionManager;
         this.realtimeBridge = realtimeBridge;
         this.systemCollectionRouteListener = systemCollectionRouteListener;
         this.configEventListener = configEventListener;
         this.cerbosCacheInvalidationListener = cerbosCacheInvalidationListener;
+        this.customDomainCacheInvalidationListener = customDomainCacheInvalidationListener;
     }
 
     @EventListener(ApplicationStartedEvent.class)
@@ -60,5 +64,9 @@ public class NatsSubscriptionConfig {
         subscriptionManager.register(EventSubscription.broadcast(
                 "gateway-cerbos-cache", "kelta.cerbos.policies.changed.*",
                 cerbosCacheInvalidationListener::handlePolicyChanged));
+
+        subscriptionManager.register(EventSubscription.broadcast(
+                "gateway-custom-domain-cache", "kelta.config.domain.changed.*",
+                customDomainCacheInvalidationListener::handleDomainChanged));
     }
 }

--- a/kelta-gateway/src/main/java/io/kelta/gateway/listener/CustomDomainCacheInvalidationListener.java
+++ b/kelta-gateway/src/main/java/io/kelta/gateway/listener/CustomDomainCacheInvalidationListener.java
@@ -1,0 +1,58 @@
+package io.kelta.gateway.listener;
+
+import io.kelta.gateway.cache.GatewayCacheManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Subscribes to {@code kelta.config.domain.changed.*} (broadcast) and evicts
+ * the matching entry from {@link GatewayCacheManager}'s custom domain cache.
+ *
+ * <p>The gateway caches both positive (domain → tenantSlug) and negative
+ * (domain → NOT_FOUND) lookups. Either kind must be dropped when the upstream
+ * row changes so the next request re-resolves against the worker.
+ */
+@Component
+public class CustomDomainCacheInvalidationListener {
+
+    private static final Logger log = LoggerFactory.getLogger(CustomDomainCacheInvalidationListener.class);
+
+    private final GatewayCacheManager cacheManager;
+    private final ObjectMapper objectMapper;
+
+    public CustomDomainCacheInvalidationListener(GatewayCacheManager cacheManager, ObjectMapper objectMapper) {
+        this.cacheManager = cacheManager;
+        this.objectMapper = objectMapper;
+    }
+
+    public void handleDomainChanged(String message) {
+        try {
+            JsonNode root = objectMapper.readTree(message);
+            JsonNode payload = root.get("payload");
+            if (payload == null || payload.isNull()) {
+                payload = root;
+            }
+            String domain = textOrNull(payload.get("domain"));
+            if (domain == null) {
+                log.warn("Custom domain changed event missing 'domain' field — evicting entire cache");
+                cacheManager.evictAllCustomDomains();
+                return;
+            }
+            log.info("Custom domain {} changed — evicting gateway cache entry", domain);
+            cacheManager.removeCustomDomain(domain);
+        } catch (Exception e) {
+            log.error("Failed to process custom domain changed event: {}", e.getMessage(), e);
+        }
+    }
+
+    private static String textOrNull(JsonNode node) {
+        if (node == null || node.isNull() || !node.isTextual()) {
+            return null;
+        }
+        String value = node.stringValue();
+        return value == null || value.isBlank() ? null : value;
+    }
+}

--- a/kelta-gateway/src/test/java/io/kelta/gateway/listener/CustomDomainCacheInvalidationListenerTest.java
+++ b/kelta-gateway/src/test/java/io/kelta/gateway/listener/CustomDomainCacheInvalidationListenerTest.java
@@ -1,0 +1,71 @@
+package io.kelta.gateway.listener;
+
+import io.kelta.gateway.cache.GatewayCacheManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import tools.jackson.databind.ObjectMapper;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CustomDomainCacheInvalidationListener (Gateway)")
+class CustomDomainCacheInvalidationListenerTest {
+
+    @Mock
+    private GatewayCacheManager cacheManager;
+
+    private CustomDomainCacheInvalidationListener listener;
+
+    @BeforeEach
+    void setUp() {
+        listener = new CustomDomainCacheInvalidationListener(cacheManager, new ObjectMapper());
+    }
+
+    @Test
+    @DisplayName("Removes the specific domain when the event carries a domain in payload")
+    void removesSpecificDomain() {
+        String message = "{\"eventType\":\"kelta.config.domain.changed\","
+                + "\"tenantId\":\"tenant-1\","
+                + "\"payload\":{\"id\":\"d-1\",\"domain\":\"app.acme.com\",\"changeType\":\"UPDATED\"}}";
+
+        listener.handleDomainChanged(message);
+
+        verify(cacheManager).removeCustomDomain("app.acme.com");
+        verify(cacheManager, never()).evictAllCustomDomains();
+    }
+
+    @Test
+    @DisplayName("Falls back to evicting all when the event lacks a domain")
+    void evictsAllWhenDomainMissing() {
+        String message = "{\"eventType\":\"kelta.config.domain.changed\","
+                + "\"tenantId\":\"tenant-1\","
+                + "\"payload\":{\"id\":\"d-1\",\"changeType\":\"DELETED\"}}";
+
+        listener.handleDomainChanged(message);
+
+        verify(cacheManager).evictAllCustomDomains();
+        verify(cacheManager, never()).removeCustomDomain(any());
+    }
+
+    @Test
+    @DisplayName("Handles flat payloads (no envelope) by reading domain directly")
+    void handlesFlatPayload() {
+        String message = "{\"domain\":\"shop.example.com\",\"changeType\":\"CREATED\"}";
+
+        listener.handleDomainChanged(message);
+
+        verify(cacheManager).removeCustomDomain("shop.example.com");
+    }
+
+    @Test
+    @DisplayName("Handles malformed JSON gracefully")
+    void handlesMalformedJson() {
+        listener.handleDomainChanged("not json");
+
+        verifyNoInteractions(cacheManager);
+    }
+}

--- a/kelta-worker/src/main/java/io/kelta/worker/config/NatsSubscriptionConfig.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/config/NatsSubscriptionConfig.java
@@ -5,10 +5,12 @@ import io.kelta.runtime.messaging.nats.NatsSubscriptionManager;
 import io.kelta.worker.listener.CerbosCacheInvalidationListener;
 import io.kelta.worker.listener.CollectionSchemaListener;
 import io.kelta.worker.listener.CredentialCacheInvalidationListener;
+import io.kelta.worker.listener.CustomDomainCacheInvalidationListener;
 import io.kelta.worker.listener.FlowEventListener;
 import io.kelta.worker.listener.SearchIndexListener;
 import io.kelta.worker.listener.SupersetCollectionSyncListener;
 import io.kelta.worker.listener.SvixWebhookPublisher;
+import io.kelta.worker.listener.SystemFeatureCacheInvalidationListener;
 import io.kelta.worker.module.ModuleEventListener;
 import jakarta.annotation.PostConstruct;
 import org.slf4j.Logger;
@@ -38,6 +40,8 @@ public class NatsSubscriptionConfig {
     private final CollectionSchemaListener collectionSchemaListener;
     private final ModuleEventListener moduleEventListener;
     private final CerbosCacheInvalidationListener cerbosCacheInvalidationListener;
+    private final CustomDomainCacheInvalidationListener customDomainCacheInvalidationListener;
+    private final SystemFeatureCacheInvalidationListener systemFeatureCacheInvalidationListener;
 
     @Autowired(required = false)
     private CredentialCacheInvalidationListener credentialCacheInvalidationListener;
@@ -53,13 +57,17 @@ public class NatsSubscriptionConfig {
                                    SearchIndexListener searchIndexListener,
                                    CollectionSchemaListener collectionSchemaListener,
                                    ModuleEventListener moduleEventListener,
-                                   CerbosCacheInvalidationListener cerbosCacheInvalidationListener) {
+                                   CerbosCacheInvalidationListener cerbosCacheInvalidationListener,
+                                   CustomDomainCacheInvalidationListener customDomainCacheInvalidationListener,
+                                   SystemFeatureCacheInvalidationListener systemFeatureCacheInvalidationListener) {
         this.subscriptionManager = subscriptionManager;
         this.flowEventListener = flowEventListener;
         this.searchIndexListener = searchIndexListener;
         this.collectionSchemaListener = collectionSchemaListener;
         this.moduleEventListener = moduleEventListener;
         this.cerbosCacheInvalidationListener = cerbosCacheInvalidationListener;
+        this.customDomainCacheInvalidationListener = customDomainCacheInvalidationListener;
+        this.systemFeatureCacheInvalidationListener = systemFeatureCacheInvalidationListener;
     }
 
     @PostConstruct
@@ -105,6 +113,20 @@ public class NatsSubscriptionConfig {
                 "worker-flow-cache", "kelta.config.flow.changed.>",
                 flowEventListener::handleFlowConfigChanged));
 
+        // Custom domain cache invalidation — every pod drops its cached
+        // domain → tenantSlug mapping when a custom domain row changes
+        // upstream, so the next /internal/domains/resolve query hits the DB.
+        subscriptionManager.register(EventSubscription.broadcast(
+                "worker-custom-domain-cache", "kelta.config.domain.changed.*",
+                customDomainCacheInvalidationListener::handleDomainChanged));
+
+        // System feature cache invalidation — every pod drops its tenant
+        // limits cache when a feature toggle changes, so subsequent reads
+        // reflect the new state immediately rather than after TTL expiry.
+        subscriptionManager.register(EventSubscription.broadcast(
+                "worker-system-feature-cache", "kelta.config.feature.changed.*",
+                systemFeatureCacheInvalidationListener::handleFeatureChanged));
+
         // Optional queue group subscriptions — only registered when the integration is enabled
         if (supersetCollectionSyncListener != null) {
             subscriptionManager.register(EventSubscription.queueGroup(
@@ -120,7 +142,7 @@ public class NatsSubscriptionConfig {
             log.info("Registered NATS subscription for Svix webhook publisher");
         }
 
-        log.info("Registered {} worker NATS subscriptions", 6
+        log.info("Registered {} worker NATS subscriptions", 8
                 + (credentialCacheInvalidationListener != null ? 1 : 0)
                 + (supersetCollectionSyncListener != null ? 1 : 0)
                 + (svixWebhookPublisher != null ? 1 : 0));

--- a/kelta-worker/src/main/java/io/kelta/worker/listener/CustomDomainCacheInvalidationListener.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/listener/CustomDomainCacheInvalidationListener.java
@@ -1,0 +1,59 @@
+package io.kelta.worker.listener;
+
+import io.kelta.worker.cache.WorkerCacheManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Subscribes to {@code kelta.config.domain.changed.*} (broadcast) and evicts
+ * the matching entry from {@link WorkerCacheManager}'s custom domain cache.
+ *
+ * <p>The event envelope is a {@code PlatformEvent} whose payload carries the
+ * affected domain name (e.g. {@code app.acme.com}). When the domain string is
+ * present we evict that specific entry; otherwise we evict the entire cache as
+ * a safety fallback.
+ */
+@Component
+public class CustomDomainCacheInvalidationListener {
+
+    private static final Logger log = LoggerFactory.getLogger(CustomDomainCacheInvalidationListener.class);
+
+    private final WorkerCacheManager cacheManager;
+    private final ObjectMapper objectMapper;
+
+    public CustomDomainCacheInvalidationListener(WorkerCacheManager cacheManager, ObjectMapper objectMapper) {
+        this.cacheManager = cacheManager;
+        this.objectMapper = objectMapper;
+    }
+
+    public void handleDomainChanged(String message) {
+        try {
+            JsonNode root = objectMapper.readTree(message);
+            JsonNode payload = root.get("payload");
+            if (payload == null || payload.isNull()) {
+                payload = root;
+            }
+            String domain = textOrNull(payload.get("domain"));
+            if (domain == null) {
+                log.warn("Custom domain changed event missing 'domain' field — evicting entire cache");
+                cacheManager.evictAllCustomDomains();
+                return;
+            }
+            log.info("Custom domain {} changed — evicting local cache entry", domain);
+            cacheManager.evictCustomDomain(domain);
+        } catch (Exception e) {
+            log.error("Failed to process custom domain changed event: {}", e.getMessage(), e);
+        }
+    }
+
+    private static String textOrNull(JsonNode node) {
+        if (node == null || node.isNull() || !node.isTextual()) {
+            return null;
+        }
+        String value = node.stringValue();
+        return value == null || value.isBlank() ? null : value;
+    }
+}

--- a/kelta-worker/src/main/java/io/kelta/worker/listener/SystemFeatureCacheInvalidationListener.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/listener/SystemFeatureCacheInvalidationListener.java
@@ -1,0 +1,59 @@
+package io.kelta.worker.listener;
+
+import io.kelta.worker.cache.WorkerCacheManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Subscribes to {@code kelta.config.feature.changed.*} (broadcast) and evicts
+ * tenant-scoped feature/limit cache entries from {@link WorkerCacheManager}.
+ *
+ * <p>System feature toggles are stored per tenant. When a toggle changes,
+ * every worker pod drops its cached governor/limits snapshot for the affected
+ * tenant so the next read re-fetches from the database.
+ */
+@Component
+public class SystemFeatureCacheInvalidationListener {
+
+    private static final Logger log = LoggerFactory.getLogger(SystemFeatureCacheInvalidationListener.class);
+
+    private final WorkerCacheManager cacheManager;
+    private final ObjectMapper objectMapper;
+
+    public SystemFeatureCacheInvalidationListener(WorkerCacheManager cacheManager, ObjectMapper objectMapper) {
+        this.cacheManager = cacheManager;
+        this.objectMapper = objectMapper;
+    }
+
+    public void handleFeatureChanged(String message) {
+        try {
+            JsonNode root = objectMapper.readTree(message);
+            String tenantId = textOrNull(root.get("tenantId"));
+            if (tenantId == null) {
+                JsonNode payload = root.get("payload");
+                if (payload != null && !payload.isNull()) {
+                    tenantId = textOrNull(payload.get("tenantId"));
+                }
+            }
+            if (tenantId == null) {
+                log.warn("Skipping feature cache invalidation: missing tenantId in event");
+                return;
+            }
+            log.info("System feature changed for tenant {} — evicting local tenant limits cache", tenantId);
+            cacheManager.evictTenantLimits(tenantId);
+        } catch (Exception e) {
+            log.error("Failed to process feature changed event: {}", e.getMessage(), e);
+        }
+    }
+
+    private static String textOrNull(JsonNode node) {
+        if (node == null || node.isNull() || !node.isTextual()) {
+            return null;
+        }
+        String value = node.stringValue();
+        return value == null || value.isBlank() ? null : value;
+    }
+}

--- a/kelta-worker/src/test/java/io/kelta/worker/config/NatsSubscriptionConfigTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/config/NatsSubscriptionConfigTest.java
@@ -5,8 +5,10 @@ import io.kelta.runtime.messaging.nats.NatsSubscriptionManager;
 import io.kelta.worker.listener.CerbosCacheInvalidationListener;
 import io.kelta.worker.listener.CollectionSchemaListener;
 import io.kelta.worker.listener.CredentialCacheInvalidationListener;
+import io.kelta.worker.listener.CustomDomainCacheInvalidationListener;
 import io.kelta.worker.listener.FlowEventListener;
 import io.kelta.worker.listener.SearchIndexListener;
+import io.kelta.worker.listener.SystemFeatureCacheInvalidationListener;
 import io.kelta.worker.module.ModuleEventListener;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -33,7 +35,9 @@ class NatsSubscriptionConfigTest {
                 mock(SearchIndexListener.class),
                 mock(CollectionSchemaListener.class),
                 mock(ModuleEventListener.class),
-                mock(CerbosCacheInvalidationListener.class));
+                mock(CerbosCacheInvalidationListener.class),
+                mock(CustomDomainCacheInvalidationListener.class),
+                mock(SystemFeatureCacheInvalidationListener.class));
     }
 
     @Test
@@ -43,10 +47,10 @@ class NatsSubscriptionConfigTest {
         // when kelta.encryption.key is not configured.
         config.registerSubscriptions();
 
-        // Six always-on subscriptions: worker-flows, worker-search-index, worker-schema,
-        // worker-modules, worker-cerbos, worker-flow-cache.
-        // Credential/Superset/Svix are conditional.
-        verify(subscriptionManager, times(6)).register(any(EventSubscription.class));
+        // Eight always-on subscriptions: worker-flows, worker-search-index, worker-schema,
+        // worker-modules, worker-cerbos, worker-flow-cache, worker-custom-domain-cache,
+        // worker-system-feature-cache. Credential/Superset/Svix are conditional.
+        verify(subscriptionManager, times(8)).register(any(EventSubscription.class));
     }
 
     @Test
@@ -57,6 +61,6 @@ class NatsSubscriptionConfigTest {
 
         config.registerSubscriptions();
 
-        verify(subscriptionManager, times(7)).register(any(EventSubscription.class));
+        verify(subscriptionManager, times(9)).register(any(EventSubscription.class));
     }
 }

--- a/kelta-worker/src/test/java/io/kelta/worker/listener/CustomDomainCacheInvalidationListenerTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/listener/CustomDomainCacheInvalidationListenerTest.java
@@ -1,0 +1,71 @@
+package io.kelta.worker.listener;
+
+import io.kelta.worker.cache.WorkerCacheManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import tools.jackson.databind.ObjectMapper;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CustomDomainCacheInvalidationListener (Worker)")
+class CustomDomainCacheInvalidationListenerTest {
+
+    @Mock
+    private WorkerCacheManager cacheManager;
+
+    private CustomDomainCacheInvalidationListener listener;
+
+    @BeforeEach
+    void setUp() {
+        listener = new CustomDomainCacheInvalidationListener(cacheManager, new ObjectMapper());
+    }
+
+    @Test
+    @DisplayName("Evicts the specific domain when the event carries a domain in payload")
+    void evictsSpecificDomain() {
+        String message = "{\"eventType\":\"kelta.config.domain.changed\","
+                + "\"tenantId\":\"tenant-1\","
+                + "\"payload\":{\"id\":\"d-1\",\"domain\":\"app.acme.com\",\"changeType\":\"UPDATED\"}}";
+
+        listener.handleDomainChanged(message);
+
+        verify(cacheManager).evictCustomDomain("app.acme.com");
+        verify(cacheManager, never()).evictAllCustomDomains();
+    }
+
+    @Test
+    @DisplayName("Falls back to evicting all when the event lacks a domain")
+    void evictsAllWhenDomainMissing() {
+        String message = "{\"eventType\":\"kelta.config.domain.changed\","
+                + "\"tenantId\":\"tenant-1\","
+                + "\"payload\":{\"id\":\"d-1\",\"changeType\":\"DELETED\"}}";
+
+        listener.handleDomainChanged(message);
+
+        verify(cacheManager).evictAllCustomDomains();
+        verify(cacheManager, never()).evictCustomDomain(any());
+    }
+
+    @Test
+    @DisplayName("Handles flat payloads (no envelope) by reading domain directly")
+    void handlesFlatPayload() {
+        String message = "{\"domain\":\"shop.example.com\",\"changeType\":\"CREATED\"}";
+
+        listener.handleDomainChanged(message);
+
+        verify(cacheManager).evictCustomDomain("shop.example.com");
+    }
+
+    @Test
+    @DisplayName("Handles malformed JSON gracefully")
+    void handlesMalformedJson() {
+        listener.handleDomainChanged("not json");
+
+        verifyNoInteractions(cacheManager);
+    }
+}

--- a/kelta-worker/src/test/java/io/kelta/worker/listener/SystemFeatureCacheInvalidationListenerTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/listener/SystemFeatureCacheInvalidationListenerTest.java
@@ -1,0 +1,68 @@
+package io.kelta.worker.listener;
+
+import io.kelta.worker.cache.WorkerCacheManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import tools.jackson.databind.ObjectMapper;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SystemFeatureCacheInvalidationListener (Worker)")
+class SystemFeatureCacheInvalidationListenerTest {
+
+    @Mock
+    private WorkerCacheManager cacheManager;
+
+    private SystemFeatureCacheInvalidationListener listener;
+
+    @BeforeEach
+    void setUp() {
+        listener = new SystemFeatureCacheInvalidationListener(cacheManager, new ObjectMapper());
+    }
+
+    @Test
+    @DisplayName("Evicts tenant limits cache when tenantId is on the envelope")
+    void evictsForEnvelopeTenantId() {
+        String message = "{\"eventType\":\"kelta.config.feature.changed\","
+                + "\"tenantId\":\"tenant-1\","
+                + "\"payload\":{\"name\":\"audit_log\",\"enabled\":true}}";
+
+        listener.handleFeatureChanged(message);
+
+        verify(cacheManager).evictTenantLimits("tenant-1");
+    }
+
+    @Test
+    @DisplayName("Falls back to tenantId inside payload when not on the envelope")
+    void evictsForPayloadTenantId() {
+        String message = "{\"eventType\":\"kelta.config.feature.changed\","
+                + "\"payload\":{\"tenantId\":\"tenant-2\",\"name\":\"audit_log\"}}";
+
+        listener.handleFeatureChanged(message);
+
+        verify(cacheManager).evictTenantLimits("tenant-2");
+    }
+
+    @Test
+    @DisplayName("Does nothing when tenantId is missing")
+    void skipsWhenTenantIdMissing() {
+        String message = "{\"payload\":{\"name\":\"audit_log\"}}";
+
+        listener.handleFeatureChanged(message);
+
+        verifyNoInteractions(cacheManager);
+    }
+
+    @Test
+    @DisplayName("Handles malformed JSON gracefully")
+    void handlesMalformedJson() {
+        listener.handleFeatureChanged("not json");
+
+        verifyNoInteractions(cacheManager);
+    }
+}


### PR DESCRIPTION
Adds broadcast-mode subscriptions on both gateway and worker for the
new kelta.config.domain.changed.* and kelta.config.feature.changed.*
subjects published by CHORE-2026-05-10-0006. Each pod evicts its local
Caffeine cache entry so config edits propagate without waiting on TTL.

- Worker: CustomDomainCacheInvalidationListener -> WorkerCacheManager.evictCustomDomain
- Gateway: CustomDomainCacheInvalidationListener -> GatewayCacheManager.removeCustomDomain
- Worker: SystemFeatureCacheInvalidationListener -> WorkerCacheManager.evictTenantLimits
- Registered all three in NatsSubscriptionConfig (worker + gateway)

CHORE-2026-05-10-0007

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
