### PR TITLE
feat(layout-editor): reorder display columns in related list config

### DIFF
--- a/kelta-ui/app/src/pages/PageLayoutsPage/components/RelatedListPanel.tsx
+++ b/kelta-ui/app/src/pages/PageLayoutsPage/components/RelatedListPanel.tsx
@@ -13,6 +13,12 @@ import { useQuery } from '@tanstack/react-query'
 import { useApi } from '../../../context/ApiContext'
 import { useCollectionSummaries } from '../../../hooks/useCollectionSummaries'
 import { useLayoutEditor, type EditorRelatedList } from './LayoutEditorContext'
+import {
+  computeDisplayOrder,
+  reorderColumns,
+  selectedInDisplayOrder,
+  swapAdjacent,
+} from './relatedListColumnOrder'
 
 // ---------------------------------------------------------------------------
 // Types
@@ -78,6 +84,9 @@ export function RelatedListPanel(): React.ReactElement {
   const [isFormOpen, setIsFormOpen] = useState(false)
   const [editingId, setEditingId] = useState<string | null>(null)
   const [formData, setFormData] = useState<RelatedListFormData>(INITIAL_FORM_DATA)
+  const [orderedFieldNames, setOrderedFieldNames] = useState<string[]>([])
+  const [draggedColumn, setDraggedColumn] = useState<string | null>(null)
+  const [dragOverColumn, setDragOverColumn] = useState<string | null>(null)
 
   // Fetch all collections for the dropdown
   const { summaries: collections } = useCollectionSummaries()
@@ -257,6 +266,7 @@ export function RelatedListPanel(): React.ReactElement {
   const handleOpenForm = useCallback(() => {
     setEditingId(null)
     setFormData(INITIAL_FORM_DATA)
+    setOrderedFieldNames([])
     setIsFormOpen(true)
   }, [])
 
@@ -301,6 +311,8 @@ export function RelatedListPanel(): React.ReactElement {
       sortDirection: rl.sortDirection,
       rowLimit: rl.rowLimit,
     })
+    // Seed user-arranged order from saved columns so reopening preserves it
+    setOrderedFieldNames(parsedColumns)
     setIsFormOpen(true)
   }, [])
 
@@ -308,6 +320,9 @@ export function RelatedListPanel(): React.ReactElement {
     setIsFormOpen(false)
     setEditingId(null)
     setFormData(INITIAL_FORM_DATA)
+    setOrderedFieldNames([])
+    setDraggedColumn(null)
+    setDragOverColumn(null)
   }, [])
 
   const handleCollectionChange = useCallback((value: string) => {
@@ -318,6 +333,7 @@ export function RelatedListPanel(): React.ReactElement {
       selectedDisplayColumns: [],
       sortField: '',
     }))
+    setOrderedFieldNames([])
   }, [])
 
   const handleToggleDisplayColumn = useCallback((fieldName: string) => {
@@ -330,13 +346,94 @@ export function RelatedListPanel(): React.ReactElement {
     })
   }, [])
 
+  // Render order = user-arranged prefix (orderedFieldNames) followed by any
+  // remaining displayable fields in their natural order. Computed each render
+  // so we don't need an effect to reconcile when fields load or change.
+  const displayOrder = useMemo(
+    () => computeDisplayOrder(displayableFields.map((f) => f.name), orderedFieldNames),
+    [displayableFields, orderedFieldNames]
+  )
+
+  const handleReorderColumn = useCallback(
+    (draggedName: string, targetName: string) => {
+      setOrderedFieldNames(reorderColumns(displayOrder, draggedName, targetName))
+    },
+    [displayOrder]
+  )
+
+  const handleColumnDragStart = useCallback(
+    (e: React.DragEvent<HTMLDivElement>, fieldName: string) => {
+      setDraggedColumn(fieldName)
+      e.dataTransfer.effectAllowed = 'move'
+      e.dataTransfer.setData('text/plain', fieldName)
+    },
+    []
+  )
+
+  const handleColumnDragEnd = useCallback(() => {
+    setDraggedColumn(null)
+    setDragOverColumn(null)
+  }, [])
+
+  const handleColumnDragOver = useCallback(
+    (e: React.DragEvent<HTMLDivElement>, fieldName: string) => {
+      e.preventDefault()
+      e.dataTransfer.dropEffect = 'move'
+      if (draggedColumn && draggedColumn !== fieldName) {
+        setDragOverColumn(fieldName)
+      }
+    },
+    [draggedColumn]
+  )
+
+  const handleColumnDragLeave = useCallback(() => {
+    setDragOverColumn(null)
+  }, [])
+
+  const handleColumnDrop = useCallback(
+    (e: React.DragEvent<HTMLDivElement>, targetName: string) => {
+      e.preventDefault()
+      setDragOverColumn(null)
+      if (!draggedColumn || draggedColumn === targetName) return
+      handleReorderColumn(draggedColumn, targetName)
+    },
+    [draggedColumn, handleReorderColumn]
+  )
+
+  const handleColumnKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>, index: number) => {
+      if (!e.altKey) return
+      if (e.key === 'ArrowUp' && index > 0) {
+        e.preventDefault()
+        setOrderedFieldNames(swapAdjacent(displayOrder, index, -1))
+      } else if (e.key === 'ArrowDown' && index < displayOrder.length - 1) {
+        e.preventDefault()
+        setOrderedFieldNames(swapAdjacent(displayOrder, index, 1))
+      }
+    },
+    [displayOrder]
+  )
+
+  const fieldByName = useMemo(() => {
+    const map = new Map<string, CollectionFieldDetail>()
+    for (const f of displayableFields) map.set(f.name, f)
+    return map
+  }, [displayableFields])
+
   const handleSubmit = useCallback(
     (e: React.FormEvent) => {
       e.preventDefault()
       if (!formData.relatedCollectionId || !formData.relationshipFieldId) return
 
+      // Persist in the order the user arranged in the modal: filter the
+      // ordered list to checked items, falling back to the toggle order if
+      // the ordered list hasn't been seeded yet.
+      const orderedSelection =
+        displayOrder.length > 0
+          ? selectedInDisplayOrder(displayOrder, formData.selectedDisplayColumns)
+          : formData.selectedDisplayColumns
       // Store as JSON array string since the backend column is JSONB
-      const displayColumns = JSON.stringify(formData.selectedDisplayColumns)
+      const displayColumns = JSON.stringify(orderedSelection)
 
       if (editingId) {
         updateRelatedList(editingId, {
@@ -361,7 +458,15 @@ export function RelatedListPanel(): React.ReactElement {
       }
       handleCloseForm()
     },
-    [formData, editingId, relatedLists, addRelatedList, updateRelatedList, handleCloseForm]
+    [
+      formData,
+      displayOrder,
+      editingId,
+      relatedLists,
+      addRelatedList,
+      updateRelatedList,
+      handleCloseForm,
+    ]
   )
 
   const handleDelete = useCallback(
@@ -522,27 +627,72 @@ export function RelatedListPanel(): React.ReactElement {
                 ) : displayableFields.length === 0 ? (
                   <div className="text-[12px] text-muted-foreground">No fields available</div>
                 ) : (
-                  <div
-                    className="flex max-h-[160px] flex-col gap-1 overflow-y-auto rounded-md border border-input bg-background p-2"
-                    data-testid="rl-form-display-columns"
-                  >
-                    {displayableFields.map((f) => (
-                      <label
-                        key={f.id}
-                        className="flex items-center gap-2 rounded px-1.5 py-1 text-[13px] text-foreground cursor-pointer hover:bg-muted"
-                      >
-                        <input
-                          type="checkbox"
-                          className="h-3.5 w-3.5 accent-primary"
-                          checked={formData.selectedDisplayColumns.includes(f.name)}
-                          onChange={() => handleToggleDisplayColumn(f.name)}
-                        />
-                        <span className="overflow-hidden text-ellipsis whitespace-nowrap">
-                          {f.displayName || f.name}
-                        </span>
-                      </label>
-                    ))}
-                  </div>
+                  <>
+                    <div
+                      className="flex max-h-[200px] flex-col gap-1 overflow-y-auto rounded-md border border-input bg-background p-2"
+                      data-testid="rl-form-display-columns"
+                      role="list"
+                      aria-label="Display columns, drag to reorder"
+                    >
+                      {/* eslint-disable jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/no-noninteractive-tabindex */}
+                      {displayOrder.map((fieldName, index) => {
+                        const f = fieldByName.get(fieldName)
+                        if (!f) return null
+                        const checked = formData.selectedDisplayColumns.includes(f.name)
+                        const isDragging = draggedColumn === f.name
+                        const isDragOver = dragOverColumn === f.name
+                        return (
+                          <div
+                            key={f.id}
+                            className={`flex items-center gap-2 rounded px-1.5 py-1 text-[13px] text-foreground cursor-grab transition-colors duration-150 hover:bg-muted focus:outline-2 focus:outline-primary focus:-outline-offset-2 ${
+                              isDragging ? 'opacity-50 bg-muted' : ''
+                            } ${
+                              isDragOver
+                                ? 'bg-primary/10 shadow-[inset_0_-2px_0_hsl(var(--primary))]'
+                                : ''
+                            }`}
+                            role="listitem"
+                            draggable
+                            tabIndex={0}
+                            onDragStart={(e) => handleColumnDragStart(e, f.name)}
+                            onDragEnd={handleColumnDragEnd}
+                            onDragOver={(e) => handleColumnDragOver(e, f.name)}
+                            onDragLeave={handleColumnDragLeave}
+                            onDrop={(e) => handleColumnDrop(e, f.name)}
+                            onKeyDown={(e) => handleColumnKeyDown(e, index)}
+                            aria-label={`${f.displayName || f.name}${checked ? ', selected' : ''}`}
+                            data-testid={`rl-form-column-${f.name}`}
+                          >
+                            <span
+                              className="flex h-4 w-4 shrink-0 items-center justify-center text-muted-foreground active:cursor-grabbing"
+                              aria-hidden="true"
+                              data-testid={`rl-form-column-drag-handle-${f.name}`}
+                            >
+                              <span className="text-[12px] leading-none tracking-[-2px]">
+                                &#x22EE;&#x22EE;
+                              </span>
+                            </span>
+                            <input
+                              type="checkbox"
+                              className="h-3.5 w-3.5 accent-primary cursor-pointer"
+                              checked={checked}
+                              onChange={() => handleToggleDisplayColumn(f.name)}
+                              onClick={(e) => e.stopPropagation()}
+                              aria-label={`Include ${f.displayName || f.name}`}
+                              data-testid={`rl-form-column-checkbox-${f.name}`}
+                            />
+                            <span className="overflow-hidden text-ellipsis whitespace-nowrap">
+                              {f.displayName || f.name}
+                            </span>
+                          </div>
+                        )
+                      })}
+                      {/* eslint-enable jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/no-noninteractive-tabindex */}
+                    </div>
+                    <div className="text-[11px] text-muted-foreground">
+                      Drag rows or press Alt+Up/Down to reorder columns.
+                    </div>
+                  </>
                 )}
               </fieldset>
 

--- a/kelta-ui/app/src/pages/PageLayoutsPage/components/relatedListColumnOrder.test.ts
+++ b/kelta-ui/app/src/pages/PageLayoutsPage/components/relatedListColumnOrder.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest'
+import {
+  computeDisplayOrder,
+  reorderColumns,
+  selectedInDisplayOrder,
+  swapAdjacent,
+} from './relatedListColumnOrder'
+
+describe('computeDisplayOrder', () => {
+  it('returns available fields in natural order when no user order is set', () => {
+    expect(computeDisplayOrder(['a', 'b', 'c'], [])).toEqual(['a', 'b', 'c'])
+  })
+
+  it('floats user-arranged fields to the front in their stored order', () => {
+    expect(computeDisplayOrder(['a', 'b', 'c', 'd'], ['c', 'a'])).toEqual([
+      'c',
+      'a',
+      'b',
+      'd',
+    ])
+  })
+
+  it('drops stored names that are no longer available', () => {
+    expect(computeDisplayOrder(['a', 'b'], ['c', 'a'])).toEqual(['a', 'b'])
+  })
+
+  it('appends newly available fields after the user-arranged prefix', () => {
+    expect(computeDisplayOrder(['a', 'b', 'newField'], ['b', 'a'])).toEqual([
+      'b',
+      'a',
+      'newField',
+    ])
+  })
+})
+
+describe('reorderColumns', () => {
+  it('moves dragged item into the target position', () => {
+    expect(reorderColumns(['a', 'b', 'c', 'd'], 'd', 'b')).toEqual([
+      'a',
+      'd',
+      'b',
+      'c',
+    ])
+  })
+
+  it('returns a fresh copy when the move is a no-op', () => {
+    const current = ['a', 'b', 'c']
+    const result = reorderColumns(current, 'a', 'a')
+    expect(result).toEqual(current)
+    expect(result).not.toBe(current)
+  })
+
+  it('returns a fresh copy when either name is missing', () => {
+    const current = ['a', 'b', 'c']
+    expect(reorderColumns(current, 'missing', 'a')).toEqual(current)
+    expect(reorderColumns(current, 'a', 'missing')).toEqual(current)
+  })
+
+  it('handles moving the first item to the last position', () => {
+    expect(reorderColumns(['a', 'b', 'c'], 'a', 'c')).toEqual(['b', 'c', 'a'])
+  })
+})
+
+describe('swapAdjacent', () => {
+  it('moves the item up when direction is -1', () => {
+    expect(swapAdjacent(['a', 'b', 'c'], 2, -1)).toEqual(['a', 'c', 'b'])
+  })
+
+  it('moves the item down when direction is +1', () => {
+    expect(swapAdjacent(['a', 'b', 'c'], 0, 1)).toEqual(['b', 'a', 'c'])
+  })
+
+  it('is a no-op at the top boundary', () => {
+    expect(swapAdjacent(['a', 'b', 'c'], 0, -1)).toEqual(['a', 'b', 'c'])
+  })
+
+  it('is a no-op at the bottom boundary', () => {
+    expect(swapAdjacent(['a', 'b', 'c'], 2, 1)).toEqual(['a', 'b', 'c'])
+  })
+})
+
+describe('selectedInDisplayOrder', () => {
+  it('filters selected names to the order from displayOrder', () => {
+    expect(selectedInDisplayOrder(['a', 'b', 'c', 'd'], ['d', 'b'])).toEqual([
+      'b',
+      'd',
+    ])
+  })
+
+  it('drops selected names that are not in displayOrder', () => {
+    expect(selectedInDisplayOrder(['a', 'b'], ['x', 'a'])).toEqual(['a'])
+  })
+
+  it('returns an empty array when nothing is selected', () => {
+    expect(selectedInDisplayOrder(['a', 'b'], [])).toEqual([])
+  })
+})

--- a/kelta-ui/app/src/pages/PageLayoutsPage/components/relatedListColumnOrder.ts
+++ b/kelta-ui/app/src/pages/PageLayoutsPage/components/relatedListColumnOrder.ts
@@ -1,0 +1,74 @@
+/**
+ * Pure helpers for ordering display columns in the related-list editor.
+ * Extracted from RelatedListPanel so the reorder logic is independently testable.
+ */
+
+/**
+ * Compute the order in which display-column rows should render.
+ *
+ * - User-arranged names (from previous reorder or saved selection) come first
+ *   in their stored order.
+ * - Any remaining available field names follow in their natural order.
+ * - Names in `orderedFieldNames` that are no longer available are dropped.
+ */
+export function computeDisplayOrder(
+  availableFieldNames: readonly string[],
+  orderedFieldNames: readonly string[]
+): string[] {
+  const available = new Set(availableFieldNames)
+  const kept = orderedFieldNames.filter((n) => available.has(n))
+  const keptSet = new Set(kept)
+  const remaining = availableFieldNames.filter((n) => !keptSet.has(n))
+  return [...kept, ...remaining]
+}
+
+/**
+ * Move `draggedName` to the position currently held by `targetName` and
+ * return the new full ordering. Returns `currentOrder` unchanged if either
+ * name is missing or the move is a no-op.
+ */
+export function reorderColumns(
+  currentOrder: readonly string[],
+  draggedName: string,
+  targetName: string
+): string[] {
+  if (draggedName === targetName) return [...currentOrder]
+  const fromIdx = currentOrder.indexOf(draggedName)
+  const toIdx = currentOrder.indexOf(targetName)
+  if (fromIdx === -1 || toIdx === -1) return [...currentOrder]
+  const next = [...currentOrder]
+  const [moved] = next.splice(fromIdx, 1)
+  next.splice(toIdx, 0, moved)
+  return next
+}
+
+/**
+ * Swap two adjacent items (used by Alt+Arrow keyboard reorder).
+ * `direction` is -1 to move the item at `index` up, +1 to move it down.
+ * Returns `currentOrder` unchanged if the move is out of bounds.
+ */
+export function swapAdjacent(
+  currentOrder: readonly string[],
+  index: number,
+  direction: -1 | 1
+): string[] {
+  const j = index + direction
+  if (index < 0 || index >= currentOrder.length) return [...currentOrder]
+  if (j < 0 || j >= currentOrder.length) return [...currentOrder]
+  const next = [...currentOrder]
+  ;[next[index], next[j]] = [next[j], next[index]]
+  return next
+}
+
+/**
+ * Filter `displayOrder` to the names present in `selected`, preserving
+ * the order from `displayOrder`. Used at save time to produce the
+ * persisted column list.
+ */
+export function selectedInDisplayOrder(
+  displayOrder: readonly string[],
+  selected: readonly string[]
+): string[] {
+  const selectedSet = new Set(selected)
+  return displayOrder.filter((n) => selectedSet.has(n))
+}


### PR DESCRIPTION
## Summary

- Add drag-and-drop and Alt+Up/Down keyboard reordering to the Display Columns list in the Edit Related List dialog.
- Persist column order in the existing JSONB `displayColumns` array — no schema/backend changes needed.
- Extract reorder logic into a pure helper module (`relatedListColumnOrder.ts`) with 15 unit tests.

Before: users could pick which columns to show but had no control over their order. After: drag a row by its handle (or focus a row and press Alt+Up/Down) to reorder. Order is preserved on save and reload.

## Test plan

- [x] `npx vitest run src/pages/PageLayoutsPage/components/relatedListColumnOrder.test.ts` — 15/15 pass
- [x] `npx eslint` on touched files — clean
- [x] `npx tsc -b` — no new errors in touched files
- [ ] Manual: edit a layout's related list, drag column 3 above column 1, save, reload, verify order persists and the rendered related list shows columns in the chosen order
- [ ] Manual: Alt+Up/Down on a focused row reorders without mouse
- [ ] Playwright e2e covering the reorder flow (follow-up — see plan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)