### PR TITLE
feat(email): wire user-lifecycle templates (invite, MFA, lockout, welcome, verify)

### DIFF
--- a/kelta-auth/src/main/java/io/kelta/auth/controller/EmailVerificationController.java
+++ b/kelta-auth/src/main/java/io/kelta/auth/controller/EmailVerificationController.java
@@ -1,0 +1,110 @@
+package io.kelta.auth.controller;
+
+import io.kelta.auth.config.AuthProperties;
+import io.kelta.auth.service.WorkerClient;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Email-ownership verification flow. The user receives a {@code user.email_verification}
+ * link that hits {@link #verify(String)} — we flip {@code email_verified=true} and
+ * clear the token. Tokens live 48 hours.
+ */
+@RestController
+@RequestMapping("/auth/email")
+public class EmailVerificationController {
+
+    private static final Logger log = LoggerFactory.getLogger(EmailVerificationController.class);
+    private static final Duration TOKEN_EXPIRY = Duration.ofHours(48);
+
+    private final JdbcTemplate jdbcTemplate;
+    private final WorkerClient workerClient;
+    private final String uiBaseUrl;
+
+    public EmailVerificationController(JdbcTemplate jdbcTemplate,
+                                        WorkerClient workerClient,
+                                        AuthProperties authProperties) {
+        this.jdbcTemplate = jdbcTemplate;
+        this.workerClient = workerClient;
+        this.uiBaseUrl = authProperties.getUiBaseUrl();
+    }
+
+    public record SendVerificationRequest(@NotBlank @Email String email) {}
+
+    @PostMapping("/send-verification")
+    public ResponseEntity<Map<String, String>> sendVerification(@Valid @RequestBody SendVerificationRequest request) {
+        var rows = jdbcTemplate.queryForList(
+                "SELECT pu.id, pu.email, pu.first_name, pu.tenant_id, t.name AS tenant_name "
+                        + "FROM platform_user pu JOIN tenant t ON t.id = pu.tenant_id "
+                        + "WHERE pu.email = ? AND pu.status = 'ACTIVE'",
+                request.email());
+        if (rows.isEmpty()) {
+            // Don't leak account existence.
+            return ResponseEntity.ok(Map.of("status", "ok"));
+        }
+        var row = rows.get(0);
+        String userId = (String) row.get("id");
+        String tenantId = (String) row.get("tenant_id");
+
+        String token = UUID.randomUUID().toString();
+        Instant expires = Instant.now().plus(TOKEN_EXPIRY);
+        jdbcTemplate.update(
+                "UPDATE platform_user SET email_verification_token = ?, "
+                        + "email_verification_expires_at = ? WHERE id = ?",
+                token, Timestamp.from(expires), userId);
+
+        String actionUrl = uiBaseUrl + "/auth/email/verify?token=" + token;
+        workerClient.sendTemplateEmail(tenantId, request.email(), "user.email_verification",
+                Map.of(
+                        "tenantName", row.getOrDefault("tenant_name", "Kelta"),
+                        "firstName",  row.getOrDefault("first_name", ""),
+                        "email",      request.email(),
+                        "actionUrl",  actionUrl,
+                        "expiresIn",  "48 hours"),
+                "EMAIL_VERIFICATION", userId);
+        log.info("Email verification queued for {}", request.email());
+        return ResponseEntity.ok(Map.of("status", "ok"));
+    }
+
+    @GetMapping("/verify")
+    public ResponseEntity<Map<String, String>> verify(@RequestParam String token) {
+        var rows = jdbcTemplate.queryForList(
+                "SELECT id, email_verification_expires_at FROM platform_user "
+                        + "WHERE email_verification_token = ?",
+                token);
+        if (rows.isEmpty()) {
+            return ResponseEntity.badRequest().body(Map.of("error", "Invalid or expired token"));
+        }
+        var row = rows.get(0);
+        Timestamp expires = (Timestamp) row.get("email_verification_expires_at");
+        if (expires == null || Instant.now().isAfter(expires.toInstant())) {
+            return ResponseEntity.badRequest().body(Map.of("error", "Invalid or expired token"));
+        }
+        String userId = (String) row.get("id");
+        jdbcTemplate.update(
+                "UPDATE platform_user SET email_verified = true, "
+                        + "email_verification_token = NULL, "
+                        + "email_verification_expires_at = NULL, "
+                        + "updated_at = NOW() WHERE id = ?",
+                userId);
+        log.info("Email verified for user {}", userId);
+        return ResponseEntity.ok(Map.of("status", "verified"));
+    }
+}

--- a/kelta-auth/src/main/java/io/kelta/auth/controller/MfaController.java
+++ b/kelta-auth/src/main/java/io/kelta/auth/controller/MfaController.java
@@ -1,10 +1,12 @@
 package io.kelta.auth.controller;
 
 import io.kelta.auth.service.TotpService;
+import io.kelta.auth.service.WorkerClient;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -12,7 +14,9 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
+import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Controller for MFA challenge and setup pages.
@@ -36,9 +40,15 @@ public class MfaController {
     public static final String SESSION_MFA_SETUP_SECRET = "MFA_SETUP_SECRET";
 
     private final TotpService totpService;
+    private final WorkerClient workerClient;
+    private final JdbcTemplate jdbcTemplate;
 
-    public MfaController(@org.springframework.beans.factory.annotation.Autowired(required = false) TotpService totpService) {
+    public MfaController(@org.springframework.beans.factory.annotation.Autowired(required = false) TotpService totpService,
+                          WorkerClient workerClient,
+                          JdbcTemplate jdbcTemplate) {
         this.totpService = totpService;
+        this.workerClient = workerClient;
+        this.jdbcTemplate = jdbcTemplate;
     }
 
     // -----------------------------------------------------------------------
@@ -154,6 +164,7 @@ public class MfaController {
         try {
             List<String> recoveryCodes = totpService.enrollUser(userId, secret, code);
             securityLog.info("security_event=MFA_ENROLLED actor={} tenant={}", userId, tenantId);
+            sendMfaChangedEmail(userId, "user.mfa_enrolled");
 
             session.removeAttribute(SESSION_MFA_SETUP_SECRET);
             session.removeAttribute(SESSION_MFA_SETUP_REQUIRED);
@@ -165,6 +176,29 @@ public class MfaController {
         } catch (IllegalArgumentException e) {
             redirectAttributes.addFlashAttribute("error", "Invalid verification code. Please try again.");
             return "redirect:/mfa-setup";
+        }
+    }
+
+    private void sendMfaChangedEmail(String userId, String templateKey) {
+        try {
+            var rows = jdbcTemplate.queryForList(
+                    "SELECT pu.email, pu.first_name, pu.tenant_id, t.name AS tenant_name "
+                            + "FROM platform_user pu JOIN tenant t ON t.id = pu.tenant_id "
+                            + "WHERE pu.id = ?",
+                    userId);
+            if (rows.isEmpty()) return;
+            var row = rows.get(0);
+            workerClient.sendTemplateEmail(
+                    (String) row.get("tenant_id"),
+                    (String) row.get("email"),
+                    templateKey,
+                    Map.of(
+                            "tenantName", row.getOrDefault("tenant_name", "Kelta"),
+                            "firstName",  row.getOrDefault("first_name", ""),
+                            "changedAt",  Instant.now().toString()),
+                    "MFA_CHANGED", userId);
+        } catch (Exception e) {
+            log.warn("Failed to send MFA-change notification for {}: {}", userId, e.getMessage());
         }
     }
 

--- a/kelta-auth/src/main/java/io/kelta/auth/controller/PasswordController.java
+++ b/kelta-auth/src/main/java/io/kelta/auth/controller/PasswordController.java
@@ -128,6 +128,7 @@ public class PasswordController {
         }
 
         log.info("Password changed for user {}", email);
+        if (userId != null) sendPasswordChangedEmail(userId);
         return ResponseEntity.ok(Map.of("status", "ok"));
     }
 
@@ -204,34 +205,59 @@ public class PasswordController {
         );
 
         log.info("Password reset completed for user_id {}", userId);
+        sendPasswordChangedEmail(userId);
         return ResponseEntity.ok(Map.of("status", "ok"));
     }
 
     private void sendPasswordResetEmail(String email, String resetToken) {
         try {
-            // Resolve tenant ID from the user's record
-            var tenantResults = jdbcTemplate.queryForList(
-                    "SELECT pu.tenant_id FROM platform_user pu WHERE pu.email = ? AND pu.status = 'ACTIVE'",
+            var rows = jdbcTemplate.queryForList(
+                    "SELECT pu.tenant_id, pu.first_name, t.name AS tenant_name "
+                            + "FROM platform_user pu JOIN tenant t ON t.id = pu.tenant_id "
+                            + "WHERE pu.email = ? AND pu.status = 'ACTIVE'",
                     email
             );
-            String tenantId = tenantResults.isEmpty() ? "system" : (String) tenantResults.get(0).get("tenant_id");
+            if (rows.isEmpty()) return;
+            String tenantId   = (String) rows.get(0).get("tenant_id");
+            String firstName  = (String) rows.getFirst().getOrDefault("first_name", "");
+            String tenantName = (String) rows.getFirst().getOrDefault("tenant_name", "Kelta");
 
-            String resetLink = uiBaseUrl + "/reset-password?token=" + resetToken + "&email=" + email;
-            String subject = "Reset your password";
-            String body = """
-                    <html><body>
-                    <h2>Password Reset</h2>
-                    <p>You requested a password reset. Click the link below to set a new password:</p>
-                    <p><a href="%s">Reset Password</a></p>
-                    <p>This link expires in 1 hour. If you did not request this, ignore this email.</p>
-                    </body></html>
-                    """.formatted(resetLink);
-
-            workerClient.sendEmail(tenantId, email, subject, body, "PASSWORD_RESET");
+            String actionUrl = uiBaseUrl + "/reset-password?token=" + resetToken + "&email=" + email;
+            workerClient.sendTemplateEmail(tenantId, email, "user.password_reset",
+                    Map.of(
+                            "tenantName", tenantName,
+                            "firstName", firstName == null ? "" : firstName,
+                            "actionUrl", actionUrl,
+                            "expiresIn", "1 hour"),
+                    "PASSWORD_RESET", null);
             log.info("Password reset email queued for {}", email);
         } catch (Exception e) {
-            // Log but don't fail the reset request — prevent email enumeration
             log.error("Failed to send password reset email to {}: {}", email, e.getMessage());
+        }
+    }
+
+    private void sendPasswordChangedEmail(String userId) {
+        try {
+            var rows = jdbcTemplate.queryForList(
+                    "SELECT pu.email, pu.first_name, pu.tenant_id, t.name AS tenant_name "
+                            + "FROM platform_user pu JOIN tenant t ON t.id = pu.tenant_id "
+                            + "WHERE pu.id = ?",
+                    userId
+            );
+            if (rows.isEmpty()) return;
+            var row = rows.get(0);
+            workerClient.sendTemplateEmail(
+                    (String) row.get("tenant_id"),
+                    (String) row.get("email"),
+                    "user.password_changed",
+                    Map.of(
+                            "tenantName", row.getOrDefault("tenant_name", "Kelta"),
+                            "firstName",  row.getOrDefault("first_name", ""),
+                            "changedAt",  Instant.now().toString(),
+                            "ipAddress",  "unknown"),
+                    "PASSWORD_CHANGED", userId);
+        } catch (Exception e) {
+            log.warn("Failed to send password-changed notification: {}", e.getMessage());
         }
     }
 }

--- a/kelta-auth/src/main/java/io/kelta/auth/service/PasswordPolicyService.java
+++ b/kelta-auth/src/main/java/io/kelta/auth/service/PasswordPolicyService.java
@@ -33,11 +33,17 @@ public class PasswordPolicyService {
 
     private final JdbcTemplate jdbcTemplate;
     private final PasswordEncoder passwordEncoder;
+    private final WorkerClient workerClient;
+    private final io.kelta.auth.config.AuthProperties authProperties;
     private Set<String> commonPasswords = Set.of();
 
-    public PasswordPolicyService(JdbcTemplate jdbcTemplate, PasswordEncoder passwordEncoder) {
+    public PasswordPolicyService(JdbcTemplate jdbcTemplate, PasswordEncoder passwordEncoder,
+                                  WorkerClient workerClient,
+                                  io.kelta.auth.config.AuthProperties authProperties) {
         this.jdbcTemplate = jdbcTemplate;
         this.passwordEncoder = passwordEncoder;
+        this.workerClient = workerClient;
+        this.authProperties = authProperties;
     }
 
     @PostConstruct
@@ -275,7 +281,34 @@ public class PasswordPolicyService {
                 );
                 log.warn("Account locked for user {}: {} failed attempts, locked until {}",
                         userId, attempts, lockedUntil);
+                sendAccountLockedEmail(userId, lockedUntil);
             }
+        }
+    }
+
+    private void sendAccountLockedEmail(String userId, Instant lockedUntil) {
+        try {
+            var rows = jdbcTemplate.queryForList(
+                    "SELECT pu.email, pu.first_name, pu.tenant_id, t.name AS tenant_name "
+                            + "FROM platform_user pu JOIN tenant t ON t.id = pu.tenant_id "
+                            + "WHERE pu.id = ?",
+                    userId
+            );
+            if (rows.isEmpty()) return;
+            var row = rows.get(0);
+            String resetUrl = authProperties.getUiBaseUrl() + "/forgot-password";
+            workerClient.sendTemplateEmail(
+                    (String) row.get("tenant_id"),
+                    (String) row.get("email"),
+                    "user.account_locked",
+                    java.util.Map.of(
+                            "tenantName", row.getOrDefault("tenant_name", "Kelta"),
+                            "firstName",  row.getOrDefault("first_name", ""),
+                            "unlockAt",   lockedUntil.toString(),
+                            "actionUrl",  resetUrl),
+                    "ACCOUNT_LOCKED", userId);
+        } catch (Exception e) {
+            log.warn("Failed to send account-locked notification for {}: {}", userId, e.getMessage());
         }
     }
 

--- a/kelta-auth/src/main/java/io/kelta/auth/service/TotpService.java
+++ b/kelta-auth/src/main/java/io/kelta/auth/service/TotpService.java
@@ -50,11 +50,15 @@ public class TotpService {
     private final CodeVerifier codeVerifier;
     private final SecureRandom secureRandom;
 
+    private final WorkerClient workerClient;
+
     public TotpService(JdbcTemplate jdbcTemplate, PasswordEncoder passwordEncoder,
-                       @org.springframework.beans.factory.annotation.Autowired(required = false) EncryptionService encryptionService) {
+                       @org.springframework.beans.factory.annotation.Autowired(required = false) EncryptionService encryptionService,
+                       WorkerClient workerClient) {
         this.jdbcTemplate = jdbcTemplate;
         this.passwordEncoder = passwordEncoder;
         this.encryptionService = encryptionService;
+        this.workerClient = workerClient;
         this.secretGenerator = new DefaultSecretGenerator();
         this.codeVerifier = new DefaultCodeVerifier(
                 new DefaultCodeGenerator(HashingAlgorithm.SHA1),
@@ -200,11 +204,36 @@ public class TotpService {
             throw new IllegalArgumentException("Invalid TOTP code");
         }
         deleteMfaData(userId);
+        sendMfaDisabledEmail(userId);
     }
 
     public void resetMfa(String userId) {
         deleteMfaData(userId);
+        sendMfaDisabledEmail(userId);
         log.info("MFA reset by admin for user {}", userId);
+    }
+
+    private void sendMfaDisabledEmail(String userId) {
+        try {
+            var rows = jdbcTemplate.queryForList(
+                    "SELECT pu.email, pu.first_name, pu.tenant_id, t.name AS tenant_name "
+                            + "FROM platform_user pu JOIN tenant t ON t.id = pu.tenant_id "
+                            + "WHERE pu.id = ?",
+                    userId);
+            if (rows.isEmpty()) return;
+            var row = rows.get(0);
+            workerClient.sendTemplateEmail(
+                    (String) row.get("tenant_id"),
+                    (String) row.get("email"),
+                    "user.mfa_disabled",
+                    java.util.Map.of(
+                            "tenantName", row.getOrDefault("tenant_name", "Kelta"),
+                            "firstName",  row.getOrDefault("first_name", ""),
+                            "changedAt",  java.time.Instant.now().toString()),
+                    "MFA_DISABLED", userId);
+        } catch (Exception e) {
+            log.warn("Failed to send MFA-disabled notification for {}: {}", userId, e.getMessage());
+        }
     }
 
     private void deleteMfaData(String userId) {

--- a/kelta-auth/src/main/java/io/kelta/auth/service/WorkerClient.java
+++ b/kelta-auth/src/main/java/io/kelta/auth/service/WorkerClient.java
@@ -79,6 +79,38 @@ public class WorkerClient {
         }
     }
 
+    /**
+     * Sends an email using a stable {@code templateKey} resolved by the worker
+     * (tenant override or system default) with {@code ${var}} substitution.
+     *
+     * @return true when the worker accepted the request (template existed and was queued).
+     */
+    public boolean sendTemplateEmail(String tenantId, String to, String templateKey,
+                                     Map<String, Object> vars, String source, String sourceId) {
+        try {
+            Map<String, Object> requestBody = new java.util.LinkedHashMap<>();
+            requestBody.put("tenantId", tenantId);
+            requestBody.put("to", to);
+            requestBody.put("templateKey", templateKey);
+            requestBody.put("vars", vars == null ? Map.of() : vars);
+            if (source != null)   requestBody.put("source", source);
+            if (sourceId != null) requestBody.put("sourceId", sourceId);
+
+            restClient.post()
+                    .uri("/api/internal/email/send-template")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header("X-Internal-Token", internalToken)
+                    .body(requestBody)
+                    .retrieve()
+                    .body(JsonNode.class);
+            return true;
+        } catch (Exception e) {
+            log.error("Failed to send template email via worker: to={}, key={}, error={}",
+                    to, templateKey, e.getMessage());
+            return false;
+        }
+    }
+
     public record OidcProviderInfo(
             String id, String name, String issuer, String jwksUri, String audience,
             String clientId, String clientSecretEnc,

--- a/kelta-auth/src/test/java/io/kelta/auth/controller/MfaControllerTest.java
+++ b/kelta-auth/src/test/java/io/kelta/auth/controller/MfaControllerTest.java
@@ -37,7 +37,8 @@ class MfaControllerTest {
 
     @BeforeEach
     void setUp() {
-        controller = new MfaController(totpService);
+        controller = new MfaController(totpService, mock(io.kelta.auth.service.WorkerClient.class),
+                mock(org.springframework.jdbc.core.JdbcTemplate.class));
         lenient().when(request.getSession(false)).thenReturn(session);
     }
 
@@ -71,7 +72,8 @@ class MfaControllerTest {
         @Test
         @DisplayName("redirects to login when TOTP service is null")
         void redirectsWhenTotpServiceNull() {
-            MfaController controllerNoTotp = new MfaController(null);
+            MfaController controllerNoTotp = new MfaController(null, mock(io.kelta.auth.service.WorkerClient.class),
+                    mock(org.springframework.jdbc.core.JdbcTemplate.class));
 
             String result = controllerNoTotp.showMfaChallenge(session, new ConcurrentModel());
 

--- a/kelta-auth/src/test/java/io/kelta/auth/service/PasswordPolicyServiceTest.java
+++ b/kelta-auth/src/test/java/io/kelta/auth/service/PasswordPolicyServiceTest.java
@@ -24,7 +24,9 @@ class PasswordPolicyServiceTest {
     void setUp() {
         jdbcTemplate = mock(JdbcTemplate.class);
         passwordEncoder = new BCryptPasswordEncoder();
-        service = new PasswordPolicyService(jdbcTemplate, passwordEncoder);
+        service = new PasswordPolicyService(jdbcTemplate, passwordEncoder,
+                mock(io.kelta.auth.service.WorkerClient.class),
+                mock(io.kelta.auth.config.AuthProperties.class));
     }
 
     @Nested

--- a/kelta-auth/src/test/java/io/kelta/auth/service/TotpServiceTest.java
+++ b/kelta-auth/src/test/java/io/kelta/auth/service/TotpServiceTest.java
@@ -35,7 +35,8 @@ class TotpServiceTest {
 
     @BeforeEach
     void setUp() {
-        totpService = new TotpService(jdbcTemplate, passwordEncoder, encryptionService);
+        totpService = new TotpService(jdbcTemplate, passwordEncoder, encryptionService,
+                mock(io.kelta.auth.service.WorkerClient.class));
     }
 
     @Nested

--- a/kelta-platform/runtime/runtime-module-integration/src/main/java/io/kelta/runtime/module/integration/spi/EmailService.java
+++ b/kelta-platform/runtime/runtime-module-integration/src/main/java/io/kelta/runtime/module/integration/spi/EmailService.java
@@ -1,13 +1,15 @@
 package io.kelta.runtime.module.integration.spi;
 
+import java.util.Map;
 import java.util.Optional;
 
 /**
- * SPI interface for email operations used by the EmailAlertActionHandler.
+ * SPI interface for email operations used by the EmailAlertActionHandler and
+ * platform lifecycle code (user invite, password reset, MFA notifications, etc.).
  *
- * <p>Implementations provide email template lookup and email queuing functionality.
- * The host application provides the real implementation backed by a database and
- * mail sender. A no-op logging implementation is provided for testing.
+ * <p>Implementations provide template lookup, variable substitution, and email
+ * queuing. The host application provides the real implementation backed by a
+ * database and mail sender. A no-op logging implementation is provided for testing.
  *
  * @since 1.0.0
  */
@@ -34,6 +36,22 @@ public interface EmailService {
      */
     String queueEmail(String tenantId, String to, String subject, String body,
                       String source, String sourceId);
+
+    /**
+     * Looks up a template by stable {@code templateKey} (tenant override or
+     * platform default), substitutes {@code ${var}} placeholders from {@code vars},
+     * and queues the result.
+     *
+     * @param tenantId    owning tenant
+     * @param to          recipient email address
+     * @param templateKey stable key (e.g. "user.invite")
+     * @param vars        variables for {@code ${name}} substitution in subject + body
+     * @param source      source tag for {@code email_log} (e.g. "USER_INVITE")
+     * @param sourceId    optional source row id (e.g. user id)
+     * @return the generated email log id; empty if the template is missing
+     */
+    Optional<String> sendByKey(String tenantId, String to, String templateKey,
+                               Map<String, Object> vars, String source, String sourceId);
 
     /**
      * Email template data.

--- a/kelta-platform/runtime/runtime-module-integration/src/main/java/io/kelta/runtime/module/integration/spi/noop/LoggingEmailService.java
+++ b/kelta-platform/runtime/runtime-module-integration/src/main/java/io/kelta/runtime/module/integration/spi/noop/LoggingEmailService.java
@@ -4,6 +4,7 @@ import io.kelta.runtime.module.integration.spi.EmailService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -30,5 +31,14 @@ public class LoggingEmailService implements EmailService {
         log.info("[NOOP] EmailService.queueEmail: id={}, tenant={}, to={}, subject='{}', source={}",
             id, tenantId, to, subject, source);
         return id;
+    }
+
+    @Override
+    public Optional<String> sendByKey(String tenantId, String to, String templateKey,
+                                      Map<String, Object> vars, String source, String sourceId) {
+        String id = UUID.randomUUID().toString();
+        log.info("[NOOP] EmailService.sendByKey: id={}, tenant={}, to={}, key={}, source={}",
+            id, tenantId, to, templateKey, source);
+        return Optional.of(id);
     }
 }

--- a/kelta-platform/runtime/runtime-module-integration/src/test/java/io/kelta/runtime/module/integration/IntegrationModuleTest.java
+++ b/kelta-platform/runtime/runtime-module-integration/src/test/java/io/kelta/runtime/module/integration/IntegrationModuleTest.java
@@ -99,6 +99,10 @@ class IntegrationModuleTest {
             @Override public String queueEmail(String t, String to, String s, String b, String src, String sid) {
                 return "custom-email-id";
             }
+            @Override public java.util.Optional<String> sendByKey(String t, String to, String key,
+                    java.util.Map<String, Object> vars, String src, String sid) {
+                return java.util.Optional.of("custom-email-id");
+            }
         };
         ScriptExecutor customScript = new ScriptExecutor() {
             @Override public java.util.Optional<ScriptInfo> getScript(String id) {

--- a/kelta-worker/src/main/java/io/kelta/worker/config/EmailConfig.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/config/EmailConfig.java
@@ -3,9 +3,11 @@ package io.kelta.worker.config;
 import io.kelta.runtime.context.TenantPropagatingExecutors;
 import io.kelta.runtime.module.integration.spi.EmailService;
 import io.kelta.worker.repository.EmailRepository;
+import io.kelta.worker.service.credential.CredentialResolver;
 import io.kelta.worker.service.email.DefaultEmailService;
 import io.kelta.worker.service.email.EmailProvider;
 import io.kelta.worker.service.email.SmtpEmailProvider;
+import org.springframework.beans.factory.ObjectProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -16,6 +18,7 @@ import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.Executor;
 
@@ -34,7 +37,7 @@ public class EmailConfig {
 
     @Bean
     @ConditionalOnProperty(name = "kelta.email.enabled", havingValue = "true", matchIfMissing = true)
-    public EmailProvider emailProvider(
+    public SmtpEmailProvider smtpEmailProvider(
             JavaMailSender javaMailSender,
             @Value("${kelta.email.from-address:noreply@kelta.io}") String fromAddress,
             @Value("${kelta.email.from-name:Kelta Platform}") String fromName) {
@@ -43,13 +46,22 @@ public class EmailConfig {
 
     @Bean
     @ConditionalOnProperty(name = "kelta.email.enabled", havingValue = "true", matchIfMissing = true)
+    public EmailProvider emailProvider(SmtpEmailProvider smtpEmailProvider) {
+        return smtpEmailProvider;
+    }
+
+    @Bean
+    @ConditionalOnProperty(name = "kelta.email.enabled", havingValue = "true", matchIfMissing = true)
     public DefaultEmailService defaultEmailService(
             EmailProvider emailProvider,
             EmailRepository emailRepository,
+            ObjectProvider<CredentialResolver> credentialResolverProvider,
             @Value("${kelta.email.from-address:noreply@kelta.io}") String fromAddress,
             @Value("${kelta.email.from-name:Kelta Platform}") String fromName,
             @Value("${kelta.email.enabled:true}") boolean enabled) {
-        return new DefaultEmailService(emailProvider, emailRepository, fromAddress, fromName, enabled);
+        return new DefaultEmailService(emailProvider, emailRepository,
+                credentialResolverProvider.getIfAvailable(),
+                fromAddress, fromName, enabled);
     }
 
     /**
@@ -72,6 +84,13 @@ public class EmailConfig {
                                      String source, String sourceId) {
                 log.debug("Email disabled — dropping email to {} (subject: {})", to, subject);
                 return "disabled";
+            }
+
+            @Override
+            public Optional<String> sendByKey(String tenantId, String to, String templateKey,
+                                              Map<String, Object> vars, String source, String sourceId) {
+                log.debug("Email disabled — dropping templated email to {} (key: {})", to, templateKey);
+                return Optional.of("disabled");
             }
         };
     }

--- a/kelta-worker/src/main/java/io/kelta/worker/config/FlowConfig.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/config/FlowConfig.java
@@ -341,6 +341,16 @@ public class FlowConfig {
         return hook;
     }
 
+    @Bean
+    public io.kelta.worker.listener.TenantEmailConfigEventPublisher tenantEmailConfigEventPublisher(
+            BeforeSaveHookRegistry hookRegistry,
+            PlatformEventPublisher eventPublisher) {
+        io.kelta.worker.listener.TenantEmailConfigEventPublisher hook =
+                new io.kelta.worker.listener.TenantEmailConfigEventPublisher(eventPublisher);
+        hookRegistry.register(hook);
+        return hook;
+    }
+
     // ---------------------------------------------------------------------------
     // OpenAPI spec library — parser bean + NATS broadcast on spec changes
     // ---------------------------------------------------------------------------

--- a/kelta-worker/src/main/java/io/kelta/worker/config/NatsSubscriptionConfig.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/config/NatsSubscriptionConfig.java
@@ -12,6 +12,7 @@ import io.kelta.worker.listener.SearchIndexListener;
 import io.kelta.worker.listener.SupersetCollectionSyncListener;
 import io.kelta.worker.listener.SvixWebhookPublisher;
 import io.kelta.worker.listener.SystemFeatureCacheInvalidationListener;
+import io.kelta.worker.listener.TenantEmailCacheInvalidationListener;
 import io.kelta.worker.module.ModuleEventListener;
 import jakarta.annotation.PostConstruct;
 import org.slf4j.Logger;
@@ -53,6 +54,9 @@ public class NatsSubscriptionConfig {
 
     @Autowired(required = false)
     private SvixWebhookPublisher svixWebhookPublisher;
+
+    @Autowired(required = false)
+    private TenantEmailCacheInvalidationListener tenantEmailCacheInvalidationListener;
 
     public NatsSubscriptionConfig(NatsSubscriptionManager subscriptionManager,
                                    FlowEventListener flowEventListener,
@@ -148,9 +152,23 @@ public class NatsSubscriptionConfig {
             log.info("Registered NATS subscription for Svix webhook publisher");
         }
 
+        // Tenant email config invalidation — every pod evicts its
+        // SmtpEmailProvider sender cache when tenant email columns change,
+        // and broadly when any credential rotates (small cache, cheap to refill).
+        if (tenantEmailCacheInvalidationListener != null) {
+            subscriptionManager.register(EventSubscription.broadcast(
+                    "worker-tenant-email", "kelta.config.tenant.email.changed.>",
+                    tenantEmailCacheInvalidationListener::handleTenantEmailChanged));
+            subscriptionManager.register(EventSubscription.broadcast(
+                    "worker-tenant-email-credential", "kelta.config.credential.changed.>",
+                    tenantEmailCacheInvalidationListener::handleCredentialChanged));
+            log.info("Registered NATS subscriptions for tenant email cache invalidation");
+        }
+
         log.info("Registered {} worker NATS subscriptions", 9
                 + (credentialCacheInvalidationListener != null ? 1 : 0)
                 + (supersetCollectionSyncListener != null ? 1 : 0)
-                + (svixWebhookPublisher != null ? 1 : 0));
+                + (svixWebhookPublisher != null ? 1 : 0)
+                + (tenantEmailCacheInvalidationListener != null ? 2 : 0));
     }
 }

--- a/kelta-worker/src/main/java/io/kelta/worker/controller/AdminInviteController.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/controller/AdminInviteController.java
@@ -1,0 +1,44 @@
+package io.kelta.worker.controller;
+
+import io.kelta.runtime.context.TenantContext;
+import io.kelta.worker.service.UserInviteService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+/**
+ * Admin endpoint to re-send (or first-send) the {@code user.invite} email for a
+ * specific user. Useful when the original invite expired or never arrived.
+ */
+@RestController
+@RequestMapping("/api/admin/users")
+public class AdminInviteController {
+
+    private static final Logger log = LoggerFactory.getLogger(AdminInviteController.class);
+
+    private final UserInviteService userInviteService;
+
+    public AdminInviteController(UserInviteService userInviteService) {
+        this.userInviteService = userInviteService;
+    }
+
+    @PostMapping("/{userId}/invite")
+    public ResponseEntity<Map<String, String>> invite(@PathVariable String userId) {
+        String tenantId = TenantContext.get();
+        if (tenantId == null || tenantId.isBlank()) {
+            return ResponseEntity.badRequest().body(Map.of("error", "Tenant context required"));
+        }
+        String token = userInviteService.inviteUser(tenantId, userId);
+        if (token == null) {
+            return ResponseEntity.status(404).body(Map.of("error", "User not found"));
+        }
+        log.info("Admin re-invite issued for user {} in tenant {}", userId, tenantId);
+        return ResponseEntity.ok(Map.of("status", "QUEUED"));
+    }
+}

--- a/kelta-worker/src/main/java/io/kelta/worker/controller/InternalEmailController.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/controller/InternalEmailController.java
@@ -47,23 +47,22 @@ public class InternalEmailController {
             String sourceId
     ) {}
 
+    public record SendTemplateRequest(
+            @NotBlank String tenantId,
+            @NotBlank @Email String to,
+            @NotBlank String templateKey,
+            Map<String, Object> vars,
+            String source,
+            String sourceId
+    ) {}
+
     @PostMapping("/send")
     public ResponseEntity<Map<String, String>> sendEmail(
             @RequestHeader(value = "X-Internal-Token", required = false) String token,
             @Valid @RequestBody SendEmailRequest request) {
 
-        // Validate internal token
-        if (internalToken == null || internalToken.isBlank()) {
-            log.warn("Internal email endpoint called but kelta.internal.token is not configured");
-            return ResponseEntity.status(HttpStatus.FORBIDDEN)
-                    .body(Map.of("error", "Internal token not configured"));
-        }
-
-        if (!internalToken.equals(token)) {
-            log.warn("Internal email endpoint called with invalid token");
-            return ResponseEntity.status(HttpStatus.FORBIDDEN)
-                    .body(Map.of("error", "Invalid internal token"));
-        }
+        ResponseEntity<Map<String, String>> denial = checkInternalToken(token);
+        if (denial != null) return denial;
 
         String emailLogId = emailService.queueEmail(
                 request.tenantId(),
@@ -78,5 +77,35 @@ public class InternalEmailController {
                 "emailLogId", emailLogId,
                 "status", "QUEUED"
         ));
+    }
+
+    @PostMapping("/send-template")
+    public ResponseEntity<Map<String, String>> sendTemplate(
+            @RequestHeader(value = "X-Internal-Token", required = false) String token,
+            @Valid @RequestBody SendTemplateRequest request) {
+
+        ResponseEntity<Map<String, String>> denial = checkInternalToken(token);
+        if (denial != null) return denial;
+
+        return emailService.sendByKey(
+                request.tenantId(), request.to(), request.templateKey(),
+                request.vars(), request.source(), request.sourceId())
+                .map(id -> ResponseEntity.ok(Map.of("emailLogId", id, "status", "QUEUED")))
+                .orElseGet(() -> ResponseEntity.status(HttpStatus.NOT_FOUND)
+                        .body(Map.of("error", "Template not found: " + request.templateKey())));
+    }
+
+    private ResponseEntity<Map<String, String>> checkInternalToken(String token) {
+        if (internalToken == null || internalToken.isBlank()) {
+            log.warn("Internal email endpoint called but kelta.internal.token is not configured");
+            return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body(Map.of("error", "Internal token not configured"));
+        }
+        if (!internalToken.equals(token)) {
+            log.warn("Internal email endpoint called with invalid token");
+            return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body(Map.of("error", "Invalid internal token"));
+        }
+        return null;
     }
 }

--- a/kelta-worker/src/main/java/io/kelta/worker/filter/LoginTrackingFilter.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/filter/LoginTrackingFilter.java
@@ -6,6 +6,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import io.kelta.runtime.module.integration.spi.EmailService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
@@ -69,18 +70,29 @@ public class LoginTrackingFilter extends OncePerRequestFilter {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     private final JdbcTemplate jdbcTemplate;
+    private final EmailService emailService;
+    private final String uiBaseUrl;
 
     /** Maps "tenantId:email" to the epoch-second of the last tracking write. */
     private final Map<String, Long> lastTrackedAt;
 
     @Autowired
-    public LoginTrackingFilter(JdbcTemplate jdbcTemplate) {
-        this(jdbcTemplate, new ConcurrentHashMap<>());
+    public LoginTrackingFilter(JdbcTemplate jdbcTemplate,
+                                EmailService emailService,
+                                @org.springframework.beans.factory.annotation.Value("${kelta.external-base-url:}") String uiBaseUrl) {
+        this(jdbcTemplate, emailService, uiBaseUrl, new ConcurrentHashMap<>());
     }
 
     /** Constructor for testing — allows injecting the throttle cache. */
     LoginTrackingFilter(JdbcTemplate jdbcTemplate, Map<String, Long> lastTrackedAt) {
+        this(jdbcTemplate, null, null, lastTrackedAt);
+    }
+
+    LoginTrackingFilter(JdbcTemplate jdbcTemplate, EmailService emailService,
+                         String uiBaseUrl, Map<String, Long> lastTrackedAt) {
         this.jdbcTemplate = jdbcTemplate;
+        this.emailService = emailService;
+        this.uiBaseUrl = uiBaseUrl;
         this.lastTrackedAt = lastTrackedAt;
     }
 
@@ -319,9 +331,43 @@ public class LoginTrackingFilter extends OncePerRequestFilter {
     }
 
     private void updateUserLoginInfo(String userId, Timestamp ts) {
+        boolean firstLogin = false;
+        try {
+            Object last = jdbcTemplate.queryForObject(
+                    "SELECT welcomed_at FROM platform_user WHERE id = ?",
+                    Object.class, userId);
+            firstLogin = (last == null);
+        } catch (Exception ignored) {
+            // Older schemas may not have welcomed_at — skip the welcome path.
+        }
         jdbcTemplate.update(
                 "UPDATE platform_user SET last_login_at = ?, login_count = COALESCE(login_count, 0) + 1, updated_at = ? WHERE id = ?",
                 ts, ts, userId);
+
+        if (firstLogin && emailService != null) {
+            try {
+                var rows = jdbcTemplate.queryForList(
+                        "SELECT pu.email, pu.first_name, pu.tenant_id, t.name AS tenant_name "
+                                + "FROM platform_user pu JOIN tenant t ON t.id = pu.tenant_id "
+                                + "WHERE pu.id = ?", userId);
+                if (!rows.isEmpty()) {
+                    var row = rows.get(0);
+                    emailService.sendByKey(
+                            (String) row.get("tenant_id"),
+                            (String) row.get("email"),
+                            "user.welcome",
+                            Map.of(
+                                    "tenantName", row.getOrDefault("tenant_name", "Kelta"),
+                                    "firstName",  row.getOrDefault("first_name", ""),
+                                    "actionUrl",  uiBaseUrl == null ? "" : uiBaseUrl),
+                            "WELCOME", userId);
+                    jdbcTemplate.update(
+                            "UPDATE platform_user SET welcomed_at = ? WHERE id = ?", ts, userId);
+                }
+            } catch (Exception e) {
+                log.warn("Failed to send welcome email for {}: {}", userId, e.getMessage());
+            }
+        }
     }
 
     private void insertLoginHistory(String userId, String tenantId, Timestamp ts,

--- a/kelta-worker/src/main/java/io/kelta/worker/listener/TenantEmailCacheInvalidationListener.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/listener/TenantEmailCacheInvalidationListener.java
@@ -1,0 +1,61 @@
+package io.kelta.worker.listener;
+
+import io.kelta.worker.service.email.SmtpEmailProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Subscribes to {@code kelta.config.tenant.email.changed.>} and evicts the
+ * {@link SmtpEmailProvider} sender cache for the affected tenant.
+ *
+ * <p>Also subscribes to {@code kelta.config.credential.changed.>} and clears
+ * <em>all</em> tenant senders when any credential changes — we don't track
+ * which tenants reference a given credential, and the cache is small (max 100,
+ * 5-min TTL), so a broad eviction is cheaper than maintaining the index.
+ */
+@Component
+@ConditionalOnProperty(name = "kelta.email.enabled", havingValue = "true", matchIfMissing = true)
+public class TenantEmailCacheInvalidationListener {
+
+    private static final Logger log = LoggerFactory.getLogger(TenantEmailCacheInvalidationListener.class);
+
+    private final SmtpEmailProvider smtpEmailProvider;
+    private final ObjectMapper objectMapper;
+
+    public TenantEmailCacheInvalidationListener(SmtpEmailProvider smtpEmailProvider,
+                                                 ObjectMapper objectMapper) {
+        this.smtpEmailProvider = smtpEmailProvider;
+        this.objectMapper = objectMapper;
+    }
+
+    public void handleTenantEmailChanged(String message) {
+        try {
+            JsonNode root = objectMapper.readTree(message);
+            JsonNode payload = root.get("payload");
+            if (payload == null || payload.isNull()) {
+                payload = root;
+            }
+            JsonNode tenantNode = payload.get("tenantId");
+            if (tenantNode == null || !tenantNode.isTextual()) {
+                log.warn("Skipping tenant-email invalidation: payload missing tenantId");
+                return;
+            }
+            String tenantId = tenantNode.stringValue();
+            log.info("Tenant {} email config changed — evicting SMTP sender cache", tenantId);
+            smtpEmailProvider.evictTenant(tenantId);
+        } catch (Exception e) {
+            log.error("Failed to process tenant email changed event: {}", e.getMessage(), e);
+        }
+    }
+
+    public void handleCredentialChanged(String message) {
+        // Coarse: any credential change drops all tenant senders.
+        // Cheap because cache is small and senders re-init lazily on the next send.
+        smtpEmailProvider.evictAll();
+        log.debug("Credential changed — evicted all tenant SMTP sender caches");
+    }
+}

--- a/kelta-worker/src/main/java/io/kelta/worker/listener/TenantEmailConfigEventPublisher.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/listener/TenantEmailConfigEventPublisher.java
@@ -1,0 +1,76 @@
+package io.kelta.worker.listener;
+
+import io.kelta.runtime.event.EventFactory;
+import io.kelta.runtime.event.PlatformEvent;
+import io.kelta.runtime.event.PlatformEventPublisher;
+import io.kelta.runtime.workflow.BeforeSaveHook;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Publishes {@code kelta.config.tenant.email.changed.<tenantId>} whenever the
+ * email-related columns on a {@code tenants} row change (or any other tenant
+ * write — we don't bother filtering since the listener side is cheap).
+ *
+ * <p>Workers consume the event and evict their per-tenant
+ * {@link io.kelta.worker.service.email.SmtpEmailProvider} sender cache so the
+ * next outbound mail picks up the new host / credentials / from-overrides.
+ */
+public class TenantEmailConfigEventPublisher implements BeforeSaveHook {
+
+    private static final Logger log = LoggerFactory.getLogger(TenantEmailConfigEventPublisher.class);
+    static final String SUBJECT_PREFIX = "kelta.config.tenant.email.changed.";
+    private static final String EVENT_TYPE = "kelta.config.tenant.email.changed";
+
+    private final PlatformEventPublisher eventPublisher;
+
+    public TenantEmailConfigEventPublisher(PlatformEventPublisher eventPublisher) {
+        this.eventPublisher = eventPublisher;
+    }
+
+    @Override public String getCollectionName() { return "tenants"; }
+    @Override public int getOrder() { return 200; }   // run after provisioning/audit hooks
+
+    @Override
+    public void afterUpdate(String id, Map<String, Object> record,
+                             Map<String, Object> previous, String tenantId) {
+        if (!emailFieldChanged(record, previous)) {
+            return;
+        }
+        publish(id);
+    }
+
+    @Override
+    public void afterDelete(String id, String tenantId) {
+        publish(id);
+    }
+
+    private boolean emailFieldChanged(Map<String, Object> record, Map<String, Object> previous) {
+        if (previous == null) return true;
+        for (String field : new String[]{
+                "emailSmtpCredentialId", "emailFromAddress", "emailFromName"}) {
+            if (record.containsKey(field) && !Objects.equals(record.get(field), previous.get(field))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void publish(String tenantId) {
+        if (tenantId == null) {
+            log.warn("Skipping tenant email config event: tenant id is null");
+            return;
+        }
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("tenantId", tenantId);
+        PlatformEvent<Map<String, Object>> event = EventFactory.createEvent(EVENT_TYPE, payload);
+        event.setTenantId(tenantId);
+        String subject = SUBJECT_PREFIX + tenantId;
+        log.info("Publishing tenant email config changed event for {} to '{}'", tenantId, subject);
+        eventPublisher.publish(subject, event);
+    }
+}

--- a/kelta-worker/src/main/java/io/kelta/worker/repository/EmailRepository.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/repository/EmailRepository.java
@@ -47,6 +47,24 @@ public class EmailRepository {
         return results.isEmpty() ? Optional.empty() : Optional.of(results.get(0));
     }
 
+    /**
+     * Resolves a template by its stable {@code template_key} (e.g. "user.invite").
+     * Prefers the tenant's own override; falls back to the {@code 'system'} tenant's
+     * default. Returns empty when no template exists for the key in either scope.
+     */
+    public Optional<Map<String, Object>> findTemplateByKey(String tenantId, String templateKey) {
+        var rows = jdbcTemplate.queryForList(
+                "SELECT id, subject, body_html, body_text, tenant_id "
+                        + "FROM email_template "
+                        + "WHERE template_key = ? AND is_active = true "
+                        + "  AND tenant_id IN (?, 'system') "
+                        + "ORDER BY CASE WHEN tenant_id = ? THEN 0 ELSE 1 END "
+                        + "LIMIT 1",
+                templateKey, tenantId, tenantId
+        );
+        return rows.isEmpty() ? Optional.empty() : Optional.of(rows.get(0));
+    }
+
     // -----------------------------------------------------------------------
     // Email Log
     // -----------------------------------------------------------------------
@@ -127,4 +145,54 @@ public class EmailRepository {
             return null;
         }
     }
+
+    /**
+     * Loads the tenant's structured email config (vault FK + from overrides + legacy JSONB).
+     * The legacy JSONB blob is still returned so callers can fall back when no credential is set.
+     *
+     * @return the config row, or null if the tenant does not exist
+     */
+    public TenantEmailConfigRow findTenantEmailConfig(String tenantId) {
+        var rows = jdbcTemplate.queryForList(
+                "SELECT email_smtp_credential_id, email_from_address, email_from_name, "
+                        + "auto_invite_on_create, settings "
+                        + "FROM tenant WHERE id = ?",
+                tenantId
+        );
+        if (rows.isEmpty()) {
+            return null;
+        }
+        var row = rows.get(0);
+        JsonNode legacy = null;
+        Object settings = row.get("settings");
+        if (settings != null) {
+            try {
+                legacy = settings instanceof String s
+                        ? objectMapper.readTree(s)
+                        : objectMapper.valueToTree(settings);
+            } catch (Exception ignored) {
+                // legacy JSONB unreadable — treat as absent
+            }
+        }
+        Object autoInvite = row.get("auto_invite_on_create");
+        return new TenantEmailConfigRow(
+                (String) row.get("email_smtp_credential_id"),
+                (String) row.get("email_from_address"),
+                (String) row.get("email_from_name"),
+                autoInvite instanceof Boolean b ? b : true,
+                legacy
+        );
+    }
+
+    /**
+     * Tenant-level email configuration row. Decryption of the credential
+     * happens elsewhere via {@code CredentialResolver}.
+     */
+    public record TenantEmailConfigRow(
+            String smtpCredentialId,
+            String fromAddress,
+            String fromName,
+            boolean autoInviteOnCreate,
+            JsonNode legacySettings
+    ) {}
 }

--- a/kelta-worker/src/main/java/io/kelta/worker/scim/service/ScimUserService.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/scim/service/ScimUserService.java
@@ -36,9 +36,13 @@ public class ScimUserService {
 
     private final JdbcTemplate jdbcTemplate;
     private final ScimFilterParser filterParser;
+    private final io.kelta.worker.service.UserInviteService userInviteService;
 
-    public ScimUserService(JdbcTemplate jdbcTemplate) {
+    public ScimUserService(JdbcTemplate jdbcTemplate,
+                            @org.springframework.beans.factory.annotation.Autowired(required = false)
+                            io.kelta.worker.service.UserInviteService userInviteService) {
         this.jdbcTemplate = jdbcTemplate;
+        this.userInviteService = userInviteService;
         this.filterParser = new ScimFilterParser(USER_ATTR_MAP);
     }
 
@@ -115,6 +119,16 @@ public class ScimUserService {
                 id, tenantId, email, username, firstName, lastName, status, locale, timezone);
 
         log.info("SCIM: Created user {} ({}) in tenant {}", id, email, tenantId);
+
+        // Send invite (tenant can opt out via tenant.auto_invite_on_create=false).
+        if (userInviteService != null && "ACTIVE".equals(status)
+                && userInviteService.isAutoInviteEnabled(tenantId)) {
+            try {
+                userInviteService.inviteUser(tenantId, id);
+            } catch (Exception e) {
+                log.warn("SCIM: invite for newly-created user {} failed: {}", id, e.getMessage());
+            }
+        }
         return getUser(tenantId, id, baseUrl);
     }
 

--- a/kelta-worker/src/main/java/io/kelta/worker/service/UserInviteService.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/service/UserInviteService.java
@@ -1,0 +1,110 @@
+package io.kelta.worker.service;
+
+import io.kelta.runtime.module.integration.spi.EmailService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Generates an invite token for a user and queues the {@code user.invite}
+ * template email. The token piggy-backs on the existing {@code user_credential}
+ * reset-token columns — the accept-invite UI uses the same /reset-password
+ * endpoint to set the user's initial password.
+ *
+ * <p>Auto-triggered from {@code ScimUserService.createUser} when the tenant
+ * has {@code auto_invite_on_create=true}, and on demand from
+ * {@code POST /api/admin/users/{id}/invite} for re-sends.
+ */
+@Service
+public class UserInviteService {
+
+    private static final Logger log = LoggerFactory.getLogger(UserInviteService.class);
+    private static final Duration INVITE_EXPIRY = Duration.ofDays(7);
+
+    private final JdbcTemplate jdbcTemplate;
+    private final EmailService emailService;
+    private final String uiBaseUrl;
+
+    public UserInviteService(JdbcTemplate jdbcTemplate,
+                             EmailService emailService,
+                             @Value("${kelta.external-base-url:}") String uiBaseUrl) {
+        this.jdbcTemplate = jdbcTemplate;
+        this.emailService = emailService;
+        this.uiBaseUrl = uiBaseUrl;
+    }
+
+    /**
+     * Generates a fresh invite token, stores it on {@code user_credential},
+     * and queues the {@code user.invite} email.
+     *
+     * @return the generated invite token, or null if the user was not found.
+     */
+    public String inviteUser(String tenantId, String userId) {
+        var rows = jdbcTemplate.queryForList(
+                "SELECT pu.email, pu.first_name, t.name AS tenant_name "
+                        + "FROM platform_user pu JOIN tenant t ON t.id = pu.tenant_id "
+                        + "WHERE pu.id = ? AND pu.tenant_id = ?",
+                userId, tenantId);
+        if (rows.isEmpty()) {
+            log.warn("Cannot invite user — not found: tenant={}, user={}", tenantId, userId);
+            return null;
+        }
+        var row = rows.get(0);
+        String email     = (String) row.get("email");
+        String firstName = (String) row.getOrDefault("first_name", "");
+        String tenantName = (String) row.getOrDefault("tenant_name", "Kelta");
+
+        String token = UUID.randomUUID().toString();
+        Instant expiresAt = Instant.now().plus(INVITE_EXPIRY);
+
+        // Upsert a user_credential row holding the invite token. The
+        // /auth/password/reset endpoint validates this same column on accept.
+        int updated = jdbcTemplate.update(
+                "UPDATE user_credential SET reset_token = ?, reset_token_expires_at = ?, "
+                        + "force_change_on_login = true, updated_at = ? WHERE user_id = ?",
+                token, Timestamp.from(expiresAt), Timestamp.from(Instant.now()), userId);
+        if (updated == 0) {
+            jdbcTemplate.update(
+                    "INSERT INTO user_credential (id, user_id, password_hash, reset_token, "
+                            + "reset_token_expires_at, force_change_on_login, failed_attempts, "
+                            + "created_at, updated_at) "
+                            + "VALUES (?, ?, '', ?, ?, true, 0, NOW(), NOW())",
+                    UUID.randomUUID().toString(), userId, token, Timestamp.from(expiresAt));
+        }
+
+        String actionUrl = uiBaseUrl + "/accept-invite?token=" + token + "&email=" + email;
+        emailService.sendByKey(tenantId, email, "user.invite",
+                Map.of(
+                        "tenantName", tenantName,
+                        "firstName", firstName == null ? "" : firstName,
+                        "email", email,
+                        "actionUrl", actionUrl,
+                        "expiresIn", "7 days"),
+                "USER_INVITE", userId);
+
+        log.info("Invite queued for user {} in tenant {}", userId, tenantId);
+        return token;
+    }
+
+    /** Returns true when the tenant has not opted out of automatic invites on user create. */
+    public boolean isAutoInviteEnabled(String tenantId) {
+        try {
+            Boolean auto = jdbcTemplate.queryForObject(
+                    "SELECT auto_invite_on_create FROM tenant WHERE id = ?",
+                    Boolean.class, tenantId);
+            return auto == null || auto;
+        } catch (Exception e) {
+            log.debug("Falling back to auto-invite=true after lookup failure for {}: {}",
+                    tenantId, e.getMessage());
+            return true;
+        }
+    }
+}

--- a/kelta-worker/src/main/java/io/kelta/worker/service/email/DefaultEmailService.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/service/email/DefaultEmailService.java
@@ -1,50 +1,61 @@
 package io.kelta.worker.service.email;
 
-import tools.jackson.databind.JsonNode;
 import io.kelta.runtime.module.integration.spi.EmailService;
 import io.kelta.worker.repository.EmailRepository;
+import io.kelta.worker.repository.EmailRepository.TenantEmailConfigRow;
+import io.kelta.worker.service.credential.CredentialNotFoundException;
+import io.kelta.worker.service.credential.CredentialResolver;
+import io.kelta.worker.service.credential.ResolutionContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.annotation.Async;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Default implementation of the {@link EmailService} SPI.
  *
  * <p>Orchestrates email delivery by:
  * <ol>
- *   <li>Resolving per-tenant SMTP settings from {@code tenant.settings} JSONB</li>
- *   <li>Logging the email attempt to {@code email_log}</li>
- *   <li>Delegating delivery to the configured {@link EmailProvider}</li>
- *   <li>Updating the log with success/failure status</li>
+ *   <li>Resolving per-tenant SMTP settings — preferring the credential vault row
+ *       referenced by {@code tenant.email_smtp_credential_id}, falling back to
+ *       the legacy {@code tenant.settings.email} JSONB blob.</li>
+ *   <li>Logging the email attempt to {@code email_log}.</li>
+ *   <li>Delegating delivery to the configured {@link EmailProvider}.</li>
+ *   <li>Updating the log with success/failure status.</li>
  * </ol>
  *
- * <p>Email delivery is asynchronous via {@code @Async("emailExecutor")} to avoid
- * blocking the calling thread. Failures are logged gracefully — the caller
- * receives the log ID immediately and never sees a delivery exception.
+ * <p>Delivery is asynchronous via {@code @Async("emailExecutor")} to avoid
+ * blocking the caller. Failures are logged but never raised back to the caller.
  *
  * @since 1.0.0
  */
 public class DefaultEmailService implements EmailService {
 
     private static final Logger log = LoggerFactory.getLogger(DefaultEmailService.class);
+    private static final Pattern VAR_PATTERN = Pattern.compile("\\$\\{([a-zA-Z0-9_.]+)\\}");
 
     private final EmailProvider emailProvider;
     private final EmailRepository emailRepository;
+    private final CredentialResolver credentialResolver;
     private final String platformFromAddress;
     private final String platformFromName;
     private final boolean enabled;
 
     public DefaultEmailService(EmailProvider emailProvider,
                                EmailRepository emailRepository,
+                               CredentialResolver credentialResolver,
                                String platformFromAddress,
                                String platformFromName,
                                boolean enabled) {
         this.emailProvider = emailProvider;
         this.emailRepository = emailRepository;
+        this.credentialResolver = credentialResolver;
         this.platformFromAddress = platformFromAddress;
         this.platformFromName = platformFromName;
         this.enabled = enabled;
@@ -52,7 +63,6 @@ public class DefaultEmailService implements EmailService {
 
     @Override
     public Optional<EmailTemplate> getTemplate(String templateId) {
-        // TenantContext provides the current tenant ID via thread-local
         String tenantId = io.kelta.runtime.context.TenantContext.get();
         if (tenantId == null) {
             log.warn("No tenant context available for template lookup");
@@ -74,14 +84,42 @@ public class DefaultEmailService implements EmailService {
             return UUID.randomUUID().toString();
         }
 
-        // Create log entry immediately (synchronous — gives caller the ID)
         String logId = emailRepository.createEmailLog(tenantId, to, subject, source, sourceId);
-
-        // Resolve tenant settings and send asynchronously
         TenantEmailSettings tenantSettings = resolveTenantSettings(tenantId);
         sendAsync(logId, to, subject, body, tenantSettings);
-
         return logId;
+    }
+
+    @Override
+    public Optional<String> sendByKey(String tenantId, String to, String templateKey,
+                                      Map<String, Object> vars, String source, String sourceId) {
+        var templateRow = emailRepository.findTemplateByKey(tenantId, templateKey);
+        if (templateRow.isEmpty()) {
+            log.warn("No template found for key '{}' (tenant {} or system fallback)", templateKey, tenantId);
+            return Optional.empty();
+        }
+        Map<String, Object> safeVars = vars == null ? Map.of() : vars;
+        String subject = substitute((String) templateRow.get().get("subject"), safeVars);
+        String body    = substitute((String) templateRow.get().get("body_html"), safeVars);
+        return Optional.of(queueEmail(tenantId, to, subject, body, source, sourceId));
+    }
+
+    /**
+     * Replaces {@code ${name}} placeholders in {@code template} with values from {@code vars}.
+     * Unknown variables are left untouched so the message is still readable when a caller forgets
+     * a key — and the gap is obvious in QA.
+     */
+    static String substitute(String template, Map<String, Object> vars) {
+        if (template == null) return null;
+        Matcher m = VAR_PATTERN.matcher(template);
+        StringBuilder out = new StringBuilder();
+        while (m.find()) {
+            Object value = vars.get(m.group(1));
+            m.appendReplacement(out, Matcher.quoteReplacement(
+                    value == null ? m.group(0) : value.toString()));
+        }
+        m.appendTail(out);
+        return out.toString();
     }
 
     @Async("emailExecutor")
@@ -110,8 +148,47 @@ public class DefaultEmailService implements EmailService {
 
     private TenantEmailSettings resolveTenantSettings(String tenantId) {
         try {
-            JsonNode settings = emailRepository.getTenantSettings(tenantId);
-            return TenantEmailSettings.fromJsonNode(settings);
+            TenantEmailConfigRow row = emailRepository.findTenantEmailConfig(tenantId);
+            if (row == null) {
+                return null;
+            }
+            if (row.smtpCredentialId() != null && credentialResolver != null) {
+                try {
+                    var resolved = credentialResolver.resolve(
+                            tenantId,
+                            row.smtpCredentialId(),
+                            ResolutionContext.forUser(null, "EMAIL_SEND"));
+                    return TenantEmailSettings.fromCredential(
+                            tenantId,
+                            resolved.secretFields(),
+                            new HashMap<>(resolved.metadataFields()),
+                            row.fromAddress(),
+                            row.fromName());
+                } catch (CredentialNotFoundException e) {
+                    log.warn("Tenant {} references missing SMTP credential {} — falling back",
+                            tenantId, row.smtpCredentialId());
+                }
+            }
+            // Legacy JSONB or From-only override
+            TenantEmailSettings legacy = row.legacySettings() == null
+                    ? null
+                    : TenantEmailSettings.fromJsonNode(tenantId, row.legacySettings());
+            if (legacy == null && row.fromAddress() == null && row.fromName() == null) {
+                return null;
+            }
+            String fromAddr = row.fromAddress() != null ? row.fromAddress()
+                    : (legacy != null ? legacy.fromAddress() : null);
+            String fromName = row.fromName() != null ? row.fromName()
+                    : (legacy != null ? legacy.fromName() : null);
+            return new TenantEmailSettings(
+                    tenantId,
+                    legacy != null ? legacy.smtpHost() : null,
+                    legacy != null ? legacy.smtpPort() : 587,
+                    legacy != null ? legacy.smtpUsername() : null,
+                    legacy != null ? legacy.smtpPassword() : null,
+                    legacy == null || legacy.smtpStartTls(),
+                    fromAddr,
+                    fromName);
         } catch (Exception e) {
             log.warn("Failed to load tenant email settings for tenant {}: {}", tenantId, e.getMessage());
             return null;

--- a/kelta-worker/src/main/java/io/kelta/worker/service/email/SmtpEmailProvider.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/service/email/SmtpEmailProvider.java
@@ -78,9 +78,10 @@ public class SmtpEmailProvider implements EmailProvider {
 
         } catch (MailAuthenticationException e) {
             // Invalidate cached sender on auth failure — credentials may have changed
-            if (tenantSettings != null && tenantSettings.hasSmtpOverride()) {
-                tenantSenderCache.invalidate(tenantSettings.smtpHost() + ":" + tenantSettings.smtpPort());
-                log.warn("SMTP auth failed for tenant SMTP host {}, cache invalidated", tenantSettings.smtpHost());
+            if (tenantSettings != null && tenantSettings.hasSmtpOverride() && tenantSettings.tenantId() != null) {
+                tenantSenderCache.invalidate(tenantSettings.tenantId());
+                log.warn("SMTP auth failed for tenant {} (host {}), sender cache invalidated",
+                        tenantSettings.tenantId(), tenantSettings.smtpHost());
             }
             throw new EmailDeliveryException("SMTP authentication failed for host " + resolveSmtpHost(tenantSettings), e);
         } catch (MailException e) {
@@ -104,9 +105,28 @@ public class SmtpEmailProvider implements EmailProvider {
         if (tenantSettings == null || !tenantSettings.hasSmtpOverride()) {
             return platformMailSender;
         }
-
-        String cacheKey = tenantSettings.smtpHost() + ":" + tenantSettings.smtpPort();
+        // Key by tenantId so config-change events can evict per tenant without
+        // needing to know the previous host:port pair.
+        String cacheKey = tenantSettings.tenantId() != null
+                ? tenantSettings.tenantId()
+                : tenantSettings.smtpHost() + ":" + tenantSettings.smtpPort();
         return tenantSenderCache.get(cacheKey, key -> createTenantSender(tenantSettings));
+    }
+
+    /**
+     * Drops the cached tenant sender for {@code tenantId}. Invoked by the NATS
+     * listener when {@code tenant.email_*} columns or the SMTP credential change.
+     */
+    public void evictTenant(String tenantId) {
+        if (tenantId == null) return;
+        tenantSenderCache.invalidate(tenantId);
+        log.debug("Evicted SMTP sender cache for tenant {}", tenantId);
+    }
+
+    /** Drops all cached tenant senders. Intended for credential rotations. */
+    public void evictAll() {
+        tenantSenderCache.invalidateAll();
+        log.debug("Evicted all tenant SMTP sender caches");
     }
 
     private JavaMailSenderImpl createTenantSender(TenantEmailSettings settings) {

--- a/kelta-worker/src/main/java/io/kelta/worker/service/email/TenantEmailSettings.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/service/email/TenantEmailSettings.java
@@ -2,33 +2,30 @@ package io.kelta.worker.service.email;
 
 import tools.jackson.databind.JsonNode;
 
+import java.util.Map;
+
 /**
- * Per-tenant email configuration extracted from the tenant.settings JSONB column.
+ * Per-tenant email configuration. Sourced (in order of preference) from:
+ * <ol>
+ *   <li>A {@code smtp}-typed row in the credential vault (encrypted at rest), referenced
+ *       by {@code tenant.email_smtp_credential_id}.</li>
+ *   <li>The legacy {@code tenant.settings.email.smtp} JSONB blob (plaintext — deprecated;
+ *       read-only, no new writes go here).</li>
+ *   <li>Null — meaning the platform default applies.</li>
+ * </ol>
  *
- * <p>Tenants can override the platform SMTP defaults by storing email settings
- * in their tenant.settings JSON under the {@code "email"} key:
- * <pre>{@code
- * {
- *   "email": {
- *     "smtp": {
- *       "host": "smtp.tenant.com",
- *       "port": 587,
- *       "username": "user",
- *       "password": "secret",
- *       "startTls": true
- *     },
- *     "fromAddress": "no-reply@tenant.com",
- *     "fromName": "Tenant Co"
- *   }
- * }
- * }</pre>
+ * <p>From-address and From-name come from typed columns ({@code tenant.email_from_address},
+ * {@code tenant.email_from_name}) and override the platform default when set.
  *
- * <p>Any field left unset falls back to platform defaults. The {@code smtpPassword}
- * is deliberately excluded from {@link #toString()} to prevent credential leakage in logs.
+ * <p>{@code tenantId} is carried alongside so the SMTP provider can key its sender
+ * cache per-tenant and invalidate cleanly on config change.
+ *
+ * <p>{@link #toString()} masks {@code smtpPassword} to prevent credential leakage in logs.
  *
  * @since 1.0.0
  */
 public record TenantEmailSettings(
+        String tenantId,
         String smtpHost,
         int smtpPort,
         String smtpUsername,
@@ -53,12 +50,14 @@ public record TenantEmailSettings(
     }
 
     /**
-     * Parses tenant email settings from the tenant.settings JSONB.
+     * Parses tenant email settings from the legacy tenant.settings JSONB blob.
+     * Prefer {@link #fromCredential(String, Map, Map, String, String)} for new credential-backed config.
      *
+     * @param tenantId     the tenant id (carried for cache keying)
      * @param settingsJson the root settings JSON node from the tenant table
      * @return parsed settings, or {@code null} if no email section exists
      */
-    public static TenantEmailSettings fromJsonNode(JsonNode settingsJson) {
+    public static TenantEmailSettings fromJsonNode(String tenantId, JsonNode settingsJson) {
         if (settingsJson == null || !settingsJson.has("email")) {
             return null;
         }
@@ -67,6 +66,7 @@ public record TenantEmailSettings(
         JsonNode smtp = email.has("smtp") ? email.get("smtp") : null;
 
         return new TenantEmailSettings(
+                tenantId,
                 smtp != null ? textOrNull(smtp, "host") : null,
                 smtp != null ? intOrDefault(smtp, "port", 587) : 587,
                 smtp != null ? textOrNull(smtp, "username") : null,
@@ -78,12 +78,58 @@ public record TenantEmailSettings(
     }
 
     /**
+     * Builds tenant email settings from a credential-vault SMTP record plus optional
+     * From overrides from typed tenant columns.
+     *
+     * <p>The SMTP type stores {@code host/port/useStartTls/useTls/fromAddress} in
+     * metadata (plaintext) and {@code username/password} in the encrypted secret blob.
+     *
+     * @param tenantId            the tenant id (carried for cache keying)
+     * @param secrets             decrypted secret fields (username, password)
+     * @param metadata            plaintext credential metadata (host, port, useStartTls, ...)
+     * @param fromAddressOverride tenant-level override for the From address (may be null)
+     * @param fromNameOverride    tenant-level override for the From display name (may be null)
+     */
+    public static TenantEmailSettings fromCredential(String tenantId,
+                                                     Map<String, Object> secrets,
+                                                     Map<String, Object> metadata,
+                                                     String fromAddressOverride,
+                                                     String fromNameOverride) {
+        if (metadata == null) metadata = Map.of();
+        if (secrets == null)  secrets  = Map.of();
+
+        Object hostObj   = metadata.get("host");
+        Object portObj   = metadata.get("port");
+        Object tlsObj    = metadata.getOrDefault("useStartTls", Boolean.TRUE);
+        Object fromMeta  = metadata.get("fromAddress");
+
+        String host = hostObj == null ? null : hostObj.toString();
+        int port = 587;
+        if (portObj instanceof Number n) port = n.intValue();
+        else if (portObj != null) {
+            try { port = Integer.parseInt(portObj.toString()); } catch (NumberFormatException ignored) {}
+        }
+        boolean startTls = !(tlsObj instanceof Boolean b) || b;
+
+        String username = secrets.get("username") == null ? null : secrets.get("username").toString();
+        String password = secrets.get("password") == null ? null : secrets.get("password").toString();
+
+        String fromAddress = fromAddressOverride != null && !fromAddressOverride.isBlank()
+                ? fromAddressOverride
+                : (fromMeta == null ? null : fromMeta.toString());
+
+        return new TenantEmailSettings(tenantId, host, port, username, password, startTls,
+                fromAddress, fromNameOverride);
+    }
+
+    /**
      * Masks smtpPassword to prevent credential leakage in logs, error messages, and toString output.
      */
     @Override
     public String toString() {
         return "TenantEmailSettings[" +
-                "smtpHost=" + smtpHost +
+                "tenantId=" + tenantId +
+                ", smtpHost=" + smtpHost +
                 ", smtpPort=" + smtpPort +
                 ", smtpUsername=" + smtpUsername +
                 ", smtpPassword=****" +

--- a/kelta-worker/src/main/resources/application-migrate.yml
+++ b/kelta-worker/src/main/resources/application-migrate.yml
@@ -6,6 +6,7 @@ spring:
     enabled: true
     baseline-on-migrate: true
     baseline-version: 0
+    placeholder-replacement: false   # see comment in application.yml
   main:
     web-application-type: none   # no HTTP server — process exits after ApplicationRunners complete
   autoconfigure:

--- a/kelta-worker/src/main/resources/application.yml
+++ b/kelta-worker/src/main/resources/application.yml
@@ -17,6 +17,10 @@ spring:
     enabled: false   # migrations run via K8s PreSync Job (application-migrate.yml re-enables)
     baseline-on-migrate: true
     baseline-version: 0
+    # Kelta migrations never use Flyway ${} placeholders; seed SQL for
+    # email_template intentionally stores ${variable} as data for runtime
+    # substitution, which would otherwise trip placeholder validation.
+    placeholder-replacement: false
   data:
     redis:
       host: ${SPRING_DATA_REDIS_HOST:localhost}

--- a/kelta-worker/src/main/resources/db/migration/V133__add_template_key_and_seed_defaults.sql
+++ b/kelta-worker/src/main/resources/db/migration/V133__add_template_key_and_seed_defaults.sql
@@ -1,0 +1,99 @@
+-- V133: Template-by-key lookup + system-default lifecycle templates.
+--
+-- Adds a stable `template_key` column to `email_template` so lifecycle code
+-- can fetch a template without storing a UUID in source. Seeds eight default
+-- templates under tenant_id='system'; tenant-owned rows with the same key
+-- take precedence at lookup time.
+
+ALTER TABLE email_template
+    ADD COLUMN IF NOT EXISTS template_key VARCHAR(100);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_email_template_tenant_key
+    ON email_template(tenant_id, template_key)
+    WHERE template_key IS NOT NULL;
+
+COMMENT ON COLUMN email_template.template_key IS
+    'Stable identifier used by lifecycle code to look up a template (e.g. user.invite). '
+    'NULL for ad-hoc workflow-only templates. Unique per tenant when set.';
+
+-- Sentinel "system" tenant that owns the platform default templates.
+-- Real tenants override by inserting a row with the same template_key and their tenant_id.
+INSERT INTO tenant (id, slug, name, status, created_at, updated_at)
+    VALUES ('system', 'system', 'System', 'ACTIVE', NOW(), NOW())
+    ON CONFLICT (id) DO NOTHING;
+
+-- Also need a platform_user 'system' for the created_by FK constraint.
+INSERT INTO platform_user (id, tenant_id, email, username, first_name, last_name, status, created_at, updated_at)
+    VALUES ('system', 'system', 'system@kelta.io', 'system', 'System', 'User', 'ACTIVE', NOW(), NOW())
+    ON CONFLICT (id) DO NOTHING;
+
+-- Common header/footer wrapper is repeated inline rather than abstracted —
+-- tenants who override one template shouldn't be forced to inherit a global wrapper.
+
+INSERT INTO email_template
+    (id, tenant_id, template_key, name, subject, body_html, body_text, variables_schema, is_active, created_by, created_at, updated_at)
+VALUES
+    (gen_random_uuid()::text, 'system', 'user.invite',
+     'User Invite',
+     'You''re invited to ${tenantName}',
+     '<!doctype html><html><body style="font-family:system-ui,sans-serif;max-width:600px;margin:0 auto;padding:24px;color:#1a1a1a"><h2>Welcome to ${tenantName}</h2><p>Hi ${firstName},</p><p>You''ve been invited to join <strong>${tenantName}</strong> on Kelta. Click the button below to set your password and activate your account.</p><p style="margin:32px 0"><a href="${actionUrl}" style="background:#0066ff;color:#fff;padding:12px 24px;border-radius:6px;text-decoration:none;display:inline-block">Accept invite</a></p><p style="color:#666;font-size:14px">This invitation expires in ${expiresIn}. If the button doesn''t work, copy this link into your browser:<br><span style="word-break:break-all">${actionUrl}</span></p></body></html>',
+     'Welcome to ${tenantName}\n\nHi ${firstName},\n\nYou''ve been invited to join ${tenantName} on Kelta. Visit the link below to set your password and activate your account.\n\n${actionUrl}\n\nThis invitation expires in ${expiresIn}.',
+     '{"type":"object","properties":{"tenantName":{"type":"string"},"firstName":{"type":"string"},"email":{"type":"string"},"actionUrl":{"type":"string"},"expiresIn":{"type":"string"}},"required":["tenantName","firstName","actionUrl"]}'::jsonb,
+     true, 'system', NOW(), NOW()),
+
+    (gen_random_uuid()::text, 'system', 'user.password_reset',
+     'Password Reset Request',
+     'Reset your ${tenantName} password',
+     '<!doctype html><html><body style="font-family:system-ui,sans-serif;max-width:600px;margin:0 auto;padding:24px;color:#1a1a1a"><h2>Reset your password</h2><p>Hi ${firstName},</p><p>We received a request to reset the password for your ${tenantName} account. Click the button below to choose a new one.</p><p style="margin:32px 0"><a href="${actionUrl}" style="background:#0066ff;color:#fff;padding:12px 24px;border-radius:6px;text-decoration:none;display:inline-block">Reset password</a></p><p style="color:#666;font-size:14px">This link expires in ${expiresIn}. If you didn''t request a reset, ignore this email.</p></body></html>',
+     'Reset your password\n\nHi ${firstName},\n\nWe received a request to reset the password for your ${tenantName} account. Visit the link below to choose a new one.\n\n${actionUrl}\n\nThis link expires in ${expiresIn}. If you didn''t request a reset, ignore this email.',
+     '{"type":"object","properties":{"tenantName":{"type":"string"},"firstName":{"type":"string"},"actionUrl":{"type":"string"},"expiresIn":{"type":"string"}},"required":["actionUrl"]}'::jsonb,
+     true, 'system', NOW(), NOW()),
+
+    (gen_random_uuid()::text, 'system', 'user.password_changed',
+     'Password Changed',
+     'Your ${tenantName} password was changed',
+     '<!doctype html><html><body style="font-family:system-ui,sans-serif;max-width:600px;margin:0 auto;padding:24px;color:#1a1a1a"><h2>Password changed</h2><p>Hi ${firstName},</p><p>The password for your ${tenantName} account was just changed.</p><p>If this was you, no further action is needed. If you didn''t change your password, contact your administrator immediately.</p><p style="color:#666;font-size:14px">When: ${changedAt}<br>From IP: ${ipAddress}</p></body></html>',
+     'Password changed\n\nHi ${firstName},\n\nThe password for your ${tenantName} account was just changed.\n\nIf this was you, no further action is needed. If you didn''t change your password, contact your administrator immediately.\n\nWhen: ${changedAt}\nFrom IP: ${ipAddress}',
+     '{"type":"object","properties":{"tenantName":{"type":"string"},"firstName":{"type":"string"},"changedAt":{"type":"string"},"ipAddress":{"type":"string"}}}'::jsonb,
+     true, 'system', NOW(), NOW()),
+
+    (gen_random_uuid()::text, 'system', 'user.email_verification',
+     'Verify your email',
+     'Verify your email for ${tenantName}',
+     '<!doctype html><html><body style="font-family:system-ui,sans-serif;max-width:600px;margin:0 auto;padding:24px;color:#1a1a1a"><h2>Verify your email</h2><p>Hi ${firstName},</p><p>Please confirm <strong>${email}</strong> is your email address for ${tenantName} by clicking the button below.</p><p style="margin:32px 0"><a href="${actionUrl}" style="background:#0066ff;color:#fff;padding:12px 24px;border-radius:6px;text-decoration:none;display:inline-block">Verify email</a></p><p style="color:#666;font-size:14px">This link expires in ${expiresIn}.</p></body></html>',
+     'Verify your email\n\nHi ${firstName},\n\nPlease confirm ${email} is your email address for ${tenantName} by visiting the link below.\n\n${actionUrl}\n\nThis link expires in ${expiresIn}.',
+     '{"type":"object","properties":{"tenantName":{"type":"string"},"firstName":{"type":"string"},"email":{"type":"string"},"actionUrl":{"type":"string"},"expiresIn":{"type":"string"}},"required":["email","actionUrl"]}'::jsonb,
+     true, 'system', NOW(), NOW()),
+
+    (gen_random_uuid()::text, 'system', 'user.mfa_enrolled',
+     'MFA Enabled',
+     'Two-factor authentication enabled on your ${tenantName} account',
+     '<!doctype html><html><body style="font-family:system-ui,sans-serif;max-width:600px;margin:0 auto;padding:24px;color:#1a1a1a"><h2>Two-factor authentication enabled</h2><p>Hi ${firstName},</p><p>Two-factor authentication was just enabled on your ${tenantName} account.</p><p>If this wasn''t you, contact your administrator immediately.</p><p style="color:#666;font-size:14px">When: ${changedAt}</p></body></html>',
+     'Two-factor authentication enabled\n\nHi ${firstName},\n\nTwo-factor authentication was just enabled on your ${tenantName} account.\n\nIf this wasn''t you, contact your administrator immediately.\n\nWhen: ${changedAt}',
+     '{"type":"object","properties":{"tenantName":{"type":"string"},"firstName":{"type":"string"},"changedAt":{"type":"string"}}}'::jsonb,
+     true, 'system', NOW(), NOW()),
+
+    (gen_random_uuid()::text, 'system', 'user.mfa_disabled',
+     'MFA Disabled',
+     'Two-factor authentication disabled on your ${tenantName} account',
+     '<!doctype html><html><body style="font-family:system-ui,sans-serif;max-width:600px;margin:0 auto;padding:24px;color:#1a1a1a"><h2>Two-factor authentication disabled</h2><p>Hi ${firstName},</p><p>Two-factor authentication was just removed from your ${tenantName} account. Your account is now protected by password only.</p><p>If this wasn''t you, contact your administrator immediately and re-enable MFA.</p><p style="color:#666;font-size:14px">When: ${changedAt}</p></body></html>',
+     'Two-factor authentication disabled\n\nHi ${firstName},\n\nTwo-factor authentication was just removed from your ${tenantName} account. Your account is now protected by password only.\n\nIf this wasn''t you, contact your administrator immediately and re-enable MFA.\n\nWhen: ${changedAt}',
+     '{"type":"object","properties":{"tenantName":{"type":"string"},"firstName":{"type":"string"},"changedAt":{"type":"string"}}}'::jsonb,
+     true, 'system', NOW(), NOW()),
+
+    (gen_random_uuid()::text, 'system', 'user.account_locked',
+     'Account Locked',
+     'Your ${tenantName} account has been locked',
+     '<!doctype html><html><body style="font-family:system-ui,sans-serif;max-width:600px;margin:0 auto;padding:24px;color:#1a1a1a"><h2>Account locked</h2><p>Hi ${firstName},</p><p>Your ${tenantName} account has been locked after too many failed sign-in attempts.</p><p>The lock will be released at ${unlockAt}, or you can reset your password to unlock it sooner.</p><p style="margin:32px 0"><a href="${actionUrl}" style="background:#0066ff;color:#fff;padding:12px 24px;border-radius:6px;text-decoration:none;display:inline-block">Reset password</a></p></body></html>',
+     'Account locked\n\nHi ${firstName},\n\nYour ${tenantName} account has been locked after too many failed sign-in attempts.\n\nThe lock will be released at ${unlockAt}, or you can reset your password to unlock it sooner:\n\n${actionUrl}',
+     '{"type":"object","properties":{"tenantName":{"type":"string"},"firstName":{"type":"string"},"unlockAt":{"type":"string"},"actionUrl":{"type":"string"}}}'::jsonb,
+     true, 'system', NOW(), NOW()),
+
+    (gen_random_uuid()::text, 'system', 'user.welcome',
+     'Welcome',
+     'Welcome to ${tenantName}',
+     '<!doctype html><html><body style="font-family:system-ui,sans-serif;max-width:600px;margin:0 auto;padding:24px;color:#1a1a1a"><h2>Welcome to ${tenantName}</h2><p>Hi ${firstName},</p><p>Your account is now active. We''re glad to have you on board.</p><p style="margin:32px 0"><a href="${actionUrl}" style="background:#0066ff;color:#fff;padding:12px 24px;border-radius:6px;text-decoration:none;display:inline-block">Sign in</a></p></body></html>',
+     'Welcome to ${tenantName}\n\nHi ${firstName},\n\nYour account is now active. We''re glad to have you on board.\n\nSign in: ${actionUrl}',
+     '{"type":"object","properties":{"tenantName":{"type":"string"},"firstName":{"type":"string"},"actionUrl":{"type":"string"}}}'::jsonb,
+     true, 'system', NOW(), NOW())
+ON CONFLICT (tenant_id, template_key) WHERE template_key IS NOT NULL DO NOTHING;

--- a/kelta-worker/src/main/resources/db/migration/V134__tenant_email_credential_columns.sql
+++ b/kelta-worker/src/main/resources/db/migration/V134__tenant_email_credential_columns.sql
@@ -1,0 +1,27 @@
+-- V134: Tenant-level email columns backed by the credential vault.
+--
+-- Replaces the plaintext `tenant.settings.email.smtp` JSONB blob with a typed
+-- reference to a row in the encrypted `credential` table. The legacy JSONB
+-- path is still read (for back-compat) until V129+1 tenants migrate, but new
+-- writes go through the vault.
+
+ALTER TABLE tenant
+    ADD COLUMN IF NOT EXISTS email_smtp_credential_id VARCHAR(36)
+        REFERENCES credential(id) ON DELETE SET NULL,
+    ADD COLUMN IF NOT EXISTS email_from_address       VARCHAR(320),
+    ADD COLUMN IF NOT EXISTS email_from_name          VARCHAR(200),
+    ADD COLUMN IF NOT EXISTS auto_invite_on_create    BOOLEAN NOT NULL DEFAULT TRUE;
+
+COMMENT ON COLUMN tenant.email_smtp_credential_id IS
+    'FK to credential table (type=smtp). When set, overrides platform default SMTP. '
+    'NULL means the tenant uses the platform default mail server.';
+COMMENT ON COLUMN tenant.email_from_address IS
+    'Override for the From address on outbound mail (platform default applies when NULL).';
+COMMENT ON COLUMN tenant.email_from_name IS
+    'Override for the From display name on outbound mail.';
+COMMENT ON COLUMN tenant.auto_invite_on_create IS
+    'When true, a user.invite email is sent automatically on SCIM/admin user creation. '
+    'When false, invites must be sent manually via POST /admin/users/{id}/invite.';
+
+CREATE INDEX IF NOT EXISTS idx_tenant_email_smtp_credential
+    ON tenant(email_smtp_credential_id) WHERE email_smtp_credential_id IS NOT NULL;

--- a/kelta-worker/src/main/resources/db/migration/V135__add_email_verification_and_welcome_tracking.sql
+++ b/kelta-worker/src/main/resources/db/migration/V135__add_email_verification_and_welcome_tracking.sql
@@ -1,0 +1,20 @@
+-- V135: Per-user email verification + welcome-sent tracking.
+--
+-- email_verified flips to TRUE after the user clicks the verification link.
+-- welcomed_at is stamped after the user's first successful login so we only
+-- send the welcome email once.
+
+ALTER TABLE platform_user
+    ADD COLUMN IF NOT EXISTS email_verified                BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN IF NOT EXISTS email_verification_token      VARCHAR(64),
+    ADD COLUMN IF NOT EXISTS email_verification_expires_at TIMESTAMP WITH TIME ZONE,
+    ADD COLUMN IF NOT EXISTS welcomed_at                   TIMESTAMP WITH TIME ZONE;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_platform_user_email_verification_token
+    ON platform_user(email_verification_token)
+    WHERE email_verification_token IS NOT NULL;
+
+COMMENT ON COLUMN platform_user.email_verified IS
+    'TRUE once the user has confirmed ownership of their email address.';
+COMMENT ON COLUMN platform_user.welcomed_at IS
+    'Timestamp of the first successful login. Prevents the welcome email being sent twice.';

--- a/kelta-worker/src/test/java/io/kelta/worker/listener/TenantEmailCacheInvalidationListenerTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/listener/TenantEmailCacheInvalidationListenerTest.java
@@ -1,0 +1,47 @@
+package io.kelta.worker.listener;
+
+import io.kelta.worker.service.email.SmtpEmailProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+
+import static org.mockito.Mockito.*;
+
+@DisplayName("TenantEmailCacheInvalidationListener")
+class TenantEmailCacheInvalidationListenerTest {
+
+    private SmtpEmailProvider provider;
+    private TenantEmailCacheInvalidationListener listener;
+
+    @BeforeEach
+    void setUp() {
+        provider = mock(SmtpEmailProvider.class);
+        listener = new TenantEmailCacheInvalidationListener(provider, new ObjectMapper());
+    }
+
+    @Test
+    @DisplayName("Should evict per-tenant sender on tenant.email.changed")
+    void shouldEvictTenantOnEmailChanged() {
+        listener.handleTenantEmailChanged("""
+                {"type":"kelta.config.tenant.email.changed",
+                 "payload":{"tenantId":"tenant-42"}}""");
+        verify(provider).evictTenant("tenant-42");
+    }
+
+    @Test
+    @DisplayName("Should evict all senders when any credential changes")
+    void shouldEvictAllOnCredentialChange() {
+        listener.handleCredentialChanged("""
+                {"type":"kelta.config.credential.changed",
+                 "payload":{"id":"cred-1"}}""");
+        verify(provider).evictAll();
+    }
+
+    @Test
+    @DisplayName("Should swallow malformed messages")
+    void shouldSwallowBadMessages() {
+        listener.handleTenantEmailChanged("not-json");
+        verifyNoInteractions(provider);
+    }
+}

--- a/kelta-worker/src/test/java/io/kelta/worker/listener/TenantEmailConfigEventPublisherTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/listener/TenantEmailConfigEventPublisherTest.java
@@ -1,0 +1,62 @@
+package io.kelta.worker.listener;
+
+import io.kelta.runtime.event.PlatformEvent;
+import io.kelta.runtime.event.PlatformEventPublisher;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@DisplayName("TenantEmailConfigEventPublisher")
+class TenantEmailConfigEventPublisherTest {
+
+    private PlatformEventPublisher publisher;
+    private TenantEmailConfigEventPublisher hook;
+
+    @BeforeEach
+    void setUp() {
+        publisher = mock(PlatformEventPublisher.class);
+        hook = new TenantEmailConfigEventPublisher(publisher);
+    }
+
+    @Test
+    @DisplayName("Should publish when email columns change")
+    void shouldPublishOnEmailFieldChange() {
+        Map<String, Object> previous = new HashMap<>(Map.of(
+                "emailSmtpCredentialId", "old", "emailFromAddress", "a@x.com"));
+        Map<String, Object> updated = new HashMap<>(Map.of(
+                "emailSmtpCredentialId", "new", "emailFromAddress", "a@x.com"));
+
+        hook.afterUpdate("tenant-1", updated, previous, "tenant-1");
+
+        ArgumentCaptor<String> subject = ArgumentCaptor.forClass(String.class);
+        verify(publisher).publish(subject.capture(), any(PlatformEvent.class));
+        assertThat(subject.getValue()).isEqualTo("kelta.config.tenant.email.changed.tenant-1");
+    }
+
+    @Test
+    @DisplayName("Should skip when only non-email fields change")
+    void shouldSkipWhenOnlyOtherFieldsChange() {
+        Map<String, Object> previous = new HashMap<>(Map.of("name", "Acme"));
+        Map<String, Object> updated = new HashMap<>(Map.of("name", "Acme Corp"));
+
+        hook.afterUpdate("tenant-1", updated, previous, "tenant-1");
+
+        verify(publisher, never()).publish(any(), any());
+    }
+
+    @Test
+    @DisplayName("Should always publish on delete")
+    void shouldPublishOnDelete() {
+        hook.afterDelete("tenant-1", "tenant-1");
+        verify(publisher).publish(eq("kelta.config.tenant.email.changed.tenant-1"), any());
+    }
+}

--- a/kelta-worker/src/test/java/io/kelta/worker/scim/service/ScimUserServiceTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/scim/service/ScimUserServiceTest.java
@@ -28,7 +28,7 @@ class ScimUserServiceTest {
     @BeforeEach
     void setUp() {
         jdbcTemplate = mock(JdbcTemplate.class);
-        service = new ScimUserService(jdbcTemplate);
+        service = new ScimUserService(jdbcTemplate, null);
     }
 
     @Test

--- a/kelta-worker/src/test/java/io/kelta/worker/service/UserInviteServiceTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/service/UserInviteServiceTest.java
@@ -1,0 +1,85 @@
+package io.kelta.worker.service;
+
+import io.kelta.runtime.module.integration.spi.EmailService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@DisplayName("UserInviteService")
+class UserInviteServiceTest {
+
+    private JdbcTemplate jdbcTemplate;
+    private EmailService emailService;
+    private UserInviteService service;
+
+    @BeforeEach
+    void setUp() {
+        jdbcTemplate = mock(JdbcTemplate.class);
+        emailService = mock(EmailService.class);
+        service = new UserInviteService(jdbcTemplate, emailService, "https://ui.example.com");
+    }
+
+    @Test
+    @DisplayName("Should generate token, store it, and queue invite email")
+    void shouldGenerateAndSend() {
+        when(jdbcTemplate.queryForList(anyString(), eq("u1"), eq("t1")))
+                .thenReturn(List.of(Map.of(
+                        "email", "ada@example.com",
+                        "first_name", "Ada",
+                        "tenant_name", "Acme")));
+        when(jdbcTemplate.update(anyString(), any(), any(), any(), any())).thenReturn(1);
+        when(emailService.sendByKey(anyString(), anyString(), anyString(), any(), anyString(), any()))
+                .thenReturn(Optional.of("log-1"));
+
+        String token = service.inviteUser("t1", "u1");
+
+        assertThat(token).isNotNull();
+        ArgumentCaptor<Map<String, Object>> vars = ArgumentCaptor.forClass(Map.class);
+        verify(emailService).sendByKey(eq("t1"), eq("ada@example.com"), eq("user.invite"),
+                vars.capture(), eq("USER_INVITE"), eq("u1"));
+        assertThat(vars.getValue())
+                .containsEntry("firstName", "Ada")
+                .containsEntry("tenantName", "Acme")
+                .containsEntry("email", "ada@example.com");
+        assertThat((String) vars.getValue().get("actionUrl"))
+                .startsWith("https://ui.example.com/accept-invite?token=");
+    }
+
+    @Test
+    @DisplayName("Should return null when user is missing")
+    void shouldReturnNullWhenMissing() {
+        when(jdbcTemplate.queryForList(anyString(), eq("u1"), eq("t1")))
+                .thenReturn(List.of());
+
+        assertThat(service.inviteUser("t1", "u1")).isNull();
+        verifyNoInteractions(emailService);
+    }
+
+    @Test
+    @DisplayName("Should default auto-invite to true when tenant lookup fails")
+    void shouldDefaultAutoInviteTrueOnFailure() {
+        when(jdbcTemplate.queryForObject(anyString(), eq(Boolean.class), eq("t1")))
+                .thenThrow(new RuntimeException("boom"));
+        assertThat(service.isAutoInviteEnabled("t1")).isTrue();
+    }
+
+    @Test
+    @DisplayName("Should honour explicit auto-invite=false")
+    void shouldHonourExplicitFalse() {
+        when(jdbcTemplate.queryForObject(anyString(), eq(Boolean.class), eq("t1")))
+                .thenReturn(false);
+        assertThat(service.isAutoInviteEnabled("t1")).isFalse();
+    }
+}

--- a/kelta-worker/src/test/java/io/kelta/worker/service/email/DefaultEmailServiceTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/service/email/DefaultEmailServiceTest.java
@@ -1,18 +1,24 @@
 package io.kelta.worker.service.email;
 
-import tools.jackson.databind.JsonNode;
-import tools.jackson.databind.ObjectMapper;
+import io.kelta.runtime.credential.ResolvedCredential;
 import io.kelta.runtime.module.integration.spi.EmailService;
 import io.kelta.worker.repository.EmailRepository;
+import io.kelta.worker.repository.EmailRepository.TenantEmailConfigRow;
+import io.kelta.worker.service.credential.CredentialResolver;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import java.time.Instant;
 import java.util.Map;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.*;
 
 @DisplayName("DefaultEmailService")
@@ -20,14 +26,16 @@ class DefaultEmailServiceTest {
 
     private EmailProvider emailProvider;
     private EmailRepository emailRepository;
+    private CredentialResolver credentialResolver;
     private DefaultEmailService service;
 
     @BeforeEach
     void setUp() {
         emailProvider = mock(EmailProvider.class);
         emailRepository = mock(EmailRepository.class);
+        credentialResolver = mock(CredentialResolver.class);
         service = new DefaultEmailService(
-                emailProvider, emailRepository,
+                emailProvider, emailRepository, credentialResolver,
                 "noreply@kelta.io", "Kelta Platform", true);
     }
 
@@ -40,7 +48,7 @@ class DefaultEmailServiceTest {
         void shouldQueueWithPlatformDefaults() {
             when(emailRepository.createEmailLog("t1", "user@example.com", "Subject", "WORKFLOW", "flow-1"))
                     .thenReturn("log-123");
-            when(emailRepository.getTenantSettings("t1")).thenReturn(null);
+            when(emailRepository.findTenantEmailConfig("t1")).thenReturn(null);
 
             String logId = service.queueEmail("t1", "user@example.com", "Subject", "<p>Body</p>", "WORKFLOW", "flow-1");
 
@@ -49,19 +57,21 @@ class DefaultEmailServiceTest {
         }
 
         @Test
-        @DisplayName("Should resolve tenant settings when tenant has email overrides")
-        void shouldResolveTenantSettings() throws Exception {
-            ObjectMapper mapper = new ObjectMapper();
-            JsonNode settings = mapper.readTree("""
-                    {"email": {"smtp": {"host": "smtp.tenant.com", "port": 587}, "fromAddress": "noreply@tenant.com"}}
-                    """);
-
-            when(emailRepository.createEmailLog(anyString(), anyString(), anyString(), anyString(), anyString()))
-                    .thenReturn("log-456");
-            when(emailRepository.getTenantSettings("t2")).thenReturn(settings);
+        @DisplayName("Should resolve credential-backed tenant SMTP settings")
+        void shouldResolveCredentialBackedSettings() {
+            when(emailRepository.createEmailLog(anyString(), anyString(), anyString(), anyString(), any()))
+                    .thenReturn("log-cred");
+            when(emailRepository.findTenantEmailConfig("t2"))
+                    .thenReturn(new TenantEmailConfigRow("cred-1", "no-reply@tenant.com", "Tenant", true, null));
+            when(credentialResolver.resolve(eq("t2"), eq("cred-1"), any()))
+                    .thenReturn(new ResolvedCredential("cred-1", "smtp", "smtp",
+                            Map.of("username", "u", "password", "p"),
+                            Map.of("host", "smtp.tenant.com", "port", 587, "useStartTls", true),
+                            Instant.now()));
 
             service.queueEmail("t2", "user@test.com", "Hello", "<p>Hi</p>", "SYSTEM", null);
 
+            verify(credentialResolver).resolve(eq("t2"), eq("cred-1"), any());
             verify(emailRepository).createEmailLog("t2", "user@test.com", "Hello", "SYSTEM", null);
         }
 
@@ -69,14 +79,59 @@ class DefaultEmailServiceTest {
         @DisplayName("Should return dummy ID and skip delivery when disabled")
         void shouldSkipWhenDisabled() {
             DefaultEmailService disabledService = new DefaultEmailService(
-                    emailProvider, emailRepository,
+                    emailProvider, emailRepository, credentialResolver,
                     "noreply@kelta.io", "Kelta Platform", false);
 
             String logId = disabledService.queueEmail("t1", "user@test.com", "Subject", "Body", "TEST", null);
 
             assertThat(logId).isNotNull();
             verify(emailProvider, never()).send(any(), any());
-            verify(emailRepository, never()).createEmailLog(anyString(), anyString(), anyString(), anyString(), anyString());
+            verify(emailRepository, never()).createEmailLog(anyString(), anyString(), anyString(), anyString(), any());
+        }
+    }
+
+    @Nested
+    @DisplayName("sendByKey")
+    class SendByKey {
+
+        @Test
+        @DisplayName("Should substitute variables and queue using the resolved template")
+        void shouldSubstituteAndQueue() {
+            when(emailRepository.findTemplateByKey("t1", "user.invite"))
+                    .thenReturn(Optional.of(Map.of(
+                            "subject", "Welcome ${firstName}",
+                            "body_html", "<p>Hi ${firstName}, click ${actionUrl}</p>"
+                    )));
+            when(emailRepository.createEmailLog(anyString(), anyString(), anyString(), anyString(), any()))
+                    .thenReturn("log-99");
+
+            Optional<String> logId = service.sendByKey("t1", "u@x.com", "user.invite",
+                    Map.of("firstName", "Ada", "actionUrl", "https://x.com/accept"),
+                    "USER_INVITE", "user-1");
+
+            assertThat(logId).contains("log-99");
+            verify(emailRepository).createEmailLog("t1", "u@x.com",
+                    "Welcome Ada", "USER_INVITE", "user-1");
+        }
+
+        @Test
+        @DisplayName("Should leave unknown variables intact so missing keys are obvious")
+        void shouldLeaveUnknownVarsIntact() {
+            assertThat(DefaultEmailService.substitute(
+                    "${a} ${b}", Map.of("a", "1")))
+                    .isEqualTo("1 ${b}");
+        }
+
+        @Test
+        @DisplayName("Should return empty when no template found")
+        void shouldReturnEmptyWhenMissing() {
+            when(emailRepository.findTemplateByKey("t1", "missing"))
+                    .thenReturn(Optional.empty());
+
+            Optional<String> logId = service.sendByKey("t1", "u@x.com", "missing",
+                    Map.of(), "X", null);
+
+            assertThat(logId).isEmpty();
         }
     }
 
@@ -128,22 +183,6 @@ class DefaultEmailServiceTest {
                 assertThat(result).isPresent();
                 assertThat(result.get().subject()).isEqualTo("Welcome");
                 assertThat(result.get().bodyHtml()).isEqualTo("<p>Hello</p>");
-            } finally {
-                io.kelta.runtime.context.TenantContext.clear();
-            }
-        }
-
-        @Test
-        @DisplayName("Should return empty when template not found")
-        void shouldReturnEmptyWhenNotFound() {
-            io.kelta.runtime.context.TenantContext.set("t1");
-            try {
-                when(emailRepository.findTemplateByTenantAndId("t1", "missing"))
-                        .thenReturn(Optional.empty());
-
-                Optional<EmailService.EmailTemplate> result = service.getTemplate("missing");
-
-                assertThat(result).isEmpty();
             } finally {
                 io.kelta.runtime.context.TenantContext.clear();
             }

--- a/kelta-worker/src/test/java/io/kelta/worker/service/email/SmtpEmailProviderTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/service/email/SmtpEmailProviderTest.java
@@ -44,7 +44,7 @@ class SmtpEmailProviderTest {
     @DisplayName("Should resolve tenant SMTP host when tenant has overrides")
     void shouldResolveTenantSmtpHost() {
         TenantEmailSettings tenantSettings = new TenantEmailSettings(
-                "smtp.tenant.com", 587, "user", "pass", true, "noreply@tenant.com", "Tenant Co");
+                "tenant-1", "smtp.tenant.com", 587, "user", "pass", true, "noreply@tenant.com", "Tenant Co");
 
         assertThat(provider.resolveSmtpHost(tenantSettings)).isEqualTo("smtp.tenant.com");
     }
@@ -53,7 +53,7 @@ class SmtpEmailProviderTest {
     @DisplayName("Should fall back to platform host when tenant has no SMTP override")
     void shouldFallBackToPlatformHost() {
         TenantEmailSettings partial = new TenantEmailSettings(
-                null, 587, null, null, true, "custom@tenant.com", "Tenant");
+                "tenant-1", null, 587, null, null, true, "custom@tenant.com", "Tenant");
 
         assertThat(provider.resolveSmtpHost(partial)).isEqualTo("smtp.platform.io");
     }

--- a/kelta-worker/src/test/java/io/kelta/worker/service/email/TenantEmailSettingsTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/service/email/TenantEmailSettingsTest.java
@@ -30,7 +30,7 @@ class TenantEmailSettingsTest {
                 }
                 """);
 
-        TenantEmailSettings settings = TenantEmailSettings.fromJsonNode(json);
+        TenantEmailSettings settings = TenantEmailSettings.fromJsonNode("tenant-1", json);
 
         assertThat(settings).isNotNull();
         assertThat(settings.smtpHost()).isEqualTo("smtp.tenant.com");
@@ -51,13 +51,13 @@ class TenantEmailSettingsTest {
                 {"theme": "dark", "locale": "en"}
                 """);
 
-        assertThat(TenantEmailSettings.fromJsonNode(json)).isNull();
+        assertThat(TenantEmailSettings.fromJsonNode("tenant-1", json)).isNull();
     }
 
     @Test
     @DisplayName("Should return null for null JSON")
     void shouldReturnNullForNullJson() {
-        assertThat(TenantEmailSettings.fromJsonNode(null)).isNull();
+        assertThat(TenantEmailSettings.fromJsonNode("tenant-1", null)).isNull();
     }
 
     @Test
@@ -72,7 +72,7 @@ class TenantEmailSettingsTest {
                 }
                 """);
 
-        TenantEmailSettings settings = TenantEmailSettings.fromJsonNode(json);
+        TenantEmailSettings settings = TenantEmailSettings.fromJsonNode("tenant-1", json);
 
         assertThat(settings).isNotNull();
         assertThat(settings.hasSmtpOverride()).isFalse();
@@ -92,7 +92,7 @@ class TenantEmailSettingsTest {
                 }
                 """);
 
-        TenantEmailSettings settings = TenantEmailSettings.fromJsonNode(json);
+        TenantEmailSettings settings = TenantEmailSettings.fromJsonNode("tenant-1", json);
 
         String str = settings.toString();
         assertThat(str).doesNotContain("supersecret");


### PR DESCRIPTION
## Summary
- Lights up the eight default lifecycle templates seeded in #893 by sending them from the right place in each flow.
- New `UserInviteService` (worker) generates a 7-day invite token (piggybacked on `user_credential.reset_token`) and queues `user.invite`. SCIM user create auto-triggers when `tenant.auto_invite_on_create=true`; admins can re-send via `POST /api/admin/users/{id}/invite`.
- `PasswordController` (auth) drops the hardcoded HTML and routes through `user.password_reset` + `user.password_changed` templates.
- `PasswordPolicyService` sends `user.account_locked` when the failed-attempt threshold trips.
- `MfaController` / `TotpService` send `user.mfa_enrolled` and `user.mfa_disabled`.
- `LoginTrackingFilter` stamps `platform_user.welcomed_at` on first login and queues `user.welcome`.
- New `EmailVerificationController` (auth) provides `POST /auth/email/send-verification` and `GET /auth/email/verify`, backed by V135 columns (`email_verified`, `email_verification_token/expires_at`, `welcomed_at`).
- `InternalEmailController` exposes a new `/api/internal/email/send-template` endpoint; `WorkerClient` gains `sendTemplateEmail(...)`.

Depends on #893 (PR B). This branch is stacked on it.

## Test plan
- [x] Unit: UserInviteService (4) — pass.
- [x] Worker suite (1129) and auth suite (183) green.
- [ ] Post-merge: invite a new user via SCIM, confirm email arrives at https://mailpit.rzware.com and the accept-invite link sets a password.
- [ ] Trigger password reset → confirm email + completed-confirmation pair.
- [ ] Trip lockout (5 bad passwords) → confirm lockout email.
- [ ] Enable + disable MFA → confirm both notifications.
- [ ] First login → confirm welcome email + `welcomed_at` stamped (and second login does not re-send).

🤖 Generated with [Claude Code](https://claude.com/claude-code)