### PR TITLE
fix(auth): use Jackson 2 mappers for RegisteredClientRepository

### DIFF
--- a/kelta-auth/src/main/java/io/kelta/auth/config/AuthorizationServerConfig.java
+++ b/kelta-auth/src/main/java/io/kelta/auth/config/AuthorizationServerConfig.java
@@ -237,7 +237,35 @@ public class AuthorizationServerConfig {
 
     @Bean
     public RegisteredClientRepository registeredClientRepository(JdbcTemplate jdbcTemplate) {
-        return new JdbcRegisteredClientRepository(jdbcTemplate);
+        JdbcRegisteredClientRepository repository = new JdbcRegisteredClientRepository(jdbcTemplate);
+
+        // Spring AS 7.x defaults to its Jackson 3 row/params mappers
+        // (JsonMapperRegisteredClientRowMapper, JsonMapperRegisteredClientParametersMapper).
+        // Jackson 3's BasicPolymorphicTypeValidator denies the JDK collection types
+        // (Collections$UnmodifiableMap etc.) that Spring Security wrote in earlier
+        // versions, so existing oauth2_registered_client rows fail to deserialize.
+        // Spring Security's allowlist modules (SecurityJackson2Modules) are
+        // Jackson 2-only — substitute the Jackson 2 mappers and wire those modules.
+        com.fasterxml.jackson.databind.ObjectMapper objectMapper =
+                new com.fasterxml.jackson.databind.ObjectMapper();
+        objectMapper.registerModule(new com.fasterxml.jackson.datatype.jsr310.JavaTimeModule());
+        ClassLoader classLoader = JdbcRegisteredClientRepository.class.getClassLoader();
+        objectMapper.registerModules(
+                org.springframework.security.jackson2.SecurityJackson2Modules.getModules(classLoader));
+        objectMapper.registerModule(
+                new org.springframework.security.oauth2.server.authorization.jackson2.OAuth2AuthorizationServerJackson2Module());
+
+        JdbcRegisteredClientRepository.RegisteredClientRowMapper rowMapper =
+                new JdbcRegisteredClientRepository.RegisteredClientRowMapper();
+        rowMapper.setObjectMapper(objectMapper);
+        repository.setRegisteredClientRowMapper(rowMapper);
+
+        JdbcRegisteredClientRepository.RegisteredClientParametersMapper paramsMapper =
+                new JdbcRegisteredClientRepository.RegisteredClientParametersMapper();
+        paramsMapper.setObjectMapper(objectMapper);
+        repository.setRegisteredClientParametersMapper(paramsMapper);
+
+        return repository;
     }
 
     @Bean


### PR DESCRIPTION
## Summary

- Spring AS 7.0.4 hard-defaults `JdbcRegisteredClientRepository` to Jackson 3 row/params mappers. Jackson 3's `BasicPolymorphicTypeValidator` rejects `Collections\$UnmodifiableMap` etc., causing existing rows to fail to deserialize at startup.
- Substitutes the Jackson 2 row + params mappers and wires the same Spring Security module stack `authorizationService(...)` already uses.

## Crash this fixes

\`\`\`
java.lang.IllegalArgumentException: Could not resolve type id 'java.util.Collections\$UnmodifiableMap'
  as a subtype of Map<String,Object>: Configured PolymorphicTypeValidator denied resolution
  at JdbcRegisteredClientRepository\$AbstractRegisteredClientRowMapper.parseMap
  at io.kelta.auth.config.ConnectedAppRegistrar.registerPlatformClient
\`\`\`

Surfaced after #876 migrated kelta-auth to native image; the JVM pod was running an older image where startup didn't hit the new Jackson 3 default.

## Test plan

- [x] Local: \`mvn test -f kelta-auth/pom.xml\` — 180/180 pass
- [ ] Native image build in CI
- [ ] Post-deploy: auth pod reaches \`/actuator/health\` UP and \`ConnectedAppRegistrar\` logs \`Registered platform client\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)