### PR TITLE
fix(auto-merge): use PAT so squash-merge push triggers Build and Deploy

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -18,9 +18,17 @@ jobs:
        github.event.pull_request.user.login == 'github-actions[bot]') &&
       github.event.pull_request.draft == false
     steps:
+      # Use a Personal Access Token instead of GITHUB_TOKEN. Merges performed
+      # via GITHUB_TOKEN are attributed to github-actions[bot] and the
+      # resulting push to main does NOT trigger downstream workflows
+      # (GitHub anti-recursion safety). With a PAT, the squash-merge push is
+      # attributed to the PAT owner and `Build and Deploy` fires normally.
+      #
+      # ARGOCD_REPO_TOKEN already exists with `repo` scope and is used by the
+      # deploy job. Reuse here rather than introducing a new secret.
       - name: Enable auto-merge (squash)
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.ARGOCD_REPO_TOKEN }}
         run: |
           gh pr merge "${{ github.event.pull_request.number }}" \
             --auto --squash \


### PR DESCRIPTION
**Symptom:** 9 autopilot PRs merged in past 8h, ZERO Build and Deploy runs fired. ArgoCD stuck on main-698e1d1.

**Cause:** `auto-merge.yml` uses `secrets.GITHUB_TOKEN`. GitHub Actions blocks workflows triggered by GITHUB_TOKEN from triggering further runs (anti-recursion safety). Squash merge attributed to `github-actions[bot]` → push event suppressed → `Build and Deploy` never fires.

Confirmed via `gh api repos/cklinker/emf/events`:
```
PushEvent  github-actions[bot]  refs/heads/main   ← does not trigger workflows
```

**Fix:** Switch to `ARGOCD_REPO_TOKEN` (existing PAT with `repo` scope; already used by the deploy job). Merges attributed to the PAT owner produce push events that fire downstream workflows normally.

## Manual catchup needed after merge

The 8h backlog (commits `386d6654..51805dcc`) won't auto-deploy. Either:
- `gh workflow run build-and-publish-containers.yml` (deploys current main, includes all backlog)
- Or push a no-op kelta-* commit to trigger normally

## Autopilot

- [x] Autopilot-label this; the fix should self-prove on the next autopilot merge after this lands.