### PR TITLE
fix(auth): wire OAuth2 authorization writer ObjectMapper

### DIFF
--- a/kelta-auth/src/main/java/io/kelta/auth/config/AuthorizationServerConfig.java
+++ b/kelta-auth/src/main/java/io/kelta/auth/config/AuthorizationServerConfig.java
@@ -273,10 +273,12 @@ public class AuthorizationServerConfig {
         JdbcOAuth2AuthorizationService service =
                 new JdbcOAuth2AuthorizationService(jdbcTemplate, registeredClientRepository);
 
-        // Register KeltaUserDetails in the Jackson allowlist so the JDBC service
-        // can serialize/deserialize the principal stored in authorization records.
-        JdbcOAuth2AuthorizationService.OAuth2AuthorizationRowMapper rowMapper =
-                new JdbcOAuth2AuthorizationService.OAuth2AuthorizationRowMapper(registeredClientRepository);
+        // The JDBC authorization service round-trips OAuth2Authorization through Jackson.
+        // Both the read (RowMapper) and write (ParametersMapper) paths must use the
+        // same ObjectMapper — otherwise the writer succeeds but the reader cannot
+        // deserialize the stored principal (KeltaUserDetails), surfacing as a 500
+        // at /oauth2/token. Register the Security Jackson modules + the platform
+        // mixin so KeltaUserDetails is in the allowlist for both directions.
         com.fasterxml.jackson.databind.ObjectMapper objectMapper =
                 new com.fasterxml.jackson.databind.ObjectMapper();
         objectMapper.registerModule(new com.fasterxml.jackson.datatype.jsr310.JavaTimeModule());
@@ -284,8 +286,16 @@ public class AuthorizationServerConfig {
         objectMapper.registerModules(org.springframework.security.jackson2.SecurityJackson2Modules.getModules(classLoader));
         objectMapper.registerModule(new org.springframework.security.oauth2.server.authorization.jackson2.OAuth2AuthorizationServerJackson2Module());
         objectMapper.addMixIn(io.kelta.auth.model.KeltaUserDetails.class, io.kelta.auth.model.KeltaUserDetailsMixin.class);
+
+        JdbcOAuth2AuthorizationService.OAuth2AuthorizationRowMapper rowMapper =
+                new JdbcOAuth2AuthorizationService.OAuth2AuthorizationRowMapper(registeredClientRepository);
         rowMapper.setObjectMapper(objectMapper);
         service.setAuthorizationRowMapper(rowMapper);
+
+        JdbcOAuth2AuthorizationService.OAuth2AuthorizationParametersMapper parametersMapper =
+                new JdbcOAuth2AuthorizationService.OAuth2AuthorizationParametersMapper();
+        parametersMapper.setObjectMapper(objectMapper);
+        service.setAuthorizationParametersMapper(parametersMapper);
 
         return service;
     }


### PR DESCRIPTION
## Summary
- `/oauth2/token` returned 500 (\"Token exchange failed: Internal Server Error\") after a successful authorization code flow.
- Root cause: `JdbcOAuth2AuthorizationService` was wired with a custom `OAuth2AuthorizationRowMapper` (read path) carrying the SecurityJackson2Modules + `KeltaUserDetailsMixin`, but the write path used the default `OAuth2AuthorizationParametersMapper`. Its `PolymorphicTypeValidator` denies `KeltaUserDetails`, so the stored row was either rejected or written with type info the reader could not parse.
- Fix: build one `ObjectMapper` and share it across both the row mapper and the parameters mapper so the write/read paths stay symmetric.

## Test plan
- [x] `mvn test -f kelta-auth/pom.xml` — 183/183 pass.
- [ ] Manual: log in via password through `https://auth.rzware.com/login`, observe successful redirect back to `/{tenant}/auth/callback`, decode `sessionStorage.kelta_auth_tokens.accessToken` — confirm `iss=${KELTA_AUTH_ISSUER_URI}`, no 500 at token endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)