### PR TITLE
fix(layouts): resolve only DETAIL layouts on record detail page

### DIFF
--- a/kelta-ui/app/src/hooks/usePageLayout.test.ts
+++ b/kelta-ui/app/src/hooks/usePageLayout.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import React from 'react'
+import { usePageLayout } from './usePageLayout'
+
+const mockGetList = vi.fn()
+const mockGet = vi.fn()
+
+vi.mock('../context/ApiContext', () => ({
+  useApi: vi.fn(() => ({
+    apiClient: {
+      get: mockGet,
+      getList: mockGetList,
+      post: vi.fn(),
+      put: vi.fn(),
+      patch: vi.fn(),
+      delete: vi.fn(),
+    },
+  })),
+}))
+
+vi.mock('../context/CollectionStoreContext', () => ({
+  useCollectionStore: vi.fn(() => ({
+    getCollectionById: vi.fn(() => null),
+    getFieldById: vi.fn(() => null),
+  })),
+}))
+
+function TestWrapper({ children }: { children: React.ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return React.createElement(QueryClientProvider, { client: queryClient }, children)
+}
+
+describe('usePageLayout', () => {
+  beforeEach(() => {
+    mockGetList.mockReset()
+    mockGet.mockReset()
+  })
+
+  it('fallback query filters by layoutType=DETAIL to ignore LIST defaults on the same collection', async () => {
+    mockGetList.mockImplementation(async (url: string) => {
+      if (url.includes('/api/layout-assignments')) return []
+      if (url.includes('/api/page-layouts')) {
+        expect(url).toContain('filter[layoutType][eq]=DETAIL')
+        return [
+          {
+            id: 'detail-layout-id',
+            collectionId: 'coll-1',
+            isDefault: true,
+            layoutType: 'DETAIL',
+          },
+        ]
+      }
+      if (url.includes('/api/layout-rules')) return []
+      return []
+    })
+
+    mockGet.mockResolvedValueOnce({
+      data: {
+        type: 'page-layouts',
+        id: 'detail-layout-id',
+        attributes: {
+          collectionId: 'coll-1',
+          name: 'Customer Layout',
+          layoutType: 'DETAIL',
+          isDefault: true,
+        },
+      },
+      included: [
+        {
+          type: 'layout-sections',
+          id: 'sec-1',
+          attributes: { heading: 'General', columns: 2, sortOrder: 0 },
+        },
+      ],
+    })
+
+    const { result } = renderHook(() => usePageLayout('coll-1', 'user-1'), {
+      wrapper: TestWrapper,
+    })
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+
+    expect(result.current.layout?.id).toBe('detail-layout-id')
+    expect(result.current.layout?.layoutType).toBe('DETAIL')
+  })
+
+  it('returns null when the assignment-resolved layout is not a DETAIL layout', async () => {
+    mockGetList.mockImplementation(async (url: string) => {
+      if (url.includes('/api/layout-assignments')) {
+        return [
+          {
+            id: 'assign-1',
+            collectionId: 'coll-1',
+            profileId: 'user-1',
+            layoutId: 'list-layout-id',
+          },
+        ]
+      }
+      if (url.includes('/api/layout-rules')) return []
+      return []
+    })
+
+    mockGet.mockResolvedValueOnce({
+      data: {
+        type: 'page-layouts',
+        id: 'list-layout-id',
+        attributes: {
+          collectionId: 'coll-1',
+          name: 'Customer LIST',
+          layoutType: 'LIST',
+          isDefault: true,
+        },
+      },
+      included: [],
+    })
+
+    const { result } = renderHook(() => usePageLayout('coll-1', 'user-1'), {
+      wrapper: TestWrapper,
+    })
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+
+    expect(result.current.layout).toBeNull()
+  })
+
+  it('warns and picks the first layout when multiple default DETAIL layouts are returned', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    mockGetList.mockImplementation(async (url: string) => {
+      if (url.includes('/api/layout-assignments')) return []
+      if (url.includes('/api/page-layouts')) {
+        return [
+          { id: 'older', collectionId: 'coll-1', isDefault: true, layoutType: 'DETAIL' },
+          { id: 'newer', collectionId: 'coll-1', isDefault: true, layoutType: 'DETAIL' },
+        ]
+      }
+      if (url.includes('/api/layout-rules')) return []
+      return []
+    })
+
+    mockGet.mockResolvedValueOnce({
+      data: {
+        type: 'page-layouts',
+        id: 'older',
+        attributes: {
+          collectionId: 'coll-1',
+          name: 'Older',
+          layoutType: 'DETAIL',
+          isDefault: true,
+        },
+      },
+      included: [
+        {
+          type: 'layout-sections',
+          id: 'sec-1',
+          attributes: { heading: 'General', columns: 2, sortOrder: 0 },
+        },
+      ],
+    })
+
+    const { result } = renderHook(() => usePageLayout('coll-1', 'user-1'), {
+      wrapper: TestWrapper,
+    })
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+
+    expect(result.current.layout?.id).toBe('older')
+    expect(warnSpy).toHaveBeenCalled()
+    warnSpy.mockRestore()
+  })
+})

--- a/kelta-ui/app/src/hooks/usePageLayout.ts
+++ b/kelta-ui/app/src/hooks/usePageLayout.ts
@@ -165,17 +165,28 @@ export function usePageLayout(
           }
         }
 
-        // Final fallback: query page-layouts directly for a default layout
-        // matching this collection. This handles the common case where
-        // layouts exist but no layout-assignment records have been created.
+        // Final fallback: query page-layouts directly for a default DETAIL
+        // layout matching this collection. Filtering by layoutType prevents
+        // a LIST layout sharing the same collection from being resolved here
+        // (both can have isDefault=true). Sort + larger page size so the
+        // result is deterministic even if multiple defaults exist for the
+        // same type — the oldest by createdAt wins, and a console warning
+        // surfaces the conflict.
         if (!layoutId) {
           const defaultLayouts = await apiClient.getList<{
             id: string
             collectionId: string
             isDefault: boolean
+            layoutType?: string
+            createdAt?: string
           }>(
-            `/api/page-layouts?filter[collectionId][eq]=${collectionId}&filter[isDefault][eq]=true&page[size]=1`
+            `/api/page-layouts?filter[collectionId][eq]=${collectionId}&filter[isDefault][eq]=true&filter[layoutType][eq]=DETAIL&sort=createdAt&page[size]=10`
           )
+          if (defaultLayouts.length > 1) {
+            console.warn(
+              `[usePageLayout] Multiple default DETAIL layouts for collection ${collectionId}; using oldest (${defaultLayouts[0].id}). Clean up duplicate is_default flags.`
+            )
+          }
           if (defaultLayouts.length > 0) {
             layoutId = defaultLayouts[0].id
           }
@@ -213,6 +224,15 @@ export function usePageLayout(
 
         const flatLayout = flatten(raw.data)
         const included = raw.included ?? []
+
+        // Guard: an assignment can point at a LIST layout for the same
+        // collection. Detail rendering must ignore non-DETAIL layouts so we
+        // don't show empty sections / fall back unexpectedly.
+        const resolvedType =
+          typeof flatLayout.layoutType === 'string' ? flatLayout.layoutType : 'DETAIL'
+        if (resolvedType !== 'DETAIL') {
+          return null
+        }
 
         // Extract and sort sections
         const sections: LayoutSectionDto[] = included


### PR DESCRIPTION
## Summary
- Record detail page was sometimes hitting the auto-discovery fallback (first 4 schema fields, arbitrary order) instead of using the layout's configured related-list columns when a collection had both a default LIST and a default DETAIL layout.
- Postgres returned whichever default it pleased from the unfiltered fallback query in `usePageLayout`, and a LIST layout has no related-list config, so `hasLayoutRelatedLists` was false and `ObjectDetailPage` fell back.
- Reproduced against the `threadline-clothing` tenant: `customers` has two `is_default=true` page_layouts (one DETAIL with the saved Orders related list, one LIST with none). User saw `Computed Total, Order Number, Order Status, Order Date` instead of the configured `Order Number, Order Date, Order Status, Tax, Computed Total`.

## Changes
- `usePageLayout` fallback query now filters by `layoutType=DETAIL`, sorts by `createdAt`, raises page size to 10, and emits a `console.warn` when more than one default DETAIL layout exists so the data inconsistency surfaces.
- Added a post-fetch guard: when an assignment-resolved layout turns out to be non-DETAIL, return null so the caller falls back cleanly instead of rendering an empty layout.
- Added `usePageLayout.test.ts` with three cases: fallback uses the DETAIL filter, assignment-resolved LIST layout returns null, multiple-default warning fires while still picking deterministically.

## Out of scope (follow-ups)
- Backend uniqueness enforcement (`BeforeSaveHook` for `page-layouts` that unsets sibling defaults per `(tenant, collection, layoutType, recordTypeId)`).
- Data cleanup for the existing duplicate `is_default=true` rows.

## Test plan
- [x] `npm run test -- --run src/hooks/usePageLayout.test.ts` (kelta-ui/app)
- [ ] Manual: load a customer detail page in `threadline-clothing` and confirm the Orders related list shows the configured columns in order
- [ ] Manual: confirm a list page still resolves its LIST layout normally