### PR TITLE
feat(ui): modernize admin setup landing page

### DIFF
--- a/e2e-tests/pages/setup-home.page.ts
+++ b/e2e-tests/pages/setup-home.page.ts
@@ -7,6 +7,8 @@ export class SetupHomePage extends BasePage {
   readonly searchClear: Locator;
   readonly stats: Locator;
   readonly noResults: Locator;
+  readonly pinned: Locator;
+  readonly recent: Locator;
 
   constructor(page: Page, tenantSlug?: string) {
     super(page, tenantSlug);
@@ -15,6 +17,39 @@ export class SetupHomePage extends BasePage {
     this.searchClear = this.testId("setup-search-clear");
     this.stats = this.testId("setup-stats");
     this.noResults = this.testId("setup-no-results");
+    this.pinned = this.testId("setup-pinned");
+    this.recent = this.testId("setup-recent");
+  }
+
+  filterTab(key: "all" | "core" | "automation" | "platform"): Locator {
+    return this.testId(`setup-filter-${key}`);
+  }
+
+  group(key: "core" | "automation" | "platform"): Locator {
+    return this.testId(`setup-group-${key}`);
+  }
+
+  pinButton(path: string): Locator {
+    const sanitizedPath = path.replace(/\//g, "").replace(/-/g, "");
+    return this.testId(`setup-pin-${sanitizedPath}`);
+  }
+
+  pinnedChip(path: string): Locator {
+    const sanitizedPath = path.replace(/\//g, "").replace(/-/g, "");
+    return this.testId(`setup-pinned-${sanitizedPath}`);
+  }
+
+  recentChip(path: string): Locator {
+    const sanitizedPath = path.replace(/\//g, "").replace(/-/g, "");
+    return this.testId(`setup-recent-${sanitizedPath}`);
+  }
+
+  async clearLocalShortcuts(): Promise<void> {
+    await this.page.evaluate(() => {
+      Object.keys(window.localStorage)
+        .filter((k) => k.startsWith("kelta:setup:"))
+        .forEach((k) => window.localStorage.removeItem(k));
+    });
   }
 
   async goto(): Promise<void> {

--- a/e2e-tests/tests/admin/setup/setup-home.spec.ts
+++ b/e2e-tests/tests/admin/setup/setup-home.spec.ts
@@ -65,4 +65,53 @@ test.describe("Setup Home", () => {
     const statCards = await setupPage.getStatCards();
     expect(statCards.length).toBeGreaterThan(0);
   });
+
+  test("filter tab narrows the visible groups", async ({ page }) => {
+    const setupPage = new SetupHomePage(page, tenantSlug);
+    await setupPage.goto();
+
+    await expect(setupPage.group("core")).toBeVisible();
+    await expect(setupPage.group("automation")).toBeVisible();
+
+    await setupPage.filterTab("core").click();
+
+    await expect(setupPage.group("core")).toBeVisible();
+    await expect(setupPage.group("automation")).toBeHidden();
+    await expect(setupPage.group("platform")).toBeHidden();
+  });
+
+  test("pinning an item persists across reload", async ({ page }) => {
+    const setupPage = new SetupHomePage(page, tenantSlug);
+    await setupPage.goto();
+    await setupPage.clearLocalShortcuts();
+    await page.reload();
+    await setupPage.waitForPageLoad();
+
+    const card = page.locator('[data-testid="setup-category-dataModel"]');
+    await card.hover();
+    await setupPage.pinButton("/collections").click();
+
+    await expect(setupPage.pinnedChip("/collections")).toBeVisible();
+
+    await page.reload();
+    await setupPage.waitForPageLoad();
+
+    await expect(setupPage.pinnedChip("/collections")).toBeVisible();
+  });
+
+  test("visiting a setup item adds it to recently visited", async ({
+    page,
+  }) => {
+    const setupPage = new SetupHomePage(page, tenantSlug);
+    await setupPage.goto();
+    await setupPage.clearLocalShortcuts();
+    await page.reload();
+    await setupPage.waitForPageLoad();
+
+    await setupPage.clickItem("collections");
+    await page.waitForURL(/\/collections/);
+
+    await setupPage.goto();
+    await expect(setupPage.recentChip("/collections")).toBeVisible();
+  });
 });

--- a/kelta-ui/app/src/i18n/translations/de.json
+++ b/kelta-ui/app/src/i18n/translations/de.json
@@ -1237,12 +1237,40 @@
   },
   "setup": {
     "title": "Einrichtung",
-    "searchPlaceholder": "Einrichtung durchsuchen...",
+    "subtitle": "Konfigurieren Sie Ihren Mandanten — Datenmodelle, Sicherheit, Automatisierung, Integrationen.",
+    "breadcrumbLabel": "Verwaltung",
+    "searchPlaceholder": "Einrichtung durchsuchen…",
+    "shortcutHint": "⌘K",
     "stats": {
-      "collections": "Sammlungen gesamt",
-      "users": "Benutzer gesamt",
-      "reports": "Berichte gesamt",
-      "dashboards": "Dashboards gesamt"
+      "collections": "Sammlungen",
+      "users": "Benutzer",
+      "reports": "Berichte",
+      "dashboards": "Dashboards"
+    },
+    "filters": {
+      "all": "Alle",
+      "core": "Kern",
+      "automation": "Automatisierung",
+      "platform": "Plattform"
+    },
+    "groups": {
+      "core": "Kernkonfiguration",
+      "automation": "Automatisierung & Integration",
+      "platform": "Plattform & Analytik"
+    },
+    "groupMeta": "{{sections}} Bereiche · {{items}} Einträge",
+    "pinned": "Angeheftet",
+    "recent": "Zuletzt besucht",
+    "addPin": "Anheften",
+    "removePin": "Lösen",
+    "emptyPinned": "Heften Sie häufig besuchte Elemente an.",
+    "emptyRecent": "Besuchte Einträge erscheinen hier.",
+    "relativeTime": {
+      "now": "jetzt",
+      "minutes": "vor {{count}} Min.",
+      "hours": "vor {{count}} Std.",
+      "yesterday": "gestern",
+      "days": "vor {{count}} T."
     },
     "categories": {
       "administration": "Verwaltung",
@@ -1253,6 +1281,16 @@
       "analytics": "Analytik",
       "uiCustomization": "UI & Anpassung",
       "platform": "Plattform"
+    },
+    "categoryDescriptions": {
+      "administration": "Identität, Zugriff und Berechtigungen",
+      "dataModel": "Was Ihr Mandant erfasst",
+      "security": "Richtlinien und Ereignisverlauf",
+      "automation": "Genehmigungen, Flows und Aufgaben",
+      "integration": "Apps, Anmeldedaten, APIs und Webhooks",
+      "analytics": "Dashboards und Berichte",
+      "uiCustomization": "Seiten, Menüs und Plugins",
+      "platform": "Pakete, Migrationen, Überwachung"
     }
   },
   "relatedRecords": {

--- a/kelta-ui/app/src/i18n/translations/en.json
+++ b/kelta-ui/app/src/i18n/translations/en.json
@@ -1279,12 +1279,40 @@
   },
   "setup": {
     "title": "Setup",
-    "searchPlaceholder": "Search setup...",
+    "subtitle": "Configure your tenant — data models, security, automation, integrations. Everything that powers the runtime experience.",
+    "breadcrumbLabel": "Administration",
+    "searchPlaceholder": "Search setup… try \"password policy\", \"webhook\", \"tenant\"",
+    "shortcutHint": "⌘K",
     "stats": {
-      "collections": "Total Collections",
-      "users": "Total Users",
-      "reports": "Total Reports",
-      "dashboards": "Total Dashboards"
+      "collections": "Collections",
+      "users": "Users",
+      "reports": "Reports",
+      "dashboards": "Dashboards"
+    },
+    "filters": {
+      "all": "All",
+      "core": "Core",
+      "automation": "Automation",
+      "platform": "Platform"
+    },
+    "groups": {
+      "core": "Core Configuration",
+      "automation": "Automation & Integration",
+      "platform": "Platform & Analytics"
+    },
+    "groupMeta": "{{sections}} sections · {{items}} items",
+    "pinned": "Pinned",
+    "recent": "Recently visited",
+    "addPin": "Pin",
+    "removePin": "Unpin",
+    "emptyPinned": "Pin setup items you visit often.",
+    "emptyRecent": "Items you visit will appear here.",
+    "relativeTime": {
+      "now": "now",
+      "minutes": "{{count}}m ago",
+      "hours": "{{count}}h ago",
+      "yesterday": "yesterday",
+      "days": "{{count}}d ago"
     },
     "categories": {
       "administration": "Administration",
@@ -1295,6 +1323,16 @@
       "analytics": "Analytics",
       "uiCustomization": "UI & Customization",
       "platform": "Platform"
+    },
+    "categoryDescriptions": {
+      "administration": "Identity, access, and permissions",
+      "dataModel": "Define what your tenant tracks",
+      "security": "Policy, sign-in, and event history",
+      "automation": "Approvals, flows, and scheduled jobs",
+      "integration": "Apps, credentials, APIs, and webhooks",
+      "analytics": "Dashboards and reports",
+      "uiCustomization": "Pages, menus, and plugins",
+      "platform": "Packages, migrations, monitoring"
     }
   },
   "relatedRecords": {

--- a/kelta-ui/app/src/i18n/translations/pt.json
+++ b/kelta-ui/app/src/i18n/translations/pt.json
@@ -1237,12 +1237,40 @@
   },
   "setup": {
     "title": "Configuracao",
-    "searchPlaceholder": "Buscar configuracao...",
+    "subtitle": "Configure seu tenant — modelos de dados, seguranca, automacao, integracoes.",
+    "breadcrumbLabel": "Administracao",
+    "searchPlaceholder": "Buscar configuracao…",
+    "shortcutHint": "⌘K",
     "stats": {
-      "collections": "Total de Colecoes",
-      "users": "Total de Usuarios",
-      "reports": "Total de Relatorios",
-      "dashboards": "Total de Paineis"
+      "collections": "Colecoes",
+      "users": "Usuarios",
+      "reports": "Relatorios",
+      "dashboards": "Paineis"
+    },
+    "filters": {
+      "all": "Todos",
+      "core": "Nucleo",
+      "automation": "Automacao",
+      "platform": "Plataforma"
+    },
+    "groups": {
+      "core": "Configuracao do Nucleo",
+      "automation": "Automacao e Integracao",
+      "platform": "Plataforma e Analise"
+    },
+    "groupMeta": "{{sections}} secoes · {{items}} itens",
+    "pinned": "Fixados",
+    "recent": "Visitados recentemente",
+    "addPin": "Fixar",
+    "removePin": "Remover",
+    "emptyPinned": "Fixe os itens de configuracao mais usados.",
+    "emptyRecent": "Os itens visitados aparecerao aqui.",
+    "relativeTime": {
+      "now": "agora",
+      "minutes": "{{count}}min atras",
+      "hours": "{{count}}h atras",
+      "yesterday": "ontem",
+      "days": "{{count}}d atras"
     },
     "categories": {
       "administration": "Administracao",
@@ -1253,6 +1281,16 @@
       "analytics": "Analise",
       "uiCustomization": "Interface e Personalizacao",
       "platform": "Plataforma"
+    },
+    "categoryDescriptions": {
+      "administration": "Identidade, acesso e permissoes",
+      "dataModel": "O que seu tenant rastreia",
+      "security": "Politicas, login e historico",
+      "automation": "Aprovacoes, fluxos e jobs",
+      "integration": "Apps, credenciais, APIs e webhooks",
+      "analytics": "Paineis e relatorios",
+      "uiCustomization": "Paginas, menus e plugins",
+      "platform": "Pacotes, migracoes, monitoramento"
     }
   },
   "relatedRecords": {

--- a/kelta-ui/app/src/pages/SetupHomePage/SetupHomePage.tsx
+++ b/kelta-ui/app/src/pages/SetupHomePage/SetupHomePage.tsx
@@ -1,49 +1,90 @@
 /**
  * SetupHomePage Component
  *
- * A categorized directory of all admin/configuration pages with search
- * functionality. Displays quick stats at the top and organizes setup items
- * into 8 category cards with real-time filtering.
+ * Modernized admin/configuration landing page. Hero card with breadcrumb +
+ * search + stats panel; pinned + recently visited shortcut rows backed by
+ * localStorage; category filter tabs that group cards into sections.
  */
 
-import { useState, useCallback, useMemo } from 'react'
+import React, { useCallback, useMemo, useState, useSyncExternalStore } from 'react'
 import { Link } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
 import {
-  Users,
-  Database,
-  Shield,
-  Zap,
-  Link as LinkIcon,
+  Activity,
+  AppWindow,
+  ArrowUpFromLine,
   BarChart3,
-  Palette,
-  Settings,
-  Search,
-  X,
+  Building2,
+  CheckCircle,
   ChevronRight,
+  Clock,
+  Code2,
+  Database,
+  FileJson,
+  FileText,
+  Folder,
+  Gauge,
+  History,
+  IdCard,
+  KeyRound,
+  LayoutGrid,
+  Link as LinkIcon,
+  List,
+  ListChecks,
+  Lock,
+  LogIn,
+  Mail,
+  Menu,
+  Package,
+  PackageOpen,
+  Palette,
+  Pin,
+  PinOff,
+  Puzzle,
+  Search,
+  SearchCheck,
+  Settings,
+  Shield,
+  ShieldAlert,
+  ShieldCheck,
+  Table2,
+  User,
+  Users,
+  Webhook,
+  Workflow,
+  X,
+  Zap,
 } from 'lucide-react'
 import { useI18n } from '../../context/I18nContext'
 import { useApi } from '../../context/ApiContext'
 import { useTenant } from '../../context/TenantContext'
+import { useConfig } from '../../context/ConfigContext'
 import { useSystemPermissions } from '../../hooks/useSystemPermissions'
 import { useCollectionSummaries } from '../../hooks/useCollectionSummaries'
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { cn } from '@/lib/utils'
+import { usePinnedSetup } from './usePinnedSetup'
+import { useRecentSetup } from './useRecentSetup'
 
 export interface SetupHomePageProps {
   testId?: string
 }
 
+type GroupKey = 'core' | 'automation' | 'platform'
+
 interface SetupItem {
   name: string
   path: string
   description: string
+  icon: React.ComponentType<{ className?: string }>
   permission?: string
 }
 
 interface SetupCategory {
   key: string
   titleKey: string
-  icon: React.ReactNode
+  descriptionKey: string
+  icon: React.ComponentType<{ className?: string }>
   items: SetupItem[]
 }
 
@@ -54,99 +95,115 @@ interface PaginatedResponse {
 
 const CATEGORIES: SetupCategory[] = [
   {
-    key: 'administration',
-    titleKey: 'setup.categories.administration',
-    icon: <Users size={20} />,
-    items: [
-      {
-        name: 'Users',
-        path: '/users',
-        description: 'Manage user accounts and permissions',
-        permission: 'MANAGE_USERS',
-      },
-      {
-        name: 'Profiles',
-        path: '/profiles',
-        description: 'Configure profile-based permissions',
-        permission: 'MANAGE_USERS',
-      },
-      {
-        name: 'OIDC Providers',
-        path: '/oidc-providers',
-        description: 'Configure identity providers',
-        permission: 'MANAGE_CONNECTED_APPS',
-      },
-    ],
-  },
-  {
     key: 'dataModel',
     titleKey: 'setup.categories.dataModel',
-    icon: <Database size={20} />,
+    descriptionKey: 'setup.categoryDescriptions.dataModel',
+    icon: Database,
     items: [
       {
         name: 'Collections',
         path: '/collections',
         description: 'Define data objects and schemas',
+        icon: Database,
         permission: 'CUSTOMIZE_APPLICATION',
       },
       {
         name: 'Resources',
         path: '/resources',
         description: 'Browse and edit records in every collection',
+        icon: Folder,
       },
       {
         name: 'Picklists',
         path: '/picklists',
         description: 'Manage global picklist values',
+        icon: List,
         permission: 'CUSTOMIZE_APPLICATION',
       },
       {
         name: 'Page Layouts',
         path: '/layouts',
         description: 'Configure record page layouts',
+        icon: LayoutGrid,
         permission: 'CUSTOMIZE_APPLICATION',
       },
       {
         name: 'List Views',
         path: '/listviews',
         description: 'Manage list view configurations',
+        icon: Table2,
         permission: 'MANAGE_LISTVIEWS',
+      },
+    ],
+  },
+  {
+    key: 'administration',
+    titleKey: 'setup.categories.administration',
+    descriptionKey: 'setup.categoryDescriptions.administration',
+    icon: Users,
+    items: [
+      {
+        name: 'Users',
+        path: '/users',
+        description: 'Manage user accounts and permissions',
+        icon: User,
+        permission: 'MANAGE_USERS',
+      },
+      {
+        name: 'Profiles',
+        path: '/profiles',
+        description: 'Configure profile-based permissions',
+        icon: IdCard,
+        permission: 'MANAGE_USERS',
+      },
+      {
+        name: 'OIDC Providers',
+        path: '/oidc-providers',
+        description: 'Configure identity providers',
+        icon: KeyRound,
+        permission: 'MANAGE_CONNECTED_APPS',
       },
     ],
   },
   {
     key: 'security',
     titleKey: 'setup.categories.security',
-    icon: <Shield size={20} />,
+    descriptionKey: 'setup.categoryDescriptions.security',
+    icon: ShieldCheck,
     items: [
       {
         name: 'Password Policy',
         path: '/password-policy',
         description: 'Configure password complexity, lockout, and expiration rules',
+        icon: Lock,
         permission: 'MANAGE_USERS',
       },
       {
         name: 'MFA Policy',
         path: '/mfa-policy',
         description: 'Configure multi-factor authentication requirements and enrollment',
+        icon: Shield,
         permission: 'MANAGE_USERS',
       },
       {
         name: 'Login History',
         path: '/login-history',
         description: 'View user login activity',
+        icon: LogIn,
         permission: 'MANAGE_USERS',
       },
       {
         name: 'Security Audit',
         path: '/security-audit',
         description: 'Review security event trail',
+        icon: ShieldAlert,
         permission: 'MANAGE_USERS',
       },
       {
         name: 'Audit Trail',
         path: '/audit-trail',
         description: 'View configuration change history',
+        icon: History,
         permission: 'VIEW_SETUP',
       },
     ],
@@ -154,24 +211,28 @@ const CATEGORIES: SetupCategory[] = [
   {
     key: 'automation',
     titleKey: 'setup.categories.automation',
-    icon: <Zap size={20} />,
+    descriptionKey: 'setup.categoryDescriptions.automation',
+    icon: Zap,
     items: [
       {
         name: 'Approval Processes',
         path: '/approvals',
         description: 'Configure approval workflows',
+        icon: CheckCircle,
         permission: 'MANAGE_APPROVALS',
       },
       {
         name: 'Flows',
         path: '/flows',
         description: 'Build visual process flows',
+        icon: Workflow,
         permission: 'MANAGE_WORKFLOWS',
       },
       {
         name: 'Scheduled Jobs',
         path: '/scheduled-jobs',
         description: 'Manage scheduled tasks',
+        icon: Clock,
         permission: 'MANAGE_WORKFLOWS',
       },
     ],
@@ -179,48 +240,56 @@ const CATEGORIES: SetupCategory[] = [
   {
     key: 'integration',
     titleKey: 'setup.categories.integration',
-    icon: <LinkIcon size={20} />,
+    descriptionKey: 'setup.categoryDescriptions.integration',
+    icon: LinkIcon,
     items: [
       {
         name: 'Connected Apps',
         path: '/connected-apps',
         description: 'Manage OAuth connected apps',
+        icon: AppWindow,
         permission: 'MANAGE_CONNECTED_APPS',
       },
       {
         name: 'Credentials',
         path: '/credentials',
         description: 'Reusable secrets for outbound APIs and email',
+        icon: KeyRound,
         permission: 'VIEW_CREDENTIALS',
       },
       {
         name: 'API Specs',
         path: '/api-specs',
         description: 'OpenAPI spec library used by the flow builder',
+        icon: FileJson,
         permission: 'VIEW_API_SPECS',
       },
       {
         name: 'Webhooks',
         path: '/webhooks',
         description: 'Configure outbound webhooks',
+        icon: Webhook,
         permission: 'MANAGE_CONNECTED_APPS',
       },
       {
         name: 'Email Templates',
         path: '/email-templates',
         description: 'Design email templates',
+        icon: Mail,
         permission: 'MANAGE_EMAIL_TEMPLATES',
       },
       {
         name: 'Scripts',
         path: '/scripts',
         description: 'Manage server-side scripts',
+        icon: Code2,
         permission: 'MANAGE_CONNECTED_APPS',
       },
       {
         name: 'Modules',
         path: '/modules',
         description: 'Install and manage runtime modules',
+        icon: Package,
         permission: 'MANAGE_CONNECTED_APPS',
       },
     ],
@@ -228,24 +297,28 @@ const CATEGORIES: SetupCategory[] = [
   {
     key: 'uiCustomization',
     titleKey: 'setup.categories.uiCustomization',
-    icon: <Palette size={20} />,
+    descriptionKey: 'setup.categoryDescriptions.uiCustomization',
+    icon: Palette,
     items: [
       {
         name: 'Pages',
         path: '/pages',
         description: 'Build custom UI pages',
+        icon: FileText,
         permission: 'CUSTOMIZE_APPLICATION',
       },
       {
         name: 'Menus',
         path: '/menus',
         description: 'Configure navigation menus',
+        icon: Menu,
         permission: 'CUSTOMIZE_APPLICATION',
       },
       {
         name: 'Plugins',
         path: '/plugins',
         description: 'Manage installed plugins',
+        icon: Puzzle,
         permission: 'CUSTOMIZE_APPLICATION',
       },
     ],
@@ -253,12 +326,14 @@ const CATEGORIES: SetupCategory[] = [
   {
     key: 'analytics',
     titleKey: 'setup.categories.analytics',
-    icon: <BarChart3 size={20} />,
+    descriptionKey: 'setup.categoryDescriptions.analytics',
+    icon: BarChart3,
     items: [
       {
         name: 'Analytics',
         path: '/analytics',
         description: 'View dashboards and reports powered by Superset',
+        icon: BarChart3,
         permission: 'MANAGE_REPORTS',
       },
     ],
@@ -266,53 +341,81 @@ const CATEGORIES: SetupCategory[] = [
   {
     key: 'platform',
     titleKey: 'setup.categories.platform',
-    icon: <Settings size={20} />,
+    descriptionKey: 'setup.categoryDescriptions.platform',
+    icon: Settings,
     items: [
       {
         name: 'Packages',
         path: '/packages',
         description: 'Import/export configuration packages',
+        icon: PackageOpen,
         permission: 'CUSTOMIZE_APPLICATION',
       },
       {
         name: 'Migrations',
         path: '/migrations',
         description: 'View database migration history',
+        icon: ArrowUpFromLine,
         permission: 'CUSTOMIZE_APPLICATION',
       },
       {
         name: 'Governor Limits',
         path: '/governor-limits',
         description: 'Monitor usage limits',
+        icon: Gauge,
         permission: 'VIEW_SETUP',
       },
       {
         name: 'Monitoring',
         path: '/monitoring',
         description: 'View metrics, request logs, errors, and system performance',
+        icon: Activity,
         permission: 'VIEW_SETUP',
       },
       {
         name: 'Tenants',
         path: '/tenants',
         description: 'Platform-level tenant management',
+        icon: Building2,
         permission: 'MANAGE_TENANTS',
       },
       {
         name: 'Search Index',
         path: '/search-settings',
         description: 'Manage search index and rebuild data',
+        icon: SearchCheck,
         permission: 'CUSTOMIZE_APPLICATION',
       },
       {
         name: 'Bulk Jobs',
         path: '/bulk-jobs',
         description: 'Monitor bulk data operations',
+        icon: ListChecks,
         permission: 'MANAGE_DATA',
       },
     ],
   },
 ]
+
+const GROUP_OF: Record<string, GroupKey> = {
+  administration: 'core',
+  dataModel: 'core',
+  security: 'core',
+  automation: 'automation',
+  integration: 'automation',
+  uiCustomization: 'automation',
+  analytics: 'platform',
+  platform: 'platform',
+}
+
+const GROUP_ORDER: GroupKey[] = ['core', 'automation', 'platform']
+const FILTER_ORDER: (GroupKey | 'all')[] = ['all', 'core', 'automation', 'platform']
+
+const STAT_ICONS = {
+  collections: Database,
+  users: Users,
+  dashboards: BarChart3,
+} as const
 
 function extractCount(data: unknown): number {
   if (data == null) return 0
@@ -331,14 +434,53 @@ function extractCount(data: unknown): number {
   return 0
 }
 
-export function SetupHomePage({ testId = 'setup-home-page' }: SetupHomePageProps): JSX.Element {
+function sanitizeTestPath(path: string): string {
+  return path.replace(/\//g, '').replace(/-/g, '')
+}
+
+function subscribeMinute(callback: () => void): () => void {
+  const id = window.setInterval(callback, 60_000)
+  return () => window.clearInterval(id)
+}
+
+function useNow(): number {
+  return useSyncExternalStore(
+    subscribeMinute,
+    () => Date.now(),
+    () => 0
+  )
+}
+
+function formatRelative(
+  t: ReturnType<typeof useI18n>['t'],
+  visitedAt: number,
+  now: number
+): string {
+  const diff = Math.max(0, now - visitedAt)
+  const minutes = Math.floor(diff / 60_000)
+  if (minutes < 1) return t('setup.relativeTime.now')
+  if (minutes < 60) return t('setup.relativeTime.minutes', { count: minutes })
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return t('setup.relativeTime.hours', { count: hours })
+  if (hours < 48) return t('setup.relativeTime.yesterday')
+  const days = Math.floor(hours / 24)
+  return t('setup.relativeTime.days', { count: days })
+}
+
+export function SetupHomePage({
+  testId = 'setup-home-page',
+}: SetupHomePageProps): React.ReactElement {
   const { t } = useI18n()
   const { keltaClient } = useApi()
   const { tenantSlug } = useTenant()
+  const { config } = useConfig()
   const { hasPermission } = useSystemPermissions()
   const [searchQuery, setSearchQuery] = useState('')
+  const [activeFilter, setActiveFilter] = useState<GroupKey | 'all'>('all')
+  const { pinned, isPinned, toggle: togglePin, unpin } = usePinnedSetup(tenantSlug)
+  const { recent, recordVisit } = useRecentSetup(tenantSlug)
+  const now = useNow()
 
-  // Fetch stats
   const { summaries: collectionSummaries } = useCollectionSummaries()
 
   const { data: usersData } = useQuery({
@@ -356,14 +498,17 @@ export function SetupHomePage({ testId = 'setup-home-page' }: SetupHomePageProps
   const stats = useMemo(
     () => [
       {
+        key: 'collections' as const,
         label: t('setup.stats.collections'),
         value: collectionSummaries.length,
       },
       {
+        key: 'users' as const,
         label: t('setup.stats.users'),
         value: extractCount(usersData),
       },
       {
+        key: 'dashboards' as const,
         label: t('setup.stats.dashboards'),
         value: analyticsData?.length ?? 0,
       },
@@ -371,26 +516,52 @@ export function SetupHomePage({ testId = 'setup-home-page' }: SetupHomePageProps
     [collectionSummaries, usersData, analyticsData, t]
   )
 
-  const handleSearchChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
-    setSearchQuery(e.target.value)
-  }, [])
-
-  const handleClearSearch = useCallback(() => {
-    setSearchQuery('')
-  }, [])
-
-  const filteredCategories = useMemo(() => {
-    const query = searchQuery.toLowerCase().trim()
-
-    // First filter by permission, then by search query
-    const permissionFiltered = CATEGORIES.map((category) => ({
+  // Permission-filtered categories (applied once — drives counts + everything else).
+  const permissionFiltered = useMemo(() => {
+    return CATEGORIES.map((category) => ({
       ...category,
       items: category.items.filter((item) => !item.permission || hasPermission(item.permission)),
     })).filter((category) => category.items.length > 0)
+  }, [hasPermission])
 
-    if (!query) return permissionFiltered
+  // Flat item index (for pinned/recent lookups + search).
+  const itemIndex = useMemo(() => {
+    const map = new Map<string, { item: SetupItem; categoryKey: string }>()
+    for (const category of permissionFiltered) {
+      for (const item of category.items) {
+        map.set(item.path, { item, categoryKey: category.key })
+      }
+    }
+    return map
+  }, [permissionFiltered])
 
-    return permissionFiltered
+  // Filter counts (per group, post-permission).
+  const filterCounts = useMemo(() => {
+    const counts: Record<GroupKey | 'all', number> = {
+      all: 0,
+      core: 0,
+      automation: 0,
+      platform: 0,
+    }
+    for (const category of permissionFiltered) {
+      const group = GROUP_OF[category.key]
+      counts.all += category.items.length
+      if (group) counts[group] += category.items.length
+    }
+    return counts
+  }, [permissionFiltered])
+
+  // Apply group filter + search filter.
+  const visibleCategories = useMemo(() => {
+    const query = searchQuery.toLowerCase().trim()
+    const groupFiltered =
+      activeFilter === 'all'
+        ? permissionFiltered
+        : permissionFiltered.filter((c) => GROUP_OF[c.key] === activeFilter)
+
+    if (!query) return groupFiltered
+
+    return groupFiltered
       .map((category) => ({
         ...category,
         items: category.items.filter(
@@ -400,130 +571,436 @@ export function SetupHomePage({ testId = 'setup-home-page' }: SetupHomePageProps
         ),
       }))
       .filter((category) => category.items.length > 0)
-  }, [searchQuery, hasPermission])
+  }, [permissionFiltered, activeFilter, searchQuery])
+
+  // Group visible categories into sections.
+  const visibleGroups = useMemo(() => {
+    const order = activeFilter === 'all' ? GROUP_ORDER : [activeFilter as GroupKey]
+    return order
+      .map((groupKey) => {
+        const categories = visibleCategories.filter((c) => GROUP_OF[c.key] === groupKey)
+        const itemCount = categories.reduce((acc, c) => acc + c.items.length, 0)
+        return { groupKey, categories, itemCount }
+      })
+      .filter((g) => g.categories.length > 0)
+  }, [visibleCategories, activeFilter])
+
+  const handleSearchChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchQuery(e.target.value)
+  }, [])
+
+  const handleClearSearch = useCallback(() => {
+    setSearchQuery('')
+  }, [])
+
+  const tenantName = config?.branding.applicationName ?? tenantSlug
+
+  const pinnedItems = useMemo(
+    () =>
+      pinned
+        .map((path) => itemIndex.get(path))
+        .filter((entry): entry is { item: SetupItem; categoryKey: string } => entry != null),
+    [pinned, itemIndex]
+  )
+
+  const recentItems = useMemo(() => {
+    return recent
+      .map((entry) => {
+        const indexed = itemIndex.get(entry.path)
+        if (!indexed) return null
+        return {
+          item: indexed.item,
+          categoryKey: indexed.categoryKey,
+          visitedAt: entry.visitedAt,
+          relative: now > 0 ? formatRelative(t, entry.visitedAt, now) : '',
+        }
+      })
+      .filter((e): e is NonNullable<typeof e> => e != null)
+  }, [recent, itemIndex, t, now])
 
   return (
-    <div className="mx-auto max-w-[1400px] p-8 max-[767px]:p-4" data-testid={testId}>
-      {/* Header */}
-      <div className="mb-6 flex items-center justify-between gap-4 max-[767px]:flex-col max-[767px]:items-stretch">
-        <h1 className="m-0 text-[1.75rem] font-bold text-foreground max-[767px]:text-[1.375rem]">
-          {t('setup.title')}
-        </h1>
-        <div className="relative flex w-80 items-center max-[767px]:w-full">
-          <Search
-            size={16}
-            className="pointer-events-none absolute left-3 text-muted-foreground"
-            aria-hidden="true"
-          />
-          <input
-            type="text"
-            className={cn(
-              'w-full rounded-md border border-border bg-card py-2 pl-9 pr-8 text-sm text-foreground',
-              'placeholder:text-muted-foreground',
-              'outline-none transition-[border-color] duration-150',
-              'focus:border-primary focus:shadow-[0_0_0_2px_rgba(0,102,204,0.15)]'
-            )}
-            placeholder={t('setup.searchPlaceholder')}
-            value={searchQuery}
-            onChange={handleSearchChange}
-            data-testid="setup-search-input"
-            aria-label={t('setup.searchPlaceholder')}
-          />
-          {searchQuery && (
-            <button
-              className={cn(
-                'absolute right-2 flex h-5 w-5 items-center justify-center rounded-full border-none bg-muted-foreground text-white',
-                'cursor-pointer transition-colors duration-150',
-                'hover:bg-foreground',
-                'focus:outline-2 focus:outline-offset-2 focus:outline-primary',
-                'focus:not(:focus-visible):outline-none'
-              )}
-              onClick={handleClearSearch}
-              data-testid="setup-search-clear"
-              aria-label={t('common.clear')}
-            >
-              <X size={14} />
-            </button>
-          )}
-        </div>
-      </div>
-
-      {/* Quick Stats */}
-      <div
-        className="mb-8 grid grid-cols-4 gap-4 max-[767px]:grid-cols-2"
-        data-testid="setup-stats"
-      >
-        {stats.map((stat) => (
-          <div
-            key={stat.label}
-            className="flex flex-col items-center gap-1 rounded-md border border-border bg-card px-4 py-5"
-          >
-            <span className="text-[1.75rem] font-bold leading-tight text-primary">
-              {stat.value}
-            </span>
-            <span className="text-center text-[0.8125rem] font-medium text-muted-foreground">
-              {stat.label}
-            </span>
-          </div>
-        ))}
-      </div>
-
-      {/* Category Grid */}
-      {filteredCategories.length === 0 ? (
+    <div
+      className="mx-auto max-w-[1400px] space-y-6 p-8 max-[767px]:space-y-4 max-[767px]:p-4"
+      data-testid={testId}
+    >
+      {/* Hero card */}
+      <section className="relative overflow-hidden rounded-xl border border-border bg-card">
         <div
-          className="flex items-center justify-center rounded-md border border-dashed border-border bg-card p-12"
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-0 opacity-70 [background:radial-gradient(circle_at_top_left,hsl(var(--primary)/0.12),transparent_60%),radial-gradient(circle_at_bottom_right,hsl(var(--primary)/0.08),transparent_55%)]"
+        />
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-0 opacity-[0.08] [background-image:linear-gradient(hsl(var(--foreground))_1px,transparent_1px),linear-gradient(90deg,hsl(var(--foreground))_1px,transparent_1px)] [background-size:40px_40px]"
+        />
+        <div className="relative grid grid-cols-[1fr_auto] gap-10 p-8 max-[1023px]:grid-cols-1 max-[1023px]:gap-6">
+          <div className="flex min-w-0 flex-col gap-4">
+            <div className="inline-flex w-fit items-center gap-2 rounded-full border border-border bg-background/60 px-3 py-1 text-xs font-medium text-muted-foreground backdrop-blur">
+              <span className="h-1.5 w-1.5 rounded-full bg-primary" aria-hidden="true" />
+              {t('setup.breadcrumbLabel')} · <span className="text-foreground">{tenantName}</span>
+            </div>
+            <h1 className="m-0 text-[2.5rem] font-bold leading-tight tracking-tight text-foreground max-[767px]:text-[1.75rem]">
+              {t('setup.title')}
+            </h1>
+            <p className="m-0 max-w-xl text-sm text-muted-foreground">{t('setup.subtitle')}</p>
+            <div className="relative mt-2 flex w-full max-w-xl items-center">
+              <Search
+                className="pointer-events-none absolute left-3.5 h-4 w-4 text-muted-foreground"
+                aria-hidden="true"
+              />
+              <input
+                type="text"
+                className={cn(
+                  'h-11 w-full rounded-lg border border-border bg-background/80 pl-10 pr-20 text-sm text-foreground',
+                  'placeholder:text-muted-foreground',
+                  'outline-none transition-[border-color,box-shadow] duration-150',
+                  'focus:border-primary focus:shadow-[0_0_0_3px_hsl(var(--primary)/0.18)]'
+                )}
+                placeholder={t('setup.searchPlaceholder')}
+                value={searchQuery}
+                onChange={handleSearchChange}
+                data-testid="setup-search-input"
+                aria-label={t('setup.searchPlaceholder')}
+              />
+              {searchQuery ? (
+                <button
+                  type="button"
+                  className={cn(
+                    'absolute right-2 flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground',
+                    'cursor-pointer transition-colors duration-150',
+                    'hover:bg-muted hover:text-foreground',
+                    'focus:outline-2 focus:outline-offset-2 focus:outline-primary'
+                  )}
+                  onClick={handleClearSearch}
+                  data-testid="setup-search-clear"
+                  aria-label={t('common.clear')}
+                >
+                  <X className="h-4 w-4" />
+                </button>
+              ) : (
+                <kbd
+                  aria-hidden="true"
+                  className="absolute right-3 inline-flex h-6 select-none items-center rounded border border-border bg-muted px-1.5 font-mono text-[0.6875rem] font-medium text-muted-foreground"
+                >
+                  {t('setup.shortcutHint')}
+                </kbd>
+              )}
+            </div>
+          </div>
+          <div
+            data-testid="setup-stats"
+            className="grid w-[280px] grid-cols-1 content-start gap-3 max-[1023px]:w-full max-[1023px]:grid-cols-3 max-[767px]:grid-cols-1"
+          >
+            {stats.map((stat) => {
+              const Icon = STAT_ICONS[stat.key]
+              return (
+                <div
+                  key={stat.key}
+                  className="flex items-center gap-3 rounded-lg border border-border bg-background/60 px-4 py-3 backdrop-blur"
+                >
+                  <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-primary/10 text-primary">
+                    <Icon className="h-[18px] w-[18px]" />
+                  </div>
+                  <div className="flex flex-col">
+                    <span className="text-[0.6875rem] font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+                      {stat.label}
+                    </span>
+                    <span className="text-[1.5rem] font-bold leading-tight text-foreground">
+                      {stat.value}
+                    </span>
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        </div>
+      </section>
+
+      {/* Pinned + Recently visited rows */}
+      <div className="grid grid-cols-2 gap-4 max-[1023px]:grid-cols-1">
+        <ShortcutRow
+          testId="setup-pinned"
+          icon={<Pin className="h-3.5 w-3.5" />}
+          label={t('setup.pinned')}
+          emptyLabel={t('setup.emptyPinned')}
+          empty={pinnedItems.length === 0}
+        >
+          {pinnedItems.map(({ item }) => (
+            <Chip
+              key={item.path}
+              to={`/${tenantSlug}${item.path}`}
+              icon={item.icon}
+              label={item.name}
+              onVisit={() => recordVisit(item.path)}
+              onRemove={() => unpin(item.path)}
+              removeLabel={t('setup.removePin')}
+              testId={`setup-pinned-${sanitizeTestPath(item.path)}`}
+            />
+          ))}
+        </ShortcutRow>
+        <ShortcutRow
+          testId="setup-recent"
+          icon={<Clock className="h-3.5 w-3.5" />}
+          label={t('setup.recent')}
+          emptyLabel={t('setup.emptyRecent')}
+          empty={recentItems.length === 0}
+        >
+          {recentItems.map(({ item, relative }) => (
+            <Chip
+              key={item.path}
+              to={`/${tenantSlug}${item.path}`}
+              icon={item.icon}
+              label={item.name}
+              meta={relative}
+              onVisit={() => recordVisit(item.path)}
+              testId={`setup-recent-${sanitizeTestPath(item.path)}`}
+            />
+          ))}
+        </ShortcutRow>
+      </div>
+
+      {/* Filter tabs */}
+      <Tabs value={activeFilter} onValueChange={(v) => setActiveFilter(v as GroupKey | 'all')}>
+        <TabsList variant="line" className="h-9">
+          {FILTER_ORDER.map((key) => (
+            <TabsTrigger key={key} value={key} data-testid={`setup-filter-${key}`} className="px-3">
+              {t(`setup.filters.${key}`)}
+              <span
+                className={cn(
+                  'ml-1.5 inline-flex h-5 min-w-[1.25rem] items-center justify-center rounded-md px-1.5 text-[0.6875rem] font-semibold',
+                  activeFilter === key
+                    ? 'bg-primary/15 text-primary'
+                    : 'bg-muted text-muted-foreground'
+                )}
+              >
+                {filterCounts[key]}
+              </span>
+            </TabsTrigger>
+          ))}
+        </TabsList>
+      </Tabs>
+
+      {/* Sections */}
+      {visibleGroups.length === 0 ? (
+        <div
+          className="flex items-center justify-center rounded-xl border border-dashed border-border bg-card p-12"
           data-testid="setup-no-results"
         >
           <p className="m-0 text-sm text-muted-foreground">{t('common.noResults')}</p>
         </div>
       ) : (
-        <div className="grid grid-cols-2 gap-6 max-[767px]:grid-cols-1">
-          {filteredCategories.map((category) => (
-            <div
-              key={category.key}
-              className="overflow-hidden rounded-md border border-border bg-card"
-              data-testid={`setup-category-${category.key}`}
-            >
-              <div className="flex items-center gap-2.5 border-b border-border bg-muted px-5 py-4">
-                <span className="flex items-center justify-center text-primary" aria-hidden="true">
-                  {category.icon}
-                </span>
-                <h2 className="m-0 text-[0.9375rem] font-semibold text-foreground">
-                  {t(category.titleKey)}
-                </h2>
-              </div>
-              <ul className="m-0 list-none p-0">
-                {category.items.map((item) => (
-                  <li key={item.path} className="border-b border-border last:border-b-0">
-                    <Link
-                      to={`/${tenantSlug}${item.path}`}
-                      className={cn(
-                        'flex items-center justify-between px-5 py-3 text-inherit no-underline',
-                        'transition-colors duration-150',
-                        'hover:bg-muted',
-                        'focus:outline-2 focus:outline-offset-[-2px] focus:outline-primary',
-                        'focus:not(:focus-visible):outline-none',
-                        'group'
-                      )}
-                      data-testid={`setup-item-${item.path.replace(/\//g, '').replace(/-/g, '')}`}
-                    >
-                      <div className="flex min-w-0 flex-col gap-0.5">
-                        <span className="text-sm font-medium text-primary">{item.name}</span>
-                        <span className="text-xs text-muted-foreground">{item.description}</span>
-                      </div>
-                      <ChevronRight
-                        size={14}
-                        className="shrink-0 text-muted-foreground transition-transform duration-150 group-hover:translate-x-0.5 group-hover:text-primary"
-                        aria-hidden="true"
-                      />
-                    </Link>
-                  </li>
-                ))}
-              </ul>
+        visibleGroups.map(({ groupKey, categories, itemCount }) => (
+          <section key={groupKey} data-testid={`setup-group-${groupKey}`} className="space-y-4">
+            <div className="flex items-end justify-between border-b border-border pb-2">
+              <span className="text-[0.6875rem] font-semibold uppercase tracking-[0.12em] text-muted-foreground">
+                {t(`setup.groups.${groupKey}`)}
+              </span>
+              <span className="text-xs text-muted-foreground">
+                {t('setup.groupMeta', { sections: categories.length, items: itemCount })}
+              </span>
             </div>
-          ))}
-        </div>
+            <div className="grid grid-cols-3 gap-4 max-[1279px]:grid-cols-2 max-[767px]:grid-cols-1">
+              {categories.map((category) => (
+                <CategoryCard
+                  key={category.key}
+                  category={category}
+                  tenantSlug={tenantSlug}
+                  isPinned={isPinned}
+                  onTogglePin={togglePin}
+                  onVisit={recordVisit}
+                  pinLabel={t('setup.addPin')}
+                  unpinLabel={t('setup.removePin')}
+                  titleText={t(category.titleKey)}
+                  descriptionText={t(category.descriptionKey)}
+                />
+              ))}
+            </div>
+          </section>
+        ))
       )}
+    </div>
+  )
+}
+
+interface ShortcutRowProps {
+  testId: string
+  icon: React.ReactNode
+  label: string
+  emptyLabel: string
+  empty: boolean
+  children: React.ReactNode
+}
+
+function ShortcutRow({
+  testId,
+  icon,
+  label,
+  emptyLabel,
+  empty,
+  children,
+}: ShortcutRowProps): React.ReactElement {
+  return (
+    <section data-testid={testId} className="rounded-xl border border-border bg-card p-4">
+      <div className="mb-3 flex items-center gap-2 text-muted-foreground">
+        <span className="flex h-5 w-5 items-center justify-center" aria-hidden="true">
+          {icon}
+        </span>
+        <span className="text-[0.6875rem] font-semibold uppercase tracking-[0.12em]">{label}</span>
+      </div>
+      {empty ? (
+        <p className="m-0 text-xs text-muted-foreground">{emptyLabel}</p>
+      ) : (
+        <div className="flex flex-wrap gap-2">{children}</div>
+      )}
+    </section>
+  )
+}
+
+interface ChipProps {
+  to: string
+  icon: React.ComponentType<{ className?: string }>
+  label: string
+  meta?: string
+  onVisit: () => void
+  onRemove?: () => void
+  removeLabel?: string
+  testId: string
+}
+
+function Chip({
+  to,
+  icon: Icon,
+  label,
+  meta,
+  onVisit,
+  onRemove,
+  removeLabel,
+  testId,
+}: ChipProps): React.ReactElement {
+  return (
+    <div className="group inline-flex items-stretch overflow-hidden rounded-md border border-border bg-background/60 transition-colors hover:border-primary/40 hover:bg-muted">
+      <Link
+        to={to}
+        onClick={onVisit}
+        data-testid={testId}
+        className="flex items-center gap-2 px-2.5 py-1.5 text-sm text-foreground no-underline"
+      >
+        <Icon className="h-3.5 w-3.5 text-muted-foreground group-hover:text-primary" />
+        <span className="font-medium">{label}</span>
+        {meta && <span className="text-[0.6875rem] text-muted-foreground">{meta}</span>}
+      </Link>
+      {onRemove && (
+        <button
+          type="button"
+          onClick={onRemove}
+          aria-label={removeLabel}
+          className="hidden h-full items-center border-l border-border px-2 text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive group-hover:flex focus-visible:flex"
+        >
+          <X className="h-3.5 w-3.5" />
+        </button>
+      )}
+    </div>
+  )
+}
+
+interface CategoryCardProps {
+  category: SetupCategory
+  tenantSlug: string
+  isPinned: (path: string) => boolean
+  onTogglePin: (path: string) => void
+  onVisit: (path: string) => void
+  pinLabel: string
+  unpinLabel: string
+  titleText: string
+  descriptionText: string
+}
+
+function CategoryCard({
+  category,
+  tenantSlug,
+  isPinned,
+  onTogglePin,
+  onVisit,
+  pinLabel,
+  unpinLabel,
+  titleText,
+  descriptionText,
+}: CategoryCardProps): React.ReactElement {
+  const Icon = category.icon
+  return (
+    <div
+      data-testid={`setup-category-${category.key}`}
+      className="flex flex-col overflow-hidden rounded-xl border border-border bg-card transition-colors hover:border-primary/40"
+    >
+      <div className="flex items-start gap-3 p-5">
+        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+          <Icon className="h-5 w-5" />
+        </div>
+        <div className="flex flex-1 flex-col gap-0.5">
+          <div className="flex items-center justify-between gap-2">
+            <h2 className="m-0 text-[0.9375rem] font-semibold text-foreground">{titleText}</h2>
+            <span className="inline-flex h-5 min-w-[1.25rem] items-center justify-center rounded-md bg-muted px-1.5 text-[0.6875rem] font-semibold text-muted-foreground">
+              {category.items.length}
+            </span>
+          </div>
+          <p className="m-0 text-xs text-muted-foreground">{descriptionText}</p>
+        </div>
+      </div>
+      <ul className="m-0 list-none border-t border-border p-0">
+        {category.items.map((item) => {
+          const ItemIcon = item.icon
+          const pinned = isPinned(item.path)
+          return (
+            <li key={item.path} className="border-b border-border last:border-b-0">
+              <div className="group/item relative flex items-stretch">
+                <Link
+                  to={`/${tenantSlug}${item.path}`}
+                  onClick={() => onVisit(item.path)}
+                  data-testid={`setup-item-${sanitizeTestPath(item.path)}`}
+                  className={cn(
+                    'flex flex-1 items-center gap-3 px-5 py-3 text-inherit no-underline',
+                    'transition-colors duration-150',
+                    'hover:bg-muted',
+                    'focus:outline-2 focus:outline-offset-[-2px] focus:outline-primary'
+                  )}
+                >
+                  <ItemIcon className="h-4 w-4 shrink-0 text-muted-foreground group-hover/item:text-primary" />
+                  <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+                    <span className="text-sm font-medium text-foreground">{item.name}</span>
+                    <span className="truncate text-xs text-muted-foreground">
+                      {item.description}
+                    </span>
+                  </div>
+                  <ChevronRight
+                    className="h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform duration-150 group-hover/item:translate-x-0.5 group-hover/item:text-primary"
+                    aria-hidden="true"
+                  />
+                </Link>
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.preventDefault()
+                    e.stopPropagation()
+                    onTogglePin(item.path)
+                  }}
+                  data-testid={`setup-pin-${sanitizeTestPath(item.path)}`}
+                  aria-label={pinned ? unpinLabel : pinLabel}
+                  aria-pressed={pinned}
+                  className={cn(
+                    'absolute right-9 top-1/2 flex h-7 w-7 -translate-y-1/2 items-center justify-center rounded-md',
+                    'text-muted-foreground transition-opacity duration-150',
+                    'hover:bg-background hover:text-primary',
+                    'focus:outline-2 focus:outline-offset-1 focus:outline-primary',
+                    pinned ? 'opacity-100 text-primary' : 'opacity-0 group-hover/item:opacity-100'
+                  )}
+                >
+                  {pinned ? <PinOff className="h-3.5 w-3.5" /> : <Pin className="h-3.5 w-3.5" />}
+                </button>
+              </div>
+            </li>
+          )
+        })}
+      </ul>
     </div>
   )
 }

--- a/kelta-ui/app/src/pages/SetupHomePage/usePinnedSetup.ts
+++ b/kelta-ui/app/src/pages/SetupHomePage/usePinnedSetup.ts
@@ -1,0 +1,67 @@
+import { useCallback, useEffect, useState } from 'react'
+
+const MAX_PINNED = 6
+
+function storageKey(tenantSlug: string): string {
+  return `kelta:setup:pinned:${tenantSlug}`
+}
+
+function readPinned(tenantSlug: string): string[] {
+  try {
+    const raw = window.localStorage.getItem(storageKey(tenantSlug))
+    if (!raw) return []
+    const parsed = JSON.parse(raw)
+    if (!Array.isArray(parsed)) return []
+    return parsed.filter((p): p is string => typeof p === 'string').slice(0, MAX_PINNED)
+  } catch {
+    return []
+  }
+}
+
+export interface UsePinnedSetup {
+  pinned: string[]
+  isPinned: (path: string) => boolean
+  pin: (path: string) => void
+  unpin: (path: string) => void
+  toggle: (path: string) => void
+}
+
+export function usePinnedSetup(tenantSlug: string): UsePinnedSetup {
+  const [pinned, setPinned] = useState<string[]>(() => readPinned(tenantSlug))
+
+  useEffect(() => {
+    setPinned(readPinned(tenantSlug))
+  }, [tenantSlug])
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(storageKey(tenantSlug), JSON.stringify(pinned))
+    } catch {
+      // ignore quota / disabled storage
+    }
+  }, [tenantSlug, pinned])
+
+  const pin = useCallback((path: string) => {
+    setPinned((current) => {
+      if (current.includes(path)) return current
+      return [...current, path].slice(-MAX_PINNED)
+    })
+  }, [])
+
+  const unpin = useCallback((path: string) => {
+    setPinned((current) => current.filter((p) => p !== path))
+  }, [])
+
+  const toggle = useCallback((path: string) => {
+    setPinned((current) => {
+      if (current.includes(path)) {
+        return current.filter((p) => p !== path)
+      }
+      return [...current, path].slice(-MAX_PINNED)
+    })
+  }, [])
+
+  const isPinned = useCallback((path: string) => pinned.includes(path), [pinned])
+
+  return { pinned, isPinned, pin, unpin, toggle }
+}

--- a/kelta-ui/app/src/pages/SetupHomePage/useRecentSetup.ts
+++ b/kelta-ui/app/src/pages/SetupHomePage/useRecentSetup.ts
@@ -1,0 +1,65 @@
+import { useCallback, useEffect, useState } from 'react'
+
+const MAX_RECENT = 5
+
+export interface RecentEntry {
+  path: string
+  visitedAt: number
+}
+
+function storageKey(tenantSlug: string): string {
+  return `kelta:setup:recent:${tenantSlug}`
+}
+
+function readRecent(tenantSlug: string): RecentEntry[] {
+  try {
+    const raw = window.localStorage.getItem(storageKey(tenantSlug))
+    if (!raw) return []
+    const parsed = JSON.parse(raw)
+    if (!Array.isArray(parsed)) return []
+    return parsed
+      .filter(
+        (e): e is RecentEntry =>
+          e != null &&
+          typeof e === 'object' &&
+          typeof e.path === 'string' &&
+          typeof e.visitedAt === 'number'
+      )
+      .slice(0, MAX_RECENT)
+  } catch {
+    return []
+  }
+}
+
+export interface UseRecentSetup {
+  recent: RecentEntry[]
+  recordVisit: (path: string) => void
+  clear: () => void
+}
+
+export function useRecentSetup(tenantSlug: string): UseRecentSetup {
+  const [recent, setRecent] = useState<RecentEntry[]>(() => readRecent(tenantSlug))
+
+  useEffect(() => {
+    setRecent(readRecent(tenantSlug))
+  }, [tenantSlug])
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(storageKey(tenantSlug), JSON.stringify(recent))
+    } catch {
+      // ignore
+    }
+  }, [tenantSlug, recent])
+
+  const recordVisit = useCallback((path: string) => {
+    setRecent((current) => {
+      const filtered = current.filter((e) => e.path !== path)
+      return [{ path, visitedAt: Date.now() }, ...filtered].slice(0, MAX_RECENT)
+    })
+  }, [])
+
+  const clear = useCallback(() => setRecent([]), [])
+
+  return { recent, recordVisit, clear }
+}


### PR DESCRIPTION
## Summary

- New hero card with gradient background, breadcrumb pill, integrated search, and side stats panel
- Pinned + Recently visited shortcut rows (localStorage-backed, per tenant)
- Core / Automation / Platform filter tabs with live counts; grouped section headers
- Richer category cards: icon tile w/ colored bg, count badge, per-item icons, inline pin toggle

## Test plan

- [ ] /verify (or /test-frontend ui) — lint, prettier, tests
- [ ] e2e: `npx playwright test e2e-tests/tests/admin/setup/setup-home.spec.ts` (existing 6 tests + 3 new: filter tab, pin persist, recent visit)
- [ ] Manual: `pnpm --filter @kelta/app dev`, navigate to `/{tenant}/setup`
  - [ ] Hero search filters categories
  - [ ] Filter tabs narrow visible groups; counts match
  - [ ] Pin an item, reload, chip persists
  - [ ] Visit an item, return to setup, appears in Recently visited
  - [ ] Light + dark themes both render correctly
  - [ ] Responsive: 1280+ shows 3-col + side stats; <1024 collapses stats below; <768 stacks 1-col
  - [ ] Permission filter: user without MANAGE_USERS sees Administration card collapsed

🤖 Generated with [Claude Code](https://claude.com/claude-code)