### PR TITLE
fix(attachments): use presigned URL flow for upload

### DIFF
--- a/kelta-ui/app/src/components/AttachmentsSection/AttachmentsSection.test.tsx
+++ b/kelta-ui/app/src/components/AttachmentsSection/AttachmentsSection.test.tsx
@@ -154,8 +154,21 @@ describe('AttachmentsSection', () => {
     expect(fileInput.getAttribute('type')).toBe('file')
   })
 
-  it('triggers file upload when file is selected', async () => {
-    mockApiClient.postFormData.mockResolvedValue(sampleAttachment)
+  it('triggers 3-step upload flow when file is selected', async () => {
+    mockApiClient.post
+      .mockResolvedValueOnce({
+        data: {
+          id: 'att-new',
+          attributes: {
+            uploadUrl: 'https://s3.test/presigned-put',
+            headers: { 'Content-Type': 'text/plain' },
+          },
+        },
+      })
+      .mockResolvedValueOnce(sampleAttachment)
+
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200, statusText: 'OK' })
+    vi.stubGlobal('fetch', fetchMock)
 
     render(
       <TestWrapper>
@@ -174,11 +187,33 @@ describe('AttachmentsSection', () => {
     fireEvent.change(fileInput, { target: { files: [file] } })
 
     await waitFor(() => {
-      expect(mockApiClient.postFormData).toHaveBeenCalledTimes(1)
-      const [url, formData] = mockApiClient.postFormData.mock.calls[0]
-      expect(url).toBe('/api/attachments?filter[collectionId][eq]=col-1&filter[recordId][eq]=rec-1')
-      expect(formData).toBeInstanceOf(FormData)
+      expect(mockApiClient.post).toHaveBeenCalledTimes(2)
     })
+
+    // Step 1: request upload URL
+    const [step1Url, step1Body] = mockApiClient.post.mock.calls[0]
+    expect(step1Url).toBe('/api/attachments/upload-url')
+    expect(step1Body).toMatchObject({
+      fileName: 'test.txt',
+      contentType: 'text/plain',
+      fileSize: file.size,
+      collectionId: 'col-1',
+      recordId: 'rec-1',
+    })
+
+    // Step 2: PUT to S3 via fetch
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [s3Url, s3Init] = fetchMock.mock.calls[0]
+    expect(s3Url).toBe('https://s3.test/presigned-put')
+    expect(s3Init.method).toBe('PUT')
+    expect(s3Init.headers).toEqual({ 'Content-Type': 'text/plain' })
+    expect(s3Init.body).toBe(file)
+
+    // Step 3: finalize
+    const [step3Url] = mockApiClient.post.mock.calls[1]
+    expect(step3Url).toBe('/api/attachments/att-new/finalize')
+
+    vi.unstubAllGlobals()
   })
 
   it('renders download button for each attachment', () => {

--- a/kelta-ui/app/src/components/AttachmentsSection/AttachmentsSection.tsx
+++ b/kelta-ui/app/src/components/AttachmentsSection/AttachmentsSection.tsx
@@ -156,15 +156,38 @@ export function AttachmentsSection({
     },
   })
 
-  // Upload attachment mutation
+  // Upload attachment mutation — 3-step presigned URL flow
   const uploadMutation = useMutation({
     mutationFn: async (file: File) => {
-      const formData = new FormData()
-      formData.append('file', file)
-      return apiClient.postFormData<Attachment>(
-        `/api/attachments?filter[collectionId][eq]=${collectionId}&filter[recordId][eq]=${recordId}`,
-        formData
-      )
+      // Step 1: request presigned S3 PUT URL
+      const uploadUrlResp = await apiClient.post<{
+        data: {
+          id: string
+          attributes: { uploadUrl: string; headers: Record<string, string> }
+        }
+      }>('/api/attachments/upload-url', {
+        fileName: file.name,
+        contentType: file.type || 'application/octet-stream',
+        fileSize: file.size,
+        collectionId,
+        recordId,
+      })
+      const { id: attachmentId, attributes } = uploadUrlResp.data
+      const { uploadUrl, headers } = attributes
+
+      // Step 2: PUT bytes directly to S3 via raw fetch
+      // (apiClient would attach tenant/auth headers that S3 would reject)
+      const s3Resp = await fetch(uploadUrl, {
+        method: 'PUT',
+        headers,
+        body: file,
+      })
+      if (!s3Resp.ok) {
+        throw new Error(`S3 upload failed: ${s3Resp.status} ${s3Resp.statusText}`)
+      }
+
+      // Step 3: finalize
+      return apiClient.post<Attachment>(`/api/attachments/${attachmentId}/finalize`)
     },
     onSuccess: () => {
       invalidateCache()


### PR DESCRIPTION
## Summary
- Frontend was POSTing multipart `FormData` to `/api/attachments?filter[...]`, which fell through to the generic `DynamicCollectionRouter` (JSON-only) and returned 500. The backend moved attachment uploads to a 3-step presigned-S3-URL flow in commit c6382649.
- Rewrite `AttachmentsSection.uploadMutation` to call `/api/attachments/upload-url` (JSON), `PUT` bytes directly to S3 via raw `fetch` (bypasses `apiClient` auth interceptors that S3 would reject), then `/api/attachments/{id}/finalize`.
- Update the component test to mock the 3-step flow and assert each leg.

## Test plan
- [x] `npx vitest run src/components/AttachmentsSection/AttachmentsSection.test.tsx` — 14/14 pass
- [x] `npx eslint src/components/AttachmentsSection/` — clean
- [ ] Manual smoke test in the threadline-clothing tenant: open a record, upload a small file, confirm three network calls (`upload-url` 200 → S3 `PUT` 200 → `finalize` 200) and that the attachment appears in the list with a working download link.
- [ ] Negative cases: oversized file (expect 400), blocked content type (expect 400), tenant over storage limit (expect 403).

🤖 Generated with [Claude Code](https://claude.com/claude-code)