### PR TITLE
fix(auth): route SPA logins through kelta-auth; gateway accepts only internal JWTs

### DIFF
--- a/.run/kelta-gateway.run.xml
+++ b/.run/kelta-gateway.run.xml
@@ -10,8 +10,8 @@
       <env name="NATS_URL" value="nats://localhost:4222" />
       <!--
         CRITICAL: must exactly match KELTA_AUTH_ISSUER_URI in kelta-auth.
-        With SINGLE_ISSUER=true the gateway validates all JWTs against this URI.
-        See /etc/hosts note in kelta-auth.run.xml.
+        The gateway validates all JWTs against this URI — only kelta-auth-issued
+        tokens are accepted. See /etc/hosts note in kelta-auth.run.xml.
       -->
       <env name="KELTA_AUTH_ISSUER_URI" value="http://kelta-auth:8080" />
       <!-- Route to worker and AI on host ports -->
@@ -20,7 +20,6 @@
       <!-- Cerbos (from compose stack) -->
       <env name="CERBOS_HOST" value="localhost" />
       <env name="CERBOS_GRPC_PORT" value="3593" />
-      <env name="SINGLE_ISSUER" value="true" />
       <!-- Logging -->
       <env name="LOG_LEVEL" value="INFO" />
     </envs>

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ make debug SVC=kelta-worker
 
 This is necessary because `KELTA_AUTH_ISSUER_URI=http://kelta-auth:8080` is used
 everywhere — inside Docker via container DNS and from the IDE via this hosts entry.
-Without it, gateway's `single-issuer` validation will reject tokens issued by
+Without it, the gateway's issuer validation will reject tokens issued by
 kelta-auth running in the IDE.
 
 **Secrets in run configs** — the `.run/*.run.xml` files use `$VAR_NAME$` for

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -216,8 +216,6 @@ services:
       # Cerbos
       CERBOS_HOST: cerbos
       CERBOS_GRPC_PORT: "3593"
-      # Single issuer: all JWTs must come from kelta-auth
-      SINGLE_ISSUER: "true"
       LOG_LEVEL: INFO
     ports:
       - "8080:8080"

--- a/kelta-auth/src/main/java/io/kelta/auth/config/AuthorizationServerConfig.java
+++ b/kelta-auth/src/main/java/io/kelta/auth/config/AuthorizationServerConfig.java
@@ -31,7 +31,6 @@ import org.springframework.security.config.annotation.web.configurers.oauth2.ser
 import org.springframework.security.oauth2.server.authorization.settings.AuthorizationServerSettings;
 import org.springframework.security.authentication.CredentialsExpiredException;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.authentication.LoginUrlAuthenticationEntryPoint;
 import org.springframework.security.web.util.matcher.MediaTypeRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
 
@@ -94,7 +93,7 @@ public class AuthorizationServerConfig {
             .cors(Customizer.withDefaults())
             .exceptionHandling(exceptions -> exceptions
                 .defaultAuthenticationEntryPointFor(
-                        new LoginUrlAuthenticationEntryPoint("/login"),
+                        new IdpHintAwareLoginEntryPoint("/login"),
                         new MediaTypeRequestMatcher(MediaType.TEXT_HTML)
                 ))
             .with(authorizationServerConfigurer, Customizer.withDefaults());

--- a/kelta-auth/src/main/java/io/kelta/auth/config/IdpHintAwareLoginEntryPoint.java
+++ b/kelta-auth/src/main/java/io/kelta/auth/config/IdpHintAwareLoginEntryPoint.java
@@ -1,0 +1,29 @@
+package io.kelta.auth.config;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.LoginUrlAuthenticationEntryPoint;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+public class IdpHintAwareLoginEntryPoint extends LoginUrlAuthenticationEntryPoint {
+
+    public IdpHintAwareLoginEntryPoint(String loginFormUrl) {
+        super(loginFormUrl);
+    }
+
+    @Override
+    protected String determineUrlToUseForThisRequest(HttpServletRequest request,
+                                                      HttpServletResponse response,
+                                                      AuthenticationException exception) {
+        String base = super.determineUrlToUseForThisRequest(request, response, exception);
+        String hint = request.getParameter("idp_hint");
+        if (hint == null || hint.isBlank()) {
+            return base;
+        }
+        String separator = base.contains("?") ? "&" : "?";
+        return base + separator + "idp_hint=" + URLEncoder.encode(hint, StandardCharsets.UTF_8);
+    }
+}

--- a/kelta-auth/src/main/java/io/kelta/auth/controller/LoginController.java
+++ b/kelta-auth/src/main/java/io/kelta/auth/controller/LoginController.java
@@ -2,16 +2,22 @@ package io.kelta.auth.controller;
 
 import io.kelta.auth.federation.DynamicClientRegistrationRepository;
 import jakarta.servlet.http.HttpServletRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 @Controller
 public class LoginController {
+
+    private static final Logger log = LoggerFactory.getLogger(LoginController.class);
 
     private final ClientRegistrationRepository clientRegistrationRepository;
 
@@ -29,6 +35,18 @@ public class LoginController {
         }
         if (request.getParameter("federation") != null) {
             model.addAttribute("federationError", true);
+        }
+
+        String idpHint = request.getParameter("idp_hint");
+        if (idpHint != null && !idpHint.isBlank()
+                && clientRegistrationRepository instanceof DynamicClientRegistrationRepository dynamicRepo) {
+            ClientRegistration hinted = dynamicRepo.findByRegistrationId(idpHint);
+            if (hinted != null) {
+                log.info("Auto-federating login via idp_hint registration={}", idpHint);
+                return "redirect:/oauth2/authorization/"
+                        + URLEncoder.encode(idpHint, StandardCharsets.UTF_8);
+            }
+            log.warn("Ignoring idp_hint={} — no matching client registration", idpHint);
         }
 
         // Resolve tenant from the request to load SSO providers

--- a/kelta-auth/src/test/java/io/kelta/auth/controller/LoginControllerTest.java
+++ b/kelta-auth/src/test/java/io/kelta/auth/controller/LoginControllerTest.java
@@ -8,6 +8,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
@@ -22,6 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 @DisplayName("LoginController Tests")
 class LoginControllerTest {
 
@@ -85,6 +88,31 @@ class LoginControllerTest {
 
             assertThat(view).isEqualTo("login");
             assertThat(model.containsAttribute("ssoProviders")).isFalse();
+        }
+
+        @Test
+        void shouldRedirectToFederationWhenIdpHintMatchesRegistration() {
+            doReturn("tenant-1:provider-1").when(request).getParameter("idp_hint");
+            ClientRegistration reg = buildRegistration("tenant-1:provider-1", "Google SSO");
+            doReturn(reg).when(dynamicRepo).findByRegistrationId("tenant-1:provider-1");
+
+            Model model = new ConcurrentModel();
+            String view = controller.login(model, request);
+
+            assertThat(view).isEqualTo("redirect:/oauth2/authorization/tenant-1%3Aprovider-1");
+            verify(dynamicRepo).findByRegistrationId("tenant-1:provider-1");
+            verify(dynamicRepo, never()).findByTenantId(any());
+        }
+
+        @Test
+        void shouldFallBackToLoginPageWhenIdpHintIsUnknown() {
+            doReturn("tenant-1:unknown").when(request).getParameter("idp_hint");
+            doReturn(null).when(dynamicRepo).findByRegistrationId("tenant-1:unknown");
+
+            Model model = new ConcurrentModel();
+            String view = controller.login(model, request);
+
+            assertThat(view).isEqualTo("login");
         }
     }
 

--- a/kelta-gateway/src/main/java/io/kelta/gateway/auth/DynamicReactiveJwtDecoder.java
+++ b/kelta-gateway/src/main/java/io/kelta/gateway/auth/DynamicReactiveJwtDecoder.java
@@ -4,92 +4,51 @@ import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.data.redis.core.ReactiveStringRedisTemplate;
-import org.springframework.lang.Nullable;
 import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
-import org.springframework.security.oauth2.core.OAuth2TokenValidator;
-import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtException;
 import org.springframework.security.oauth2.jwt.JwtTimestampValidator;
 import org.springframework.security.oauth2.jwt.NimbusReactiveJwtDecoder;
 import org.springframework.security.oauth2.jwt.ReactiveJwtDecoder;
-import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
-import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * Dynamic JWT decoder that resolves the OIDC provider from the token's issuer claim.
- * Only accepts issuers registered in the worker's OIDC provider database.
+ * Reactive JWT decoder for the API gateway. Accepts only tokens issued by the
+ * internal kelta-auth provider — external IdPs federate through kelta-auth,
+ * which mints platform-issued JWTs.
  *
  * <p>Validation flow:
  * <ol>
- *   <li>Parse the JWT to extract the issuer (without signature validation)</li>
- *   <li>Look up the OIDC provider configuration from the worker service (cached in Redis)</li>
- *   <li>Reject the token if the issuer is not registered</li>
- *   <li>Create/cache a NimbusReactiveJwtDecoder per JWKS URI</li>
- *   <li>Validate the token with the correct decoder</li>
+ *   <li>Parse the JWT to extract the {@code iss} claim (without signature validation).</li>
+ *   <li>Reject if {@code iss} does not match the configured kelta-auth issuer.</li>
+ *   <li>Validate signature and timestamps against kelta-auth's JWKS.</li>
  * </ol>
  */
 public class DynamicReactiveJwtDecoder implements ReactiveJwtDecoder {
 
     private static final Logger log = LoggerFactory.getLogger(DynamicReactiveJwtDecoder.class);
-    private static final Duration PROVIDER_CACHE_TTL = Duration.ofMinutes(15);
-    private static final String REDIS_PREFIX = "oidc:provider:";
 
-    private final WebClient workerClient;
-    private final ReactiveStringRedisTemplate redisTemplate;
-    private final ObjectMapper objectMapper;
-    private final String fallbackIssuerUri;
+    private final String issuerUri;
     private final Duration clockSkew;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private volatile NimbusReactiveJwtDecoder delegate;
 
-    // In-memory cache of JwtDecoders keyed by JWKS URI
-    private final ConcurrentHashMap<String, NimbusReactiveJwtDecoder> decoderCache = new ConcurrentHashMap<>();
-
-    // In-memory cache of expected audiences keyed by issuer URI
-    private final ConcurrentHashMap<String, String> audienceCache = new ConcurrentHashMap<>();
-
-    /**
-     * Holds provider configuration resolved from the worker service.
-     */
-    record ProviderInfo(String jwksUri, String audience) {}
-
-    /**
-     * Creates a DynamicReactiveJwtDecoder with default clock skew (0 seconds).
-     */
-    public DynamicReactiveJwtDecoder(
-            WebClient workerClient,
-            @Nullable ReactiveStringRedisTemplate redisTemplate,
-            String fallbackIssuerUri) {
-        this(workerClient, redisTemplate, fallbackIssuerUri, Duration.ZERO);
+    public DynamicReactiveJwtDecoder(String issuerUri) {
+        this(issuerUri, Duration.ZERO);
     }
 
-    /**
-     * Creates a DynamicReactiveJwtDecoder with configurable clock skew tolerance.
-     *
-     * @param workerClient WebClient for worker service internal API calls
-     * @param redisTemplate Redis template for caching (nullable)
-     * @param fallbackIssuerUri fallback OIDC issuer URI
-     * @param clockSkew tolerance for clock drift between gateway and identity provider
-     */
-    public DynamicReactiveJwtDecoder(
-            WebClient workerClient,
-            @Nullable ReactiveStringRedisTemplate redisTemplate,
-            String fallbackIssuerUri,
-            Duration clockSkew) {
-        this.workerClient = workerClient;
-        this.redisTemplate = redisTemplate;
-        this.objectMapper = new ObjectMapper();
-        this.fallbackIssuerUri = fallbackIssuerUri;
+    public DynamicReactiveJwtDecoder(String issuerUri, Duration clockSkew) {
+        if (issuerUri == null || issuerUri.isBlank()) {
+            throw new IllegalArgumentException("issuerUri must be set to the internal kelta-auth issuer");
+        }
+        this.issuerUri = issuerUri;
         this.clockSkew = clockSkew != null ? clockSkew : Duration.ZERO;
-        log.info("DynamicReactiveJwtDecoder initialized: fallbackIssuerUri={}, redis={}, clockSkew={}s",
-                fallbackIssuerUri, redisTemplate != null ? "enabled" : "disabled",
-                this.clockSkew.getSeconds());
+        log.info("DynamicReactiveJwtDecoder initialized: issuerUri={}, clockSkew={}s",
+                issuerUri, this.clockSkew.getSeconds());
     }
 
     @Override
@@ -98,14 +57,9 @@ public class DynamicReactiveJwtDecoder implements ReactiveJwtDecoder {
     }
 
     /**
-     * Decodes a JWT token with tenant-scoped OIDC provider validation.
-     * When tenantId is provided, the OIDC provider lookup is scoped to that tenant,
-     * preventing cross-tenant JWT acceptance.
-     *
-     * @param token the JWT token string
-     * @param tenantId the tenant ID for scoped provider lookup (null for unscoped — not recommended)
-     * @return a Mono emitting the decoded JWT
-     * @throws JwtException if the token is invalid or the issuer is not registered for the tenant
+     * Decodes a JWT. The {@code tenantId} parameter is retained for source
+     * compatibility with callers and ignored — issuer validation is global
+     * because only kelta-auth-issued tokens are accepted.
      */
     public Mono<Jwt> decode(String token, String tenantId) throws JwtException {
         String issuer;
@@ -119,72 +73,33 @@ public class DynamicReactiveJwtDecoder implements ReactiveJwtDecoder {
             return Mono.error(new JwtException("JWT missing issuer (iss) claim"));
         }
 
-        return resolveProviderInfo(issuer, tenantId)
-                .flatMap(info -> decodeWithProviderInfo(token, info));
-    }
-
-    private Mono<Jwt> decodeWithProviderInfo(String token, ProviderInfo info) {
-        NimbusReactiveJwtDecoder decoder = decoderCache.computeIfAbsent(
-                info.jwksUri(),
-                uri -> {
-                    NimbusReactiveJwtDecoder d = NimbusReactiveJwtDecoder.withJwkSetUri(uri).build();
-                    // Build a composite validator: timestamp (with clock skew) + optional audience
-                    List<OAuth2TokenValidator<Jwt>> validators = new ArrayList<>();
-
-                    // Always add timestamp validation with clock skew tolerance
-                    JwtTimestampValidator timestampValidator = new JwtTimestampValidator(clockSkew);
-                    validators.add(timestampValidator);
-                    if (!clockSkew.isZero()) {
-                        log.debug("Added clock skew tolerance of {}s for JWKS URI {}",
-                                clockSkew.getSeconds(), uri);
-                    }
-
-                    // If audience is configured, add audience validation
-                    if (info.audience() != null && !info.audience().isBlank()) {
-                        log.debug("Adding audience validation for JWKS URI {}: expected audience={}",
-                                uri, info.audience());
-                        validators.add(new AudienceValidator(info.audience()));
-                    }
-
-                    d.setJwtValidator(new DelegatingOAuth2TokenValidator<>(validators));
-                    return d;
-                });
-        return decoder.decode(token);
-    }
-
-    /**
-     * JWT validator that checks the 'aud' claim contains the expected audience.
-     */
-    static class AudienceValidator implements OAuth2TokenValidator<Jwt> {
-        private final String expectedAudience;
-
-        AudienceValidator(String expectedAudience) {
-            this.expectedAudience = expectedAudience;
+        if (!issuerUri.equals(issuer)) {
+            log.warn("Rejecting JWT: iss={} expected={}", issuer, issuerUri);
+            return Mono.error(new JwtException(
+                    "JWT issuer not accepted: only tokens issued by " + issuerUri + " are allowed"));
         }
 
-        @Override
-        public OAuth2TokenValidatorResult validate(Jwt jwt) {
-            List<String> audiences = jwt.getAudience();
-            if (audiences != null && audiences.contains(expectedAudience)) {
-                return OAuth2TokenValidatorResult.success();
+        return delegate().decode(token);
+    }
+
+    private NimbusReactiveJwtDecoder delegate() {
+        NimbusReactiveJwtDecoder local = delegate;
+        if (local != null) {
+            return local;
+        }
+        synchronized (this) {
+            if (delegate == null) {
+                String jwksUri = issuerUri.endsWith("/") ? issuerUri + "oauth2/jwks" : issuerUri + "/oauth2/jwks";
+                NimbusReactiveJwtDecoder nimbus = NimbusReactiveJwtDecoder.withJwkSetUri(jwksUri).build();
+                nimbus.setJwtValidator(new DelegatingOAuth2TokenValidator<>(
+                        List.of(new JwtTimestampValidator(clockSkew))));
+                log.debug("Initialized JWKS decoder for {}", jwksUri);
+                delegate = nimbus;
             }
-            log.debug("JWT audience validation failed: expected={}, actual={}",
-                    expectedAudience, audiences);
-            return OAuth2TokenValidatorResult.failure(
-                    new org.springframework.security.oauth2.core.OAuth2Error(
-                            "invalid_token",
-                            "JWT audience does not contain expected value: " + expectedAudience,
-                            null));
-        }
-
-        String getExpectedAudience() {
-            return expectedAudience;
+            return delegate;
         }
     }
 
-    /**
-     * Extracts the issuer from the JWT payload without signature validation.
-     */
     private String extractIssuer(String token) {
         String[] parts = token.split("\\.");
         if (parts.length < 2) {
@@ -201,80 +116,13 @@ public class DynamicReactiveJwtDecoder implements ReactiveJwtDecoder {
     }
 
     /**
-     * Resolves the provider info (JWKS URI + audience) for an issuer, scoped to a tenant.
-     * Checks Redis cache first for JWKS URI, then calls the worker's internal API.
-     *
-     * @param issuer the OIDC issuer URI from the JWT
-     * @param tenantId the tenant ID for scoped lookup (null for unscoped — not recommended)
-     */
-    private Mono<ProviderInfo> resolveProviderInfo(String issuer, String tenantId) {
-        // Short-circuit for the internal kelta-auth issuer: the JWKS URI is well-known
-        // and does not need a worker round-trip. This avoids a 404 (→ 500) when
-        // kelta-auth is not registered as an OIDC federation provider in the worker DB.
-        if (fallbackIssuerUri != null && fallbackIssuerUri.equals(issuer)) {
-            String jwksUri = issuer.endsWith("/") ? issuer + "oauth2/jwks" : issuer + "/oauth2/jwks";
-            log.debug("Using built-in JWKS URI for internal issuer: {}", jwksUri);
-            return Mono.just(new ProviderInfo(jwksUri, null));
-        }
-
-        // Cache key includes tenant ID to prevent cross-tenant cache poisoning
-        String cacheKey = tenantId != null ? tenantId + ":" + issuer : issuer;
-
-        if (redisTemplate == null) {
-            return lookupFromWorker(issuer, tenantId);
-        }
-
-        String redisKey = REDIS_PREFIX + cacheKey;
-        return redisTemplate.opsForValue().get(redisKey)
-                .map(jwksUri -> new ProviderInfo(jwksUri, audienceCache.get(cacheKey)))
-                .switchIfEmpty(
-                        lookupFromWorker(issuer, tenantId)
-                                .flatMap(info ->
-                                        redisTemplate.opsForValue()
-                                                .set(redisKey, info.jwksUri(), PROVIDER_CACHE_TTL)
-                                                .thenReturn(info)));
-    }
-
-    private Mono<ProviderInfo> lookupFromWorker(String issuer, String tenantId) {
-        log.debug("Looking up OIDC provider from worker for issuer={} tenant={}", issuer, tenantId);
-
-        String uri = tenantId != null
-                ? "/internal/oidc/by-issuer?issuer={issuer}&tenantId={tenantId}"
-                : "/internal/oidc/by-issuer?issuer={issuer}";
-
-        // Cache key includes tenant ID to prevent cross-tenant cache poisoning
-        String cacheKey = tenantId != null ? tenantId + ":" + issuer : issuer;
-
-        WebClient.RequestHeadersSpec<?> request = tenantId != null
-                ? workerClient.get().uri(uri, issuer, tenantId)
-                : workerClient.get().uri(uri, issuer);
-
-        return request
-                .retrieve()
-                .bodyToMono(JsonNode.class)
-                .map(json -> {
-                    String jwksUri = json.get("jwksUri").asText();
-                    String audience = null;
-                    JsonNode audienceNode = json.get("audience");
-                    if (audienceNode != null && !audienceNode.isNull() && !audienceNode.asText().isBlank()) {
-                        audience = audienceNode.asText();
-                        audienceCache.put(cacheKey, audience);
-                        log.debug("Worker returned audience: {} for issuer: {}", audience, issuer);
-                    }
-                    log.debug("Worker returned JWKS URI: {} for issuer={} tenant={}", jwksUri, issuer, tenantId);
-                    return new ProviderInfo(jwksUri, audience);
-                });
-        // No fallback — if the issuer is not registered in the worker's OIDC provider
-        // database for this tenant, the token is rejected. This prevents cross-tenant
-        // JWT acceptance and attackers from using arbitrary issuers.
-    }
-
-    /**
-     * Evicts all cached decoders (called when OIDC configuration changes).
+     * Drops the cached JWKS decoder so the next decode rebuilds it. Called when
+     * key rotation or configuration changes are signaled.
      */
     public void evictAll() {
-        decoderCache.clear();
-        audienceCache.clear();
-        log.info("Evicted all cached JWT decoders and audience cache");
+        synchronized (this) {
+            delegate = null;
+        }
+        log.info("Evicted cached JWT decoder");
     }
 }

--- a/kelta-gateway/src/main/java/io/kelta/gateway/config/SecurityConfig.java
+++ b/kelta-gateway/src/main/java/io/kelta/gateway/config/SecurityConfig.java
@@ -5,8 +5,6 @@ import io.kelta.gateway.auth.PatAwareBearerTokenConverter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.redis.core.ReactiveStringRedisTemplate;
-import org.springframework.lang.Nullable;
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
 import org.springframework.security.config.web.server.ServerHttpSecurity;
 import org.springframework.security.oauth2.jwt.ReactiveJwtDecoder;
@@ -15,7 +13,6 @@ import org.springframework.security.web.server.SecurityWebFilterChain;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.reactive.CorsConfigurationSource;
 import org.springframework.web.cors.reactive.UrlBasedCorsConfigurationSource;
-import org.springframework.web.reactive.function.client.WebClient;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,12 +39,6 @@ public class SecurityConfig {
 
     @Value("${spring.security.oauth2.resourceserver.jwt.issuer-uri}")
     private String issuerUri;
-
-    @Value("${kelta.gateway.security.internal-issuer-uri:#{null}}")
-    private String internalIssuerUri;
-
-    @Value("${kelta.gateway.worker-service-url:http://kelta-worker:80}")
-    private String workerServiceUrl;
 
     @Value("${CORS_ALLOWED_ORIGIN_PATTERN:}")
     private String corsAllowedOriginPattern;
@@ -136,37 +127,13 @@ public class SecurityConfig {
     }
 
     /**
-     * Creates the JWT decoder bean.
-     *
-     * <p>When {@code kelta.gateway.security.single-issuer} is true (default), uses a
-     * simple {@link NimbusReactiveJwtDecoder} pointing at the configured issuer's JWKS.
-     * This is the recommended mode when kelta-auth is the sole token issuer.
-     *
-     * <p>When false, uses the legacy {@link DynamicReactiveJwtDecoder} that resolves
-     * JWKS URIs dynamically from the worker's OIDC provider database (multi-issuer).
+     * Creates the JWT decoder bean. The gateway accepts only tokens issued by
+     * the internal kelta-auth provider; external IdPs federate through kelta-auth,
+     * which mints platform JWTs.
      */
     @Bean
-    public DynamicReactiveJwtDecoder jwtDecoder(
-            @Nullable ReactiveStringRedisTemplate redisTemplate,
-            WebClient.Builder webClientBuilder,
-            @Value("${kelta.gateway.security.single-issuer:true}") boolean singleIssuer) {
-
-        if (singleIssuer) {
-            log.info("Gateway configured for single-issuer mode: {}", issuerUri);
-        }
-
-        // Use the shared builder so /internal/oidc/by-issuer lookups inherit the
-        // internal-auth bearer filter when the rollout flag is enabled.
-        WebClient workerClient = webClientBuilder
-                .baseUrl(workerServiceUrl)
-                .build();
-        // Use the dedicated internal-issuer-uri for the kelta-auth JWKS shortcut so it
-        // works even when OIDC_ISSUER_URI points to an external provider (e.g. Authentik).
-        String fallback = (internalIssuerUri != null && !internalIssuerUri.isBlank()) ? internalIssuerUri : issuerUri;
-        if (!fallback.equals(issuerUri)) {
-            log.info("Gateway internal kelta-auth issuer: {} (primary OIDC: {})", fallback, issuerUri);
-        }
-        return new DynamicReactiveJwtDecoder(workerClient, redisTemplate, fallback,
-                Duration.ofSeconds(jwtClockSkewSeconds));
+    public DynamicReactiveJwtDecoder jwtDecoder() {
+        log.info("Gateway JWT decoder: only tokens issued by {} accepted", issuerUri);
+        return new DynamicReactiveJwtDecoder(issuerUri, Duration.ofSeconds(jwtClockSkewSeconds));
     }
 }

--- a/kelta-gateway/src/main/resources/application.yml
+++ b/kelta-gateway/src/main/resources/application.yml
@@ -77,11 +77,6 @@ kelta:
     # Security settings
     security:
       jwt-clock-skew-seconds: 30   # Tolerance for clock drift between gateway and IdP
-      single-issuer: ${SINGLE_ISSUER:true}   # When true, all tokens must come from kelta-auth (recommended)
-      # Internal kelta-auth issuer URI — used for the JWKS shortcut so kelta-auth tokens
-      # always validate without a worker DB lookup, even when OIDC_ISSUER_URI points to
-      # an external provider (e.g. Authentik). Defaults to OIDC_ISSUER_URI if not set.
-      internal-issuer-uri: ${KELTA_AUTH_ISSUER_URI:${OIDC_ISSUER_URI:http://localhost:8080}}
       permissions-enabled: ${PERMISSIONS_ENABLED:true}   # Object-level permission enforcement (default: enabled)
       permissions-cache-ttl-minutes: ${PERMISSIONS_CACHE_TTL:5}   # Redis cache TTL for resolved permissions
       # Paths accessible without authentication (GET/HEAD only).

--- a/kelta-gateway/src/test/java/io/kelta/gateway/auth/DynamicReactiveJwtDecoderTest.java
+++ b/kelta-gateway/src/test/java/io/kelta/gateway/auth/DynamicReactiveJwtDecoderTest.java
@@ -1,101 +1,105 @@
 package io.kelta.gateway.auth;
 
-import tools.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
-import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtException;
 import reactor.test.StepVerifier;
 
 import java.time.Duration;
-import java.time.Instant;
 import java.util.Base64;
-import java.util.List;
-import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @DisplayName("DynamicReactiveJwtDecoder")
 class DynamicReactiveJwtDecoderTest {
+
+    private static final String INTERNAL_ISSUER = "https://auth.rzware.com";
 
     private DynamicReactiveJwtDecoder decoder;
 
     @BeforeEach
     void setUp() {
-        // No Redis, no control plane — will fall back to default issuer
-        decoder = new DynamicReactiveJwtDecoder(
-                null, null, "http://localhost:9000/realms/emf");
+        decoder = new DynamicReactiveJwtDecoder(INTERNAL_ISSUER);
     }
 
     @Test
-    @DisplayName("should reject invalid JWT format")
+    @DisplayName("rejects invalid JWT format")
     void rejectInvalidJwt() {
         StepVerifier.create(decoder.decode("not.a.jwt"))
                 .expectError(JwtException.class)
                 .verify();
     }
 
-
     @Test
-    @DisplayName("should reject token without issuer")
+    @DisplayName("rejects token without iss claim")
     void rejectTokenWithoutIssuer() {
-        String header = Base64.getUrlEncoder().withoutPadding().encodeToString("{}".getBytes());
-        String payload = Base64.getUrlEncoder().withoutPadding().encodeToString("{\"sub\":\"user\"}".getBytes());
-        String token = header + "." + payload + ".signature";
+        String token = unsignedToken("{\"sub\":\"user\"}");
 
         StepVerifier.create(decoder.decode(token))
-                .expectError(JwtException.class)
+                .expectErrorSatisfies(err -> {
+                    assertThat(err).isInstanceOf(JwtException.class);
+                    assertThat(err.getMessage()).contains("missing issuer");
+                })
                 .verify();
     }
 
     @Test
-    @DisplayName("evictAll should clear decoder cache")
+    @DisplayName("rejects token whose iss is not the internal kelta-auth issuer")
+    void rejectsForeignIssuer() {
+        String token = unsignedToken(
+                "{\"iss\":\"https://idp.rzware.com/realms/rzWare\",\"sub\":\"u\"}");
+
+        StepVerifier.create(decoder.decode(token))
+                .expectErrorSatisfies(err -> {
+                    assertThat(err).isInstanceOf(JwtException.class);
+                    assertThat(err.getMessage()).contains("only tokens issued by");
+                })
+                .verify();
+    }
+
+    @Test
+    @DisplayName("constructor rejects null or blank issuer")
+    void constructorRejectsBlankIssuer() {
+        assertThatThrownBy(() -> new DynamicReactiveJwtDecoder(null))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new DynamicReactiveJwtDecoder(""))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("evictAll clears the cached delegate")
     void evictAllClearsCache() {
         decoder.evictAll();
         // no exception — cache is empty
     }
 
     @Nested
-    @DisplayName("Clock Skew Configuration")
+    @DisplayName("Clock Skew")
     class ClockSkewTest {
 
         @Test
-        @DisplayName("should accept zero clock skew via 3-arg constructor")
-        void shouldAcceptZeroClockSkewDefault() {
+        @DisplayName("accepts explicit clock skew")
+        void acceptsExplicitClockSkew() {
             DynamicReactiveJwtDecoder d = new DynamicReactiveJwtDecoder(
-                    null, null, "http://localhost:9000/realms/emf");
-            // No exception — default clock skew is Duration.ZERO
+                    INTERNAL_ISSUER, Duration.ofSeconds(30));
             d.evictAll();
         }
 
         @Test
-        @DisplayName("should accept explicit clock skew via 4-arg constructor")
-        void shouldAcceptExplicitClockSkew() {
-            DynamicReactiveJwtDecoder d = new DynamicReactiveJwtDecoder(
-                    null, null, "http://localhost:9000/realms/emf",
-                    Duration.ofSeconds(30));
-            // No exception — clock skew is 30 seconds
+        @DisplayName("treats null clock skew as zero")
+        void nullClockSkewBecomesZero() {
+            DynamicReactiveJwtDecoder d = new DynamicReactiveJwtDecoder(INTERNAL_ISSUER, null);
             d.evictAll();
         }
 
         @Test
-        @DisplayName("should handle null clock skew gracefully")
-        void shouldHandleNullClockSkew() {
+        @DisplayName("rejects invalid JWT even when clock skew is configured")
+        void rejectsInvalidJwtWithClockSkew() {
             DynamicReactiveJwtDecoder d = new DynamicReactiveJwtDecoder(
-                    null, null, "http://localhost:9000/realms/emf", null);
-            // No exception — null clock skew defaults to Duration.ZERO
-            d.evictAll();
-        }
-
-        @Test
-        @DisplayName("should reject invalid JWT even with clock skew configured")
-        void shouldStillRejectInvalidJwtWithClockSkew() {
-            DynamicReactiveJwtDecoder d = new DynamicReactiveJwtDecoder(
-                    null, null, "http://localhost:9000/realms/emf",
-                    Duration.ofSeconds(60));
+                    INTERNAL_ISSUER, Duration.ofSeconds(60));
 
             StepVerifier.create(d.decode("not.a.jwt"))
                     .expectError(JwtException.class)
@@ -103,70 +107,11 @@ class DynamicReactiveJwtDecoderTest {
         }
     }
 
-    @Nested
-    @DisplayName("AudienceValidator")
-    class AudienceValidatorTest {
-
-        @Test
-        @DisplayName("should succeed when JWT audience contains expected value")
-        void shouldSucceedWhenAudienceMatches() {
-            DynamicReactiveJwtDecoder.AudienceValidator validator =
-                    new DynamicReactiveJwtDecoder.AudienceValidator("my-client");
-
-            Jwt jwt = Jwt.withTokenValue("token")
-                    .header("alg", "RS256")
-                    .claim("aud", List.of("my-client", "other-client"))
-                    .claim("sub", "user")
-                    .issuedAt(Instant.now())
-                    .expiresAt(Instant.now().plusSeconds(3600))
-                    .build();
-
-            OAuth2TokenValidatorResult result = validator.validate(jwt);
-            assertThat(result.hasErrors()).isFalse();
-        }
-
-        @Test
-        @DisplayName("should fail when JWT audience does not contain expected value")
-        void shouldFailWhenAudienceDoesNotMatch() {
-            DynamicReactiveJwtDecoder.AudienceValidator validator =
-                    new DynamicReactiveJwtDecoder.AudienceValidator("my-client");
-
-            Jwt jwt = Jwt.withTokenValue("token")
-                    .header("alg", "RS256")
-                    .claim("aud", List.of("other-client"))
-                    .claim("sub", "user")
-                    .issuedAt(Instant.now())
-                    .expiresAt(Instant.now().plusSeconds(3600))
-                    .build();
-
-            OAuth2TokenValidatorResult result = validator.validate(jwt);
-            assertThat(result.hasErrors()).isTrue();
-        }
-
-        @Test
-        @DisplayName("should fail when JWT has no audience claim")
-        void shouldFailWhenNoAudience() {
-            DynamicReactiveJwtDecoder.AudienceValidator validator =
-                    new DynamicReactiveJwtDecoder.AudienceValidator("my-client");
-
-            Jwt jwt = Jwt.withTokenValue("token")
-                    .header("alg", "RS256")
-                    .claim("sub", "user")
-                    .issuedAt(Instant.now())
-                    .expiresAt(Instant.now().plusSeconds(3600))
-                    .build();
-
-            OAuth2TokenValidatorResult result = validator.validate(jwt);
-            assertThat(result.hasErrors()).isTrue();
-        }
-
-        @Test
-        @DisplayName("should return expected audience value")
-        void shouldReturnExpectedAudience() {
-            DynamicReactiveJwtDecoder.AudienceValidator validator =
-                    new DynamicReactiveJwtDecoder.AudienceValidator("my-client");
-
-            assertThat(validator.getExpectedAudience()).isEqualTo("my-client");
-        }
+    private static String unsignedToken(String payloadJson) {
+        String header = Base64.getUrlEncoder().withoutPadding()
+                .encodeToString("{\"alg\":\"RS256\"}".getBytes());
+        String payload = Base64.getUrlEncoder().withoutPadding()
+                .encodeToString(payloadJson.getBytes());
+        return header + "." + payload + ".signature";
     }
 }

--- a/kelta-test-harness/src/test/java/io/kelta/testharness/KeltaStack.java
+++ b/kelta-test-harness/src/test/java/io/kelta/testharness/KeltaStack.java
@@ -185,7 +185,6 @@ public final class KeltaStack {
             .withEnv("AI_SERVICE_URL",          "http://kelta-ai:8080")
             .withEnv("CERBOS_HOST",             "cerbos")
             .withEnv("CERBOS_GRPC_PORT",        "3593")
-            .withEnv("SINGLE_ISSUER",                 "true")
             .withEnv("CORS_ALLOWED_ORIGIN_PATTERN",   "http://localhost:5173")
             .withEnv("TENANT_SLUG_REQUIRE_PREFIX",    "true")
             .withEnv("PERMISSIONS_ENABLED",           "false")

--- a/kelta-ui/app/src/context/AuthContext.test.tsx
+++ b/kelta-ui/app/src/context/AuthContext.test.tsx
@@ -40,9 +40,17 @@ let mockLocationHref = 'http://localhost:3000/dashboard'
 const mockBootstrapConfig = {
   oidcProviders: [
     {
-      id: 'provider-1',
-      name: 'Test Provider',
+      id: 'internal-1',
+      name: 'Kelta Platform (Internal)',
       issuer: 'https://auth.example.com',
+      clientId: 'kelta-platform',
+      isInternal: true,
+    },
+    {
+      id: 'provider-1',
+      name: 'External IdP',
+      issuer: 'https://external.example.com',
+      clientId: 'external-client',
     },
   ],
   pages: [],
@@ -397,7 +405,7 @@ describe('AuthContext', () => {
         expiresAt: Date.now() + 3600000,
       }
       mockSessionStorage['kelta_auth_tokens'] = JSON.stringify(storedTokens)
-      mockSessionStorage['kelta_auth_provider_id'] = 'provider-1'
+      mockSessionStorage['kelta_auth_provider_id'] = 'internal-1'
 
       const user = userEvent.setup()
       renderWithAuth()
@@ -496,6 +504,38 @@ describe('AuthContext', () => {
 
       // Should be unauthenticated
       expect(screen.getByTestId('authenticated')).toHaveTextContent('not-authenticated')
+    })
+  })
+
+  describe('Login Routes Through Internal Provider', () => {
+    it('targets the internal provider and forwards an idp_hint for externals', async () => {
+      let authValue: ReturnType<typeof useAuth> | undefined
+
+      renderWithAuth(
+        <TestComponent
+          onRender={(auth) => {
+            authValue = auth
+          }}
+        />
+      )
+
+      await waitFor(() => {
+        expect(authValue?.isLoading).toBe(false)
+      })
+
+      await authValue?.login('provider-1').catch(() => {})
+
+      // The browser is redirected to kelta-auth (the internal provider's
+      // authorization endpoint) with idp_hint = {tenantId}:{externalProviderId}.
+      // The external IdP token is never seen by the SPA — kelta-auth federates
+      // server-side and mints its own platform JWT.
+      expect(mockLocationHref).toContain('https://auth.example.com/authorize')
+      expect(mockLocationHref).toContain('client_id=kelta-platform')
+      expect(mockLocationHref).toContain('idp_hint=tenant-1%3Aprovider-1')
+
+      // Stored PROVIDER_ID is the internal provider so refresh and callback
+      // always target kelta-auth, never the external IdP.
+      expect(mockSessionStorage['kelta_auth_provider_id']).toBe('internal-1')
     })
   })
 

--- a/kelta-ui/app/src/context/AuthContext.tsx
+++ b/kelta-ui/app/src/context/AuthContext.tsx
@@ -34,7 +34,19 @@ import type {
 } from '../types/auth'
 import type { OIDCProviderSummary } from '../types/config'
 import { fetchBootstrapConfig } from '../utils/bootstrapCache'
-import { getTenantSlug, setResolvedTenantId } from './TenantContext'
+import { getTenantSlug, setResolvedTenantId, getResolvedTenantId } from './TenantContext'
+
+/**
+ * Find the internal kelta-auth provider in a list of OIDC providers.
+ * The internal provider is the OAuth target for ALL logins — external providers
+ * are passed as an idp_hint so kelta-auth handles the federation server-side
+ * and mints a platform-issued token.
+ */
+function findInternalProvider(
+  providers: OIDCProviderSummary[]
+): OIDCProviderSummary | undefined {
+  return providers.find((p) => p.isInternal === true)
+}
 
 // Storage keys
 const STORAGE_KEYS = {
@@ -236,23 +248,21 @@ export function AuthProvider({
       return null
     }
 
-    const providerId = sessionStorage.getItem(STORAGE_KEYS.PROVIDER_ID)
-    if (!providerId) {
-      return null
-    }
-
-    const provider = providers.find((p) => p.id === providerId)
-    if (!provider) {
+    // Refresh always targets the internal kelta-auth provider — it is the
+    // issuer of the stored token regardless of which external IdP federated
+    // the original login.
+    const internal = findInternalProvider(providers)
+    if (!internal) {
       return null
     }
 
     try {
-      const discovery = await fetchDiscoveryDocument(provider.issuer)
+      const discovery = await fetchDiscoveryDocument(internal.issuer)
       const tokenUrl = discovery.token_endpoint
 
       const params = new URLSearchParams({
         grant_type: 'refresh_token',
-        client_id: provider.clientId,
+        client_id: internal.clientId,
         refresh_token: storedTokens.refreshToken,
       })
 
@@ -427,15 +437,19 @@ export function AuthProvider({
         return
       }
 
-      // Use specified provider or the only available one
-      const selectedProviderId = providerId || providers[0]?.id
-      if (!selectedProviderId) {
+      // All logins authenticate against the internal kelta-auth provider.
+      // When the caller picks an external provider, we forward its id as an
+      // idp_hint so kelta-auth runs the federation server-side and returns
+      // a platform-issued token (iss=auth.rzware.com).
+      const internal = findInternalProvider(providers)
+      if (!internal) {
         loginInProgress = false
-        throw new Error('No OIDC providers configured')
+        throw new Error('Internal kelta-auth provider not configured for this tenant')
       }
 
-      const provider = providers.find((p) => p.id === selectedProviderId)
-      if (!provider) {
+      const selectedProviderId = providerId || internal.id
+      const target = providers.find((p) => p.id === selectedProviderId)
+      if (!target) {
         loginInProgress = false
         throw new Error(`Provider not found: ${selectedProviderId}`)
       }
@@ -450,28 +464,39 @@ export function AuthProvider({
         const state = generateRandomString(32)
         const nonce = generateRandomString(32)
 
-        // Store auth parameters immediately (before async calls)
+        // Store auth parameters immediately (before async calls). PROVIDER_ID
+        // tracks the internal provider so refresh and callback always target
+        // kelta-auth — the selected external provider is only a hint.
         sessionStorage.setItem(STORAGE_KEYS.CODE_VERIFIER, codeVerifier)
         sessionStorage.setItem(STORAGE_KEYS.STATE, state)
         sessionStorage.setItem(STORAGE_KEYS.NONCE, nonce)
-        sessionStorage.setItem(STORAGE_KEYS.PROVIDER_ID, selectedProviderId)
+        sessionStorage.setItem(STORAGE_KEYS.PROVIDER_ID, internal.id)
         sessionStorage.setItem(STORAGE_KEYS.REDIRECT_PATH, window.location.pathname)
         sessionStorage.setItem(STORAGE_KEYS.REDIRECT_URI, redirectUri)
 
         // Now do async operations (these are what caused the race condition)
-        const discovery = await fetchDiscoveryDocument(provider.issuer)
+        const discovery = await fetchDiscoveryDocument(internal.issuer)
         const codeChallenge = await generateCodeChallenge(codeVerifier)
 
-        // Build authorization URL
+        // Build authorization URL targeting kelta-auth (the internal provider).
         const authUrl = new URL(discovery.authorization_endpoint)
         authUrl.searchParams.set('response_type', 'code')
-        authUrl.searchParams.set('client_id', provider.clientId)
+        authUrl.searchParams.set('client_id', internal.clientId)
         authUrl.searchParams.set('scope', 'openid profile email')
         authUrl.searchParams.set('redirect_uri', redirectUri)
         authUrl.searchParams.set('state', state)
         authUrl.searchParams.set('nonce', nonce)
         authUrl.searchParams.set('code_challenge', codeChallenge)
         authUrl.searchParams.set('code_challenge_method', 'S256')
+
+        // For external providers, pass an idp_hint matching the kelta-auth
+        // ClientRegistration id ({tenantId}:{providerId}) so kelta-auth auto-
+        // federates to that IdP without rendering its login page.
+        if (!target.isInternal) {
+          const tenantId = getResolvedTenantId()
+          const hint = tenantId ? `${tenantId}:${target.id}` : target.id
+          authUrl.searchParams.set('idp_hint', hint)
+        }
 
         // If user just logged out, force the IdP to show the login form
         // instead of silently re-authenticating with the existing session
@@ -497,22 +522,13 @@ export function AuthProvider({
    * Requirement 2.6: Clear tokens and redirect on logout
    */
   const logout = useCallback(async (): Promise<void> => {
-    const providerId = sessionStorage.getItem(STORAGE_KEYS.PROVIDER_ID)
     const storedTokens = getStoredTokens()
+    const internal = findInternalProvider(providers)
 
     // Set logout flag BEFORE clearing storage so LoginPage knows to skip auto-login.
     // This survives clearAuthStorage() because it's set after the clear,
     // and it's more reliable than URL params which the IdP may strip.
     sessionStorage.setItem(STORAGE_KEYS.JUST_LOGGED_OUT, 'true')
-
-    // Clear SSO session with kelta-auth (fire-and-forget)
-    const authBaseUrl = (window as Record<string, unknown>).__KELTA_AUTH_URL__ as string | undefined
-    if (authBaseUrl) {
-      fetch(`${authBaseUrl}/auth/session`, {
-        method: 'DELETE',
-        credentials: 'include',
-      }).catch((err: unknown) => console.warn('[Auth] SSO session cleanup failed:', err))
-    }
 
     // Clear local auth state
     clearAuthStorage()
@@ -527,22 +543,19 @@ export function AuthProvider({
     logoutRedirect.searchParams.set('logged_out', 'true')
     const logoutRedirectStr = logoutRedirect.toString()
 
-    // If we have provider info, try to do OIDC logout
-    if (providerId && storedTokens?.idToken) {
-      const provider = providers.find((p) => p.id === providerId)
-      if (provider) {
-        try {
-          const discovery = await fetchDiscoveryDocument(provider.issuer)
-          if (discovery.end_session_endpoint) {
-            const logoutUrl = new URL(discovery.end_session_endpoint)
-            logoutUrl.searchParams.set('id_token_hint', storedTokens.idToken)
-            logoutUrl.searchParams.set('post_logout_redirect_uri', logoutRedirectStr)
-            window.location.href = logoutUrl.toString()
-            return
-          }
-        } catch (err) {
-          console.error('[Auth] OIDC logout failed:', err)
+    // Terminate the kelta-auth session via its OIDC end_session_endpoint.
+    if (internal && storedTokens?.idToken) {
+      try {
+        const discovery = await fetchDiscoveryDocument(internal.issuer)
+        if (discovery.end_session_endpoint) {
+          const logoutUrl = new URL(discovery.end_session_endpoint)
+          logoutUrl.searchParams.set('id_token_hint', storedTokens.idToken)
+          logoutUrl.searchParams.set('post_logout_redirect_uri', logoutRedirectStr)
+          window.location.href = logoutUrl.toString()
+          return
         }
+      } catch (err) {
+        console.error('[Auth] OIDC logout failed:', err)
       }
     }
 
@@ -574,20 +587,21 @@ export function AuthProvider({
 
       // Get stored parameters
       const codeVerifier = sessionStorage.getItem(STORAGE_KEYS.CODE_VERIFIER)
-      const providerId = sessionStorage.getItem(STORAGE_KEYS.PROVIDER_ID)
 
-      if (!code || !codeVerifier || !providerId) {
+      if (!code || !codeVerifier) {
         throw new Error('Missing authentication parameters')
       }
 
-      // Get provider info
-      const provider = availableProviders.find((p) => p.id === providerId)
-      if (!provider) {
-        throw new Error(`Provider not found: ${providerId}`)
+      // Token exchange always targets the internal kelta-auth provider —
+      // that is the OAuth client we initiated the flow with, regardless of
+      // which external IdP federated the user.
+      const internal = findInternalProvider(availableProviders)
+      if (!internal) {
+        throw new Error('Internal kelta-auth provider not configured for this tenant')
       }
 
       // Get discovery document
-      const discovery = await fetchDiscoveryDocument(provider.issuer)
+      const discovery = await fetchDiscoveryDocument(internal.issuer)
 
       // Use the stored redirect_uri (exact match with authorization request)
       const storedRedirectUri = sessionStorage.getItem(STORAGE_KEYS.REDIRECT_URI) || redirectUri
@@ -596,7 +610,7 @@ export function AuthProvider({
       const tokenUrl = discovery.token_endpoint
       const params = new URLSearchParams({
         grant_type: 'authorization_code',
-        client_id: provider.clientId,
+        client_id: internal.clientId,
         code,
         redirect_uri: storedRedirectUri,
         code_verifier: codeVerifier,
@@ -633,27 +647,6 @@ export function AuthProvider({
         setUser(newUser)
       } else {
         throw new Error('Failed to extract user information from tokens')
-      }
-
-      // Establish SSO session with kelta-auth for connected app SSO (fire-and-forget).
-      // Skip if the user logged in via kelta-auth itself (session already exists).
-      const authBaseUrl = (window as Record<string, unknown>).__KELTA_AUTH_URL__ as
-        | string
-        | undefined
-      if (authBaseUrl) {
-        const currentProviderId = sessionStorage.getItem(STORAGE_KEYS.PROVIDER_ID)
-        const currentProvider = availableProviders.find((p) => p.id === currentProviderId)
-        const isInternalProvider = currentProvider?.isInternal === true
-        if (!isInternalProvider) {
-          fetch(`${authBaseUrl}/auth/session`, {
-            method: 'POST',
-            headers: {
-              Authorization: `Bearer ${tokens.accessToken}`,
-              'X-Tenant-Slug': getTenantSlug(),
-            },
-            credentials: 'include',
-          }).catch((err: unknown) => console.warn('[Auth] SSO session establishment failed:', err))
-        }
       }
 
       // Clean up temporary storage

--- a/kelta-ui/app/src/pages/LoginPage/LoginPage.test.tsx
+++ b/kelta-ui/app/src/pages/LoginPage/LoginPage.test.tsx
@@ -15,7 +15,7 @@ import { MemoryRouter, Routes, Route } from 'react-router-dom'
 import { LoginPage } from './LoginPage'
 
 // Mock auth context
-const mockLogin = vi.fn()
+const mockLogin = vi.fn(() => Promise.resolve())
 const mockAuthContext = {
   user: null as { id: string; email: string; name: string } | null,
   isAuthenticated: false,
@@ -39,8 +39,25 @@ const mockConfigContext = {
       faviconUrl: '/favicon.ico',
     },
     oidcProviders: [
-      { id: 'provider-1', name: 'Google', issuer: 'https://accounts.google.com' },
-      { id: 'provider-2', name: 'Okta', issuer: 'https://okta.example.com' },
+      {
+        id: 'provider-1',
+        name: 'Google',
+        issuer: 'https://accounts.google.com',
+        clientId: 'google-client',
+      },
+      {
+        id: 'provider-2',
+        name: 'Okta',
+        issuer: 'https://okta.example.com',
+        clientId: 'okta-client',
+      },
+      {
+        id: 'internal-1',
+        name: 'Kelta Platform (Internal)',
+        issuer: 'https://auth.example.com',
+        clientId: 'kelta-platform',
+        isInternal: true,
+      },
     ],
   },
   isLoading: false,
@@ -213,6 +230,31 @@ describe('LoginPage', () => {
       )
 
       expect(screen.getByText('No identity providers configured.')).toBeInTheDocument()
+    })
+
+    it('auto-redirects to the internal provider when no externals are configured', async () => {
+      mockConfigContext.config = {
+        ...mockConfigContext.config,
+        oidcProviders: [
+          {
+            id: 'internal-1',
+            name: 'Kelta Platform (Internal)',
+            issuer: 'https://auth.example.com',
+            clientId: 'kelta-platform',
+            isInternal: true,
+          },
+        ],
+      }
+
+      render(
+        <TestWrapper>
+          <LoginPage />
+        </TestWrapper>
+      )
+
+      await waitFor(() => {
+        expect(mockLogin).toHaveBeenCalledWith('internal-1')
+      })
     })
   })
 

--- a/kelta-ui/app/src/pages/LoginPage/LoginPage.tsx
+++ b/kelta-ui/app/src/pages/LoginPage/LoginPage.tsx
@@ -67,33 +67,44 @@ export function LoginPage({ title }: LoginPageProps): React.ReactElement {
     }
   }, [isAuthenticated, authLoading, navigate, from])
 
-  // Get OIDC providers from config — split internal from external
+  // Get OIDC providers from config — split internal from external.
+  // All logins route through the internal kelta-auth provider; external
+  // providers are surfaced as one-click buttons that pass an idp_hint.
   const providers = config?.oidcProviders || []
+  const internalProvider = providers.find((p) => p.isInternal)
   const externalProviders = providers.filter((p) => !p.isInternal)
 
   // Track whether auto-login has been attempted to prevent duplicate calls
   const autoLoginAttempted = useRef(false)
 
-  // Auto-login only when there is exactly one *external* provider.
-  // Internal providers (kelta-auth itself) must not be auto-initiated because
-  // that would create a redirect loop: kelta-ui → kelta-auth → kelta-ui → …
+  // Auto-login when there is a single sensible choice:
+  //  - exactly one external provider (one-click SSO via kelta-auth federation), OR
+  //  - only the internal provider (redirect straight to kelta-auth's login form).
   useEffect(() => {
     if (
-      !authLoading &&
-      !configLoading &&
-      externalProviders.length === 1 &&
-      !isAuthenticated &&
-      !authError &&
-      !autoLoginAttempted.current &&
-      !justLoggedOut
+      authLoading ||
+      configLoading ||
+      isAuthenticated ||
+      authError ||
+      autoLoginAttempted.current ||
+      justLoggedOut
     ) {
-      autoLoginAttempted.current = true
-      // Clear any persisted login error and redirect directly
-      sessionStorage.removeItem('kelta_auth_login_error')
-      login(externalProviders[0].id).catch(() => {
-        // Error will be shown via authError from AuthContext
-      })
+      return
     }
+
+    let targetId: string | null = null
+    if (externalProviders.length === 1) {
+      targetId = externalProviders[0].id
+    } else if (externalProviders.length === 0 && internalProvider) {
+      targetId = internalProvider.id
+    }
+    if (!targetId) return
+
+    autoLoginAttempted.current = true
+    sessionStorage.removeItem('kelta_auth_login_error')
+    login(targetId).catch(() => {
+      // Error will be shown via authError from AuthContext
+    })
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [authLoading, configLoading, isAuthenticated, authError, justLoggedOut])
 
@@ -179,34 +190,36 @@ export function LoginPage({ title }: LoginPageProps): React.ReactElement {
             <p className="p-6 text-center text-muted-foreground">{t('login.noProviders')}</p>
           ) : (
             <div className="flex flex-col gap-2">
-              {providers.map((provider) => (
-                <button
-                  key={provider.id}
-                  type="button"
-                  className={cn(
-                    'flex w-full items-center gap-2 rounded-lg border border-border bg-muted p-4 text-left',
-                    'transition-colors duration-200',
-                    'hover:bg-accent hover:border-primary',
-                    'focus:outline-2 focus:outline-offset-2 focus:outline-ring',
-                    'disabled:cursor-not-allowed disabled:opacity-70'
-                  )}
-                  onClick={() => handleLogin(provider.id)}
-                  disabled={isLoggingIn}
-                  aria-busy={isLoggingIn && selectedProvider === provider.id}
-                >
-                  {isLoggingIn && selectedProvider === provider.id ? (
-                    <LoadingSpinner size="small" />
-                  ) : (
-                    <span className="text-2xl" aria-hidden="true">
-                      <KeyRound size={20} />
+              {[...externalProviders, ...(internalProvider ? [internalProvider] : [])].map(
+                (provider) => (
+                  <button
+                    key={provider.id}
+                    type="button"
+                    className={cn(
+                      'flex w-full items-center gap-2 rounded-lg border border-border bg-muted p-4 text-left',
+                      'transition-colors duration-200',
+                      'hover:bg-accent hover:border-primary',
+                      'focus:outline-2 focus:outline-offset-2 focus:outline-ring',
+                      'disabled:cursor-not-allowed disabled:opacity-70'
+                    )}
+                    onClick={() => handleLogin(provider.id)}
+                    disabled={isLoggingIn}
+                    aria-busy={isLoggingIn && selectedProvider === provider.id}
+                  >
+                    {isLoggingIn && selectedProvider === provider.id ? (
+                      <LoadingSpinner size="small" />
+                    ) : (
+                      <span className="text-2xl" aria-hidden="true">
+                        <KeyRound size={20} />
+                      </span>
+                    )}
+                    <span className="flex-1 font-medium text-foreground">{provider.name}</span>
+                    <span className="max-w-[150px] truncate text-sm text-muted-foreground max-[480px]:hidden">
+                      {provider.issuer}
                     </span>
-                  )}
-                  <span className="flex-1 font-medium text-foreground">{provider.name}</span>
-                  <span className="max-w-[150px] truncate text-sm text-muted-foreground max-[480px]:hidden">
-                    {provider.issuer}
-                  </span>
-                </button>
-              ))}
+                  </button>
+                )
+              )}
             </div>
           )}
         </div>


### PR DESCRIPTION
## Summary
- Frontend always authenticates against the internal kelta-auth provider; external IdPs are passed as `idp_hint` so federation runs server-side and the SPA receives a platform-issued JWT (`iss=auth.rzware.com`, `azp=kelta-platform`).
- Kelta-auth honors `idp_hint` via new `IdpHintAwareLoginEntryPoint` + `LoginController` short-circuit that 302s to `/oauth2/authorization/{tenantId}:{providerId}`.
- Gateway's `DynamicReactiveJwtDecoder` stripped down: no flag, no worker lookup, no audience cache. Rejects any `iss` other than `KELTA_AUTH_ISSUER_URI`. `SINGLE_ISSUER` env var removed from compose / IDE run config / KeltaStack.

## Test plan
- [x] `mvn test -f kelta-auth/pom.xml` — 182/182 (new `LoginControllerTest` cases for `idp_hint`)
- [x] `mvn test -f kelta-gateway/pom.xml` — 429/429 (new foreign-issuer rejection + blank-issuer guard tests)
- [x] `kelta-ui/app` vitest — 26/26 (new `AuthContext` test asserts `idp_hint=tenant-1:provider-1`, `client_id=kelta-platform`, `PROVIDER_ID=internal-1`)
- [ ] Manual end-to-end: log in via external Keycloak, decode `sessionStorage.kelta_auth_tokens.accessToken`, confirm `iss === ${KELTA_AUTH_ISSUER_URI}` and `azp === kelta-platform`.
- [ ] Manual end-to-end: present an `idp.rzware.com`-issued token directly to the gateway, expect 401 with "only tokens issued by …".

🤖 Generated with [Claude Code](https://claude.com/claude-code)