### PR TITLE
chore(cache): add NATS listeners for domain and feature change events

### DIFF
--- a/.claude/CHANGELOG.md
+++ b/.claude/CHANGELOG.md
@@ -14,3 +14,4 @@ This file tracks merged autopilot work. Entries are appended by autopilot worker
 - 2026-05-11 chore(docs): add CONTRIBUTING.md outlining the autopilot workflow (CHORE-2026-05-10-0003)
 - 2026-05-11 chore(autopilot): use task title+type for fallback commit message in worker.sh so `gh pr create --fill` produces a useful PR title (CHORE-2026-05-10-0005)
 - 2026-05-11 doc(ui): add UI component consolidation plan covering DataTable/FilterBuilder/FieldRenderer/ResourceForm/RelatedList unification, feature superset, and migration order (DOC-2026-05-10-0002)
+- 2026-05-11 chore(cache): wire NATS broadcast listeners on gateway and worker for `kelta.config.domain.changed.*` and `kelta.config.feature.changed.*` cache invalidation (CHORE-2026-05-10-0007)

--- a/kelta-gateway/src/main/java/io/kelta/gateway/config/NatsSubscriptionConfig.java
+++ b/kelta-gateway/src/main/java/io/kelta/gateway/config/NatsSubscriptionConfig.java
@@ -2,6 +2,7 @@ package io.kelta.gateway.config;
 
 import io.kelta.gateway.listener.CerbosCacheInvalidationListener;
 import io.kelta.gateway.listener.ConfigEventListener;
+import io.kelta.gateway.listener.CustomDomainCacheInvalidationListener;
 import io.kelta.gateway.listener.RealtimeBridge;
 import io.kelta.gateway.listener.SystemCollectionRouteListener;
 import io.kelta.runtime.event.EventSubscription;
@@ -26,17 +27,20 @@ public class NatsSubscriptionConfig {
     private final SystemCollectionRouteListener systemCollectionRouteListener;
     private final ConfigEventListener configEventListener;
     private final CerbosCacheInvalidationListener cerbosCacheInvalidationListener;
+    private final CustomDomainCacheInvalidationListener customDomainCacheInvalidationListener;
 
     public NatsSubscriptionConfig(NatsSubscriptionManager subscriptionManager,
                                    RealtimeBridge realtimeBridge,
                                    SystemCollectionRouteListener systemCollectionRouteListener,
                                    ConfigEventListener configEventListener,
-                                   CerbosCacheInvalidationListener cerbosCacheInvalidationListener) {
+                                   CerbosCacheInvalidationListener cerbosCacheInvalidationListener,
+                                   CustomDomainCacheInvalidationListener customDomainCacheInvalidationListener) {
         this.subscriptionManager = subscriptionManager;
         this.realtimeBridge = realtimeBridge;
         this.systemCollectionRouteListener = systemCollectionRouteListener;
         this.configEventListener = configEventListener;
         this.cerbosCacheInvalidationListener = cerbosCacheInvalidationListener;
+        this.customDomainCacheInvalidationListener = customDomainCacheInvalidationListener;
     }
 
     @EventListener(ApplicationStartedEvent.class)
@@ -60,5 +64,9 @@ public class NatsSubscriptionConfig {
         subscriptionManager.register(EventSubscription.broadcast(
                 "gateway-cerbos-cache", "kelta.cerbos.policies.changed.*",
                 cerbosCacheInvalidationListener::handlePolicyChanged));
+
+        subscriptionManager.register(EventSubscription.broadcast(
+                "gateway-domain-cache", "kelta.config.domain.changed.*",
+                customDomainCacheInvalidationListener::handleDomainChanged));
     }
 }

--- a/kelta-gateway/src/main/java/io/kelta/gateway/listener/CustomDomainCacheInvalidationListener.java
+++ b/kelta-gateway/src/main/java/io/kelta/gateway/listener/CustomDomainCacheInvalidationListener.java
@@ -1,0 +1,55 @@
+package io.kelta.gateway.listener;
+
+import io.kelta.gateway.cache.GatewayCacheManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Subscribes to {@code kelta.config.domain.changed.*} (broadcast) and drops
+ * the gateway's local domain → tenant slug mapping so the next lookup re-fetches
+ * from the worker. Every gateway pod runs this listener so cache stays
+ * consistent across the fleet.
+ *
+ * <p>The cache is keyed by domain name. If the event payload includes the
+ * {@code domain} field, only that entry is evicted; otherwise the full custom
+ * domain cache is invalidated as a safety fallback.
+ */
+@Component
+public class CustomDomainCacheInvalidationListener {
+
+    private static final Logger log = LoggerFactory.getLogger(CustomDomainCacheInvalidationListener.class);
+
+    private final GatewayCacheManager cacheManager;
+    private final ObjectMapper objectMapper;
+
+    public CustomDomainCacheInvalidationListener(GatewayCacheManager cacheManager, ObjectMapper objectMapper) {
+        this.cacheManager = cacheManager;
+        this.objectMapper = objectMapper;
+    }
+
+    public void handleDomainChanged(String message) {
+        try {
+            JsonNode root = objectMapper.readTree(message);
+            JsonNode payload = root.get("payload");
+            if (payload == null || payload.isNull()) {
+                payload = root;
+            }
+
+            JsonNode domainNode = payload.get("domain");
+            if (domainNode != null && !domainNode.isNull() && domainNode.isTextual()) {
+                String domain = domainNode.stringValue();
+                log.info("Custom domain {} changed — evicting gateway cache entry", domain);
+                cacheManager.removeCustomDomain(domain);
+                return;
+            }
+
+            log.info("Custom domain changed event missing 'domain' field — evicting all custom domain cache entries");
+            cacheManager.evictAllCustomDomains();
+        } catch (Exception e) {
+            log.error("Failed to process domain changed event: {}", e.getMessage(), e);
+        }
+    }
+}

--- a/kelta-gateway/src/test/java/io/kelta/gateway/listener/CustomDomainCacheInvalidationListenerTest.java
+++ b/kelta-gateway/src/test/java/io/kelta/gateway/listener/CustomDomainCacheInvalidationListenerTest.java
@@ -1,0 +1,63 @@
+package io.kelta.gateway.listener;
+
+import io.kelta.gateway.cache.GatewayCacheManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import tools.jackson.databind.ObjectMapper;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CustomDomainCacheInvalidationListener (Gateway)")
+class CustomDomainCacheInvalidationListenerTest {
+
+    @Mock
+    private GatewayCacheManager cacheManager;
+
+    private CustomDomainCacheInvalidationListener listener;
+
+    @BeforeEach
+    void setUp() {
+        listener = new CustomDomainCacheInvalidationListener(cacheManager, new ObjectMapper());
+    }
+
+    @Test
+    @DisplayName("Evicts the specific domain when the envelope payload includes 'domain'")
+    void evictsSpecificDomain() {
+        String message = "{\"tenantId\":\"tenant-1\",\"payload\":{\"id\":\"d-1\",\"domain\":\"app.acme.com\"}}";
+        listener.handleDomainChanged(message);
+        verify(cacheManager).removeCustomDomain("app.acme.com");
+        verify(cacheManager, never()).evictAllCustomDomains();
+    }
+
+    @Test
+    @DisplayName("Accepts a raw payload (no envelope) when 'domain' is at the top level")
+    void evictsSpecificDomainFromRawPayload() {
+        String message = "{\"id\":\"d-1\",\"domain\":\"app.acme.com\"}";
+        listener.handleDomainChanged(message);
+        verify(cacheManager).removeCustomDomain("app.acme.com");
+    }
+
+    @Test
+    @DisplayName("Falls back to evicting all custom domains when 'domain' field is missing")
+    void evictsAllWhenDomainFieldMissing() {
+        String message = "{\"tenantId\":\"tenant-1\",\"payload\":{\"id\":\"d-1\"}}";
+        listener.handleDomainChanged(message);
+        verify(cacheManager).evictAllCustomDomains();
+        verify(cacheManager, never()).removeCustomDomain(anyString());
+    }
+
+    @Test
+    @DisplayName("Handles malformed JSON gracefully")
+    void handlesMalformedJson() {
+        listener.handleDomainChanged("not json");
+        verify(cacheManager, never()).removeCustomDomain(anyString());
+        verify(cacheManager, never()).evictAllCustomDomains();
+    }
+}

--- a/kelta-worker/src/main/java/io/kelta/worker/config/NatsSubscriptionConfig.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/config/NatsSubscriptionConfig.java
@@ -5,10 +5,12 @@ import io.kelta.runtime.messaging.nats.NatsSubscriptionManager;
 import io.kelta.worker.listener.CerbosCacheInvalidationListener;
 import io.kelta.worker.listener.CollectionSchemaListener;
 import io.kelta.worker.listener.CredentialCacheInvalidationListener;
+import io.kelta.worker.listener.CustomDomainCacheInvalidationListener;
 import io.kelta.worker.listener.FlowEventListener;
 import io.kelta.worker.listener.SearchIndexListener;
 import io.kelta.worker.listener.SupersetCollectionSyncListener;
 import io.kelta.worker.listener.SvixWebhookPublisher;
+import io.kelta.worker.listener.SystemFeatureCacheInvalidationListener;
 import io.kelta.worker.module.ModuleEventListener;
 import jakarta.annotation.PostConstruct;
 import org.slf4j.Logger;
@@ -38,6 +40,8 @@ public class NatsSubscriptionConfig {
     private final CollectionSchemaListener collectionSchemaListener;
     private final ModuleEventListener moduleEventListener;
     private final CerbosCacheInvalidationListener cerbosCacheInvalidationListener;
+    private final CustomDomainCacheInvalidationListener customDomainCacheInvalidationListener;
+    private final SystemFeatureCacheInvalidationListener systemFeatureCacheInvalidationListener;
 
     @Autowired(required = false)
     private CredentialCacheInvalidationListener credentialCacheInvalidationListener;
@@ -53,13 +57,17 @@ public class NatsSubscriptionConfig {
                                    SearchIndexListener searchIndexListener,
                                    CollectionSchemaListener collectionSchemaListener,
                                    ModuleEventListener moduleEventListener,
-                                   CerbosCacheInvalidationListener cerbosCacheInvalidationListener) {
+                                   CerbosCacheInvalidationListener cerbosCacheInvalidationListener,
+                                   CustomDomainCacheInvalidationListener customDomainCacheInvalidationListener,
+                                   SystemFeatureCacheInvalidationListener systemFeatureCacheInvalidationListener) {
         this.subscriptionManager = subscriptionManager;
         this.flowEventListener = flowEventListener;
         this.searchIndexListener = searchIndexListener;
         this.collectionSchemaListener = collectionSchemaListener;
         this.moduleEventListener = moduleEventListener;
         this.cerbosCacheInvalidationListener = cerbosCacheInvalidationListener;
+        this.customDomainCacheInvalidationListener = customDomainCacheInvalidationListener;
+        this.systemFeatureCacheInvalidationListener = systemFeatureCacheInvalidationListener;
     }
 
     @PostConstruct
@@ -105,6 +113,18 @@ public class NatsSubscriptionConfig {
                 "worker-flow-cache", "kelta.config.flow.changed.>",
                 flowEventListener::handleFlowConfigChanged));
 
+        // Custom domain cache invalidation — every pod drops cached domain
+        // resolutions when a domain row changes upstream.
+        subscriptionManager.register(EventSubscription.broadcast(
+                "worker-domain-cache", "kelta.config.domain.changed.*",
+                customDomainCacheInvalidationListener::handleDomainChanged));
+
+        // System feature cache invalidation — every pod evicts tenant-scoped
+        // caches that may depend on feature flags when features change.
+        subscriptionManager.register(EventSubscription.broadcast(
+                "worker-feature-cache", "kelta.config.feature.changed.*",
+                systemFeatureCacheInvalidationListener::handleFeatureChanged));
+
         // Optional queue group subscriptions — only registered when the integration is enabled
         if (supersetCollectionSyncListener != null) {
             subscriptionManager.register(EventSubscription.queueGroup(
@@ -120,7 +140,7 @@ public class NatsSubscriptionConfig {
             log.info("Registered NATS subscription for Svix webhook publisher");
         }
 
-        log.info("Registered {} worker NATS subscriptions", 6
+        log.info("Registered {} worker NATS subscriptions", 8
                 + (credentialCacheInvalidationListener != null ? 1 : 0)
                 + (supersetCollectionSyncListener != null ? 1 : 0)
                 + (svixWebhookPublisher != null ? 1 : 0));

--- a/kelta-worker/src/main/java/io/kelta/worker/listener/CustomDomainCacheInvalidationListener.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/listener/CustomDomainCacheInvalidationListener.java
@@ -1,0 +1,55 @@
+package io.kelta.worker.listener;
+
+import io.kelta.worker.cache.WorkerCacheManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Subscribes to {@code kelta.config.domain.changed.*} (broadcast) and drops
+ * the cached domain → tenant slug mapping so subsequent lookups re-query the
+ * database. Every worker pod runs this listener so cache stays consistent
+ * across the fleet.
+ *
+ * <p>The cache is keyed by domain name. If the event payload includes the
+ * {@code domain} field, only that entry is evicted; otherwise the full custom
+ * domain cache is invalidated as a safety fallback.
+ */
+@Component
+public class CustomDomainCacheInvalidationListener {
+
+    private static final Logger log = LoggerFactory.getLogger(CustomDomainCacheInvalidationListener.class);
+
+    private final WorkerCacheManager cacheManager;
+    private final ObjectMapper objectMapper;
+
+    public CustomDomainCacheInvalidationListener(WorkerCacheManager cacheManager, ObjectMapper objectMapper) {
+        this.cacheManager = cacheManager;
+        this.objectMapper = objectMapper;
+    }
+
+    public void handleDomainChanged(String message) {
+        try {
+            JsonNode root = objectMapper.readTree(message);
+            JsonNode payload = root.get("payload");
+            if (payload == null || payload.isNull()) {
+                payload = root;
+            }
+
+            JsonNode domainNode = payload.get("domain");
+            if (domainNode != null && !domainNode.isNull() && domainNode.isTextual()) {
+                String domain = domainNode.stringValue();
+                log.info("Custom domain {} changed — evicting worker cache entry", domain);
+                cacheManager.evictCustomDomain(domain);
+                return;
+            }
+
+            log.info("Custom domain changed event missing 'domain' field — evicting all custom domain cache entries");
+            cacheManager.evictAllCustomDomains();
+        } catch (Exception e) {
+            log.error("Failed to process domain changed event: {}", e.getMessage(), e);
+        }
+    }
+}

--- a/kelta-worker/src/main/java/io/kelta/worker/listener/SystemFeatureCacheInvalidationListener.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/listener/SystemFeatureCacheInvalidationListener.java
@@ -1,0 +1,67 @@
+package io.kelta.worker.listener;
+
+import io.kelta.worker.cache.WorkerCacheManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Subscribes to {@code kelta.config.feature.changed.*} (broadcast) and evicts
+ * tenant-scoped caches whose contents may be derived from system feature
+ * toggles. Every worker pod runs this listener so cache stays consistent
+ * across the fleet.
+ *
+ * <p>Subject pattern is {@code kelta.config.feature.changed.<tenantId>}; the
+ * tenant id is extracted from the {@code tenantId} field of the
+ * {@link io.kelta.runtime.event.PlatformEvent} envelope. Currently evicts the
+ * tenant limits cache, since governor limits are the cached value most likely
+ * to depend on feature flags. Additional caches can be evicted here as new
+ * feature-derived caches are introduced.
+ */
+@Component
+public class SystemFeatureCacheInvalidationListener {
+
+    private static final Logger log = LoggerFactory.getLogger(SystemFeatureCacheInvalidationListener.class);
+
+    private final WorkerCacheManager cacheManager;
+    private final ObjectMapper objectMapper;
+
+    public SystemFeatureCacheInvalidationListener(WorkerCacheManager cacheManager, ObjectMapper objectMapper) {
+        this.cacheManager = cacheManager;
+        this.objectMapper = objectMapper;
+    }
+
+    public void handleFeatureChanged(String message) {
+        try {
+            JsonNode root = objectMapper.readTree(message);
+
+            String tenantId = textOrNull(root.get("tenantId"));
+            if (tenantId == null) {
+                JsonNode payload = root.get("payload");
+                if (payload != null && !payload.isNull()) {
+                    tenantId = textOrNull(payload.get("tenantId"));
+                }
+            }
+
+            if (tenantId == null) {
+                log.warn("Skipping feature invalidation: missing tenantId in event");
+                return;
+            }
+
+            log.info("System feature changed for tenant {} — evicting tenant limits cache", tenantId);
+            cacheManager.evictTenantLimits(tenantId);
+        } catch (Exception e) {
+            log.error("Failed to process feature changed event: {}", e.getMessage(), e);
+        }
+    }
+
+    private static String textOrNull(JsonNode node) {
+        if (node == null || node.isNull() || !node.isTextual()) {
+            return null;
+        }
+        String value = node.stringValue();
+        return value.isBlank() ? null : value;
+    }
+}

--- a/kelta-worker/src/test/java/io/kelta/worker/config/NatsSubscriptionConfigTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/config/NatsSubscriptionConfigTest.java
@@ -5,8 +5,10 @@ import io.kelta.runtime.messaging.nats.NatsSubscriptionManager;
 import io.kelta.worker.listener.CerbosCacheInvalidationListener;
 import io.kelta.worker.listener.CollectionSchemaListener;
 import io.kelta.worker.listener.CredentialCacheInvalidationListener;
+import io.kelta.worker.listener.CustomDomainCacheInvalidationListener;
 import io.kelta.worker.listener.FlowEventListener;
 import io.kelta.worker.listener.SearchIndexListener;
+import io.kelta.worker.listener.SystemFeatureCacheInvalidationListener;
 import io.kelta.worker.module.ModuleEventListener;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -33,7 +35,9 @@ class NatsSubscriptionConfigTest {
                 mock(SearchIndexListener.class),
                 mock(CollectionSchemaListener.class),
                 mock(ModuleEventListener.class),
-                mock(CerbosCacheInvalidationListener.class));
+                mock(CerbosCacheInvalidationListener.class),
+                mock(CustomDomainCacheInvalidationListener.class),
+                mock(SystemFeatureCacheInvalidationListener.class));
     }
 
     @Test
@@ -43,10 +47,10 @@ class NatsSubscriptionConfigTest {
         // when kelta.encryption.key is not configured.
         config.registerSubscriptions();
 
-        // Six always-on subscriptions: worker-flows, worker-search-index, worker-schema,
-        // worker-modules, worker-cerbos, worker-flow-cache.
-        // Credential/Superset/Svix are conditional.
-        verify(subscriptionManager, times(6)).register(any(EventSubscription.class));
+        // Eight always-on subscriptions: worker-flows, worker-search-index, worker-schema,
+        // worker-modules, worker-cerbos, worker-flow-cache, worker-domain-cache,
+        // worker-feature-cache. Credential/Superset/Svix are conditional.
+        verify(subscriptionManager, times(8)).register(any(EventSubscription.class));
     }
 
     @Test
@@ -57,6 +61,6 @@ class NatsSubscriptionConfigTest {
 
         config.registerSubscriptions();
 
-        verify(subscriptionManager, times(7)).register(any(EventSubscription.class));
+        verify(subscriptionManager, times(9)).register(any(EventSubscription.class));
     }
 }

--- a/kelta-worker/src/test/java/io/kelta/worker/listener/CustomDomainCacheInvalidationListenerTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/listener/CustomDomainCacheInvalidationListenerTest.java
@@ -1,0 +1,62 @@
+package io.kelta.worker.listener;
+
+import io.kelta.worker.cache.WorkerCacheManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import tools.jackson.databind.ObjectMapper;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CustomDomainCacheInvalidationListener (Worker)")
+class CustomDomainCacheInvalidationListenerTest {
+
+    @Mock
+    private WorkerCacheManager cacheManager;
+
+    private CustomDomainCacheInvalidationListener listener;
+
+    @BeforeEach
+    void setUp() {
+        listener = new CustomDomainCacheInvalidationListener(cacheManager, new ObjectMapper());
+    }
+
+    @Test
+    @DisplayName("Evicts the specific domain when the envelope payload includes 'domain'")
+    void evictsSpecificDomain() {
+        String message = "{\"tenantId\":\"tenant-1\",\"payload\":{\"id\":\"d-1\",\"domain\":\"app.acme.com\"}}";
+        listener.handleDomainChanged(message);
+        verify(cacheManager).evictCustomDomain("app.acme.com");
+        verify(cacheManager, never()).evictAllCustomDomains();
+    }
+
+    @Test
+    @DisplayName("Accepts a raw payload (no envelope) when 'domain' is at the top level")
+    void evictsSpecificDomainFromRawPayload() {
+        String message = "{\"id\":\"d-1\",\"domain\":\"app.acme.com\"}";
+        listener.handleDomainChanged(message);
+        verify(cacheManager).evictCustomDomain("app.acme.com");
+    }
+
+    @Test
+    @DisplayName("Falls back to evicting all custom domains when 'domain' field is missing")
+    void evictsAllWhenDomainFieldMissing() {
+        String message = "{\"tenantId\":\"tenant-1\",\"payload\":{\"id\":\"d-1\"}}";
+        listener.handleDomainChanged(message);
+        verify(cacheManager).evictAllCustomDomains();
+        verify(cacheManager, never()).evictCustomDomain(org.mockito.ArgumentMatchers.anyString());
+    }
+
+    @Test
+    @DisplayName("Handles malformed JSON gracefully")
+    void handlesMalformedJson() {
+        listener.handleDomainChanged("not json");
+        verify(cacheManager, never()).evictCustomDomain(org.mockito.ArgumentMatchers.anyString());
+        verify(cacheManager, never()).evictAllCustomDomains();
+    }
+}

--- a/kelta-worker/src/test/java/io/kelta/worker/listener/SystemFeatureCacheInvalidationListenerTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/listener/SystemFeatureCacheInvalidationListenerTest.java
@@ -1,0 +1,68 @@
+package io.kelta.worker.listener;
+
+import io.kelta.worker.cache.WorkerCacheManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import tools.jackson.databind.ObjectMapper;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SystemFeatureCacheInvalidationListener (Worker)")
+class SystemFeatureCacheInvalidationListenerTest {
+
+    @Mock
+    private WorkerCacheManager cacheManager;
+
+    private SystemFeatureCacheInvalidationListener listener;
+
+    @BeforeEach
+    void setUp() {
+        listener = new SystemFeatureCacheInvalidationListener(cacheManager, new ObjectMapper());
+    }
+
+    @Test
+    @DisplayName("Evicts the tenant's limits cache from the envelope tenantId")
+    void evictsFromEnvelopeTenantId() {
+        String message = "{\"tenantId\":\"tenant-1\",\"payload\":{\"feature\":\"AI_ASSIST\"}}";
+        listener.handleFeatureChanged(message);
+        verify(cacheManager).evictTenantLimits("tenant-1");
+    }
+
+    @Test
+    @DisplayName("Falls back to payload.tenantId when the envelope is missing one")
+    void evictsFromPayloadTenantId() {
+        String message = "{\"payload\":{\"tenantId\":\"tenant-2\",\"feature\":\"AI_ASSIST\"}}";
+        listener.handleFeatureChanged(message);
+        verify(cacheManager).evictTenantLimits("tenant-2");
+    }
+
+    @Test
+    @DisplayName("Skips eviction when no tenantId is present")
+    void skipsWhenTenantIdMissing() {
+        String message = "{\"payload\":{\"feature\":\"AI_ASSIST\"}}";
+        listener.handleFeatureChanged(message);
+        verify(cacheManager, never()).evictTenantLimits(anyString());
+    }
+
+    @Test
+    @DisplayName("Skips eviction when tenantId is blank")
+    void skipsWhenTenantIdBlank() {
+        String message = "{\"tenantId\":\"  \",\"payload\":{\"feature\":\"AI_ASSIST\"}}";
+        listener.handleFeatureChanged(message);
+        verify(cacheManager, never()).evictTenantLimits(anyString());
+    }
+
+    @Test
+    @DisplayName("Handles malformed JSON gracefully")
+    void handlesMalformedJson() {
+        listener.handleFeatureChanged("not json");
+        verify(cacheManager, never()).evictTenantLimits(anyString());
+    }
+}


### PR DESCRIPTION
Wires CustomDomainCacheInvalidationListener on both gateway and worker to
subscribe to `kelta.config.domain.changed.*` (broadcast). Each listener
extracts the `domain` field from the PlatformEvent envelope and evicts the
matching cache entry, falling back to a full custom-domain cache flush when
the field is absent.

Adds SystemFeatureCacheInvalidationListener on the worker to subscribe to
`kelta.config.feature.changed.*` (broadcast) and evict the tenant limits
cache for the affected tenant — features can gate governor limits, and
tenant-limits is the cache most likely to drift on a feature flip.

Both listeners follow the existing CredentialCacheInvalidationListener /
CerbosCacheInvalidationListener pattern (raw String message → ObjectMapper
→ defensive payload extraction → cache evict).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
