### PR TITLE
fix(auth): render SSO buttons when idp_hint short-circuit fails

### DIFF
--- a/kelta-auth/src/main/java/io/kelta/auth/controller/LoginController.java
+++ b/kelta-auth/src/main/java/io/kelta/auth/controller/LoginController.java
@@ -77,6 +77,22 @@ public class LoginController {
             return param;
         }
 
+        // Fall back to the tenant prefix of idp_hint ({tenantId}:{providerId}) so SSO
+        // buttons render even when the auto-federation short-circuit could not match
+        // a client registration. Without this, a user hitting /login?idp_hint=...
+        // with no prior session sees only the password form and is stuck.
+        String hint = request.getParameter("idp_hint");
+        if (hint != null && !hint.isBlank()) {
+            int colon = hint.indexOf(':');
+            if (colon > 0) {
+                String hintTenant = hint.substring(0, colon);
+                if (!hintTenant.isBlank()) {
+                    request.getSession().setAttribute("tenantId", hintTenant);
+                    return hintTenant;
+                }
+            }
+        }
+
         return null;
     }
 

--- a/kelta-auth/src/test/java/io/kelta/auth/controller/LoginControllerTest.java
+++ b/kelta-auth/src/test/java/io/kelta/auth/controller/LoginControllerTest.java
@@ -114,6 +114,28 @@ class LoginControllerTest {
 
             assertThat(view).isEqualTo("login");
         }
+
+        @Test
+        void shouldRenderSsoButtonsForHintTenantWhenAutoFederationFails() {
+            // Hint short-circuit can't match a registration (e.g. provider missing
+            // client_secret), so the user lands on /login. They must still see the
+            // tenant's SSO buttons so they can pick a provider manually.
+            doReturn("tenant-7:does-not-exist").when(request).getParameter("idp_hint");
+            doReturn(null).when(dynamicRepo).findByRegistrationId("tenant-7:does-not-exist");
+            when(session.getAttribute("tenantId")).thenReturn(null);
+            ClientRegistration reg = buildRegistration("tenant-7:authentik", "Authentik");
+            when(dynamicRepo.findByTenantId("tenant-7")).thenReturn(List.of(reg));
+
+            Model model = new ConcurrentModel();
+            String view = controller.login(model, request);
+
+            assertThat(view).isEqualTo("login");
+            verify(session).setAttribute("tenantId", "tenant-7");
+            @SuppressWarnings("unchecked")
+            var providers = (List<LoginController.SsoProviderInfo>) model.getAttribute("ssoProviders");
+            assertThat(providers).hasSize(1);
+            assertThat(providers.get(0).name()).isEqualTo("Authentik");
+        }
     }
 
     @Nested


### PR DESCRIPTION
## Summary
- When the SPA forwards `idp_hint=tenantId:providerId` but `findByRegistrationId` returns null (e.g. provider missing `client_secret_enc`, worker unreachable, encryption disabled), kelta-auth renders `/login` with no SSO buttons because `session.tenantId` is still empty.
- `resolveTenantId` now extracts the tenant prefix from `idp_hint` as a final fallback so the page renders the SSO buttons for the right tenant. User can click through manually instead of being stuck on the password form.

## Repro
1. Hit `https://emf-ui.rzware.com/threadline-clothing` unauthenticated.
2. Frontend redirects to `https://auth.rzware.com/oauth2/authorize?...&idp_hint=ec000000-...:authentik`.
3. Auth entry point preserves hint, redirects to `/login?idp_hint=ec000000-...:authentik`.
4. **Before**: provider lookup fails, page renders with no SSO buttons — user stuck.
5. **After**: tenant resolved from hint, SSO buttons for `ec000000-...` render — user can click "Authentik" manually.

## Test plan
- [x] `mvn test -f kelta-auth/pom.xml -Dtest=LoginControllerTest` — 7/7 (new `shouldRenderSsoButtonsForHintTenantWhenAutoFederationFails`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)