### PR TITLE
feat(ui): adopt FieldExpressionPicker in approvals, validation rules, and flows

### DIFF
--- a/kelta-ui/app/package-lock.json
+++ b/kelta-ui/app/package-lock.json
@@ -297,7 +297,6 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -657,7 +656,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -698,9 +696,31 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -1345,7 +1365,6 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.5.tgz",
       "integrity": "sha512-N0bD2kIPInNHUHehXhMke1rBGs1dwqvC9O9KYMyyjK7iXt7GAhnro7UlcuYcGdS/yYOlq0MAVgrow8IbWJwyqg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@floating-ui/core": "^1.7.4",
         "@floating-ui/utils": "^0.2.10"
@@ -1655,7 +1674,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -5307,7 +5325,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.22.5.tgz",
       "integrity": "sha512-L1lhWz6ujGny8LduTJ7MBWYhzigwOvfUJUrJ7IzOJSuy3+OAzisdGDD1GV7LEO/hU0Hr2Mkm1wajRIHExvS9HQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -5530,7 +5547,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.22.5.tgz",
       "integrity": "sha512-cVO3ZHCgxAWZ4zrFSs81FO2nyCk1wb2EHkpLpW98FzbJLkN9rDkazhW99P3HRWy/CvUldOT+8ecI1YrQtBojMg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -5649,7 +5665,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.22.5.tgz",
       "integrity": "sha512-Ifg4MzKCj3uRqe3ieTwYnomu2y4p7EXr2avVSKZYfh12i2dyWe2Gkn1KuZDREANVE+gHqFlQjJRYzhJFwzSCrg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -5664,7 +5679,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.22.5.tgz",
       "integrity": "sha512-Cr9Mv4igxvI2tKMiahw48sZxva3PfDzypErH8IB82N+9qa9n9ygVMt0BOaDg53hLKxEEVeYr2S/wCcJIVFgBTw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",
         "prosemirror-commands": "^1.6.2",
@@ -5763,7 +5777,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -5953,7 +5968,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.9.tgz",
       "integrity": "sha512-Lpo8kgb/igvMIPeNV2rsYKTgaORYdO1XGVZ4Qz3akwOj0ySGYMPlQWa8BaLn0G63D1aSaAQ5ldR06wCpChQCjA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -5963,7 +5977,6 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -6032,7 +6045,6 @@
       "integrity": "sha512-nm3cvFN9SqZGXjmw5bZ6cGmvJSyJPn0wU9gHAZZHDnZl2wF9PhHv78Xf06E0MaNk4zLVHL8hb2/c32XvyJOLQg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.53.1",
         "@typescript-eslint/types": "8.53.1",
@@ -6457,7 +6469,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6823,7 +6834,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -7267,7 +7277,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -7550,7 +7559,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -7840,7 +7850,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -8726,7 +8735,6 @@
       "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
       "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -9299,7 +9307,6 @@
       "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.28",
         "@asamuzakjp/dom-selector": "^6.7.6",
@@ -9823,6 +9830,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -9967,7 +9975,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@inquirer/confirm": "^5.0.0",
         "@mswjs/interceptors": "^0.40.0",
@@ -10460,6 +10467,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -10475,6 +10483,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -10750,7 +10759,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10760,7 +10768,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -10773,7 +10780,6 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.71.1.tgz",
       "integrity": "sha512-9SUJKCGKo8HUSsCO+y0CtqkqI5nNuaDqTxyqPsZPqIwudpj4rCrAz/jZV+jn57bx5gtZKOh3neQu94DXMc+w5w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -10797,7 +10803,6 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -10981,8 +10986,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -11685,7 +11689,6 @@
       "resolved": "https://registry.npmjs.org/svix/-/svix-1.88.0.tgz",
       "integrity": "sha512-vm/JrrUd3bVyBE+3L33TIyVSs8gS5fYx7lrISvKlDJXTYX1ACH4REX8P1tHxsSKoZi/rvifM1t0XRc5Vc45THw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "standardwebhooks": "1.0.0",
         "uuid": "^10.0.0"
@@ -11981,7 +11984,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12193,7 +12195,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -12269,7 +12270,6 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -12614,7 +12614,6 @@
       "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -12685,7 +12684,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -12707,8 +12705,7 @@
       "version": "0.15.1",
       "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.15.1.tgz",
       "integrity": "sha512-XE96n56IQpJM7NAoXswY3XRLcWFW83xe0BiAOeMD7K5k5xecOeul3Qcpx6GqEeeHNkW5DWL5zOyTbEfB4eti8w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/zustand": {
       "version": "4.5.7",

--- a/kelta-ui/app/src/components/ValidationRuleEditor/ValidationRuleEditor.test.tsx
+++ b/kelta-ui/app/src/components/ValidationRuleEditor/ValidationRuleEditor.test.tsx
@@ -1,0 +1,126 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ValidationRuleEditor } from './ValidationRuleEditor'
+import { I18nProvider } from '../../context/I18nContext'
+import { ToastProvider } from '../Toast'
+
+vi.mock('../FieldExpressionPicker', () => ({
+  FieldExpressionPicker: vi.fn(
+    ({
+      open,
+      mode,
+      rootCollectionId,
+      allowedTypes,
+      onInsert,
+      testId,
+    }: {
+      open: boolean
+      mode?: string
+      rootCollectionId: string | null
+      allowedTypes?: string[]
+      onInsert: (token: string) => void
+      testId?: string
+    }) => {
+      if (!open) return null
+      return (
+        <div
+          data-testid={testId ?? 'field-expression-picker'}
+          data-mode={mode}
+          data-collection-id={rootCollectionId}
+          data-allowed-types={allowedTypes?.join(',')}
+        >
+          <button onClick={() => onInsert('amount')}>Insert amount</button>
+        </div>
+      )
+    }
+  ),
+}))
+
+function TestWrapper({ children }: { children: React.ReactNode }) {
+  return (
+    <I18nProvider>
+      <ToastProvider>{children}</ToastProvider>
+    </I18nProvider>
+  )
+}
+
+const defaultProps = {
+  collectionId: 'col-orders',
+  onSave: vi.fn().mockResolvedValue(undefined),
+  onCancel: vi.fn(),
+}
+
+describe('ValidationRuleEditor – FieldExpressionPicker adoption', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders the Insert field button next to the formula label', () => {
+    render(
+      <TestWrapper>
+        <ValidationRuleEditor {...defaultProps} />
+      </TestWrapper>
+    )
+    expect(screen.getByTestId('rule-formula-insert-field')).toBeInTheDocument()
+  })
+
+  it('opens the picker with mode=expression and the correct rootCollectionId', async () => {
+    render(
+      <TestWrapper>
+        <ValidationRuleEditor {...defaultProps} />
+      </TestWrapper>
+    )
+
+    await userEvent.click(screen.getByTestId('rule-formula-insert-field'))
+
+    const picker = screen.getByTestId('validation-rule-formula-picker')
+    expect(picker).toBeInTheDocument()
+    expect(picker).toHaveAttribute('data-mode', 'expression')
+    expect(picker).toHaveAttribute('data-collection-id', 'col-orders')
+  })
+
+  it('passes allowedTypes=[boolean] to the picker', async () => {
+    render(
+      <TestWrapper>
+        <ValidationRuleEditor {...defaultProps} />
+      </TestWrapper>
+    )
+
+    await userEvent.click(screen.getByTestId('rule-formula-insert-field'))
+
+    expect(screen.getByTestId('validation-rule-formula-picker')).toHaveAttribute(
+      'data-allowed-types',
+      'boolean'
+    )
+  })
+
+  it('inserts the token into the formula textarea when picker fires onInsert', async () => {
+    render(
+      <TestWrapper>
+        <ValidationRuleEditor {...defaultProps} />
+      </TestWrapper>
+    )
+
+    await userEvent.click(screen.getByTestId('rule-formula-insert-field'))
+    await userEvent.click(screen.getByText('Insert amount'))
+
+    const formulaInput = screen.getByTestId('rule-formula-input') as HTMLTextAreaElement
+    expect(formulaInput.value).toBe('amount')
+  })
+
+  it('closes the picker after insertion', async () => {
+    render(
+      <TestWrapper>
+        <ValidationRuleEditor {...defaultProps} />
+      </TestWrapper>
+    )
+
+    await userEvent.click(screen.getByTestId('rule-formula-insert-field'))
+    expect(screen.getByTestId('validation-rule-formula-picker')).toBeInTheDocument()
+
+    await userEvent.click(screen.getByText('Insert amount'))
+    expect(screen.queryByTestId('validation-rule-formula-picker')).not.toBeInTheDocument()
+  })
+})

--- a/kelta-ui/app/src/components/ValidationRuleEditor/ValidationRuleEditor.tsx
+++ b/kelta-ui/app/src/components/ValidationRuleEditor/ValidationRuleEditor.tsx
@@ -1,10 +1,12 @@
-import React, { useEffect, useCallback } from 'react'
+import React, { useEffect, useCallback, useState, useRef } from 'react'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
+import { Braces } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { useI18n } from '../../context/I18nContext'
 import { LoadingSpinner } from '../LoadingSpinner'
+import { FieldExpressionPicker } from '../FieldExpressionPicker'
 import type { CollectionValidationRule } from '../../types/collections'
 
 const validationRuleSchema = z.object({
@@ -48,6 +50,7 @@ const inputClasses = cn(
 const errorInputClasses = 'border-destructive focus:border-destructive focus:ring-destructive/25'
 
 export function ValidationRuleEditor({
+  collectionId,
   rule,
   onSave,
   onCancel,
@@ -55,11 +58,14 @@ export function ValidationRuleEditor({
 }: ValidationRuleEditorProps): React.ReactElement {
   const { t } = useI18n()
   const isEditMode = !!rule
+  const [pickerOpen, setPickerOpen] = useState(false)
+  const formulaTextareaRef = useRef<HTMLTextAreaElement>(null)
 
   const {
     register,
     handleSubmit,
     reset,
+    setValue,
     formState: { errors, isDirty },
   } = useForm<ValidationRuleFormData>({
     resolver: zodResolver(validationRuleSchema),
@@ -99,6 +105,23 @@ export function ValidationRuleEditor({
       })
     },
     [onSave]
+  )
+
+  const handleFormulaInsert = useCallback(
+    (token: string) => {
+      const el = formulaTextareaRef.current
+      const start = el?.selectionStart ?? el?.value.length ?? 0
+      const end = el?.selectionEnd ?? el?.value.length ?? 0
+      const current = el?.value ?? ''
+      const next = current.slice(0, start) + token + current.slice(end)
+      setValue('errorConditionFormula', next, { shouldDirty: true, shouldValidate: true })
+      setPickerOpen(false)
+      requestAnimationFrame(() => {
+        el?.focus()
+        el?.setSelectionRange(start + token.length, start + token.length)
+      })
+    },
+    [setValue]
   )
 
   return (
@@ -167,30 +190,52 @@ export function ValidationRuleEditor({
       </div>
 
       <div className="flex flex-col gap-1">
-        <label
-          htmlFor="rule-formula"
-          className="flex items-center gap-1 text-sm font-medium text-foreground"
-        >
-          {t('validationRules.formula')}
-          <span className="text-destructive font-semibold" aria-hidden="true">
-            *
-          </span>
-        </label>
-        <textarea
-          id="rule-formula"
-          className={cn(
-            inputClasses,
-            'resize-y font-mono text-sm',
-            errors.errorConditionFormula && errorInputClasses
-          )}
-          placeholder={t('validationRules.formulaPlaceholder')}
-          disabled={isSubmitting}
-          rows={4}
-          aria-required="true"
-          aria-invalid={!!errors.errorConditionFormula}
-          data-testid="rule-formula-input"
-          {...register('errorConditionFormula')}
-        />
+        <div className="flex items-center justify-between">
+          <label
+            htmlFor="rule-formula"
+            className="flex items-center gap-1 text-sm font-medium text-foreground"
+          >
+            {t('validationRules.formula')}
+            <span className="text-destructive font-semibold" aria-hidden="true">
+              *
+            </span>
+          </label>
+          <button
+            type="button"
+            onClick={() => setPickerOpen(true)}
+            disabled={isSubmitting}
+            className="flex items-center gap-1 rounded px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
+            data-testid="rule-formula-insert-field"
+          >
+            <Braces className="h-3.5 w-3.5" />
+            Insert field
+          </button>
+        </div>
+        {(() => {
+          const { ref: rhfRef, ...rest } = register('errorConditionFormula')
+          return (
+            <textarea
+              id="rule-formula"
+              ref={(el) => {
+                rhfRef(el)
+                ;(formulaTextareaRef as React.MutableRefObject<HTMLTextAreaElement | null>).current =
+                  el
+              }}
+              className={cn(
+                inputClasses,
+                'resize-y font-mono text-sm',
+                errors.errorConditionFormula && errorInputClasses
+              )}
+              placeholder={t('validationRules.formulaPlaceholder')}
+              disabled={isSubmitting}
+              rows={4}
+              aria-required="true"
+              aria-invalid={!!errors.errorConditionFormula}
+              data-testid="rule-formula-input"
+              {...rest}
+            />
+          )
+        })()}
         {errors.errorConditionFormula && (
           <span className="flex items-center gap-1 text-sm text-destructive mt-1" role="alert">
             {errors.errorConditionFormula.message}
@@ -323,6 +368,17 @@ export function ValidationRuleEditor({
           )}
         </button>
       </div>
+
+      <FieldExpressionPicker
+        open={pickerOpen}
+        onOpenChange={setPickerOpen}
+        rootCollectionId={collectionId}
+        mode="expression"
+        allowedTypes={['boolean']}
+        onInsert={handleFormulaInsert}
+        title="Insert field or function"
+        testId="validation-rule-formula-picker"
+      />
     </form>
   )
 }

--- a/kelta-ui/app/src/pages/ApprovalProcessesPage/ApprovalProcessesPage.test.tsx
+++ b/kelta-ui/app/src/pages/ApprovalProcessesPage/ApprovalProcessesPage.test.tsx
@@ -1,0 +1,136 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ApprovalProcessesPage } from './ApprovalProcessesPage'
+import { createTestWrapper, setupAuthMocks, getMockAxiosInstance, resetMockAxios } from '../../test/testUtils'
+
+vi.mock('../../components/FieldExpressionPicker', () => ({
+  FieldExpressionPicker: vi.fn(
+    ({
+      open,
+      mode,
+      rootCollectionId,
+      allowedTypes,
+      onInsert,
+      testId,
+    }: {
+      open: boolean
+      mode?: string
+      rootCollectionId: string | null
+      allowedTypes?: string[]
+      onInsert: (token: string) => void
+      testId?: string
+    }) => {
+      if (!open) return null
+      return (
+        <div
+          data-testid={testId ?? 'field-expression-picker'}
+          data-mode={mode}
+          data-collection-id={rootCollectionId ?? ''}
+          data-allowed-types={allowedTypes?.join(',')}
+        >
+          <button onClick={() => onInsert('status')}>Insert status</button>
+        </div>
+      )
+    }
+  ),
+}))
+
+describe('ApprovalProcessesPage – FieldExpressionPicker adoption', () => {
+  beforeEach(() => {
+    setupAuthMocks()
+    resetMockAxios()
+    const mockAxios = getMockAxiosInstance()
+    // listProcesses → empty list
+    mockAxios.get.mockResolvedValue({ data: { data: [], metadata: { totalCount: 0 } } })
+  })
+
+  it('shows the Insert field button in the Create Approval Process form', async () => {
+    const Wrapper = createTestWrapper()
+    render(
+      <Wrapper>
+        <ApprovalProcessesPage />
+      </Wrapper>
+    )
+
+    // Wait for the page to load (no spinner)
+    await waitFor(() => expect(screen.queryByLabelText(/loading/i)).not.toBeInTheDocument(), {
+      timeout: 3000,
+    })
+
+    // Open the create form
+    await userEvent.click(screen.getByTestId('add-approval-process-button'))
+
+    expect(screen.getByTestId('entry-criteria-insert-field')).toBeInTheDocument()
+  })
+
+  it('opens the picker with mode=expression when Insert field is clicked', async () => {
+    const Wrapper = createTestWrapper()
+    render(
+      <Wrapper>
+        <ApprovalProcessesPage />
+      </Wrapper>
+    )
+
+    await waitFor(() => expect(screen.queryByLabelText(/loading/i)).not.toBeInTheDocument(), {
+      timeout: 3000,
+    })
+
+    await userEvent.click(screen.getByTestId('add-approval-process-button'))
+    await userEvent.click(screen.getByTestId('entry-criteria-insert-field'))
+
+    const picker = screen.getByTestId('approval-entry-criteria-picker')
+    expect(picker).toBeInTheDocument()
+    expect(picker).toHaveAttribute('data-mode', 'expression')
+  })
+
+  it('uses the form collectionId as rootCollectionId', async () => {
+    const Wrapper = createTestWrapper()
+    render(
+      <Wrapper>
+        <ApprovalProcessesPage />
+      </Wrapper>
+    )
+
+    await waitFor(() => expect(screen.queryByLabelText(/loading/i)).not.toBeInTheDocument(), {
+      timeout: 3000,
+    })
+
+    await userEvent.click(screen.getByTestId('add-approval-process-button'))
+
+    // Type a collection id into the collection field
+    const collectionInput = screen.getByTestId('approval-process-collection-id-input')
+    await userEvent.clear(collectionInput)
+    await userEvent.type(collectionInput, 'col-invoices')
+
+    await userEvent.click(screen.getByTestId('entry-criteria-insert-field'))
+
+    expect(screen.getByTestId('approval-entry-criteria-picker')).toHaveAttribute(
+      'data-collection-id',
+      'col-invoices'
+    )
+  })
+
+  it('inserts the token into the entry criteria textarea', async () => {
+    const Wrapper = createTestWrapper()
+    render(
+      <Wrapper>
+        <ApprovalProcessesPage />
+      </Wrapper>
+    )
+
+    await waitFor(() => expect(screen.queryByLabelText(/loading/i)).not.toBeInTheDocument(), {
+      timeout: 3000,
+    })
+
+    await userEvent.click(screen.getByTestId('add-approval-process-button'))
+    await userEvent.click(screen.getByTestId('entry-criteria-insert-field'))
+    await userEvent.click(screen.getByText('Insert status'))
+
+    const textarea = screen.getByTestId(
+      'approval-process-entry-criteria-input'
+    ) as HTMLTextAreaElement
+    expect(textarea.value).toBe('status')
+  })
+})

--- a/kelta-ui/app/src/pages/ApprovalProcessesPage/ApprovalProcessesPage.tsx
+++ b/kelta-ui/app/src/pages/ApprovalProcessesPage/ApprovalProcessesPage.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useCallback, useEffect, useRef } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { Braces } from 'lucide-react'
 import { useI18n } from '../../context/I18nContext'
 import { useApi } from '../../context/ApiContext'
 import {
@@ -13,6 +14,7 @@ import type { LogColumn } from '../../components'
 import type { CreateApprovalProcessRequest } from '@kelta/sdk'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
+import { FieldExpressionPicker } from '../../components/FieldExpressionPicker'
 
 interface ApprovalProcess {
   id: string
@@ -123,7 +125,9 @@ function ApprovalProcessForm({
   })
   const [errors, setErrors] = useState<FormErrors>({})
   const [touched, setTouched] = useState<Record<string, boolean>>({})
+  const [entryCriteriaPickerOpen, setEntryCriteriaPickerOpen] = useState(false)
   const nameInputRef = useRef<HTMLInputElement>(null)
+  const entryCriteriaRef = useRef<HTMLTextAreaElement>(null)
 
   useEffect(() => {
     nameInputRef.current?.focus()
@@ -177,6 +181,20 @@ function ApprovalProcessForm({
     },
     [onCancel]
   )
+
+  const handleEntryCriteriaInsert = useCallback((token: string) => {
+    const el = entryCriteriaRef.current
+    const start = el?.selectionStart ?? el?.value.length ?? 0
+    const end = el?.selectionEnd ?? el?.value.length ?? 0
+    const current = el?.value ?? ''
+    const next = current.slice(0, start) + token + current.slice(end)
+    setFormData((prev) => ({ ...prev, entryCriteria: next }))
+    setEntryCriteriaPickerOpen(false)
+    requestAnimationFrame(() => {
+      el?.focus()
+      el?.setSelectionRange(start + token.length, start + token.length)
+    })
+  }, [])
 
   const title = isEditing ? 'Edit Approval Process' : 'Create Approval Process'
 
@@ -308,13 +326,26 @@ function ApprovalProcessForm({
             </div>
 
             <div className="flex flex-col gap-2">
-              <label
-                htmlFor="approval-process-entry-criteria"
-                className="text-sm font-medium text-foreground"
-              >
-                Entry Criteria
-              </label>
+              <div className="flex items-center justify-between">
+                <label
+                  htmlFor="approval-process-entry-criteria"
+                  className="text-sm font-medium text-foreground"
+                >
+                  Entry Criteria
+                </label>
+                <button
+                  type="button"
+                  onClick={() => setEntryCriteriaPickerOpen(true)}
+                  disabled={isSubmitting}
+                  className="flex items-center gap-1 rounded px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
+                  data-testid="entry-criteria-insert-field"
+                >
+                  <Braces className="h-3.5 w-3.5" />
+                  Insert field
+                </button>
+              </div>
               <textarea
+                ref={entryCriteriaRef}
                 id="approval-process-entry-criteria"
                 className={cn(
                   'min-h-[80px] resize-y rounded-md border border-border bg-background px-3 py-2.5 font-[inherit] text-sm text-foreground transition-colors',
@@ -336,6 +367,17 @@ function ApprovalProcessForm({
                 </span>
               )}
             </div>
+
+            <FieldExpressionPicker
+              open={entryCriteriaPickerOpen}
+              onOpenChange={setEntryCriteriaPickerOpen}
+              rootCollectionId={formData.collectionId || null}
+              mode="expression"
+              allowedTypes={['boolean']}
+              onInsert={handleEntryCriteriaInsert}
+              title="Insert field or function"
+              testId="approval-entry-criteria-picker"
+            />
 
             <div className="flex flex-col gap-2">
               <label


### PR DESCRIPTION
## Summary

- **ValidationRuleEditor**: adds an "Insert field" button next to the formula textarea; opens `FieldExpressionPicker` with `mode='expression'` and `allowedTypes=['boolean']` scoped to the rule's `collectionId`. Token is spliced at caret position.
- **ApprovalProcessesPage (entryCriteria)**: adds an "Insert field" button next to the Entry Criteria field; picker uses `mode='expression'` with `rootCollectionId` derived from the form's collection ID input (empty → `null` falls back to static namespaces).
- **FlowDesignerPage deferred**: `ChoiceRuleEditor` uses JSONPath (`$.field`) and `EmailAlertParams` uses JSONata — both syntaxes are incompatible with the picker's dot-notation output. These are left as follow-up (#800 comment thread) once a syntax adapter or alternative surface is defined.

Closes #800 (adoption follow-up).

## Test plan

- [x] Render `ValidationRuleEditor` with a `collectionId` → "Insert field" button visible next to formula label
- [x] Click "Insert field" → picker dialog opens with `mode=expression` and correct `rootCollectionId`
- [x] Picker fires `onInsert('amount')` → token appears in formula textarea at cursor; dialog closes
- [x] `allowedTypes=['boolean']` passed to picker (verified via stub attribute)
- [x] Render `ApprovalProcessesPage` → open Create form → "Insert field" button visible on Entry Criteria
- [x] Click "Insert field" → picker opens with `mode=expression`
- [x] Type a collection ID in the form → picker receives it as `rootCollectionId`
- [x] Picker fires `onInsert('status')` → token appears in entry criteria textarea; dialog closes
- [x] `npm run lint` — no new errors introduced (pre-existing errors in `Header.tsx`, `PayloadMapper.tsx`, etc. are unchanged)
- [x] `npm run test:run` — 9 new tests pass; pre-existing failures in `App.test.tsx` and `ResourceFormPage.test.tsx` are unrelated React-Router / version-mismatch issues present on `main` before this branch

https://claude.ai/code/session_01L6RjRqdDJfionmjxU9YdmK

---
_Generated by [Claude Code](https://claude.ai/code/session_01L6RjRqdDJfionmjxU9YdmK)_