### PR TITLE
feat(detail-page): tab bar at bottom of every record detail page

### DIFF
--- a/kelta-ui/app/src/components/RelatedList/RelatedList.tsx
+++ b/kelta-ui/app/src/components/RelatedList/RelatedList.tsx
@@ -13,7 +13,7 @@
  * - Loading skeleton and empty state
  */
 
-import React, { useMemo } from 'react'
+import React, { useEffect, useMemo } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import { Plus, ExternalLink } from 'lucide-react'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -90,6 +90,12 @@ export interface RelatedListProps {
    * network requests when the parent fetches with reverse includes.
    */
   includedData?: unknown
+  /**
+   * Optional: called when the total record count resolves or changes. Used by
+   * containers (e.g. the detail-page tab bar) that need to surface the count
+   * outside the list itself.
+   */
+  onTotalChange?: (total: number) => void
 }
 
 /**
@@ -122,6 +128,7 @@ export function RelatedList({
   sortField,
   sortDirection,
   includedData,
+  onTotalChange,
 }: RelatedListProps): React.ReactElement {
   const navigate = useNavigate()
   const basePath = `/${tenantSlug}/app`
@@ -249,6 +256,12 @@ export function RelatedList({
     (collectionName ? collectionName.charAt(0).toUpperCase() + collectionName.slice(1) : 'Related')
 
   const isLoading = schemaLoading || (!hasPreloadedData && recordsLoading)
+
+  useEffect(() => {
+    if (!onTotalChange) return
+    if (isLoading) return
+    onTotalChange(total)
+  }, [total, isLoading, onTotalChange])
 
   // Handle row click → navigate to record detail
   const handleRowClick = (record: CollectionRecord) => {

--- a/kelta-ui/app/src/pages/ResourceDetailPage/DetailTabBar.tsx
+++ b/kelta-ui/app/src/pages/ResourceDetailPage/DetailTabBar.tsx
@@ -1,0 +1,288 @@
+/**
+ * DetailTabBar
+ *
+ * Bottom-of-page tab bar for record detail pages. Renders one tab per
+ * configured related list (in layout sortOrder) followed by Notes,
+ * Attachments, and System Information. Counts in parentheses display
+ * record totals for related-list, Notes, and Attachments tabs.
+ */
+
+import React, { useCallback, useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { Copy } from 'lucide-react'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { Button } from '@/components/ui/button'
+import { RelatedList } from '@/components/RelatedList'
+import { NotesSection } from '@/components/NotesSection/NotesSection'
+import { AttachmentsSection } from '@/components/AttachmentsSection/AttachmentsSection'
+import { useCollectionSchema } from '@/hooks/useCollectionSchema'
+import { parseDisplayColumns } from '@/components/LayoutRelatedLists/parseDisplayColumns'
+import { useI18n } from '@/context/I18nContext'
+import { useToast } from '@/components'
+import type { LayoutRelatedListDto } from '@/hooks/usePageLayout'
+import type { Note, Attachment } from '@/hooks/useRecordContext'
+import type { ApiClient } from '@/services/apiClient'
+
+const NOTES_TAB = '__notes__'
+const ATTACHMENTS_TAB = '__attachments__'
+const SYSTEM_TAB = '__system__'
+
+interface UserDisplay {
+  name: string
+  linkTo: string
+}
+
+export interface DetailTabBarProps {
+  /** Related list configurations from the resolved page layout (may be empty) */
+  relatedLists: LayoutRelatedListDto[]
+  /** Parent record id (UUID) */
+  recordId: string
+  /** Collection ID (UUID) */
+  collectionId: string
+  /** Tenant slug for building URLs */
+  tenantSlug: string
+  /** Raw JSON:API response from the parent record request (for include resolution) */
+  includedData?: unknown
+  /** Parent record object — provides id, created_at, updated_at, created_by, updated_by */
+  resource: Record<string, unknown> & { id: string }
+  /** Notes pre-fetched via useRecordContext */
+  notes: Note[]
+  /** Attachments pre-fetched via useRecordContext */
+  attachments: Attachment[]
+  /** API client */
+  apiClient: ApiClient
+  /** Invalidate notes/attachments cache after mutation */
+  invalidateRecordContext: () => void
+  /** Resolve a userId to a display name + link, or null when not yet resolved */
+  getUserDisplay: (userId: string) => UserDisplay | null
+}
+
+function normalizeSortDirection(raw: string | null | undefined): 'asc' | 'desc' {
+  return raw && raw.trim().toLowerCase() === 'desc' ? 'desc' : 'asc'
+}
+
+interface RelatedListTabTriggerProps {
+  rl: LayoutRelatedListDto
+  count: number | undefined
+}
+
+function RelatedListTabTrigger({ rl, count }: RelatedListTabTriggerProps): React.ReactElement {
+  const { schema } = useCollectionSchema(rl.relatedCollectionName)
+  const fallback =
+    rl.relatedCollectionName.charAt(0).toUpperCase() + rl.relatedCollectionName.slice(1)
+  const label = schema?.displayName ?? fallback
+  return (
+    <TabsTrigger value={rl.id} data-testid={`detail-tab-${rl.relatedCollectionName}`}>
+      {label}
+      {typeof count === 'number' ? ` (${count})` : ''}
+    </TabsTrigger>
+  )
+}
+
+export function DetailTabBar({
+  relatedLists,
+  recordId,
+  collectionId,
+  tenantSlug,
+  includedData,
+  resource,
+  notes,
+  attachments,
+  apiClient,
+  invalidateRecordContext,
+  getUserDisplay,
+}: DetailTabBarProps): React.ReactElement {
+  const { t, formatDate } = useI18n()
+  const { showToast } = useToast()
+
+  const sortedLists = useMemo(
+    () => [...relatedLists].sort((a, b) => a.sortOrder - b.sortOrder),
+    [relatedLists]
+  )
+
+  const [counts, setCounts] = useState<Record<string, number>>({})
+  const setCount = useCallback((id: string, n: number) => {
+    setCounts((prev) => (prev[id] === n ? prev : { ...prev, [id]: n }))
+  }, [])
+
+  const defaultTab = sortedLists[0]?.id ?? NOTES_TAB
+
+  const copyId = useCallback(() => {
+    void navigator.clipboard
+      .writeText(resource.id)
+      .then(() => showToast('Internal Id copied', 'success'))
+      .catch(() => showToast('Copy failed', 'error'))
+  }, [resource.id, showToast])
+
+  const createdAt = (resource.created_at ?? resource.createdAt) as string | undefined
+  const updatedAt = (resource.updated_at ?? resource.updatedAt) as string | undefined
+
+  return (
+    <section
+      className="rounded-md border border-border bg-card p-6 max-md:p-4"
+      aria-labelledby="detail-tabs-heading"
+      data-testid="detail-tab-bar"
+    >
+      <h2 id="detail-tabs-heading" className="sr-only">
+        Record details
+      </h2>
+      <Tabs defaultValue={defaultTab} className="w-full">
+        <div className="-mx-1 overflow-x-auto">
+          <TabsList variant="line" className="flex w-max">
+            {sortedLists.map((rl) => (
+              <RelatedListTabTrigger key={rl.id} rl={rl} count={counts[rl.id]} />
+            ))}
+            <TabsTrigger value={NOTES_TAB} data-testid="detail-tab-notes">
+              Notes ({notes.length})
+            </TabsTrigger>
+            <TabsTrigger value={ATTACHMENTS_TAB} data-testid="detail-tab-attachments">
+              Attachments ({attachments.length})
+            </TabsTrigger>
+            <TabsTrigger value={SYSTEM_TAB} data-testid="detail-tab-system">
+              System Information
+            </TabsTrigger>
+          </TabsList>
+        </div>
+
+        {sortedLists.map((rl) => (
+          <TabsContent forceMount key={rl.id} value={rl.id} className="mt-4">
+            <RelatedList
+              collectionName={rl.relatedCollectionName}
+              foreignKeyField={rl.relationshipFieldName}
+              parentRecordId={recordId}
+              tenantSlug={tenantSlug}
+              limit={rl.rowLimit}
+              displayColumns={parseDisplayColumns(rl.displayColumns)}
+              sortField={rl.sortField ?? undefined}
+              sortDirection={normalizeSortDirection(rl.sortDirection)}
+              includedData={includedData}
+              onTotalChange={(n) => setCount(rl.id, n)}
+            />
+          </TabsContent>
+        ))}
+
+        <TabsContent forceMount value={NOTES_TAB} className="mt-4">
+          <NotesSection
+            collectionId={collectionId}
+            recordId={recordId}
+            apiClient={apiClient}
+            notes={notes}
+            onMutate={invalidateRecordContext}
+          />
+        </TabsContent>
+
+        <TabsContent forceMount value={ATTACHMENTS_TAB} className="mt-4">
+          <AttachmentsSection
+            collectionId={collectionId}
+            recordId={recordId}
+            apiClient={apiClient}
+            attachments={attachments}
+            onMutate={invalidateRecordContext}
+          />
+        </TabsContent>
+
+        <TabsContent forceMount value={SYSTEM_TAB} className="mt-4">
+          <div
+            className="grid grid-cols-[repeat(auto-fill,minmax(220px,1fr))] gap-4 max-md:grid-cols-1"
+            data-testid="system-information-panel"
+          >
+            <div className="flex flex-col gap-1">
+              <span className="text-sm font-medium text-muted-foreground">Internal Id</span>
+              <span className="inline-flex items-center gap-2">
+                <code
+                  className="break-all rounded bg-muted px-2 py-1 font-mono text-xs text-foreground"
+                  data-testid="system-internal-id"
+                >
+                  {resource.id}
+                </code>
+                <Button
+                  variant="ghost"
+                  size="xs"
+                  onClick={copyId}
+                  aria-label="Copy Internal Id"
+                  data-testid="system-internal-id-copy"
+                >
+                  <Copy size={12} aria-hidden="true" />
+                </Button>
+              </span>
+            </div>
+            {createdAt && (
+              <div className="flex flex-col gap-1">
+                <span className="text-sm font-medium text-muted-foreground">
+                  {t('collections.created')}
+                </span>
+                <span className="text-base text-foreground" data-testid="system-created-at">
+                  {formatDate(new Date(createdAt), {
+                    year: 'numeric',
+                    month: 'long',
+                    day: 'numeric',
+                    hour: '2-digit',
+                    minute: '2-digit',
+                  })}
+                </span>
+              </div>
+            )}
+            {updatedAt && (
+              <div className="flex flex-col gap-1">
+                <span className="text-sm font-medium text-muted-foreground">
+                  {t('collections.updated')}
+                </span>
+                <span className="text-base text-foreground" data-testid="system-updated-at">
+                  {formatDate(new Date(updatedAt), {
+                    year: 'numeric',
+                    month: 'long',
+                    day: 'numeric',
+                    hour: '2-digit',
+                    minute: '2-digit',
+                  })}
+                </span>
+              </div>
+            )}
+            {resource.created_by != null && (
+              <div className="flex flex-col gap-1">
+                <span className="text-sm font-medium text-muted-foreground">Created by</span>
+                <span className="text-base text-foreground" data-testid="system-created-by">
+                  {(() => {
+                    const display = getUserDisplay(String(resource.created_by))
+                    return display ? (
+                      <Link
+                        to={display.linkTo}
+                        className="text-primary no-underline hover:text-primary/80 hover:underline"
+                      >
+                        {display.name}
+                      </Link>
+                    ) : (
+                      String(resource.created_by)
+                    )
+                  })()}
+                </span>
+              </div>
+            )}
+            {resource.updated_by != null && (
+              <div className="flex flex-col gap-1">
+                <span className="text-sm font-medium text-muted-foreground">Last modified by</span>
+                <span className="text-base text-foreground" data-testid="system-updated-by">
+                  {(() => {
+                    const display = getUserDisplay(String(resource.updated_by))
+                    return display ? (
+                      <Link
+                        to={display.linkTo}
+                        className="text-primary no-underline hover:text-primary/80 hover:underline"
+                      >
+                        {display.name}
+                      </Link>
+                    ) : (
+                      String(resource.updated_by)
+                    )
+                  })()}
+                </span>
+              </div>
+            )}
+          </div>
+        </TabsContent>
+      </Tabs>
+    </section>
+  )
+}
+
+export default DetailTabBar

--- a/kelta-ui/app/src/pages/ResourceDetailPage/ResourceDetailPage.test.tsx
+++ b/kelta-ui/app/src/pages/ResourceDetailPage/ResourceDetailPage.test.tsx
@@ -495,12 +495,13 @@ describe('ResourceDetailPage', () => {
       expect(screen.getByText('Boolean')).toBeInTheDocument()
     })
 
-    it('should display metadata section with timestamps', async () => {
+    it('should display system information panel with timestamps', async () => {
       renderWithProviders(<ResourceDetailPage />)
 
       await waitFor(() => {
-        expect(screen.getByTestId('created-at')).toBeInTheDocument()
-        expect(screen.getByTestId('updated-at')).toBeInTheDocument()
+        expect(screen.getByTestId('system-created-at')).toBeInTheDocument()
+        expect(screen.getByTestId('system-updated-at')).toBeInTheDocument()
+        expect(screen.getByTestId('system-internal-id')).toBeInTheDocument()
       })
     })
 
@@ -825,7 +826,7 @@ describe('ResourceDetailPage', () => {
 
       await waitFor(() => {
         expect(screen.getByRole('heading', { name: 'Fields' })).toBeInTheDocument()
-        expect(screen.getByRole('heading', { name: 'Metadata' })).toBeInTheDocument()
+        expect(screen.getByTestId('detail-tab-system')).toBeInTheDocument()
       })
     })
   })

--- a/kelta-ui/app/src/pages/ResourceDetailPage/ResourceDetailPage.tsx
+++ b/kelta-ui/app/src/pages/ResourceDetailPage/ResourceDetailPage.tsx
@@ -23,15 +23,12 @@ import { useRecentRecords } from '../../hooks/useRecentRecords'
 import { useFavorites } from '../../hooks/useFavorites'
 import { RecordHeader } from '../../components/RecordHeader/RecordHeader'
 import { RecordActionsBar } from '../../components/RecordActionsBar/RecordActionsBar'
-import { RelatedRecordsSection } from '../../components/RelatedRecordsSection/RelatedRecordsSection'
 import { ActivityTimeline } from '../../components/ActivityTimeline/ActivityTimeline'
-import { NotesSection } from '../../components/NotesSection/NotesSection'
-import { AttachmentsSection } from '../../components/AttachmentsSection/AttachmentsSection'
 import { useRecordContext } from '../../hooks/useRecordContext'
 import { usePageLayout } from '../../hooks/usePageLayout'
 import { useLookupDisplayMap } from '../../hooks/useLookupDisplayMap'
 import { LayoutFieldSections } from '../../components/LayoutFieldSections/LayoutFieldSections'
-import { LayoutRelatedLists } from '../../components/LayoutRelatedLists/LayoutRelatedLists'
+import { DetailTabBar } from './DetailTabBar'
 import { unwrapResource, extractIncluded } from '../../utils/jsonapi'
 import type { ApiClient } from '../../services/apiClient'
 
@@ -865,90 +862,6 @@ export function ResourceDetailPage({
         </section>
       )}
 
-      {/* Metadata Section */}
-      <section
-        className="rounded-md border border-border bg-card p-6 max-md:p-4"
-        aria-labelledby="metadata-heading"
-      >
-        <h2 id="metadata-heading" className="m-0 mb-4 text-lg font-semibold text-foreground">
-          Metadata
-        </h2>
-        <div className="grid grid-cols-[repeat(auto-fill,minmax(200px,1fr))] gap-4 max-md:grid-cols-1">
-          {(resource.created_at || resource.createdAt) && (
-            <div className="flex flex-col gap-1">
-              <span className="text-sm font-medium text-muted-foreground">
-                {t('collections.created')}
-              </span>
-              <span className="text-base text-foreground" data-testid="created-at">
-                {formatDate(new Date((resource.created_at || resource.createdAt) as string), {
-                  year: 'numeric',
-                  month: 'long',
-                  day: 'numeric',
-                  hour: '2-digit',
-                  minute: '2-digit',
-                })}
-              </span>
-            </div>
-          )}
-          {(resource.updated_at || resource.updatedAt) && (
-            <div className="flex flex-col gap-1">
-              <span className="text-sm font-medium text-muted-foreground">
-                {t('collections.updated')}
-              </span>
-              <span className="text-base text-foreground" data-testid="updated-at">
-                {formatDate(new Date((resource.updated_at || resource.updatedAt) as string), {
-                  year: 'numeric',
-                  month: 'long',
-                  day: 'numeric',
-                  hour: '2-digit',
-                  minute: '2-digit',
-                })}
-              </span>
-            </div>
-          )}
-          {resource.created_by && (
-            <div className="flex flex-col gap-1">
-              <span className="text-sm font-medium text-muted-foreground">Created by</span>
-              <span className="text-base text-foreground" data-testid="created-by">
-                {(() => {
-                  const display = getUserDisplay(String(resource.created_by))
-                  return display ? (
-                    <Link
-                      to={display.linkTo}
-                      className="text-primary no-underline hover:underline hover:text-primary/80"
-                    >
-                      {display.name}
-                    </Link>
-                  ) : (
-                    String(resource.created_by)
-                  )
-                })()}
-              </span>
-            </div>
-          )}
-          {resource.updated_by && (
-            <div className="flex flex-col gap-1">
-              <span className="text-sm font-medium text-muted-foreground">Last modified by</span>
-              <span className="text-base text-foreground" data-testid="updated-by">
-                {(() => {
-                  const display = getUserDisplay(String(resource.updated_by))
-                  return display ? (
-                    <Link
-                      to={display.linkTo}
-                      className="text-primary no-underline hover:underline hover:text-primary/80"
-                    >
-                      {display.name}
-                    </Link>
-                  ) : (
-                    String(resource.updated_by)
-                  )
-                })()}
-              </span>
-            </div>
-          )}
-        </div>
-      </section>
-
       {/* Sharing Section */}
       <section
         className="rounded-md border border-border bg-card p-6 max-md:p-4"
@@ -1036,37 +949,18 @@ export function ResourceDetailPage({
         )}
       </section>
 
-      {/* Related Records Section (T6) — use layout related lists when available */}
-      {layout && layout.relatedLists.length > 0 ? (
-        <LayoutRelatedLists
-          relatedLists={layout.relatedLists}
-          parentRecordId={resourceId}
-          tenantSlug={getTenantSlug()}
-        />
-      ) : (
-        <RelatedRecordsSection
-          collectionName={collectionName}
-          recordId={resourceId}
-          apiClient={apiClient}
-        />
-      )}
-
-      {/* Notes Section (T20) */}
-      <NotesSection
-        collectionId={schema.id}
+      {/* Bottom tab bar: related lists + Notes + Attachments + System Information */}
+      <DetailTabBar
+        relatedLists={layout?.relatedLists ?? []}
         recordId={resourceId}
-        apiClient={apiClient}
+        collectionId={schema.id}
+        tenantSlug={getTenantSlug()}
+        resource={resource as Record<string, unknown> & { id: string }}
         notes={notes}
-        onMutate={invalidateRecordContext}
-      />
-
-      {/* Attachments Section (T20) */}
-      <AttachmentsSection
-        collectionId={schema.id}
-        recordId={resourceId}
-        apiClient={apiClient}
         attachments={attachments}
-        onMutate={invalidateRecordContext}
+        apiClient={apiClient}
+        invalidateRecordContext={invalidateRecordContext}
+        getUserDisplay={getUserDisplay}
       />
 
       {/* Activity Timeline (T7) */}


### PR DESCRIPTION
## Summary
- Replaces inline Metadata/related-lists/Notes/Attachments stack at the bottom of every record detail page with a single tab bar.
- Tabs: one per configured related list (collection display name + count), then Notes (count), Attachments (count), System Information.
- System Information is a fixed five-field panel: Internal Id (record UUID, copyable), Created, Updated, Created By, Updated By.

## Implementation
- New \`DetailTabBar\` in \`kelta-ui/app/src/pages/ResourceDetailPage/DetailTabBar.tsx\` composes the tab bar from layout \`relatedLists\`, pre-fetched notes/attachments from \`useRecordContext\`, and the resource audit fields.
- Related list panels use \`forceMount\` so each \`RelatedList\` mounts and reports its total via a new \`onTotalChange\` callback, populating the count badge regardless of which tab is active.
- \`ResourceDetailPage\` drops the inline Metadata, \`LayoutRelatedLists\`/\`RelatedRecordsSection\`, \`NotesSection\`, and \`AttachmentsSection\` blocks. Sharing and Activity Timeline remain in place.

## Test plan
- [x] \`npx vitest run src/components/RelatedList src/pages/ResourceDetailPage\` — 34/34 passing.
- [x] \`npx tsc -p tsconfig.app.json --noEmit\` — no new errors in touched files.
- [x] \`npm run lint\` / \`format:check\` — no new findings in touched files.
- [ ] Manual smoke at \`emf-ui.rzware.com/threadline-clothing/app/o/customers/{id}\`: verify Orders tab + count, Notes count updates after add, Attachments tab, System Information shows 5 fields, Internal Id copy button works.
- [ ] Manual on a collection with no related lists configured (tab bar opens on Notes).
- [ ] Mobile viewport (375px) — tab list scrolls horizontally without overflow break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)