### PR TITLE
fix(auth): native hint for Spring Security 7 FactorGrantedAuthority

### DIFF
--- a/kelta-auth/src/main/java/io/kelta/auth/aot/AuthRuntimeHints.java
+++ b/kelta-auth/src/main/java/io/kelta/auth/aot/AuthRuntimeHints.java
@@ -189,6 +189,15 @@ public class AuthRuntimeHints implements RuntimeHintsRegistrar {
                 "org.springframework.security.authentication.RememberMeAuthenticationToken",
                 "org.springframework.security.core.authority.SimpleGrantedAuthority",
                 "org.springframework.security.core.authority.AuthorityUtils",
+                // Spring Security 7 stamps authentication tokens with a
+                // FactorGrantedAuthority describing the auth factor (password,
+                // OTT, passkey, ...). The JdbcOAuth2AuthorizationService
+                // serializes the principal's authorities, and the strict
+                // AllowlistTypeIdResolver loads each authority class by name on
+                // read — without these entries the native image can't resolve
+                // FactorGrantedAuthority and /oauth2/token returns 500.
+                "org.springframework.security.core.authority.FactorGrantedAuthority",
+                "org.springframework.security.core.authority.FactorGrantedAuthority$Builder",
                 "org.springframework.security.core.userdetails.User",
                 "org.springframework.security.web.savedrequest.DefaultSavedRequest",
                 "org.springframework.security.web.savedrequest.SavedCookie",


### PR DESCRIPTION
## Summary
- Production /oauth2/token was returning 500 (\"Token exchange failed: Internal Server Error\") on the GraalVM native build only.
- Logs showed: \`Could not resolve type id 'org.springframework.security.core.authority.FactorGrantedAuthority' as a subtype of \`java.lang.Object\`: no such class found\`.
- Spring Security 7 tags every authentication token with a \`FactorGrantedAuthority\` describing the auth factor. The mixin (\`FactorGrantedAuthorityMixin\`) was already in \`AuthRuntimeHints\`, but the authority class itself was not, so the strict \`AllowlistTypeIdResolver.typeFromId\` failed on \`Class.forName\` in the native image.
- Added \`FactorGrantedAuthority\` + its \`Builder\` to the OAuth2 domain hints.

## Test plan
- [x] \`mvn compile -pl kelta-auth\` — clean.
- [ ] After deploy: log in as admin@kelta.local via the SPA, observe successful redirect to \`/{tenant}/app\` and decode the access token — confirm \`iss=auth.rzware.com\` and no 500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)