### PR TITLE
chore(test-harness): skip Testcontainers PG when CI_DB_JDBC_URL is set

### DIFF
--- a/.claude/CHANGELOG.md
+++ b/.claude/CHANGELOG.md
@@ -14,3 +14,4 @@ This file tracks merged autopilot work. Entries are appended by autopilot worker
 - 2026-05-11 chore(docs): add CONTRIBUTING.md outlining the autopilot workflow (CHORE-2026-05-10-0003)
 - 2026-05-11 chore(autopilot): use task title+type for fallback commit message in worker.sh so `gh pr create --fill` produces a useful PR title (CHORE-2026-05-10-0005)
 - 2026-05-11 doc(ui): add UI component consolidation plan covering DataTable/FilterBuilder/FieldRenderer/ResourceForm/RelatedList unification, feature superset, and migration order (DOC-2026-05-10-0002)
+- 2026-05-11 chore(test-harness): KeltaStack skips Testcontainers Postgres when `$CI_DB_JDBC_URL` is set and reuses the kelta-ci-db pool URL/credentials (CHORE-2026-05-10-0008)

--- a/.claude/docs/integrations.md
+++ b/.claude/docs/integrations.md
@@ -16,6 +16,7 @@
 | Store | Purpose | Config Key | Details |
 |-------|---------|-----------|---------|
 | PostgreSQL 15 | Primary DB | `${SPRING_DATASOURCE_URL}` | Multi-tenant per-tenant schemas, Flyway migrations in `kelta-worker/.../db/migration/` |
+| `kelta-ci-db` pool | Shared CI Postgres | `${CI_DB_JDBC_URL}` | 4-replica StatefulSet on node `fc17`; per-run schemas via `scripts/ci/checkout-db.sh` / `release-db.sh`. `KeltaStack` skips Testcontainers PG when `CI_DB_JDBC_URL` is set. |
 | OpenSearch 2.17.1 | Full-text search + audit | Port 9200 | `kelta-worker/.../service/OpenSearchQueryService.java`, `OpenSearchAuditService.java` |
 | Redis 7 | Cache + sessions | `${REDIS_HOST}:${REDIS_PORT:6379}` | Route caching, permission caching, session management |
 | Caffeine | Local in-memory cache | — | Hot-path caching alongside Redis |

--- a/.claude/docs/testing.md
+++ b/.claude/docs/testing.md
@@ -50,6 +50,10 @@ class GatewayMetricsTest {
 - Immutable test data: `List.of(...)` for constants
 - Focus on behavior over state
 
+### Cross-service harness Postgres
+
+`kelta-test-harness` (`KeltaStack`) boots a Testcontainers Postgres by default for local runs. In CI, set `CI_DB_JDBC_URL`, `CI_DB_USER`, and `CI_DB_PASSWORD` (the trio emitted by `scripts/ci/checkout-db.sh` against the `kelta-ci-db` pool) and `KeltaStack` will reuse that database directly — the Testcontainers PG container is not started. The pool URL pins `currentSchema=ci_<run-tag>`, so Flyway migrations land in that schema and the rest of the stack inherits it. Local dev with the env var unset retains the Testcontainers behavior unchanged.
+
 ## TypeScript Testing
 
 ### Frameworks

--- a/kelta-test-harness/src/test/java/io/kelta/testharness/KeltaStack.java
+++ b/kelta-test-harness/src/test/java/io/kelta/testharness/KeltaStack.java
@@ -60,14 +60,43 @@ public final class KeltaStack {
         }
     }
 
+    // ── Database resolution: external (CI pool) or Testcontainers (local) ────
+    //
+    // When CI_DB_JDBC_URL is set (e.g. by scripts/ci/checkout-db.sh against the
+    // shared kelta-ci-db pool), reuse that database directly and skip booting a
+    // Testcontainers Postgres. The pool-issued URL already targets a per-run
+    // schema via currentSchema=ci_<run-tag>, so Flyway migrates into that schema
+    // and the rest of the harness inherits it as the default.
+    //
+    // Without the env var, fall back to the Testcontainers PG container so local
+    // dev runs are self-contained.
+
+    private static final boolean USE_EXTERNAL_DB =
+            System.getenv("CI_DB_JDBC_URL") != null && !System.getenv("CI_DB_JDBC_URL").isBlank();
+
+    private static final String DB_JDBC_URL =
+            USE_EXTERNAL_DB
+                    ? System.getenv("CI_DB_JDBC_URL")
+                    : "jdbc:postgresql://postgres:5432/kelta_control_plane";
+
+    private static final String DB_USERNAME =
+            USE_EXTERNAL_DB ? requireEnv("CI_DB_USER") : "kelta";
+
+    private static final String DB_PASSWORD =
+            USE_EXTERNAL_DB ? requireEnv("CI_DB_PASSWORD") : "kelta";
+
     // ── Docker network shared by all containers ──────────────────────────────
 
     public static final Network NETWORK = Network.newNetwork();
 
     // ── Infrastructure containers ────────────────────────────────────────────
 
+    /**
+     * Null when {@link #USE_EXTERNAL_DB} is true — services in that mode
+     * connect to the externally-supplied JDBC URL instead.
+     */
     @SuppressWarnings("resource")
-    public static final PostgreSQLContainer<?> POSTGRES =
+    public static final PostgreSQLContainer<?> POSTGRES = USE_EXTERNAL_DB ? null :
             new PostgreSQLContainer<>(DockerImageName.parse("postgres:15-alpine"))
                     .withNetworkAliases("postgres")
                     .withNetwork(NETWORK)
@@ -121,9 +150,9 @@ public final class KeltaStack {
     public static final GenericContainer<?> WORKER = serviceContainer("kelta-worker")
             .withNetworkAliases("kelta-worker")
             .withNetwork(NETWORK)
-            .withEnv("SPRING_DATASOURCE_URL",     "jdbc:postgresql://postgres:5432/kelta_control_plane")
-            .withEnv("SPRING_DATASOURCE_USERNAME", "kelta")
-            .withEnv("SPRING_DATASOURCE_PASSWORD", "kelta")
+            .withEnv("SPRING_DATASOURCE_URL",      DB_JDBC_URL)
+            .withEnv("SPRING_DATASOURCE_USERNAME", DB_USERNAME)
+            .withEnv("SPRING_DATASOURCE_PASSWORD", DB_PASSWORD)
             .withEnv("SPRING_DATA_REDIS_HOST",     "redis")
             .withEnv("SPRING_DATA_REDIS_PORT",     "6379")
             .withEnv("NATS_URL",                   "nats://nats:4222")
@@ -144,9 +173,9 @@ public final class KeltaStack {
     public static final GenericContainer<?> AUTH = serviceContainer("kelta-auth")
             .withNetworkAliases("kelta-auth")
             .withNetwork(NETWORK)
-            .withEnv("SPRING_DATASOURCE_URL",     "jdbc:postgresql://postgres:5432/kelta_control_plane")
-            .withEnv("SPRING_DATASOURCE_USERNAME", "kelta")
-            .withEnv("SPRING_DATASOURCE_PASSWORD", "kelta")
+            .withEnv("SPRING_DATASOURCE_URL",      DB_JDBC_URL)
+            .withEnv("SPRING_DATASOURCE_USERNAME", DB_USERNAME)
+            .withEnv("SPRING_DATASOURCE_PASSWORD", DB_PASSWORD)
             .withEnv("SPRING_DATA_REDIS_HOST",    "redis")
             .withEnv("SPRING_DATA_REDIS_PORT",    "6379")
             .withEnv("KELTA_AUTH_ISSUER_URI",     "http://kelta-auth:8080")
@@ -201,6 +230,9 @@ public final class KeltaStack {
      */
     public static void start() {
         log.info("Starting Kelta test stack...");
+        if (USE_EXTERNAL_DB) {
+            log.info("CI_DB_JDBC_URL set; using external Postgres (Testcontainers PG skipped)");
+        }
 
         // Phase 1: infrastructure in parallel.
         // Use a dedicated 4-thread executor rather than ForkJoinPool.commonPool().
@@ -216,11 +248,13 @@ public final class KeltaStack {
             return t;
         });
         try {
-            CompletableFuture<Void> postgresF = CompletableFuture.runAsync(() -> {
-                log.info("  [POSTGRES] starting...");
-                POSTGRES.start();
-                log.info("  [POSTGRES] up");
-            }, infra);
+            CompletableFuture<Void> postgresF = USE_EXTERNAL_DB
+                    ? CompletableFuture.completedFuture(null)
+                    : CompletableFuture.runAsync(() -> {
+                        log.info("  [POSTGRES] starting...");
+                        POSTGRES.start();
+                        log.info("  [POSTGRES] up");
+                    }, infra);
             CompletableFuture<Void> redisF = CompletableFuture.runAsync(() -> {
                 log.info("  [REDIS] starting...");
                 REDIS.start();
@@ -265,7 +299,7 @@ public final class KeltaStack {
         CERBOS.stop();
         NATS.stop();
         REDIS.stop();
-        POSTGRES.stop();
+        if (POSTGRES != null) POSTGRES.stop();
         NETWORK.close();
     }
 
@@ -360,6 +394,17 @@ public final class KeltaStack {
     private static String cerbosPoliciesPath() {
         return Path.of(harnessBasedir()).getParent()
                    .resolve("docker/cerbos/policies").toAbsolutePath().toString();
+    }
+
+    private static String requireEnv(String name) {
+        String value = System.getenv(name);
+        if (value == null || value.isBlank()) {
+            throw new IllegalStateException(
+                    "CI_DB_JDBC_URL is set but " + name + " is missing. " +
+                    "Both CI_DB_USER and CI_DB_PASSWORD must accompany CI_DB_JDBC_URL " +
+                    "(see scripts/ci/checkout-db.sh).");
+        }
+        return value;
     }
 
     private static String generateEncryptionKey() {

--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -71,9 +71,11 @@ The `k8s-runner-integration` pool already has `kubectl` and runs inside the
 cluster, so DNS works directly. For external runners add a sidecar that
 exposes the pool via NodePort or LoadBalancer.
 
-## What's NOT included
+## Java test harness integration
 
-- The Java test harness (`kelta-test-harness`) currently uses Testcontainers
-  to boot its own PG. Migrating the harness to read `CI_DB_JDBC_URL` from
-  env (and skip Testcontainers when set) is a follow-up task. The pool is
-  ready; the integration is the next PR.
+`kelta-test-harness` (`KeltaStack`) honours `CI_DB_JDBC_URL`: when set, it
+skips its Testcontainers Postgres and points the in-stack `kelta-worker` and
+`kelta-auth` containers at the pool URL using `CI_DB_USER` / `CI_DB_PASSWORD`
+for credentials. The pool URL already pins `currentSchema=ci_<run-tag>`, so
+Flyway migrates into that schema. Without the env var the harness keeps the
+Testcontainers PG fallback for local dev.


### PR DESCRIPTION
KeltaStack now resolves its DB connection at class-load time. With
$CI_DB_JDBC_URL set (and CI_DB_USER / CI_DB_PASSWORD alongside, e.g. as
emitted by scripts/ci/checkout-db.sh against the kelta-ci-db pool), the
Testcontainers Postgres is skipped and kelta-worker / kelta-auth point
directly at the pooled URL. The pool URL pins currentSchema=ci_<run-tag>
so Flyway migrates into the per-run schema. Without the env var, the
Testcontainers PG fallback is unchanged for local dev.

Docs: integrations.md, testing.md, scripts/ci/README.md updated.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
