### PR TITLE
fix(auth): native hints for OAuth2 domain types + JDK collections

### DIFF
--- a/kelta-auth/src/main/java/io/kelta/auth/aot/AuthRuntimeHints.java
+++ b/kelta-auth/src/main/java/io/kelta/auth/aot/AuthRuntimeHints.java
@@ -26,6 +26,8 @@ public class AuthRuntimeHints implements RuntimeHintsRegistrar {
         registerKeltaModels(hints);
         registerWorkerClientPayloads(hints);
         registerSpringSecurityJackson2(hints);
+        registerOAuth2DomainTypes(hints);
+        registerJdkPolymorphicTypes(hints);
         registerSerialization(hints);
         registerResources(hints);
     }
@@ -139,6 +141,91 @@ public class AuthRuntimeHints implements RuntimeHintsRegistrar {
                 "org.springframework.security.oauth2.client.jackson2.StdConverters$AuthenticationMethodConverter",
                 "org.springframework.security.oauth2.client.jackson2.StdConverters$AuthorizationGrantTypeConverter",
                 "org.springframework.security.oauth2.client.jackson2.StdConverters$ClientAuthenticationMethodConverter"
+        };
+        for (String name : classNames) {
+            hints.reflection().registerType(TypeReference.of(name), MemberCategory.values());
+        }
+    }
+
+    /**
+     * Domain classes referenced by @class type IDs in serialized OAuth2 client
+     * settings + authorization payloads. AllowlistTypeIdResolver calls
+     * Class.forName() on these names, so the native image must keep them.
+     */
+    private void registerOAuth2DomainTypes(RuntimeHints hints) {
+        String[] classNames = {
+                // Token + client settings values
+                "org.springframework.security.oauth2.server.authorization.settings.OAuth2TokenFormat",
+                "org.springframework.security.oauth2.server.authorization.settings.ConfigurationSettingNames",
+                "org.springframework.security.oauth2.server.authorization.settings.AuthorizationServerSettings",
+                "org.springframework.security.oauth2.server.authorization.settings.ClientSettings",
+                "org.springframework.security.oauth2.server.authorization.settings.TokenSettings",
+                "org.springframework.security.oauth2.jose.jws.SignatureAlgorithm",
+                "org.springframework.security.oauth2.jose.jws.MacAlgorithm",
+                "org.springframework.security.oauth2.jose.jws.JwsAlgorithm",
+
+                // OAuth2 core types
+                "org.springframework.security.oauth2.core.AuthorizationGrantType",
+                "org.springframework.security.oauth2.core.ClientAuthenticationMethod",
+                "org.springframework.security.oauth2.core.AuthenticationMethod",
+                "org.springframework.security.oauth2.core.OAuth2AccessToken",
+                "org.springframework.security.oauth2.core.OAuth2AccessToken$TokenType",
+                "org.springframework.security.oauth2.core.OAuth2RefreshToken",
+                "org.springframework.security.oauth2.core.OAuth2Token",
+                "org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest",
+                "org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationResponseType",
+                "org.springframework.security.oauth2.core.oidc.IdTokenClaimNames",
+                "org.springframework.security.oauth2.core.oidc.OidcIdToken",
+
+                // Authorization server authentication tokens
+                "org.springframework.security.oauth2.server.authorization.authentication.OAuth2TokenExchangeActor",
+                "org.springframework.security.oauth2.server.authorization.authentication.OAuth2TokenExchangeCompositeAuthenticationToken",
+                "org.springframework.security.oauth2.server.authorization.authentication.OAuth2ClientAuthenticationToken",
+                "org.springframework.security.oauth2.server.authorization.authentication.OAuth2AuthorizationCodeRequestAuthenticationToken",
+
+                // Spring Security core authentication tokens commonly serialized
+                "org.springframework.security.authentication.UsernamePasswordAuthenticationToken",
+                "org.springframework.security.authentication.AnonymousAuthenticationToken",
+                "org.springframework.security.authentication.RememberMeAuthenticationToken",
+                "org.springframework.security.core.authority.SimpleGrantedAuthority",
+                "org.springframework.security.core.authority.AuthorityUtils",
+                "org.springframework.security.core.userdetails.User",
+                "org.springframework.security.web.savedrequest.DefaultSavedRequest",
+                "org.springframework.security.web.savedrequest.SavedCookie",
+                "org.springframework.security.web.authentication.WebAuthenticationDetails"
+        };
+        for (String name : classNames) {
+            hints.reflection().registerType(TypeReference.of(name), MemberCategory.values());
+        }
+    }
+
+    /**
+     * JDK types that show up as @class type IDs after Spring Security wraps
+     * collections in unmodifiable views or stores enums/durations.
+     */
+    private void registerJdkPolymorphicTypes(RuntimeHints hints) {
+        String[] classNames = {
+                "java.time.Duration",
+                "java.time.Instant",
+                "java.util.HashSet",
+                "java.util.LinkedHashSet",
+                "java.util.TreeSet",
+                "java.util.HashMap",
+                "java.util.LinkedHashMap",
+                "java.util.TreeMap",
+                "java.util.ArrayList",
+                "java.util.LinkedList",
+                "java.util.Collections$UnmodifiableMap",
+                "java.util.Collections$UnmodifiableList",
+                "java.util.Collections$UnmodifiableSet",
+                "java.util.Collections$UnmodifiableCollection",
+                "java.util.Collections$UnmodifiableRandomAccessList",
+                "java.util.Collections$EmptyMap",
+                "java.util.Collections$EmptyList",
+                "java.util.Collections$EmptySet",
+                "java.util.Collections$SingletonMap",
+                "java.util.Collections$SingletonList",
+                "java.util.Collections$SingletonSet"
         };
         for (String name : classNames) {
             hints.reflection().registerType(TypeReference.of(name), MemberCategory.values());


### PR DESCRIPTION
## Summary

Third iteration on the native auth startup. After #877 (Jackson 2 row mapper) and #878 (Spring Security Jackson 2 module classes), startup now fails at:

\`\`\`
InvalidTypeIdException: Could not resolve type id
  'org.springframework.security.oauth2.server.authorization.settings.OAuth2TokenFormat'
  as a subtype of Object: no such class found
\`\`\`

\`AllowlistTypeIdResolver\` calls \`Class.forName(typeId)\` on \`@class\` strings stored in \`oauth2_registered_client\` JSON columns (token + client settings, grant types, etc.). The native image stripped those classes because no bean references them by hard type.

Adds two more registration buckets in \`AuthRuntimeHints\`:
- **registerOAuth2DomainTypes** — Spring Security settings enums (\`OAuth2TokenFormat\`, \`SignatureAlgorithm\`, \`MacAlgorithm\`), OAuth2 core types, Spring AS authentication tokens, core Spring Security tokens.
- **registerJdkPolymorphicTypes** — \`Duration\`, \`Instant\`, the HashMap/LinkedHashMap/HashSet/LinkedHashSet quad, and the full family of \`Collections\$Unmodifiable*\` / \`Empty*\` / \`Singleton*\`.

All entries use \`MemberCategory.values()\`.

## Test plan

- [x] Local: \`mvn test -f kelta-auth/pom.xml\` — 180/180 pass
- [ ] Native build + deploy: pod reaches \`/actuator/health UP\`, \`ConnectedAppRegistrar\` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)