### PR TITLE
fix(layouts): instant invalidation of related list and layout caches

### DIFF
--- a/kelta-ui/app/src/hooks/usePageLayout.ts
+++ b/kelta-ui/app/src/hooks/usePageLayout.ts
@@ -305,7 +305,7 @@ export function usePageLayout(
       }
     },
     enabled: !!collectionId && !!profileId,
-    staleTime: 5 * 60 * 1000, // Layouts rarely change; cache for 5 min
+    staleTime: 30 * 1000,
   })
 
   return {

--- a/kelta-ui/app/src/pages/PageLayoutsPage/PageLayoutsPage.tsx
+++ b/kelta-ui/app/src/pages/PageLayoutsPage/PageLayoutsPage.tsx
@@ -970,6 +970,7 @@ function LayoutEditorViewInner({ layoutId, onBack }: LayoutEditorViewProps): Rea
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['pageLayouts'] })
       queryClient.invalidateQueries({ queryKey: ['pageLayout', layoutId] })
+      queryClient.invalidateQueries({ queryKey: ['page-layout-resolve'] })
       markSaved()
       showToast('Layout saved successfully', 'success')
     },

--- a/kelta-worker/src/main/java/io/kelta/worker/config/FlowConfig.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/config/FlowConfig.java
@@ -28,7 +28,11 @@ import io.kelta.worker.listener.CredentialEncryptionHook;
 import io.kelta.worker.listener.CredentialEventPublisher;
 import io.kelta.runtime.module.integration.api.OpenApiSpecParser;
 import io.kelta.worker.listener.RecordTypeEnforcementHook;
+import io.kelta.worker.listener.LayoutFieldRefreshHook;
+import io.kelta.worker.listener.LayoutRelatedListRefreshHook;
 import io.kelta.worker.listener.LayoutRuleRefreshHook;
+import io.kelta.worker.listener.LayoutSectionRefreshHook;
+import io.kelta.worker.listener.PageLayoutConfigEventPublisher;
 import io.kelta.worker.listener.ValidationRuleRefreshHook;
 import io.kelta.crypto.EncryptionService;
 import io.kelta.runtime.credential.CredentialTypeRegistry;
@@ -371,6 +375,43 @@ public class FlowConfig {
             BeforeSaveHookRegistry hookRegistry,
             PlatformEventPublisher eventPublisher) {
         LayoutRuleRefreshHook hook = new LayoutRuleRefreshHook(eventPublisher);
+        hookRegistry.register(hook);
+        return hook;
+    }
+
+    @Bean
+    public PageLayoutConfigEventPublisher pageLayoutConfigEventPublisher(
+            BeforeSaveHookRegistry hookRegistry,
+            PlatformEventPublisher eventPublisher) {
+        PageLayoutConfigEventPublisher hook = new PageLayoutConfigEventPublisher(eventPublisher);
+        hookRegistry.register(hook);
+        return hook;
+    }
+
+    @Bean
+    public LayoutSectionRefreshHook layoutSectionRefreshHook(
+            BeforeSaveHookRegistry hookRegistry,
+            PlatformEventPublisher eventPublisher) {
+        LayoutSectionRefreshHook hook = new LayoutSectionRefreshHook(eventPublisher);
+        hookRegistry.register(hook);
+        return hook;
+    }
+
+    @Bean
+    public LayoutFieldRefreshHook layoutFieldRefreshHook(
+            BeforeSaveHookRegistry hookRegistry,
+            PlatformEventPublisher eventPublisher,
+            JdbcTemplate jdbcTemplate) {
+        LayoutFieldRefreshHook hook = new LayoutFieldRefreshHook(eventPublisher, jdbcTemplate);
+        hookRegistry.register(hook);
+        return hook;
+    }
+
+    @Bean
+    public LayoutRelatedListRefreshHook layoutRelatedListRefreshHook(
+            BeforeSaveHookRegistry hookRegistry,
+            PlatformEventPublisher eventPublisher) {
+        LayoutRelatedListRefreshHook hook = new LayoutRelatedListRefreshHook(eventPublisher);
         hookRegistry.register(hook);
         return hook;
     }

--- a/kelta-worker/src/main/java/io/kelta/worker/listener/LayoutFieldRefreshHook.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/listener/LayoutFieldRefreshHook.java
@@ -1,0 +1,106 @@
+package io.kelta.worker.listener;
+
+import io.kelta.runtime.event.ChangeType;
+import io.kelta.runtime.event.CollectionChangedPayload;
+import io.kelta.runtime.event.EventFactory;
+import io.kelta.runtime.event.PlatformEvent;
+import io.kelta.runtime.event.PlatformEventPublisher;
+import io.kelta.runtime.workflow.BeforeSaveHook;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * After-save hook for the "layout-fields" system collection. Publishes a
+ * layout-changed event whenever a layout field is created or updated. The
+ * record only carries {@code sectionId}, so the parent {@code layoutId} is
+ * resolved via a small JDBC lookup against {@code layout_section}.
+ *
+ * <p>Subject: {@code kelta.config.layout.changed.<layoutId>}.
+ */
+public class LayoutFieldRefreshHook implements BeforeSaveHook {
+
+    private static final Logger log = LoggerFactory.getLogger(LayoutFieldRefreshHook.class);
+
+    static final String SUBJECT_PREFIX = "kelta.config.layout.changed.";
+    static final String EVENT_TYPE = "kelta.config.layout.changed";
+
+    private static final String SELECT_LAYOUT_ID =
+            "SELECT layout_id FROM layout_section WHERE id = ? LIMIT 1";
+
+    private final PlatformEventPublisher eventPublisher;
+    private final JdbcTemplate jdbcTemplate;
+
+    public LayoutFieldRefreshHook(PlatformEventPublisher eventPublisher,
+                                   JdbcTemplate jdbcTemplate) {
+        this.eventPublisher = eventPublisher;
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    @Override
+    public String getCollectionName() {
+        return "layout-fields";
+    }
+
+    @Override
+    public int getOrder() {
+        return 200;
+    }
+
+    @Override
+    public void afterCreate(Map<String, Object> record, String tenantId) {
+        publishLayoutChanged(record, tenantId, ChangeType.CREATED);
+    }
+
+    @Override
+    public void afterUpdate(String id, Map<String, Object> record,
+                             Map<String, Object> previous, String tenantId) {
+        publishLayoutChanged(record, tenantId, ChangeType.UPDATED);
+    }
+
+    @Override
+    public void afterDelete(String id, String tenantId) {
+        log.info("Layout field deleted (id={}); clients refresh on next layout fetch", id);
+    }
+
+    private void publishLayoutChanged(Map<String, Object> record, String tenantId, ChangeType changeType) {
+        String sectionId = (String) record.get("sectionId");
+        if (sectionId == null) {
+            log.warn("Layout field record missing sectionId, cannot broadcast refresh");
+            return;
+        }
+
+        String layoutId = resolveLayoutId(sectionId);
+        if (layoutId == null) {
+            log.warn("Could not resolve layoutId for sectionId={}, skipping broadcast", sectionId);
+            return;
+        }
+
+        CollectionChangedPayload payload = new CollectionChangedPayload();
+        payload.setId(layoutId);
+        payload.setChangeType(changeType);
+
+        PlatformEvent<CollectionChangedPayload> event = EventFactory.createEvent(EVENT_TYPE, payload);
+        event.setTenantId(tenantId);
+        String subject = SUBJECT_PREFIX + layoutId;
+        log.info("Publishing layout-changed event from field change (layoutId={}, changeType={})",
+                layoutId, changeType);
+        eventPublisher.publish(subject, event);
+    }
+
+    private String resolveLayoutId(String sectionId) {
+        try {
+            List<Map<String, Object>> rows = jdbcTemplate.queryForList(SELECT_LAYOUT_ID, sectionId);
+            if (!rows.isEmpty()) {
+                Object value = rows.get(0).get("layout_id");
+                return value != null ? value.toString() : null;
+            }
+        } catch (Exception e) {
+            log.warn("Failed to resolve layoutId for sectionId={}: {}", sectionId, e.getMessage());
+        }
+        return null;
+    }
+}

--- a/kelta-worker/src/main/java/io/kelta/worker/listener/LayoutRelatedListRefreshHook.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/listener/LayoutRelatedListRefreshHook.java
@@ -1,0 +1,80 @@
+package io.kelta.worker.listener;
+
+import io.kelta.runtime.event.ChangeType;
+import io.kelta.runtime.event.CollectionChangedPayload;
+import io.kelta.runtime.event.EventFactory;
+import io.kelta.runtime.event.PlatformEvent;
+import io.kelta.runtime.event.PlatformEventPublisher;
+import io.kelta.runtime.workflow.BeforeSaveHook;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+
+/**
+ * After-save hook for the "layout-related-lists" system collection. Publishes a
+ * layout-changed event whenever a related list configuration is created or
+ * updated so admin UIs and other pods refresh promptly.
+ *
+ * <p>Subject: {@code kelta.config.layout.changed.<layoutId>} — same naming
+ * convention as {@link LayoutRuleRefreshHook}. Delete is not broadcast because
+ * the record body is not provided to {@code afterDelete}.
+ */
+public class LayoutRelatedListRefreshHook implements BeforeSaveHook {
+
+    private static final Logger log = LoggerFactory.getLogger(LayoutRelatedListRefreshHook.class);
+
+    static final String SUBJECT_PREFIX = "kelta.config.layout.changed.";
+    static final String EVENT_TYPE = "kelta.config.layout.changed";
+
+    private final PlatformEventPublisher eventPublisher;
+
+    public LayoutRelatedListRefreshHook(PlatformEventPublisher eventPublisher) {
+        this.eventPublisher = eventPublisher;
+    }
+
+    @Override
+    public String getCollectionName() {
+        return "layout-related-lists";
+    }
+
+    @Override
+    public int getOrder() {
+        return 200;
+    }
+
+    @Override
+    public void afterCreate(Map<String, Object> record, String tenantId) {
+        publishLayoutChanged(record, tenantId, ChangeType.CREATED);
+    }
+
+    @Override
+    public void afterUpdate(String id, Map<String, Object> record,
+                             Map<String, Object> previous, String tenantId) {
+        publishLayoutChanged(record, tenantId, ChangeType.UPDATED);
+    }
+
+    @Override
+    public void afterDelete(String id, String tenantId) {
+        log.info("Layout related list deleted (id={}); clients refresh on next layout fetch", id);
+    }
+
+    private void publishLayoutChanged(Map<String, Object> record, String tenantId, ChangeType changeType) {
+        String layoutId = (String) record.get("layoutId");
+        if (layoutId == null) {
+            log.warn("Layout related list record missing layoutId, cannot broadcast refresh");
+            return;
+        }
+
+        CollectionChangedPayload payload = new CollectionChangedPayload();
+        payload.setId(layoutId);
+        payload.setChangeType(changeType);
+
+        PlatformEvent<CollectionChangedPayload> event = EventFactory.createEvent(EVENT_TYPE, payload);
+        event.setTenantId(tenantId);
+        String subject = SUBJECT_PREFIX + layoutId;
+        log.info("Publishing layout-changed event from related list change (layoutId={}, changeType={})",
+                layoutId, changeType);
+        eventPublisher.publish(subject, event);
+    }
+}

--- a/kelta-worker/src/main/java/io/kelta/worker/listener/LayoutSectionRefreshHook.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/listener/LayoutSectionRefreshHook.java
@@ -1,0 +1,78 @@
+package io.kelta.worker.listener;
+
+import io.kelta.runtime.event.ChangeType;
+import io.kelta.runtime.event.CollectionChangedPayload;
+import io.kelta.runtime.event.EventFactory;
+import io.kelta.runtime.event.PlatformEvent;
+import io.kelta.runtime.event.PlatformEventPublisher;
+import io.kelta.runtime.workflow.BeforeSaveHook;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+
+/**
+ * After-save hook for the "layout-sections" system collection. Publishes a
+ * layout-changed event whenever a section is created or updated so admin UIs
+ * and other pods refresh promptly.
+ *
+ * <p>Subject: {@code kelta.config.layout.changed.<layoutId>}.
+ */
+public class LayoutSectionRefreshHook implements BeforeSaveHook {
+
+    private static final Logger log = LoggerFactory.getLogger(LayoutSectionRefreshHook.class);
+
+    static final String SUBJECT_PREFIX = "kelta.config.layout.changed.";
+    static final String EVENT_TYPE = "kelta.config.layout.changed";
+
+    private final PlatformEventPublisher eventPublisher;
+
+    public LayoutSectionRefreshHook(PlatformEventPublisher eventPublisher) {
+        this.eventPublisher = eventPublisher;
+    }
+
+    @Override
+    public String getCollectionName() {
+        return "layout-sections";
+    }
+
+    @Override
+    public int getOrder() {
+        return 200;
+    }
+
+    @Override
+    public void afterCreate(Map<String, Object> record, String tenantId) {
+        publishLayoutChanged(record, tenantId, ChangeType.CREATED);
+    }
+
+    @Override
+    public void afterUpdate(String id, Map<String, Object> record,
+                             Map<String, Object> previous, String tenantId) {
+        publishLayoutChanged(record, tenantId, ChangeType.UPDATED);
+    }
+
+    @Override
+    public void afterDelete(String id, String tenantId) {
+        log.info("Layout section deleted (id={}); clients refresh on next layout fetch", id);
+    }
+
+    private void publishLayoutChanged(Map<String, Object> record, String tenantId, ChangeType changeType) {
+        String layoutId = (String) record.get("layoutId");
+        if (layoutId == null) {
+            log.warn("Layout section record missing layoutId, cannot broadcast refresh");
+            return;
+        }
+
+        CollectionChangedPayload payload = new CollectionChangedPayload();
+        payload.setId(layoutId);
+        payload.setChangeType(changeType);
+
+        PlatformEvent<CollectionChangedPayload> event = EventFactory.createEvent(EVENT_TYPE, payload);
+        event.setTenantId(tenantId);
+        String subject = SUBJECT_PREFIX + layoutId;
+        log.info("Publishing layout-changed event from section change (layoutId={}, changeType={})",
+                layoutId, changeType);
+        eventPublisher.publish(subject, event);
+    }
+}

--- a/kelta-worker/src/main/java/io/kelta/worker/listener/PageLayoutConfigEventPublisher.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/listener/PageLayoutConfigEventPublisher.java
@@ -1,0 +1,80 @@
+package io.kelta.worker.listener;
+
+import io.kelta.runtime.event.ChangeType;
+import io.kelta.runtime.event.CollectionChangedPayload;
+import io.kelta.runtime.event.EventFactory;
+import io.kelta.runtime.event.PlatformEvent;
+import io.kelta.runtime.event.PlatformEventPublisher;
+import io.kelta.runtime.workflow.BeforeSaveHook;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+
+/**
+ * After-save hook for the "page-layouts" system collection. Publishes a
+ * layout-changed event for create, update, and delete (the delete callback
+ * provides the layout id directly).
+ *
+ * <p>Subject: {@code kelta.config.layout.changed.<layoutId>}.
+ */
+public class PageLayoutConfigEventPublisher implements BeforeSaveHook {
+
+    private static final Logger log = LoggerFactory.getLogger(PageLayoutConfigEventPublisher.class);
+
+    static final String SUBJECT_PREFIX = "kelta.config.layout.changed.";
+    static final String EVENT_TYPE = "kelta.config.layout.changed";
+
+    private final PlatformEventPublisher eventPublisher;
+
+    public PageLayoutConfigEventPublisher(PlatformEventPublisher eventPublisher) {
+        this.eventPublisher = eventPublisher;
+    }
+
+    @Override
+    public String getCollectionName() {
+        return "page-layouts";
+    }
+
+    @Override
+    public int getOrder() {
+        return 200;
+    }
+
+    @Override
+    public void afterCreate(Map<String, Object> record, String tenantId) {
+        String layoutId = (String) record.get("id");
+        Object name = record.get("name");
+        publish(layoutId, name != null ? name.toString() : null, tenantId, ChangeType.CREATED);
+    }
+
+    @Override
+    public void afterUpdate(String id, Map<String, Object> record,
+                             Map<String, Object> previous, String tenantId) {
+        Object name = record.get("name");
+        publish(id, name != null ? name.toString() : null, tenantId, ChangeType.UPDATED);
+    }
+
+    @Override
+    public void afterDelete(String id, String tenantId) {
+        publish(id, null, tenantId, ChangeType.DELETED);
+    }
+
+    private void publish(String layoutId, String name, String tenantId, ChangeType changeType) {
+        if (layoutId == null) {
+            log.warn("Page layout {} event missing id, cannot broadcast", changeType);
+            return;
+        }
+
+        CollectionChangedPayload payload = new CollectionChangedPayload();
+        payload.setId(layoutId);
+        payload.setName(name);
+        payload.setChangeType(changeType);
+
+        PlatformEvent<CollectionChangedPayload> event = EventFactory.createEvent(EVENT_TYPE, payload);
+        event.setTenantId(tenantId);
+        String subject = SUBJECT_PREFIX + layoutId;
+        log.info("Publishing page-layout {} event (layoutId={})", changeType, layoutId);
+        eventPublisher.publish(subject, event);
+    }
+}

--- a/kelta-worker/src/test/java/io/kelta/worker/listener/LayoutFieldRefreshHookTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/listener/LayoutFieldRefreshHookTest.java
@@ -1,0 +1,103 @@
+package io.kelta.worker.listener;
+
+import io.kelta.runtime.event.ChangeType;
+import io.kelta.runtime.event.CollectionChangedPayload;
+import io.kelta.runtime.event.PlatformEvent;
+import io.kelta.runtime.event.PlatformEventPublisher;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class LayoutFieldRefreshHookTest {
+
+    private PlatformEventPublisher publisher;
+    private JdbcTemplate jdbcTemplate;
+    private LayoutFieldRefreshHook hook;
+
+    @BeforeEach
+    void setUp() {
+        publisher = mock(PlatformEventPublisher.class);
+        jdbcTemplate = mock(JdbcTemplate.class);
+        hook = new LayoutFieldRefreshHook(publisher, jdbcTemplate);
+    }
+
+    @Test
+    void getCollectionNameIsLayoutFields() {
+        assertEquals("layout-fields", hook.getCollectionName());
+    }
+
+    @Test
+    void afterCreateResolvesLayoutIdAndPublishes() {
+        Map<String, Object> record = new HashMap<>();
+        record.put("sectionId", "section-1");
+
+        when(jdbcTemplate.queryForList(anyString(), eq("section-1")))
+                .thenReturn(List.of(Map.of("layout_id", "layout-7")));
+
+        hook.afterCreate(record, "tenant-1");
+
+        ArgumentCaptor<String> subjectCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<PlatformEvent> eventCaptor = ArgumentCaptor.forClass(PlatformEvent.class);
+        verify(publisher).publish(subjectCaptor.capture(), eventCaptor.capture());
+
+        assertEquals("kelta.config.layout.changed.layout-7", subjectCaptor.getValue());
+        CollectionChangedPayload payload = (CollectionChangedPayload) eventCaptor.getValue().getPayload();
+        assertEquals("layout-7", payload.getId());
+        assertEquals(ChangeType.CREATED, payload.getChangeType());
+    }
+
+    @Test
+    void afterUpdateResolvesLayoutIdAndPublishes() {
+        Map<String, Object> record = new HashMap<>();
+        record.put("sectionId", "section-2");
+
+        when(jdbcTemplate.queryForList(anyString(), eq("section-2")))
+                .thenReturn(List.of(Map.of("layout_id", "layout-8")));
+
+        hook.afterUpdate("field-1", record, null, "tenant-1");
+
+        ArgumentCaptor<PlatformEvent> eventCaptor = ArgumentCaptor.forClass(PlatformEvent.class);
+        verify(publisher).publish(anyString(), eventCaptor.capture());
+        CollectionChangedPayload payload = (CollectionChangedPayload) eventCaptor.getValue().getPayload();
+        assertEquals(ChangeType.UPDATED, payload.getChangeType());
+        assertEquals("layout-8", payload.getId());
+    }
+
+    @Test
+    void missingSectionIdSkipsBroadcast() {
+        hook.afterCreate(new HashMap<>(), "tenant-1");
+        verify(publisher, never()).publish(anyString(), any());
+    }
+
+    @Test
+    void unresolvedSectionSkipsBroadcast() {
+        Map<String, Object> record = new HashMap<>();
+        record.put("sectionId", "section-missing");
+        when(jdbcTemplate.queryForList(anyString(), eq("section-missing")))
+                .thenReturn(List.of());
+
+        hook.afterCreate(record, "tenant-1");
+
+        verify(publisher, never()).publish(anyString(), any());
+    }
+
+    @Test
+    void afterDeleteDoesNotPublish() {
+        hook.afterDelete("field-1", "tenant-1");
+        verify(publisher, never()).publish(anyString(), any());
+    }
+}

--- a/kelta-worker/src/test/java/io/kelta/worker/listener/LayoutRelatedListRefreshHookTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/listener/LayoutRelatedListRefreshHookTest.java
@@ -1,0 +1,87 @@
+package io.kelta.worker.listener;
+
+import io.kelta.runtime.event.ChangeType;
+import io.kelta.runtime.event.CollectionChangedPayload;
+import io.kelta.runtime.event.PlatformEvent;
+import io.kelta.runtime.event.PlatformEventPublisher;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+class LayoutRelatedListRefreshHookTest {
+
+    private PlatformEventPublisher publisher;
+    private LayoutRelatedListRefreshHook hook;
+
+    @BeforeEach
+    void setUp() {
+        publisher = mock(PlatformEventPublisher.class);
+        hook = new LayoutRelatedListRefreshHook(publisher);
+    }
+
+    @Test
+    void getCollectionNameIsLayoutRelatedLists() {
+        assertEquals("layout-related-lists", hook.getCollectionName());
+    }
+
+    @Test
+    void orderIsAfterAuditHooks() {
+        assertEquals(200, hook.getOrder());
+    }
+
+    @Test
+    void afterCreatePublishesLayoutChangedEvent() {
+        Map<String, Object> record = new HashMap<>();
+        record.put("layoutId", "layout-123");
+
+        hook.afterCreate(record, "tenant-1");
+
+        ArgumentCaptor<String> subjectCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<PlatformEvent> eventCaptor = ArgumentCaptor.forClass(PlatformEvent.class);
+        verify(publisher).publish(subjectCaptor.capture(), eventCaptor.capture());
+
+        assertEquals("kelta.config.layout.changed.layout-123", subjectCaptor.getValue());
+        PlatformEvent<?> event = eventCaptor.getValue();
+        assertEquals("tenant-1", event.getTenantId());
+        CollectionChangedPayload payload = (CollectionChangedPayload) event.getPayload();
+        assertEquals("layout-123", payload.getId());
+        assertEquals(ChangeType.CREATED, payload.getChangeType());
+    }
+
+    @Test
+    void afterUpdatePublishesUpdatedEvent() {
+        Map<String, Object> record = new HashMap<>();
+        record.put("layoutId", "layout-456");
+
+        hook.afterUpdate("rl-789", record, null, "tenant-2");
+
+        ArgumentCaptor<PlatformEvent> eventCaptor = ArgumentCaptor.forClass(PlatformEvent.class);
+        verify(publisher).publish(anyString(), eventCaptor.capture());
+
+        CollectionChangedPayload payload = (CollectionChangedPayload) eventCaptor.getValue().getPayload();
+        assertEquals(ChangeType.UPDATED, payload.getChangeType());
+        assertEquals("layout-456", payload.getId());
+    }
+
+    @Test
+    void missingLayoutIdSkipsBroadcast() {
+        hook.afterCreate(new HashMap<>(), "tenant-1");
+        verify(publisher, never()).publish(anyString(), any());
+    }
+
+    @Test
+    void afterDeleteDoesNotPublish() {
+        hook.afterDelete("rl-1", "tenant-1");
+        verify(publisher, never()).publish(anyString(), any());
+    }
+}

--- a/kelta-worker/src/test/java/io/kelta/worker/listener/LayoutSectionRefreshHookTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/listener/LayoutSectionRefreshHookTest.java
@@ -1,0 +1,79 @@
+package io.kelta.worker.listener;
+
+import io.kelta.runtime.event.ChangeType;
+import io.kelta.runtime.event.CollectionChangedPayload;
+import io.kelta.runtime.event.PlatformEvent;
+import io.kelta.runtime.event.PlatformEventPublisher;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+class LayoutSectionRefreshHookTest {
+
+    private PlatformEventPublisher publisher;
+    private LayoutSectionRefreshHook hook;
+
+    @BeforeEach
+    void setUp() {
+        publisher = mock(PlatformEventPublisher.class);
+        hook = new LayoutSectionRefreshHook(publisher);
+    }
+
+    @Test
+    void getCollectionNameIsLayoutSections() {
+        assertEquals("layout-sections", hook.getCollectionName());
+    }
+
+    @Test
+    void afterCreatePublishesLayoutChangedEvent() {
+        Map<String, Object> record = new HashMap<>();
+        record.put("layoutId", "layout-1");
+
+        hook.afterCreate(record, "tenant-1");
+
+        ArgumentCaptor<String> subjectCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<PlatformEvent> eventCaptor = ArgumentCaptor.forClass(PlatformEvent.class);
+        verify(publisher).publish(subjectCaptor.capture(), eventCaptor.capture());
+
+        assertEquals("kelta.config.layout.changed.layout-1", subjectCaptor.getValue());
+        CollectionChangedPayload payload = (CollectionChangedPayload) eventCaptor.getValue().getPayload();
+        assertEquals("layout-1", payload.getId());
+        assertEquals(ChangeType.CREATED, payload.getChangeType());
+    }
+
+    @Test
+    void afterUpdatePublishesUpdatedEvent() {
+        Map<String, Object> record = new HashMap<>();
+        record.put("layoutId", "layout-2");
+
+        hook.afterUpdate("section-9", record, null, "tenant-2");
+
+        ArgumentCaptor<PlatformEvent> eventCaptor = ArgumentCaptor.forClass(PlatformEvent.class);
+        verify(publisher).publish(anyString(), eventCaptor.capture());
+        CollectionChangedPayload payload = (CollectionChangedPayload) eventCaptor.getValue().getPayload();
+        assertEquals(ChangeType.UPDATED, payload.getChangeType());
+        assertEquals("layout-2", payload.getId());
+    }
+
+    @Test
+    void missingLayoutIdSkipsBroadcast() {
+        hook.afterCreate(new HashMap<>(), "tenant-1");
+        verify(publisher, never()).publish(anyString(), any());
+    }
+
+    @Test
+    void afterDeleteDoesNotPublish() {
+        hook.afterDelete("section-1", "tenant-1");
+        verify(publisher, never()).publish(anyString(), any());
+    }
+}

--- a/kelta-worker/src/test/java/io/kelta/worker/listener/PageLayoutConfigEventPublisherTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/listener/PageLayoutConfigEventPublisherTest.java
@@ -1,0 +1,90 @@
+package io.kelta.worker.listener;
+
+import io.kelta.runtime.event.ChangeType;
+import io.kelta.runtime.event.CollectionChangedPayload;
+import io.kelta.runtime.event.PlatformEvent;
+import io.kelta.runtime.event.PlatformEventPublisher;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+class PageLayoutConfigEventPublisherTest {
+
+    private PlatformEventPublisher publisher;
+    private PageLayoutConfigEventPublisher hook;
+
+    @BeforeEach
+    void setUp() {
+        publisher = mock(PlatformEventPublisher.class);
+        hook = new PageLayoutConfigEventPublisher(publisher);
+    }
+
+    @Test
+    void getCollectionNameIsPageLayouts() {
+        assertEquals("page-layouts", hook.getCollectionName());
+    }
+
+    @Test
+    void afterCreatePublishesCreatedEvent() {
+        Map<String, Object> record = new HashMap<>();
+        record.put("id", "layout-1");
+        record.put("name", "Account Detail");
+
+        hook.afterCreate(record, "tenant-1");
+
+        ArgumentCaptor<String> subjectCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<PlatformEvent> eventCaptor = ArgumentCaptor.forClass(PlatformEvent.class);
+        verify(publisher).publish(subjectCaptor.capture(), eventCaptor.capture());
+
+        assertEquals("kelta.config.layout.changed.layout-1", subjectCaptor.getValue());
+        CollectionChangedPayload payload = (CollectionChangedPayload) eventCaptor.getValue().getPayload();
+        assertEquals("layout-1", payload.getId());
+        assertEquals("Account Detail", payload.getName());
+        assertEquals(ChangeType.CREATED, payload.getChangeType());
+    }
+
+    @Test
+    void afterUpdatePublishesUpdatedEventWithProvidedId() {
+        Map<String, Object> record = new HashMap<>();
+        record.put("name", "Renamed Layout");
+
+        hook.afterUpdate("layout-2", record, null, "tenant-1");
+
+        ArgumentCaptor<String> subjectCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<PlatformEvent> eventCaptor = ArgumentCaptor.forClass(PlatformEvent.class);
+        verify(publisher).publish(subjectCaptor.capture(), eventCaptor.capture());
+
+        assertEquals("kelta.config.layout.changed.layout-2", subjectCaptor.getValue());
+        CollectionChangedPayload payload = (CollectionChangedPayload) eventCaptor.getValue().getPayload();
+        assertEquals("layout-2", payload.getId());
+        assertEquals(ChangeType.UPDATED, payload.getChangeType());
+    }
+
+    @Test
+    void afterDeletePublishesDeletedEvent() {
+        hook.afterDelete("layout-3", "tenant-1");
+
+        ArgumentCaptor<PlatformEvent> eventCaptor = ArgumentCaptor.forClass(PlatformEvent.class);
+        verify(publisher).publish(anyString(), eventCaptor.capture());
+
+        CollectionChangedPayload payload = (CollectionChangedPayload) eventCaptor.getValue().getPayload();
+        assertEquals("layout-3", payload.getId());
+        assertEquals(ChangeType.DELETED, payload.getChangeType());
+    }
+
+    @Test
+    void afterCreateWithoutIdSkipsBroadcast() {
+        hook.afterCreate(new HashMap<>(), "tenant-1");
+        verify(publisher, never()).publish(anyString(), any());
+    }
+}


### PR DESCRIPTION
## Summary

- Editing a related list (or any layout section/field/page-layout) in the layout editor now propagates to record detail pages immediately instead of after a ~5–10 minute cache window.
- Worker publishes `kelta.config.layout.changed.<layoutId>` on create/update for `layout-related-lists`, `layout-sections`, `layout-fields`, and `page-layouts` (matching the existing `LayoutRuleRefreshHook` pattern). Required by the multi-pod NATS rule and consumable by the planned SSE bridge.
- Layout editor `saveMutation.onSuccess` now invalidates the `page-layout-resolve` React Query key (prefix match covers every collection/profile/recordType combo). `usePageLayout` staleTime drops from 5 min to 30 s so stale caches recover fast even when invalidation is missed.

## Test plan

- [x] `mvn test -f kelta-worker/pom.xml -Dtest="Layout*RefreshHookTest,PageLayoutConfigEventPublisherTest"` — 29 tests pass
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` on changed files — clean
- [ ] Manual two-browser: edit related list in browser B, verify browser A's record detail reflects change without 5-min wait
- [ ] `nats sub 'kelta.config.layout.changed.>'` confirms one event per save

🤖 Generated with [Claude Code](https://claude.com/claude-code)