### PR TITLE
fix(ui): lift dark-theme card surface for detail page contrast

### DIFF
--- a/kelta-ui/app/src/index.css
+++ b/kelta-ui/app/src/index.css
@@ -114,10 +114,16 @@
   }
 
   .dark {
-    /* shadcn/ui dark theme (Slate base, Blue-400 primary) */
+    /* shadcn/ui dark theme (Slate base, Blue-400 primary)
+     *
+     * --card is intentionally lifted off --background so cards, highlights
+     * panels, and tab containers separate visually on the dark slate page
+     * background. Matches design tokens at
+     * design_handoff_kelta_detail_layout/colors_and_type.css
+     * (--surface: #0F172A on --bg: #020617). */
     --background: 222.2 84% 4.9%;
     --foreground: 210 40% 98%;
-    --card: 222.2 84% 4.9%;
+    --card: 222 47% 11%;
     --card-foreground: 210 40% 98%;
     --popover: 222.2 84% 4.9%;
     --popover-foreground: 210 40% 98%;


### PR DESCRIPTION
## Summary

Bump dark theme `--card` from `222.2 84% 4.9%` (identical to `--background`) to `222 47% 11%` (≈ `#0F172A`). FieldSection, highlights panel, and tab container now visibly separate from the page background.

Follow-up to [#885](https://github.com/cklinker/emf/pull/885) — this fix was pushed to that branch after auto-merge had already squashed only the first commit, so it never reached main.

Matches handoff tokens at `design_handoff_kelta_detail_layout/colors_and_type.css` (`--surface: #0F172A` on `--bg: #020617`).

## Test plan

- [x] `pnpm build` clean on touched file.
- [ ] Manual: open a record detail page in dark mode — cards now lift off the page bg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)