### PR TITLE
fix(auth): register WebServletJackson2Module for OAuth2 authorization persistence

### DIFF
--- a/kelta-auth/src/main/java/io/kelta/auth/aot/AuthRuntimeHints.java
+++ b/kelta-auth/src/main/java/io/kelta/auth/aot/AuthRuntimeHints.java
@@ -102,6 +102,22 @@ public class AuthRuntimeHints implements RuntimeHintsRegistrar {
                 "org.springframework.security.jackson2.UsernamePasswordAuthenticationTokenDeserializer",
                 "org.springframework.security.jackson2.UsernamePasswordAuthenticationTokenMixin",
 
+                // spring-security-web (servlet) — registers mixins for
+                // WebAuthenticationDetails, DefaultSavedRequest, SavedCookie,
+                // Cookie, and SwitchUserGrantedAuthority. All persisted on the
+                // OAuth2Authorization row when form login completes.
+                "org.springframework.security.web.jackson2.WebServletJackson2Module",
+                "org.springframework.security.web.jackson2.WebJackson2Module",
+                "org.springframework.security.web.jackson2.CookieMixin",
+                "org.springframework.security.web.jackson2.CookieDeserializer",
+                "org.springframework.security.web.jackson2.DefaultCsrfTokenMixin",
+                "org.springframework.security.web.jackson2.DefaultSavedRequestMixin",
+                "org.springframework.security.web.jackson2.PreAuthenticatedAuthenticationTokenDeserializer",
+                "org.springframework.security.web.jackson2.PreAuthenticatedAuthenticationTokenMixin",
+                "org.springframework.security.web.jackson2.SavedCookieMixin",
+                "org.springframework.security.web.jackson2.SwitchUserGrantedAuthorityMixIn",
+                "org.springframework.security.web.jackson2.WebAuthenticationDetailsMixin",
+
                 // spring-security-oauth2-authorization-server
                 "org.springframework.security.oauth2.server.authorization.jackson2.OAuth2AuthorizationServerJackson2Module",
                 "org.springframework.security.oauth2.server.authorization.jackson2.DurationMixin",

--- a/kelta-auth/src/main/java/io/kelta/auth/config/AuthorizationServerConfig.java
+++ b/kelta-auth/src/main/java/io/kelta/auth/config/AuthorizationServerConfig.java
@@ -284,6 +284,13 @@ public class AuthorizationServerConfig {
         objectMapper.registerModule(new com.fasterxml.jackson.datatype.jsr310.JavaTimeModule());
         ClassLoader classLoader = JdbcOAuth2AuthorizationService.class.getClassLoader();
         objectMapper.registerModules(org.springframework.security.jackson2.SecurityJackson2Modules.getModules(classLoader));
+        // SecurityJackson2Modules detects WebServletJackson2Module reflectively; in
+        // the GraalVM native image that detection silently fails, so we register the
+        // module explicitly. Without it, WebAuthenticationDetails (set on the
+        // authentication during the form-login flow and persisted with the
+        // OAuth2Authorization) is rejected by AllowlistTypeIdResolver and
+        // /oauth2/token returns 500.
+        objectMapper.registerModule(new org.springframework.security.web.jackson2.WebServletJackson2Module());
         objectMapper.registerModule(new org.springframework.security.oauth2.server.authorization.jackson2.OAuth2AuthorizationServerJackson2Module());
         objectMapper.addMixIn(io.kelta.auth.model.KeltaUserDetails.class, io.kelta.auth.model.KeltaUserDetailsMixin.class);
 


### PR DESCRIPTION
## Summary
After PR #883 unblocked FactorGrantedAuthority, /oauth2/token surfaced a new 500:

\`\`\`
The class with org.springframework.security.web.authentication.WebAuthenticationDetails
and name of org.springframework.security.web.authentication.WebAuthenticationDetails
is not in the allowlist.
\`\`\`

\`WebAuthenticationDetails\` is set on the form-login authentication and serialized on the \`OAuth2Authorization\` row. Its mixin lives in \`WebServletJackson2Module\`, which \`SecurityJackson2Modules\` loads conditionally via a reflective classpath probe. That probe evaluates to false in the native image, so the module is never registered and \`AllowlistTypeIdResolver\` rejects \`WebAuthenticationDetails\` on read.

Fix:
1. Register \`WebServletJackson2Module\` explicitly on the OAuth2 authorization \`ObjectMapper\`.
2. Add the module + servlet-side mixins to the native image hints so reflective lookups resolve.

## Test plan
- [x] \`mvn test -f kelta-auth/pom.xml\` — 183/183.
- [ ] After deploy: log in as admin@kelta.local via the SPA, confirm \`/oauth2/token\` returns 200 and the SPA receives an access token with \`iss=auth.rzware.com\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)