### PR TITLE
chore(ci): wire checkout-db/release-db into integration-tests job

### DIFF
--- a/.claude/CHANGELOG.md
+++ b/.claude/CHANGELOG.md
@@ -15,3 +15,4 @@ This file tracks merged autopilot work. Entries are appended by autopilot worker
 - 2026-05-11 chore(autopilot): use task title+type for fallback commit message in worker.sh so `gh pr create --fill` produces a useful PR title (CHORE-2026-05-10-0005)
 - 2026-05-11 doc(ui): add UI component consolidation plan covering DataTable/FilterBuilder/FieldRenderer/ResourceForm/RelatedList unification, feature superset, and migration order (DOC-2026-05-10-0002)
 - 2026-05-11 chore(cache): wire NATS broadcast listeners on gateway and worker for `kelta.config.domain.changed.*` and `kelta.config.feature.changed.*` cache invalidation (CHORE-2026-05-10-0007)
+- 2026-05-11 chore(ci): wire checkout-db/release-db into integration-tests job and drop postgres:15-alpine pre-pull so KeltaStack uses the kelta-ci-db pool (CHORE-2026-05-10-0009)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,12 +194,39 @@ jobs:
         # Docker's cache and the registry is slow or unreachable from the K8s pod,
         # the pull blocks the test JVM thread indefinitely. Pre-pulling all images
         # here ensures everything is cached before the test process starts.
+        # Note: postgres:15-alpine is no longer pulled — KeltaStack bypasses
+        # Testcontainers PG when $CI_DB_JDBC_URL is set (kelta-ci-db pool).
         run: |
-          docker pull postgres:15-alpine
           docker pull redis:7-alpine
           docker pull nats:2.10-alpine
           docker pull ghcr.io/cerbos/cerbos:0.40.0
           docker pull eclipse-temurin:25-jre-alpine
+
+      - name: Install psql client
+        # checkout-db.sh / release-db.sh need psql to create/drop the per-run
+        # schema on the kelta-ci-db pool. The runner image
+        # (harbor.rzware.com/emf/github-runner-emf) does not bake in
+        # postgresql-client yet; install it here. TODO: move into the runner
+        # Dockerfile at homelab-argo/github-runner/Dockerfile when convenient.
+        run: |
+          if ! command -v psql >/dev/null 2>&1; then
+            apt-get update
+            apt-get install -y --no-install-recommends postgresql-client
+          fi
+          psql --version
+
+      - name: Checkout CI DB schema
+        # Claim a throwaway schema on the kelta-ci-db pool and expose
+        # $CI_DB_JDBC_URL / $CI_DB_USER / $CI_DB_PASSWORD to subsequent steps.
+        # KeltaStack honours these env vars and skips its Testcontainers PG.
+        run: |
+          eval "$(scripts/ci/checkout-db.sh)"
+          echo "::add-mask::$CI_DB_PASSWORD"
+          {
+            echo "CI_DB_JDBC_URL=$CI_DB_JDBC_URL"
+            echo "CI_DB_USER=$CI_DB_USER"
+            echo "CI_DB_PASSWORD=$CI_DB_PASSWORD"
+          } >> "$GITHUB_ENV"
 
       - name: Pre-build service images
         # Build the three service container images using the pre-built fat JARs.
@@ -247,6 +274,13 @@ jobs:
           name: harness-failsafe-reports
           path: kelta-test-harness/target/failsafe-reports/
           retention-days: 7
+
+      - name: Release CI DB schema
+        # Drop the per-run schema even when tests fail, so the kelta-ci-db pool
+        # does not leak schemas. release-db.sh is a no-op if checkout-db.sh
+        # never ran (e.g. the install-psql step failed first).
+        if: always()
+        run: scripts/ci/release-db.sh
 
   # ===========================================================================
   # Quality gate - all checks must pass


### PR DESCRIPTION
KeltaStack now skips its Testcontainers PG when $CI_DB_JDBC_URL is set
(landed in CHORE-2026-05-10-0008). Have the integration-tests job:
  - install postgresql-client (psql is needed by the scripts)
  - call scripts/ci/checkout-db.sh to claim a throwaway schema on the
    kelta-ci-db pool and export CI_DB_{JDBC_URL,USER,PASSWORD} via
    $GITHUB_ENV (with the password masked from job logs)
  - drop postgres:15-alpine from the docker pre-pull list (no longer
    needed)
  - call scripts/ci/release-db.sh with if: always() so the per-run
    schema is dropped even when tests fail (no schema leakage)

The runner image at homelab-argo/github-runner/Dockerfile does not yet
bake in postgresql-client; the install-psql step is the workaround
until that Dockerfile is updated (noted inline).

Refs CHORE-2026-05-10-0009.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
