### PR TITLE
chore(test-harness): skip Testcontainers PG when $CI_DB_JDBC_URL is set

### DIFF
--- a/.claude/CHANGELOG.md
+++ b/.claude/CHANGELOG.md
@@ -17,3 +17,4 @@ This file tracks merged autopilot work. Entries are appended by autopilot worker
 - 2026-05-11 chore(cache): wire NATS broadcast listeners on gateway and worker for `kelta.config.domain.changed.*` and `kelta.config.feature.changed.*` cache invalidation (CHORE-2026-05-10-0007)
 - 2026-05-11 chore(events): publish `kelta.config.domain.changed.<id>` and `kelta.config.feature.changed.<tenantId>` from admin domain/governor-limits endpoints so all pods evict caches across the fleet (CHORE-2026-05-10-0006)
 - 2026-05-11 chore(events): publish `kelta.config.domain.changed.<id>` and `kelta.config.feature.changed.<tenantId>` from admin domain/governor-limits endpoints so all pods evict caches across the fleet (CHORE-2026-05-10-0006)
+- 2026-05-11 chore(test-harness): skip Testcontainers PG in `KeltaStack` when `$CI_DB_JDBC_URL` is set; use shared `kelta-ci-db` pool with per-run schema isolation (CHORE-2026-05-10-0008)

--- a/.claude/docs/integrations.md
+++ b/.claude/docs/integrations.md
@@ -15,7 +15,7 @@
 
 | Store | Purpose | Config Key | Details |
 |-------|---------|-----------|---------|
-| PostgreSQL 15 | Primary DB | `${SPRING_DATASOURCE_URL}` | Multi-tenant per-tenant schemas, Flyway migrations in `kelta-worker/.../db/migration/` |
+| PostgreSQL 15 | Primary DB | `${SPRING_DATASOURCE_URL}` | Multi-tenant per-tenant schemas, Flyway migrations in `kelta-worker/.../db/migration/`. CI: shared `kelta-ci-db` pool (schema-isolated per run, see `scripts/ci/README.md`); local: docker-compose or Testcontainers |
 | OpenSearch 2.17.1 | Full-text search + audit | Port 9200 | `kelta-worker/.../service/OpenSearchQueryService.java`, `OpenSearchAuditService.java` |
 | Redis 7 | Cache + sessions | `${REDIS_HOST}:${REDIS_PORT:6379}` | Route caching, permission caching, session management |
 | Caffeine | Local in-memory cache | — | Hot-path caching alongside Redis |

--- a/.claude/docs/testing.md
+++ b/.claude/docs/testing.md
@@ -11,6 +11,12 @@
 - **MockWebServer** — HTTP service mocks
 - **Awaitility** — async assertions
 
+### Integration harness (`kelta-test-harness`)
+
+Boots a full mini-stack (Postgres, Redis, NATS, Cerbos, worker, auth, gateway) via Testcontainers and runs `*ScenarioTest.java` against it under the `integration-tests` profile.
+
+**Database selection**: `KeltaStack` reads `CI_DB_JDBC_URL` at startup. When set (CI), it skips the Testcontainers PG and points worker + auth at the shared `kelta-ci-db` pool — the URL emitted by `scripts/ci/checkout-db.sh` already pins `currentSchema=ci_<run-tag>` for per-run isolation. When unset (local dev), it falls back to a Testcontainers PG on the docker network alias `postgres`. The Testcontainers dependency stays in `pom.xml` either way.
+
 ### Organization
 - Unit tests: `src/test/java/io/kelta/...Test.java`
 - Test resources: `src/test/resources/`

--- a/.task-context/doc-required.txt
+++ b/.task-context/doc-required.txt
@@ -1,1 +1,2 @@
-architecture.md
+integrations.md
+testing.md

--- a/kelta-test-harness/src/test/java/io/kelta/testharness/HarnessDbConfig.java
+++ b/kelta-test-harness/src/test/java/io/kelta/testharness/HarnessDbConfig.java
@@ -1,0 +1,40 @@
+package io.kelta.testharness;
+
+import java.util.function.Function;
+
+/**
+ * Datasource credentials passed to {@code kelta-worker} and {@code kelta-auth}
+ * by {@link KeltaStack}.
+ *
+ * <p>When {@code CI_DB_JDBC_URL} is set we use the shared {@code kelta-ci-db}
+ * pool (schema-isolated per CI run via {@code scripts/ci/checkout-db.sh}) and
+ * Testcontainers PG must NOT be started. Otherwise we fall back to a
+ * Testcontainers PG reachable on the docker network alias {@code postgres}.
+ *
+ * <p>The external JDBC URL is passed through verbatim — it already carries
+ * {@code currentSchema=ci_<run-tag>} so Flyway lands in the isolated schema.
+ * If the harness ever creates per-test schemas, the URL's schema must remain
+ * the default to honour the outer isolation contract.
+ */
+record HarnessDbConfig(String jdbcUrl, String username, String password, boolean external) {
+
+    static final String LOCAL_JDBC_URL = "jdbc:postgresql://postgres:5432/kelta_control_plane";
+    static final String LOCAL_USERNAME = "kelta";
+    static final String LOCAL_PASSWORD = "kelta";
+
+    static HarnessDbConfig resolve(Function<String, String> env) {
+        String url = env.apply("CI_DB_JDBC_URL");
+        if (url == null || url.isBlank()) {
+            return new HarnessDbConfig(LOCAL_JDBC_URL, LOCAL_USERNAME, LOCAL_PASSWORD, false);
+        }
+        String user = env.apply("CI_DB_USER");
+        String pwd  = env.apply("CI_DB_PASSWORD");
+        if (user == null || user.isBlank()) {
+            throw new IllegalStateException("CI_DB_JDBC_URL is set but CI_DB_USER is missing");
+        }
+        if (pwd == null) {
+            throw new IllegalStateException("CI_DB_JDBC_URL is set but CI_DB_PASSWORD is missing");
+        }
+        return new HarnessDbConfig(url, user, pwd, true);
+    }
+}

--- a/kelta-test-harness/src/test/java/io/kelta/testharness/KeltaStack.java
+++ b/kelta-test-harness/src/test/java/io/kelta/testharness/KeltaStack.java
@@ -51,6 +51,14 @@ public final class KeltaStack {
     private static final String JWK_SET;
     private static final String INTERNAL_TOKEN = "harness-internal-token";
 
+    /**
+     * Datasource configuration for the worker + auth services. Built once from env
+     * via {@link HarnessDbConfig#resolve}: external when {@code CI_DB_JDBC_URL}
+     * is set (shared {@code kelta-ci-db} pool, schema-isolated per CI run), otherwise
+     * a Testcontainers PG (local dev fallback).
+     */
+    static final HarnessDbConfig DB_CONFIG = HarnessDbConfig.resolve(System::getenv);
+
     static {
         try {
             ENCRYPTION_KEY = generateEncryptionKey();
@@ -66,9 +74,14 @@ public final class KeltaStack {
 
     // ── Infrastructure containers ────────────────────────────────────────────
 
+    /**
+     * Testcontainers PG. {@code null} when an external DB is supplied via
+     * {@code CI_DB_JDBC_URL} — see {@link HarnessDbConfig#resolve}.
+     */
     @SuppressWarnings("resource")
-    public static final PostgreSQLContainer<?> POSTGRES =
-            new PostgreSQLContainer<>(DockerImageName.parse("postgres:15-alpine"))
+    public static final PostgreSQLContainer<?> POSTGRES = DB_CONFIG.external()
+            ? null
+            : new PostgreSQLContainer<>(DockerImageName.parse("postgres:15-alpine"))
                     .withNetworkAliases("postgres")
                     .withNetwork(NETWORK)
                     .withDatabaseName("kelta_control_plane")
@@ -121,9 +134,9 @@ public final class KeltaStack {
     public static final GenericContainer<?> WORKER = serviceContainer("kelta-worker")
             .withNetworkAliases("kelta-worker")
             .withNetwork(NETWORK)
-            .withEnv("SPRING_DATASOURCE_URL",     "jdbc:postgresql://postgres:5432/kelta_control_plane")
-            .withEnv("SPRING_DATASOURCE_USERNAME", "kelta")
-            .withEnv("SPRING_DATASOURCE_PASSWORD", "kelta")
+            .withEnv("SPRING_DATASOURCE_URL",      DB_CONFIG.jdbcUrl())
+            .withEnv("SPRING_DATASOURCE_USERNAME", DB_CONFIG.username())
+            .withEnv("SPRING_DATASOURCE_PASSWORD", DB_CONFIG.password())
             .withEnv("SPRING_DATA_REDIS_HOST",     "redis")
             .withEnv("SPRING_DATA_REDIS_PORT",     "6379")
             .withEnv("NATS_URL",                   "nats://nats:4222")
@@ -144,9 +157,9 @@ public final class KeltaStack {
     public static final GenericContainer<?> AUTH = serviceContainer("kelta-auth")
             .withNetworkAliases("kelta-auth")
             .withNetwork(NETWORK)
-            .withEnv("SPRING_DATASOURCE_URL",     "jdbc:postgresql://postgres:5432/kelta_control_plane")
-            .withEnv("SPRING_DATASOURCE_USERNAME", "kelta")
-            .withEnv("SPRING_DATASOURCE_PASSWORD", "kelta")
+            .withEnv("SPRING_DATASOURCE_URL",      DB_CONFIG.jdbcUrl())
+            .withEnv("SPRING_DATASOURCE_USERNAME", DB_CONFIG.username())
+            .withEnv("SPRING_DATASOURCE_PASSWORD", DB_CONFIG.password())
             .withEnv("SPRING_DATA_REDIS_HOST",    "redis")
             .withEnv("SPRING_DATA_REDIS_PORT",    "6379")
             .withEnv("KELTA_AUTH_ISSUER_URI",     "http://kelta-auth:8080")
@@ -201,6 +214,9 @@ public final class KeltaStack {
      */
     public static void start() {
         log.info("Starting Kelta test stack...");
+        if (DB_CONFIG.external()) {
+            log.info("Using external Postgres via $CI_DB_JDBC_URL — skipping Testcontainers PG");
+        }
 
         // Phase 1: infrastructure in parallel.
         // Use a dedicated 4-thread executor rather than ForkJoinPool.commonPool().
@@ -216,11 +232,13 @@ public final class KeltaStack {
             return t;
         });
         try {
-            CompletableFuture<Void> postgresF = CompletableFuture.runAsync(() -> {
-                log.info("  [POSTGRES] starting...");
-                POSTGRES.start();
-                log.info("  [POSTGRES] up");
-            }, infra);
+            CompletableFuture<Void> postgresF = POSTGRES == null
+                    ? CompletableFuture.completedFuture(null)
+                    : CompletableFuture.runAsync(() -> {
+                        log.info("  [POSTGRES] starting...");
+                        POSTGRES.start();
+                        log.info("  [POSTGRES] up");
+                    }, infra);
             CompletableFuture<Void> redisF = CompletableFuture.runAsync(() -> {
                 log.info("  [REDIS] starting...");
                 REDIS.start();
@@ -265,7 +283,9 @@ public final class KeltaStack {
         CERBOS.stop();
         NATS.stop();
         REDIS.stop();
-        POSTGRES.stop();
+        if (POSTGRES != null) {
+            POSTGRES.stop();
+        }
         NETWORK.close();
     }
 

--- a/kelta-test-harness/src/test/java/io/kelta/testharness/KeltaStackDbConfigTest.java
+++ b/kelta-test-harness/src/test/java/io/kelta/testharness/KeltaStackDbConfigTest.java
@@ -1,0 +1,93 @@
+package io.kelta.testharness;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("HarnessDbConfig#resolve")
+class KeltaStackDbConfigTest {
+
+    private static Function<String, String> env(Map<String, String> entries) {
+        return entries::get;
+    }
+
+    @Nested
+    @DisplayName("Local dev (CI_DB_JDBC_URL unset)")
+    class LocalDev {
+
+        @Test
+        @DisplayName("falls back to Testcontainers PG defaults when env var is absent")
+        void fallsBackWhenAbsent() {
+            var cfg = HarnessDbConfig.resolve(env(Map.of()));
+
+            assertThat(cfg.external()).isFalse();
+            assertThat(cfg.jdbcUrl()).isEqualTo("jdbc:postgresql://postgres:5432/kelta_control_plane");
+            assertThat(cfg.username()).isEqualTo("kelta");
+            assertThat(cfg.password()).isEqualTo("kelta");
+        }
+
+        @Test
+        @DisplayName("falls back when CI_DB_JDBC_URL is blank")
+        void fallsBackWhenBlank() {
+            var entries = new HashMap<String, String>();
+            entries.put("CI_DB_JDBC_URL", "   ");
+            var cfg = HarnessDbConfig.resolve(env(entries));
+
+            assertThat(cfg.external()).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("CI pool (CI_DB_JDBC_URL set)")
+    class CiPool {
+
+        @Test
+        @DisplayName("uses the external URL/user/password verbatim, preserving currentSchema")
+        void usesExternalConfig() {
+            var entries = Map.of(
+                    "CI_DB_JDBC_URL", "jdbc:postgresql://kelta-ci-db-1:5432/ci?currentSchema=ci_42_1",
+                    "CI_DB_USER", "ci",
+                    "CI_DB_PASSWORD", "secret");
+
+            var cfg = HarnessDbConfig.resolve(env(entries));
+
+            assertThat(cfg.external()).isTrue();
+            assertThat(cfg.jdbcUrl())
+                    .isEqualTo("jdbc:postgresql://kelta-ci-db-1:5432/ci?currentSchema=ci_42_1")
+                    .contains("currentSchema=ci_42_1");
+            assertThat(cfg.username()).isEqualTo("ci");
+            assertThat(cfg.password()).isEqualTo("secret");
+        }
+
+        @Test
+        @DisplayName("rejects missing CI_DB_USER with a clear error")
+        void rejectsMissingUser() {
+            var entries = Map.of(
+                    "CI_DB_JDBC_URL", "jdbc:postgresql://h/ci?currentSchema=s",
+                    "CI_DB_PASSWORD", "pw");
+
+            assertThatThrownBy(() -> HarnessDbConfig.resolve(env(entries)))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("CI_DB_USER");
+        }
+
+        @Test
+        @DisplayName("rejects missing CI_DB_PASSWORD with a clear error")
+        void rejectsMissingPassword() {
+            var entries = Map.of(
+                    "CI_DB_JDBC_URL", "jdbc:postgresql://h/ci?currentSchema=s",
+                    "CI_DB_USER", "ci");
+
+            assertThatThrownBy(() -> HarnessDbConfig.resolve(env(entries)))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("CI_DB_PASSWORD");
+        }
+    }
+}


### PR DESCRIPTION
KeltaStack now resolves its datasource via HarnessDbConfig.resolve at
class init. When CI_DB_JDBC_URL is non-blank the harness uses the
external kelta-ci-db pool (schema-isolated per run via
scripts/ci/checkout-db.sh) and the PostgreSQLContainer field is left
null; otherwise the original Testcontainers PG starts on the docker
network alias "postgres". start()/stop() guard the container against
the null case. WORKER and AUTH containers now read their datasource
URL/user/password from the resolved config so both paths boot
consistently.

The Testcontainers PG dependency is retained for local dev. Added
KeltaStackDbConfigTest covering the env fallback and validation paths
so the resolver runs under surefire without the harness's docker
prereqs.

Refs CHORE-2026-05-10-0008.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
