### PR TITLE
fix(ui): stabilize setup page useNow snapshot to prevent re-render loop

### DIFF
--- a/kelta-ui/app/src/pages/SetupHomePage/SetupHomePage.tsx
+++ b/kelta-ui/app/src/pages/SetupHomePage/SetupHomePage.tsx
@@ -438,17 +438,47 @@ function sanitizeTestPath(path: string): string {
   return path.replace(/\//g, '').replace(/-/g, '')
 }
 
+// Module-level minute-tick store: getSnapshot must be stable between ticks,
+// otherwise useSyncExternalStore re-renders every call and React bails with
+// "Maximum update depth exceeded" (#185).
+let cachedNow = 0
+const tickListeners = new Set<() => void>()
+let tickIntervalId: number | null = null
+
+function ensureTicker(): void {
+  if (tickIntervalId !== null) return
+  cachedNow = Date.now()
+  tickIntervalId = window.setInterval(() => {
+    cachedNow = Date.now()
+    tickListeners.forEach((listener) => listener())
+  }, 60_000)
+}
+
 function subscribeMinute(callback: () => void): () => void {
-  const id = window.setInterval(callback, 60_000)
-  return () => window.clearInterval(id)
+  ensureTicker()
+  tickListeners.add(callback)
+  // ensureTicker just set cachedNow above; notify the subscriber so React
+  // re-reads the snapshot (transitioning from the 0 it captured during render).
+  queueMicrotask(callback)
+  return () => {
+    tickListeners.delete(callback)
+    if (tickListeners.size === 0 && tickIntervalId !== null) {
+      window.clearInterval(tickIntervalId)
+      tickIntervalId = null
+    }
+  }
+}
+
+function getNowSnapshot(): number {
+  return cachedNow
+}
+
+function getNowServerSnapshot(): number {
+  return 0
 }
 
 function useNow(): number {
-  return useSyncExternalStore(
-    subscribeMinute,
-    () => Date.now(),
-    () => 0
-  )
+  return useSyncExternalStore(subscribeMinute, getNowSnapshot, getNowServerSnapshot)
 }
 
 function formatRelative(


### PR DESCRIPTION
## Summary

Follow-up to [#890](https://github.com/cklinker/emf/pull/890).

The new SetupHomePage relative-time helper used `useSyncExternalStore` with a `getSnapshot` callback that returned a fresh `Date.now()` on every call. React polls the snapshot multiple times per render to detect tearing — since the value always changed, React kept rescheduling renders and eventually threw React error #185 ("Maximum update depth exceeded"). The error boundary fires intermittently after pinning a setup item and reloading.

Replace with a module-level cached value updated only by the minute-tick interval, so the snapshot is stable between ticks.

## Test plan

- [ ] Manual: visit `/{tenant}/setup`, pin an item, reload, confirm no error boundary, confirm pin persists
- [ ] Verify Recently visited row still renders relative timestamps and refreshes within a minute

🤖 Generated with [Claude Code](https://claude.com/claude-code)