### PR TITLE
fix(worker): drop ::uuid cast on file_attachment.id

### DIFF
--- a/kelta-worker/src/main/java/io/kelta/worker/controller/AttachmentUploadController.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/controller/AttachmentUploadController.java
@@ -43,21 +43,24 @@ public class AttachmentUploadController {
             "application/x-msdos-program"
     );
 
+    // file_attachment.id is VARCHAR(36) (see V42 migration), so do NOT cast to ::uuid —
+    // PostgreSQL has no implicit varchar=uuid operator and the comparison fails with
+    // SQLState 42883 (BadSqlGrammarException). Pass UUID strings as plain text.
     private static final String INSERT_ATTACHMENT = """
             INSERT INTO file_attachment (id, tenant_id, collection_id, record_id,
                 file_name, file_size, content_type, storage_key, uploaded_by, created_at, updated_at)
-            VALUES (?::uuid, ?, ?, ?, ?, ?, ?, ?, ?, NOW(), NOW())
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(), NOW())
             """;
 
     private static final String UPDATE_ATTACHMENT_STORAGE_KEY = """
             UPDATE file_attachment SET storage_key = ?, uploaded_at = NOW(), updated_at = NOW()
-            WHERE id = ?::uuid AND tenant_id = ?
+            WHERE id = ? AND tenant_id = ?
             """;
 
     private static final String SELECT_ATTACHMENT = """
             SELECT id, tenant_id, collection_id, record_id, file_name, file_size,
                    content_type, storage_key, uploaded_by, uploaded_at, created_at
-            FROM file_attachment WHERE id = ?::uuid AND tenant_id = ?
+            FROM file_attachment WHERE id = ? AND tenant_id = ?
             """;
 
     private final S3StorageService storageService;


### PR DESCRIPTION
## Summary
POST `/api/attachments/{id}/finalize` returns 500. Worker logs:

```
Unexpected error: PreparedStatementCallback; bad SQL grammar
[SELECT ... FROM file_attachment WHERE id = ?::uuid AND tenant_id = ?]
org.springframework.jdbc.BadSqlGrammarException ... SQLState 42883
```

`file_attachment.id` is `VARCHAR(36)` (`V42__add_notes_and_attachments.sql`). PostgreSQL has no implicit operator `varchar = uuid`, so `WHERE id = ?::uuid` fails.

The INSERT also used `?::uuid` and happened to work — UUID → VARCHAR has an implicit cast on the insert path, but not on the equality compare. Make all three queries use VARCHAR semantics.

## Test plan
- [x] `mvn -f kelta-worker/pom.xml test -Dtest="AttachmentUploadController*"` → 9/9 pass
- [ ] After CI image roll, retry upload from UI: `upload-url` → S3 PUT → `finalize` should all return 2xx
- [ ] Attachment row's `storage_key` populated, `uploaded_at` set, and the attachment appears in the list with a working download link

🤖 Generated with [Claude Code](https://claude.com/claude-code)