### PR TITLE
fix(e2e,runtime): harden rollup_summary test against schema-propagation race

### DIFF
--- a/e2e-tests/helpers/data-factory.ts
+++ b/e2e-tests/helpers/data-factory.ts
@@ -184,7 +184,58 @@ export class DataFactory {
         },
       },
     );
+    // Field add propagates across worker pods asynchronously via NATS. Without
+    // a barrier here, the very next createRecord may land on a pod whose
+    // in-memory CollectionDefinition does not yet include the new field, and
+    // its INSERT loop will silently drop the value — caught only later by a
+    // surprising NULL or missing-attribute assertion.
+    await this.waitForFieldVisible(collectionId, field.name);
     return result.data as JsonApiResource;
+  }
+
+  /**
+   * Poll the fields system collection until a field with the given name is
+   * visible on the given collection. Issues several extra confirming reads in
+   * a row to bias for catching the slowest pod in a multi-replica deployment.
+   */
+  async waitForFieldVisible(
+    collectionId: string,
+    fieldName: string,
+    timeoutMs = STORAGE_READY_TIMEOUT_MS,
+  ): Promise<void> {
+    const deadline = Date.now() + timeoutMs;
+    const requiredConsecutive = 4;
+    let consecutive = 0;
+    while (Date.now() < deadline) {
+      try {
+        const response = await this.request(
+          "GET",
+          `/api/fields?filter[collectionId][eq]=${collectionId}`,
+        );
+        const data = response.data as JsonApiResource[] | JsonApiResource;
+        const list = Array.isArray(data) ? data : [data];
+        const present = list.some(
+          (r) =>
+            r &&
+            r.attributes &&
+            (r.attributes.name as string | undefined) === fieldName,
+        );
+        if (present) {
+          consecutive += 1;
+          if (consecutive >= requiredConsecutive) return;
+        } else {
+          consecutive = 0;
+        }
+      } catch {
+        consecutive = 0;
+      }
+      await new Promise((resolve) =>
+        setTimeout(resolve, STORAGE_READY_POLL_MS / 4),
+      );
+    }
+    throw new Error(
+      `Field '${fieldName}' on collection '${collectionId}' not visible after ${timeoutMs}ms`,
+    );
   }
 
   async createRecord(

--- a/e2e-tests/tests/journeys/end-user-record-lifecycle.spec.ts
+++ b/e2e-tests/tests/journeys/end-user-record-lifecycle.spec.ts
@@ -101,9 +101,13 @@ test.describe("End-User Record Lifecycle Journey", () => {
       const rowCount = await listPage.getRowCount();
       expect(rowCount).toBeGreaterThan(0);
 
-      // Click the first row to view the record
+      // Click the first row to view the record. The detail route push can lag
+      // under CI load behind the click handler's data fetch; give it a longer
+      // ceiling than the 30s default so the first attempt no longer flakes.
       await listPage.clickRow(0);
-      await page.waitForURL(new RegExp(`/app/o/${collectionName}/[^/]+`));
+      await page.waitForURL(new RegExp(`/app/o/${collectionName}/[^/]+`), {
+        timeout: 45_000,
+      });
     }
   });
 });

--- a/e2e-tests/tests/journeys/rollup-summary-journey.spec.ts
+++ b/e2e-tests/tests/journeys/rollup-summary-journey.spec.ts
@@ -1,6 +1,35 @@
 import { test, expect } from "../../fixtures";
 
 /**
+ * Poll a parent record until a rollup attribute is populated (non-undefined,
+ * non-null). Rollup compute requires the parent's CollectionDefinition to
+ * include the rollup field and the child records' physical columns to have
+ * been migrated and written; both propagate asynchronously across worker pods
+ * via NATS. The first GET after createRecord can land on a pod whose
+ * registry has not yet refreshed and silently omits the rollup attribute.
+ */
+async function waitForRollupAttribute<T>(
+  fetcher: () => Promise<{ attributes: Record<string, unknown> }>,
+  attributeName: string,
+  timeoutMs = 20_000,
+  pollMs = 500,
+): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  let lastValue: unknown = undefined;
+  while (Date.now() < deadline) {
+    const record = await fetcher();
+    lastValue = record.attributes[attributeName];
+    if (lastValue !== undefined && lastValue !== null) {
+      return lastValue as T;
+    }
+    await new Promise((resolve) => setTimeout(resolve, pollMs));
+  }
+  throw new Error(
+    `Rollup attribute '${attributeName}' did not populate within ${timeoutMs}ms (last value: ${String(lastValue)})`,
+  );
+}
+
+/**
  * Rollup Summary end-to-end coverage:
  * - Configure a ROLLUP_SUMMARY field on a parent collection via the
  *   admin/fields API with fieldTypeConfig (childCollection, foreignKeyField,
@@ -60,8 +89,11 @@ test.describe("Rollup Summary Journey", () => {
       parentRef: parentRecord.id,
     });
 
-    const fetched = await dataFactory.getRecord(parentName, parentRecord.id);
-    expect(Number(fetched.attributes.totalAmount)).toBe(12);
+    const totalAmount = await waitForRollupAttribute<number | string>(
+      () => dataFactory.getRecord(parentName, parentRecord.id),
+      "totalAmount",
+    );
+    expect(Number(totalAmount)).toBe(12);
   });
 
   test("COUNT rollup ignores aggregateField", async ({ dataFactory }) => {
@@ -101,7 +133,10 @@ test.describe("Rollup Summary Journey", () => {
     await dataFactory.createRecord(childName, { parentRef: parentRecord.id });
     await dataFactory.createRecord(childName, { parentRef: parentRecord.id });
 
-    const fetched = await dataFactory.getRecord(parentName, parentRecord.id);
-    expect(Number(fetched.attributes.lineCount)).toBe(3);
+    const lineCount = await waitForRollupAttribute<number | string>(
+      () => dataFactory.getRecord(parentName, parentRecord.id),
+      "lineCount",
+    );
+    expect(Number(lineCount)).toBe(3);
   });
 });

--- a/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/storage/PhysicalTableStorageAdapter.java
+++ b/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/storage/PhysicalTableStorageAdapter.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -390,6 +391,14 @@ public class PhysicalTableStorageAdapter implements StorageAdapter {
     public Map<String, Object> create(CollectionDefinition definition, Map<String, Object> data) {
         TableRef tableRef = getTableRef(definition);
 
+        // Surface payload keys that don't map to a known field — these are
+        // silently dropped by the INSERT loop below. The most common cause is
+        // an in-flight schema propagation race where this pod's in-memory
+        // CollectionDefinition has not yet been refreshed with the latest
+        // field set (rollup_summary tests have caught this). A WARN log keeps
+        // the drop visible in CI artifacts so the race is debuggable.
+        warnOnUnknownPayloadKeys(definition, data);
+
         // Build column names, placeholders, and values.
         // JSONB columns need ?::jsonb placeholders so PostgreSQL accepts the
         // value as JSONB instead of VARCHAR.
@@ -481,6 +490,37 @@ public class PhysicalTableStorageAdapter implements StorageAdapter {
                 definition.name(), fieldName, data.get(fieldName), e);
         } catch (DataAccessException e) {
             throw new StorageException("Failed to create record in collection: " + definition.name(), e);
+        }
+    }
+
+    private static final Set<String> PAYLOAD_SYSTEM_KEYS = Set.of(
+        "id", "createdAt", "updatedAt", "createdBy", "updatedBy",
+        "tenantId", "recordTypeId"
+    );
+
+    private void warnOnUnknownPayloadKeys(CollectionDefinition definition, Map<String, Object> data) {
+        if (data == null || data.isEmpty()) {
+            return;
+        }
+        Set<String> knownFieldNames = new HashSet<>();
+        for (FieldDefinition field : definition.fields()) {
+            knownFieldNames.add(field.name());
+            if (field.type() == FieldType.CURRENCY) {
+                knownFieldNames.add(field.name() + "_currency_code");
+            }
+            if (field.type() == FieldType.GEOLOCATION) {
+                knownFieldNames.add(field.name() + "_longitude");
+                knownFieldNames.add(field.name() + "_latitude");
+            }
+        }
+        for (String key : data.keySet()) {
+            if (PAYLOAD_SYSTEM_KEYS.contains(key) || knownFieldNames.contains(key)) {
+                continue;
+            }
+            log.warn("Dropping unknown payload key '{}' on INSERT into collection '{}' — "
+                    + "field not present in in-memory CollectionDefinition (likely a "
+                    + "schema-propagation race). Known field count: {}.",
+                    key, definition.name(), knownFieldNames.size());
         }
     }
 


### PR DESCRIPTION
## Summary

- Failing E2E run: https://github.com/cklinker/emf/actions/runs/25677118943
- Root cause for the SUM rollup_summary hard failure: a schema-propagation race. \`addField\` returns once the field row is committed locally, but the new field is broadcast to other worker pods over NATS asynchronously — the next \`createRecord\` can land on a pod whose in-memory CollectionDefinition still lacks the new field, silently dropping the payload value in \`PhysicalTableStorageAdapter.create\`. With \`amount\` lost, \`SUM\` returns NULL, the rollup attribute is omitted from the response, and \`Number(undefined) === NaN\` blows up the assertion.
- Also fixes the flaky \`end-user-record-lifecycle\` \`waitForURL\` after a list-row click.

### Changes

- **data-factory**: \`addField\` now blocks on a new \`waitForFieldVisible\` that polls \`/api/fields?filter[collectionId][eq]=…\` until the new field is observed for several consecutive reads — biases for the slowest pod in a multi-replica deployment.
- **rollup-summary-journey**: assertion polls the parent record until the rollup attribute is populated, with a 20s timeout, instead of relying on a single read.
- **PhysicalTableStorageAdapter.create**: WARN-log every payload key that was dropped because no matching field exists in the in-memory definition. Keeps the underlying race visible in CI artifacts next time it surfaces.
- **end-user-record-lifecycle**: \`waitForURL\` timeout raised from the 30s default to 45s on the post-row-click navigation.

## Test plan

- [x] \`mvn -pl kelta-platform/runtime/runtime-core -am test\` — 1166 tests, 0 failures
- [x] \`npx tsc --noEmit\` in \`e2e-tests/\` — clean
- [ ] Full \`Build and Deploy\` workflow green, including the rollup_summary journey

🤖 Generated with [Claude Code](https://claude.com/claude-code)