### PR TITLE
fix(worker): always register S3StorageService, gate at runtime

### DIFF
--- a/kelta-worker/src/main/java/io/kelta/worker/config/ModuleConfig.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/config/ModuleConfig.java
@@ -14,7 +14,6 @@ import io.kelta.worker.service.S3StorageService;
 import tools.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.annotation.Bean;
@@ -48,9 +47,18 @@ public class ModuleConfig {
         return new JdbcModuleStore(jdbcTemplate);
     }
 
+    /**
+     * Returns a {@link ModuleJarService} backed by S3 when storage is enabled at
+     * runtime, otherwise {@code null}. The bean is always defined so AOT
+     * processing for native images doesn't exclude it; the runtime decision is
+     * based on {@link S3StorageService#isEnabled()}.
+     */
     @Bean
-    @ConditionalOnBean(S3StorageService.class)
+    @Nullable
     public ModuleJarService moduleJarService(S3StorageService s3StorageService) {
+        if (!s3StorageService.isEnabled()) {
+            return null;
+        }
         return new ModuleJarService(s3StorageService);
     }
 

--- a/kelta-worker/src/main/java/io/kelta/worker/controller/AttachmentUploadController.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/controller/AttachmentUploadController.java
@@ -5,7 +5,6 @@ import io.kelta.worker.repository.GovernorLimitsRepository;
 import io.kelta.worker.service.S3StorageService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -31,7 +30,6 @@ import java.util.*;
  */
 @RestController
 @RequestMapping("/api/attachments")
-@ConditionalOnBean(S3StorageService.class)
 public class AttachmentUploadController {
 
     private static final Logger log = LoggerFactory.getLogger(AttachmentUploadController.class);
@@ -90,6 +88,12 @@ public class AttachmentUploadController {
             @RequestHeader("X-Tenant-ID") String tenantId,
             @RequestHeader("X-User-Email") String userEmail,
             @RequestBody Map<String, Object> body) {
+
+        if (!storageService.isEnabled()) {
+            return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body(
+                    JsonApiResponseBuilder.error("503", "Storage unavailable",
+                            "S3 storage is not enabled on this server"));
+        }
 
         String fileName = getStringRequired(body, "fileName");
         String contentType = getStringRequired(body, "contentType");
@@ -194,6 +198,12 @@ public class AttachmentUploadController {
             @PathVariable String id,
             @RequestHeader("X-Tenant-ID") String tenantId,
             @RequestHeader("X-User-Email") String userEmail) {
+
+        if (!storageService.isEnabled()) {
+            return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body(
+                    JsonApiResponseBuilder.error("503", "Storage unavailable",
+                            "S3 storage is not enabled on this server"));
+        }
 
         // Look up the attachment
         List<Map<String, Object>> rows = jdbcTemplate.queryForList(SELECT_ATTACHMENT, id, tenantId);

--- a/kelta-worker/src/main/java/io/kelta/worker/service/S3StorageService.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/service/S3StorageService.java
@@ -3,7 +3,6 @@ package io.kelta.worker.service;
 import io.kelta.worker.config.S3ConfigProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
@@ -35,12 +34,15 @@ import java.time.Duration;
  * <p>Uses a separate public endpoint for presigned URLs (browser access) and
  * an internal endpoint for server-side streaming (FileController).
  *
- * <p>This service is only activated when {@code kelta.storage.s3.enabled=true}.
+ * <p>The bean is always registered so that GraalVM native-image AOT processing
+ * always includes it. S3 client construction is gated at runtime on
+ * {@code kelta.storage.s3.enabled}; when disabled, clients are not built and
+ * any operation requiring S3 throws {@link IllegalStateException}. Use
+ * {@link #isEnabled()} to check availability before calling.
  *
  * @since 1.0.0
  */
 @Service
-@ConditionalOnProperty(name = "kelta.storage.s3.enabled", havingValue = "true")
 public class S3StorageService {
 
     private static final Logger logger = LoggerFactory.getLogger(S3StorageService.class);
@@ -51,10 +53,30 @@ public class S3StorageService {
 
     public S3StorageService(S3ConfigProperties config) {
         this.config = config;
-        this.s3Presigner = buildPresigner(config);
-        this.s3Client = buildS3Client(config);
-        logger.info("S3StorageService initialized with bucket '{}', publicEndpoint '{}'",
-                config.getBucket(), config.getPublicEndpoint());
+        if (config.isEnabled()) {
+            this.s3Presigner = buildPresigner(config);
+            this.s3Client = buildS3Client(config);
+            logger.info("S3StorageService initialized with bucket '{}', publicEndpoint '{}'",
+                    config.getBucket(), config.getPublicEndpoint());
+        } else {
+            logger.info("S3StorageService disabled (kelta.storage.s3.enabled=false); S3 operations will fail");
+        }
+    }
+
+    /**
+     * Returns whether S3 storage is enabled and ready for use.
+     *
+     * @return true if S3 clients are initialized
+     */
+    public boolean isEnabled() {
+        return config.isEnabled() && s3Presigner != null && s3Client != null;
+    }
+
+    private void requireEnabled() {
+        if (!isEnabled()) {
+            throw new IllegalStateException(
+                    "S3 storage is not enabled (kelta.storage.s3.enabled=false)");
+        }
     }
 
     /**
@@ -82,6 +104,7 @@ public class S3StorageService {
      * @return the presigned download URL
      */
     public String getPresignedDownloadUrl(String storageKey, Duration expiry) {
+        requireEnabled();
         GetObjectRequest getObjectRequest = GetObjectRequest.builder()
                 .bucket(config.getBucket())
                 .key(storageKey)
@@ -105,6 +128,7 @@ public class S3StorageService {
      * @return the presigned upload URL
      */
     public String getPresignedUploadUrl(String storageKey, String contentType, Duration expiry) {
+        requireEnabled();
         PutObjectRequest putObjectRequest = PutObjectRequest.builder()
                 .bucket(config.getBucket())
                 .key(storageKey)
@@ -146,6 +170,7 @@ public class S3StorageService {
      * @throws NoSuchKeyException if the key does not exist
      */
     public StorageObject streamObject(String storageKey) {
+        requireEnabled();
         GetObjectRequest request = GetObjectRequest.builder()
                 .bucket(config.getBucket())
                 .key(storageKey)
@@ -173,6 +198,7 @@ public class S3StorageService {
      * @return a StorageObject containing the partial stream
      */
     public StorageObject streamObjectRange(String storageKey, String rangeHeader) {
+        requireEnabled();
         GetObjectRequest request = GetObjectRequest.builder()
                 .bucket(config.getBucket())
                 .key(storageKey)
@@ -200,6 +226,7 @@ public class S3StorageService {
      * @param contentType the content type (e.g., "application/java-archive")
      */
     public void uploadObject(String storageKey, byte[] data, String contentType) {
+        requireEnabled();
         PutObjectRequest request = PutObjectRequest.builder()
                 .bucket(config.getBucket())
                 .key(storageKey)
@@ -218,6 +245,7 @@ public class S3StorageService {
      * @param storageKey the S3 object key
      */
     public void deleteObject(String storageKey) {
+        requireEnabled();
         s3Client.deleteObject(software.amazon.awssdk.services.s3.model.DeleteObjectRequest.builder()
                 .bucket(config.getBucket())
                 .key(storageKey)
@@ -229,6 +257,7 @@ public class S3StorageService {
      * Checks if an S3 object exists without downloading it.
      */
     public boolean objectExists(String storageKey) {
+        requireEnabled();
         try {
             s3Client.headObject(HeadObjectRequest.builder()
                     .bucket(config.getBucket())

--- a/kelta-worker/src/test/java/io/kelta/worker/controller/AttachmentUploadControllerTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/controller/AttachmentUploadControllerTest.java
@@ -38,6 +38,7 @@ class AttachmentUploadControllerTest {
     @BeforeEach
     void setUp() {
         controller = new AttachmentUploadController(storageService, governorLimitsRepository, jdbcTemplate);
+        lenient().when(storageService.isEnabled()).thenReturn(true);
     }
 
     private Map<String, Object> validUploadBody() {


### PR DESCRIPTION
## Summary
Previous PR #886 tried to bake `KELTA_S3_ENABLED` into the native image via `-Dkelta.storage.s3.enabled=true` on `mvn native:compile`, but it didn't work — `spring-boot-maven-plugin`'s `process-aot` goal forks a JVM and Maven's parent system properties are not propagated to it. Loki shows the new `main-ddb541d` pod still logs `Runtime module JAR loading disabled (S3 storage not available, using stub handlers)` and the curl still 500s.

Sidesteps the build-time conditional entirely:

- `S3StorageService`: remove `@ConditionalOnProperty`. Bean is always defined → AOT always includes it. Constructor only builds S3 clients when `kelta.storage.s3.enabled=true`; otherwise logs and leaves clients null. Methods check `isEnabled()` and throw `IllegalStateException` if disabled.
- `AttachmentUploadController`: remove `@ConditionalOnBean`. Both endpoints return 503 with a clear error if `s3.isEnabled()` is false.
- `ModuleConfig.moduleJarService`: remove `@ConditionalOnBean`. Bean method returns null when S3 disabled; downstream already accepts `@Nullable ModuleJarService`.

`AttachmentUrlEnricher`, `FileController`, `ImageController` still use `@ConditionalOnBean(S3StorageService.class)` — now harmless because the bean is always defined, so AOT includes them.

## Test plan
- [x] `mvn test -f kelta-worker/pom.xml -Dtest="AttachmentUploadController*,S3*,Module*"` → 21/21 pass
- [ ] Wait for CI to build new `emf-worker:main-<sha>`
- [ ] argo-image-updater rolls pods
- [ ] After roll, verify worker startup log: `S3StorageService initialized with bucket 'emf-attachments'...` and `Runtime module JAR loading enabled (S3 storage available)`
- [ ] `curl -X POST https://emf.rzware.com/threadline-clothing/api/attachments/upload-url ...` → expect 200 with `uploadUrl`
- [ ] UI upload smoke test on a record detail page

## Follow-up
Other native services likely have similar AOT-time-conditional gotchas — `kelta.encryption.key`, `kelta.svix.auth-token`, `kelta.superset.url`. Worth auditing.

Reverts: PR #886's Dockerfile change is now redundant. Safe to leave; harmless extra `-D` arg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)