### PR TITLE
fix(worker): bake S3 enabled into native AOT build

### DIFF
--- a/kelta-worker/Dockerfile
+++ b/kelta-worker/Dockerfile
@@ -65,7 +65,12 @@ COPY kelta-worker/pom.xml .
 RUN mvn dependency:go-offline -B -Pnative || true
 
 COPY kelta-worker/src ./src
-RUN mvn -Pnative native:compile -DskipTests -B
+# Spring Boot AOT evaluates @ConditionalOnProperty at build time and bakes the
+# decision into the native image. Bake S3 enabled so S3StorageService (and the
+# attachment upload controller that depends on it) are included in the binary.
+# Runtime env vars (KELTA_S3_*) still configure endpoint, bucket, credentials.
+RUN mvn -Pnative native:compile -DskipTests -B \
+    -Dkelta.storage.s3.enabled=true
 
 # =============================================================================
 # Stage 3: Minimal runtime (no JRE — binary is self-contained)


### PR DESCRIPTION
## Summary
- POST `/api/attachments/upload-url` returns 500 in deployed `emf-worker`. Worker logs show `HttpRequestMethodNotSupportedException: Request method 'POST' is not supported` and startup logs show `Runtime module JAR loading disabled (S3 storage not available, using stub handlers)`. `AttachmentUploadController` is never registered.
- **Root cause:** Worker is a GraalVM native image. Spring Boot AOT evaluates `@ConditionalOnProperty` at build time and bakes the decision in. `kelta.storage.s3.enabled` was not set at AOT time, so `S3StorageService` was excluded from the binary. Because `AttachmentUploadController` is `@ConditionalOnBean(S3StorageService.class)`, it was also excluded. `POST /api/attachments/upload-url` then falls through to `DynamicCollectionRouter.@PostMapping("/{collectionName}")` patterns and Spring reports POST not supported.
- **Fix:** Pass `-Dkelta.storage.s3.enabled=true` to the native compile step in `kelta-worker/Dockerfile` so the S3 service and the upload controller are included in the image. Runtime env vars (`KELTA_S3_ENDPOINT`, `KELTA_S3_BUCKET`, `KELTA_S3_ACCESS_KEY`, `KELTA_S3_SECRET_KEY`) continue to configure the actual S3 client.

## Test plan
- [ ] CI builds new worker image (`emf-worker:main-<sha>`)
- [ ] Bump worker image tag in `homelab-argo/emf/worker-deployment.yaml` and let ArgoCD roll the pods
- [ ] After roll, check pod startup logs — expect `Runtime module JAR loading enabled (S3 storage available)` and `S3StorageService initialized with bucket 'emf-attachments', publicEndpoint 'https://s3.rzware.com'`
- [ ] `curl -X POST https://emf.rzware.com/threadline-clothing/api/attachments/upload-url -H 'authorization: Bearer ...' -H 'content-type: application/json' --data-raw '{"fileName":"test.png","contentType":"image/png","fileSize":12345,"collectionId":"<id>","recordId":"<id>"}'` → expect 200 with `uploadUrl`
- [ ] Smoke-test upload from the UI (Attachments section on a record detail page) — expect a successful 3-step flow (`upload-url` → `PUT` to S3 → `finalize`) and the attachment appears

## Follow-up (not in this PR)
Other `@ConditionalOnProperty` beans in the worker (e.g. `kelta.encryption.key`, `kelta.svix.auth-token`, `kelta.superset.url`) are subject to the same AOT-time evaluation. Audit whether those are working in the native image and bake-in or refactor as needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)