### PR TITLE
feat(ui): add detail rail blocks + auto-derive header meta + persist section state

### DIFF
--- a/kelta-ui/app/src/components/LayoutFieldSections/LayoutFieldSections.tsx
+++ b/kelta-ui/app/src/components/LayoutFieldSections/LayoutFieldSections.tsx
@@ -26,6 +26,12 @@ export interface LayoutFieldSectionsProps {
   tenantSlug?: string
   /** Lookup display map: { fieldName: { recordId: displayLabel } } */
   lookupDisplayMap?: Record<string, Record<string, string>>
+  /**
+   * Prefix for persisting per-section open state. When set, each section's
+   * collapsed state survives navigation/reload via localStorage. Usually
+   * the collection name.
+   */
+  persistKeyPrefix?: string
 }
 
 /**
@@ -84,6 +90,7 @@ export function LayoutFieldSections({
   record,
   tenantSlug,
   lookupDisplayMap,
+  persistKeyPrefix,
 }: LayoutFieldSectionsProps): React.ReactElement {
   // Build lookup maps once for efficient field resolution
   const { schemaFieldsByName, schemaFieldsById } = useMemo(() => {
@@ -124,6 +131,7 @@ export function LayoutFieldSections({
             lookupDisplayMap={lookupDisplayMap}
             defaultCollapsed={section.collapsed}
             columns={(section.columns as 1 | 2 | 3 | 4) || 2}
+            persistKey={persistKeyPrefix ? `${persistKeyPrefix}.${section.id}` : undefined}
           />
         )
       })}

--- a/kelta-ui/app/src/components/detail/AICard.tsx
+++ b/kelta-ui/app/src/components/detail/AICard.tsx
@@ -1,0 +1,77 @@
+/**
+ * AICard
+ *
+ * Cyan-tinted card with a brand-gradient icon tile, summary paragraph, and a
+ * row of small ghost-button AI actions. Matches the design handoff at
+ * `design_handoff_kelta_detail_layout/`.
+ */
+
+import React from 'react'
+import { Sparkles } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
+import { cn } from '@/lib/utils'
+
+export interface AIActionConfig {
+  label: string
+  icon?: React.ReactNode
+  onClick: () => void
+}
+
+export interface AICardConfig {
+  title: string
+  /** Markdown-free summary text */
+  summary: string
+  actions?: AIActionConfig[]
+}
+
+export function AICard({
+  config,
+  className,
+}: {
+  config: AICardConfig
+  className?: string
+}): React.ReactElement {
+  const { title, summary, actions = [] } = config
+
+  return (
+    <Card
+      data-component="AICard"
+      className={cn(
+        'relative overflow-hidden rounded-xl border border-border bg-card',
+        'before:pointer-events-none before:absolute before:inset-0 before:bg-[radial-gradient(circle_at_top_right,rgba(96,165,250,0.18),transparent_55%)]',
+        'after:pointer-events-none after:absolute after:inset-x-0 after:bottom-0 after:h-12 after:bg-gradient-to-t after:from-cyan-500/10 after:to-transparent',
+        className
+      )}
+    >
+      <CardContent className="relative space-y-3 px-5 py-4">
+        <div className="flex items-center gap-2">
+          <span
+            className="inline-flex h-6 w-6 items-center justify-center rounded-md kelta-brand-gradient text-white shadow-[0_6px_14px_-4px_rgba(59,130,246,0.5)]"
+            aria-hidden="true"
+          >
+            <Sparkles className="h-3.5 w-3.5" />
+          </span>
+          <span className="text-sm font-semibold text-foreground">{title}</span>
+        </div>
+        <p className="text-[13px] leading-[1.55] text-muted-foreground">{summary}</p>
+        {actions.length > 0 && (
+          <div className="flex flex-wrap gap-1.5 pt-1">
+            {actions.map((action, idx) => (
+              <Button
+                key={`${action.label}-${idx}`}
+                size="sm"
+                variant="ghost"
+                onClick={action.onClick}
+                className="h-7 px-2 text-[12px]"
+              >
+                {action.icon && <span className="mr-1 inline-flex">{action.icon}</span>}
+                {action.label}
+              </Button>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/kelta-ui/app/src/components/detail/AddressMap.tsx
+++ b/kelta-ui/app/src/components/detail/AddressMap.tsx
@@ -1,0 +1,153 @@
+/**
+ * AddressMap
+ *
+ * Composite field section: address fields on the left, stylized map
+ * placeholder on the right (radial gradient on slate + 28px dotted grid +
+ * teardrop pin). Real map provider integration (Mapbox / Google Maps) is
+ * a deliberate follow-up — see the handoff README.
+ */
+
+import React, { useState } from 'react'
+import { ChevronRight, MapPin } from 'lucide-react'
+import { Card } from '@/components/ui/card'
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
+import { FieldRenderer } from '@/components/FieldRenderer'
+import type { FieldDefinition } from '@/hooks/useCollectionSchema'
+import type { CollectionRecord } from '@/hooks/useCollectionRecords'
+import { cn } from '@/lib/utils'
+
+export interface AddressMapProps {
+  title: string
+  /**
+   * Address fields to display on the left side. The first field is rendered
+   * full-width (typically "Street"); the remainder flow into a 2-column grid.
+   */
+  fields: FieldDefinition[]
+  /** Record-name fields used to compose the map-pin chip label */
+  mapLabelFields?: string[]
+  record: CollectionRecord
+  tenantSlug?: string
+  lookupDisplayMap?: Record<string, Record<string, string>>
+  defaultCollapsed?: boolean
+}
+
+export function AddressMap({
+  title,
+  fields,
+  mapLabelFields = [],
+  record,
+  tenantSlug,
+  lookupDisplayMap,
+  defaultCollapsed = false,
+}: AddressMapProps): React.ReactElement | null {
+  const [isOpen, setIsOpen] = useState(!defaultCollapsed)
+
+  if (fields.length === 0) return null
+
+  const [streetField, ...restFields] = fields
+
+  const mapLabel = mapLabelFields
+    .map((f) => record[f])
+    .filter((v) => v !== null && v !== undefined && v !== '')
+    .map(String)
+    .join(', ')
+
+  return (
+    <Collapsible open={isOpen} onOpenChange={setIsOpen}>
+      <Card
+        data-component="AddressMap"
+        className="overflow-hidden rounded-xl border border-border bg-card"
+      >
+        <CollapsibleTrigger asChild>
+          <button
+            type="button"
+            className="flex w-full items-center gap-2 px-5 py-3.5 text-left transition-colors hover:bg-accent/30"
+            aria-expanded={isOpen}
+          >
+            <ChevronRight
+              className={cn('kelta-chev h-4 w-4 text-muted-foreground', isOpen && 'rotate-90')}
+              aria-hidden="true"
+            />
+            <span className="text-sm font-semibold text-foreground">{title}</span>
+          </button>
+        </CollapsibleTrigger>
+
+        <CollapsibleContent>
+          <div className="grid grid-cols-1 gap-6 border-t border-border px-5 py-5 lg:grid-cols-2">
+            <div className="kelta-field-grid">
+              {streetField && (
+                <div className="min-w-0 space-y-1" style={{ gridColumn: '1 / -1' }}>
+                  <dt className="kelta-field-label">
+                    {streetField.displayName || streetField.name}
+                  </dt>
+                  <dd className="text-sm text-foreground">
+                    <FieldRenderer
+                      type={streetField.type}
+                      value={record[streetField.name]}
+                      fieldName={streetField.name}
+                      displayName={streetField.displayName || streetField.name}
+                      tenantSlug={tenantSlug}
+                      targetCollection={streetField.referenceTarget}
+                      truncate={false}
+                    />
+                  </dd>
+                </div>
+              )}
+              {restFields.map((field) => (
+                <div key={field.name} className="min-w-0 space-y-1">
+                  <dt className="kelta-field-label">{field.displayName || field.name}</dt>
+                  <dd className="text-sm text-foreground">
+                    <FieldRenderer
+                      type={field.type}
+                      value={record[field.name]}
+                      fieldName={field.name}
+                      displayName={field.displayName || field.name}
+                      tenantSlug={tenantSlug}
+                      targetCollection={field.referenceTarget}
+                      displayLabel={
+                        lookupDisplayMap?.[field.name]?.[String(record[field.name])] || undefined
+                      }
+                      truncate={false}
+                    />
+                  </dd>
+                </div>
+              ))}
+            </div>
+
+            <MapPlaceholder label={mapLabel || 'Address'} />
+          </div>
+        </CollapsibleContent>
+      </Card>
+    </Collapsible>
+  )
+}
+
+function MapPlaceholder({ label }: { label: string }): React.ReactElement {
+  return (
+    <div
+      className="relative h-[220px] overflow-hidden rounded-[10px]"
+      aria-hidden="true"
+      style={{
+        background:
+          'radial-gradient(circle at 30% 40%, rgba(59,130,246,0.18), transparent 60%), linear-gradient(180deg, #0f1c33, #0a1322)',
+      }}
+    >
+      <div
+        className="absolute inset-0 opacity-50"
+        style={{
+          backgroundImage:
+            'radial-gradient(circle, rgba(148,163,184,0.18) 1px, transparent 1px)',
+          backgroundSize: '28px 28px',
+        }}
+      />
+      <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2">
+        <span className="inline-flex h-9 w-9 items-center justify-center rounded-full kelta-brand-gradient shadow-[0_6px_14px_-4px_rgba(6,182,212,0.5)]">
+          <MapPin className="h-4 w-4 text-white" aria-hidden="true" />
+        </span>
+      </div>
+      <div className="absolute bottom-2 left-2 inline-flex items-center gap-1 rounded-md bg-black/40 px-2 py-1 font-mono text-[11px] text-white/90 backdrop-blur-sm">
+        {label}
+      </div>
+    </div>
+  )
+}

--- a/kelta-ui/app/src/components/detail/FieldSection.tsx
+++ b/kelta-ui/app/src/components/detail/FieldSection.tsx
@@ -15,7 +15,7 @@
  * `LayoutFieldSections` cleanly.
  */
 
-import React, { useState } from 'react'
+import React, { useCallback, useState } from 'react'
 import { ChevronRight } from 'lucide-react'
 import { Card } from '@/components/ui/card'
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
@@ -39,6 +39,35 @@ export interface FieldSectionProps {
   defaultCollapsed?: boolean
   /** Number of grid columns (1-4). Default: 2 */
   columns?: 1 | 2 | 3 | 4
+  /**
+   * When set, the open/collapsed state is persisted to localStorage under
+   * `kelta_detail_section_${persistKey}`. Survives navigation and reloads.
+   * Defer to a real user-prefs API when one exists.
+   */
+  persistKey?: string
+}
+
+const STORAGE_PREFIX = 'kelta_detail_section_'
+
+function readPersistedOpen(persistKey: string | undefined, fallback: boolean): boolean {
+  if (!persistKey || typeof window === 'undefined') return fallback
+  try {
+    const raw = window.localStorage.getItem(STORAGE_PREFIX + persistKey)
+    if (raw === '1') return true
+    if (raw === '0') return false
+  } catch {
+    // localStorage may be disabled (private mode, quota) — fall back silently
+  }
+  return fallback
+}
+
+function writePersistedOpen(persistKey: string | undefined, open: boolean): void {
+  if (!persistKey || typeof window === 'undefined') return
+  try {
+    window.localStorage.setItem(STORAGE_PREFIX + persistKey, open ? '1' : '0')
+  } catch {
+    // ignore — see readPersistedOpen
+  }
 }
 
 export function FieldSection({
@@ -49,8 +78,18 @@ export function FieldSection({
   lookupDisplayMap,
   defaultCollapsed = false,
   columns = 2,
+  persistKey,
 }: FieldSectionProps): React.ReactElement | null {
-  const [isOpen, setIsOpen] = useState(!defaultCollapsed)
+  const [isOpen, setIsOpenState] = useState(() =>
+    readPersistedOpen(persistKey, !defaultCollapsed)
+  )
+  const setIsOpen = useCallback(
+    (open: boolean) => {
+      setIsOpenState(open)
+      writePersistedOpen(persistKey, open)
+    },
+    [persistKey]
+  )
 
   if (fields.length === 0) return null
 

--- a/kelta-ui/app/src/components/detail/MetadataCard.tsx
+++ b/kelta-ui/app/src/components/detail/MetadataCard.tsx
@@ -1,0 +1,66 @@
+/**
+ * MetadataCard
+ *
+ * Compact list of label / value rows separated by 1px dashed dividers.
+ * Optionally renders values in monospace (useful for IDs). Matches the
+ * design handoff at `design_handoff_kelta_detail_layout/`.
+ */
+
+import React from 'react'
+import { Card, CardContent, CardHeader } from '@/components/ui/card'
+import { cn } from '@/lib/utils'
+
+export interface MetadataRow {
+  label: string
+  /** Pre-formatted display value */
+  value: React.ReactNode
+  /** Render the value in monospace */
+  mono?: boolean
+}
+
+export interface MetadataCardConfig {
+  title: string
+  rows: MetadataRow[]
+}
+
+export function MetadataCard({
+  config,
+  className,
+}: {
+  config: MetadataCardConfig
+  className?: string
+}): React.ReactElement | null {
+  const { title, rows } = config
+  if (rows.length === 0) return null
+
+  return (
+    <Card
+      data-component="MetadataCard"
+      className={cn('overflow-hidden rounded-xl border border-border bg-card', className)}
+    >
+      <CardHeader className="px-5 py-4">
+        <span className="text-sm font-semibold text-foreground">{title}</span>
+      </CardHeader>
+      <CardContent className="border-t border-border px-5 py-2">
+        <dl className="divide-y divide-dashed divide-border">
+          {rows.map((row, idx) => (
+            <div
+              key={`${row.label}-${idx}`}
+              className="flex items-baseline justify-between gap-3 py-2.5"
+            >
+              <dt className="text-[12px] text-muted-foreground">{row.label}</dt>
+              <dd
+                className={cn(
+                  'truncate text-[13px] text-foreground',
+                  row.mono && 'font-mono text-[12px]'
+                )}
+              >
+                {row.value}
+              </dd>
+            </div>
+          ))}
+        </dl>
+      </CardContent>
+    </Card>
+  )
+}

--- a/kelta-ui/app/src/components/detail/ScoreCard.tsx
+++ b/kelta-ui/app/src/components/detail/ScoreCard.tsx
@@ -1,0 +1,105 @@
+/**
+ * ScoreCard
+ *
+ * 0–100 score card with a 6px gradient progress bar, optional delta chip,
+ * and a 2×2 grid of sub-metric rows. Matches the design handoff at
+ * `design_handoff_kelta_detail_layout/`.
+ */
+
+import React from 'react'
+import { Card, CardContent, CardHeader } from '@/components/ui/card'
+import { cn } from '@/lib/utils'
+
+export type ScoreTone = 'success' | 'warning' | 'danger'
+
+export interface ScoreMetric {
+  label: string
+  value: string
+  /** Tints the value foreground in success-fg when true */
+  ok?: boolean
+}
+
+export interface ScoreCardConfig {
+  title: string
+  /** 0..100 */
+  score: number
+  statusLabel?: string
+  tone?: ScoreTone
+  /** e.g. `+4 this month` */
+  delta?: string
+  metrics?: ScoreMetric[]
+}
+
+const TONE_PILL: Record<ScoreTone, string> = {
+  success: 'bg-emerald-500/10 text-emerald-400',
+  warning: 'bg-amber-500/10 text-amber-400',
+  danger: 'bg-red-500/10 text-red-400',
+}
+
+export function ScoreCard({
+  config,
+  className,
+}: {
+  config: ScoreCardConfig
+  className?: string
+}): React.ReactElement {
+  const { title, score, statusLabel, tone = 'success', delta, metrics = [] } = config
+  const clamped = Math.max(0, Math.min(100, score))
+
+  return (
+    <Card
+      data-component="ScoreCard"
+      className={cn('overflow-hidden rounded-xl border border-border bg-card', className)}
+    >
+      <CardHeader className="flex flex-row items-center justify-between gap-2 px-5 py-4">
+        <span className="text-sm font-semibold text-foreground">{title}</span>
+        {statusLabel && (
+          <span
+            className={cn(
+              'inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-medium',
+              TONE_PILL[tone]
+            )}
+          >
+            {statusLabel}
+          </span>
+        )}
+      </CardHeader>
+      <CardContent className="space-y-3 border-t border-border px-5 py-4">
+        <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted">
+          <div
+            className="h-full rounded-full bg-gradient-to-r from-emerald-500 to-emerald-300"
+            style={{ width: `${clamped}%` }}
+            role="progressbar"
+            aria-valuenow={clamped}
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-label={`${title} score ${clamped} of 100`}
+          />
+        </div>
+        <div className="flex items-baseline justify-between gap-2">
+          <span className="text-[13px] text-foreground tabular-nums">
+            Score <span className="font-semibold">{clamped}</span> / 100
+          </span>
+          {delta && <span className="text-[11px] text-emerald-400 tabular-nums">{delta}</span>}
+        </div>
+        {metrics.length > 0 && (
+          <div className="grid grid-cols-2 gap-x-4 gap-y-3 pt-2">
+            {metrics.map((m, idx) => (
+              <div key={`${m.label}-${idx}`} className="space-y-0.5">
+                <div className="kelta-field-label">{m.label}</div>
+                <div
+                  className={cn(
+                    'text-[13px] font-medium tabular-nums',
+                    m.ok ? 'text-emerald-400' : 'text-foreground'
+                  )}
+                >
+                  {m.value}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/kelta-ui/app/src/components/detail/StatStrip.tsx
+++ b/kelta-ui/app/src/components/detail/StatStrip.tsx
@@ -1,0 +1,97 @@
+/**
+ * StatStrip
+ *
+ * Horizontal strip of equal-width stat tiles separated by 1px borders (no
+ * gaps), wrapped in a 12px-radius card. Each tile shows a label + optional
+ * icon, a 24/600 value with tabular numerals, and an optional trend chip +
+ * subtitle. Matches the design handoff at
+ * `design_handoff_kelta_detail_layout/`.
+ */
+
+import React from 'react'
+import { ArrowDownRight, ArrowUpRight } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+export type StatTileKind = 'currency' | 'number' | 'text'
+
+export interface StatTileTrend {
+  /** `up` renders green, `down` renders red */
+  dir: 'up' | 'down'
+  /** e.g. `+12.4% YoY` */
+  label: string
+}
+
+export interface StatTileConfig {
+  label: string
+  /** Pre-formatted value to display (already locale-formatted) */
+  value: string
+  kind?: StatTileKind
+  icon?: React.ReactNode
+  trend?: StatTileTrend
+  /** Small muted line under the value/trend */
+  sub?: string
+}
+
+export interface StatStripProps {
+  tiles: StatTileConfig[]
+  className?: string
+}
+
+export function StatStrip({ tiles, className }: StatStripProps): React.ReactElement | null {
+  if (tiles.length === 0) return null
+
+  return (
+    <div
+      data-component="StatStrip"
+      className={cn(
+        'overflow-hidden rounded-xl border border-border bg-card',
+        'grid grid-cols-2 divide-x divide-border md:grid-cols-3 lg:grid-cols-5',
+        className
+      )}
+    >
+      {tiles.map((tile, idx) => (
+        <StatTile key={`${tile.label}-${idx}`} tile={tile} />
+      ))}
+    </div>
+  )
+}
+
+function StatTile({ tile }: { tile: StatTileConfig }): React.ReactElement {
+  return (
+    <div className="flex flex-col gap-2 px-5 py-4">
+      <div className="flex items-center justify-between gap-2">
+        <span className="kelta-field-label">{tile.label}</span>
+        {tile.icon && (
+          <span className="text-muted-foreground" aria-hidden="true">
+            {tile.icon}
+          </span>
+        )}
+      </div>
+      <div className="text-[24px] font-semibold tracking-[-0.02em] tabular-nums text-foreground">
+        {tile.value}
+      </div>
+      {(tile.trend || tile.sub) && (
+        <div className="flex flex-wrap items-center gap-2">
+          {tile.trend && (
+            <span
+              className={cn(
+                'inline-flex items-center gap-0.5 rounded-full px-1.5 py-0.5 text-[11px] font-medium',
+                tile.trend.dir === 'up'
+                  ? 'bg-emerald-500/10 text-emerald-400'
+                  : 'bg-red-500/10 text-red-400'
+              )}
+            >
+              {tile.trend.dir === 'up' ? (
+                <ArrowUpRight className="h-3 w-3" aria-hidden="true" />
+              ) : (
+                <ArrowDownRight className="h-3 w-3" aria-hidden="true" />
+              )}
+              {tile.trend.label}
+            </span>
+          )}
+          {tile.sub && <span className="text-[12px] text-muted-foreground">{tile.sub}</span>}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/kelta-ui/app/src/components/detail/TagsCard.tsx
+++ b/kelta-ui/app/src/components/detail/TagsCard.tsx
@@ -1,0 +1,85 @@
+/**
+ * TagsCard
+ *
+ * Card holding a chip row of pills with optional tone variants. Matches the
+ * design handoff at `design_handoff_kelta_detail_layout/`.
+ */
+
+import React from 'react'
+import { Plus } from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader } from '@/components/ui/card'
+import { cn } from '@/lib/utils'
+
+export type TagTone = 'default' | 'brand' | 'success' | 'warning' | 'danger'
+
+export interface TagItem {
+  label: string
+  tone?: TagTone
+}
+
+export interface TagsCardConfig {
+  title: string
+  tags: TagItem[]
+  /** When provided, header renders a small `+` button */
+  onAdd?: () => void
+}
+
+const TONE_CLASS: Record<TagTone, string> = {
+  default: 'bg-muted text-foreground',
+  brand: 'bg-blue-400/15 text-blue-300',
+  success: 'bg-emerald-500/10 text-emerald-400',
+  warning: 'bg-amber-500/10 text-amber-400',
+  danger: 'bg-red-500/10 text-red-400',
+}
+
+export function TagsCard({
+  config,
+  className,
+}: {
+  config: TagsCardConfig
+  className?: string
+}): React.ReactElement | null {
+  const { title, tags, onAdd } = config
+  if (tags.length === 0 && !onAdd) return null
+
+  return (
+    <Card
+      data-component="TagsCard"
+      className={cn('overflow-hidden rounded-xl border border-border bg-card', className)}
+    >
+      <CardHeader className="flex flex-row items-center justify-between gap-2 px-5 py-4">
+        <span className="text-sm font-semibold text-foreground">{title}</span>
+        {onAdd && (
+          <Button
+            size="icon"
+            variant="ghost"
+            onClick={onAdd}
+            aria-label={`Add ${title.toLowerCase()}`}
+            className="h-6 w-6"
+          >
+            <Plus className="h-3.5 w-3.5" aria-hidden="true" />
+          </Button>
+        )}
+      </CardHeader>
+      <CardContent className="border-t border-border px-5 py-4">
+        {tags.length === 0 ? (
+          <span className="text-[13px] text-muted-foreground">—</span>
+        ) : (
+          <div className="flex flex-wrap gap-1.5">
+            {tags.map((tag, idx) => (
+              <Badge
+                key={`${tag.label}-${idx}`}
+                className={cn('font-medium', TONE_CLASS[tag.tone || 'default'])}
+                variant="secondary"
+              >
+                {tag.label}
+              </Badge>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/kelta-ui/app/src/components/detail/Timeline.tsx
+++ b/kelta-ui/app/src/components/detail/Timeline.tsx
@@ -1,0 +1,101 @@
+/**
+ * Timeline
+ *
+ * Generic vertical event feed: each row has a 28×28 round icon dot, a 1px
+ * vertical connector to the next row, a 13/500 title with right-aligned
+ * tabular timestamp, and a 13px muted body. Matches the design handoff at
+ * `design_handoff_kelta_detail_layout/`.
+ *
+ * For the activity-feed specific case (CREATED/UPDATED/APPROVAL_* events),
+ * see [ActivityTimeline](../ActivityTimeline/ActivityTimeline.tsx).
+ */
+
+import React from 'react'
+import { Card, CardContent, CardHeader } from '@/components/ui/card'
+import { cn } from '@/lib/utils'
+
+export type TimelineTone = 'default' | 'brand' | 'success' | 'warning' | 'danger'
+
+export interface TimelineEvent {
+  /** Pre-formatted timestamp text (e.g. "2h ago" or "Mar 28") */
+  at: string
+  icon?: React.ReactNode
+  tone?: TimelineTone
+  title: string
+  body?: string
+}
+
+export interface TimelineConfig {
+  title: string
+  events: TimelineEvent[]
+}
+
+const TONE_CLASS: Record<TimelineTone, string> = {
+  default: 'bg-muted text-foreground',
+  brand: 'bg-blue-400/15 text-blue-300',
+  success: 'bg-emerald-500/10 text-emerald-400',
+  warning: 'bg-amber-500/10 text-amber-400',
+  danger: 'bg-red-500/10 text-red-400',
+}
+
+export function Timeline({
+  config,
+  className,
+}: {
+  config: TimelineConfig
+  className?: string
+}): React.ReactElement | null {
+  const { title, events } = config
+  if (events.length === 0) return null
+
+  return (
+    <Card
+      data-component="Timeline"
+      className={cn('overflow-hidden rounded-xl border border-border bg-card', className)}
+    >
+      <CardHeader className="px-5 py-4">
+        <span className="text-sm font-semibold text-foreground">{title}</span>
+      </CardHeader>
+      <CardContent className="border-t border-border px-5 py-4">
+        <ol className="relative">
+          {events.map((event, idx) => {
+            const isLast = idx === events.length - 1
+            return (
+              <li
+                key={`${event.title}-${idx}`}
+                className="relative grid grid-cols-[28px_1fr] gap-3 pb-4 last:pb-0"
+              >
+                <span
+                  className={cn(
+                    'relative z-10 inline-flex h-7 w-7 items-center justify-center rounded-full',
+                    TONE_CLASS[event.tone || 'default']
+                  )}
+                  aria-hidden="true"
+                >
+                  {event.icon}
+                </span>
+                {!isLast && (
+                  <span
+                    className="absolute left-[13.5px] top-7 bottom-0 w-px bg-border"
+                    aria-hidden="true"
+                  />
+                )}
+                <div className="min-w-0 space-y-0.5">
+                  <div className="flex items-baseline justify-between gap-2">
+                    <span className="text-[13px] font-medium text-foreground">{event.title}</span>
+                    <span className="text-[11px] text-muted-foreground tabular-nums">
+                      {event.at}
+                    </span>
+                  </div>
+                  {event.body && (
+                    <p className="text-[13px] text-muted-foreground">{event.body}</p>
+                  )}
+                </div>
+              </li>
+            )
+          })}
+        </ol>
+      </CardContent>
+    </Card>
+  )
+}

--- a/kelta-ui/app/src/components/detail/index.ts
+++ b/kelta-ui/app/src/components/detail/index.ts
@@ -5,7 +5,30 @@ export type {
   RecordHeaderAction,
   RecordHeaderProps,
 } from './RecordHeader'
+
 export { FieldSection } from './FieldSection'
 export type { FieldSectionProps } from './FieldSection'
+
 export { Crumb } from './Crumb'
 export type { CrumbItem, CrumbPosition, CrumbProps } from './Crumb'
+
+export { StatStrip } from './StatStrip'
+export type { StatStripProps, StatTileConfig, StatTileKind, StatTileTrend } from './StatStrip'
+
+export { ScoreCard } from './ScoreCard'
+export type { ScoreCardConfig, ScoreMetric, ScoreTone } from './ScoreCard'
+
+export { TagsCard } from './TagsCard'
+export type { TagsCardConfig, TagItem, TagTone } from './TagsCard'
+
+export { MetadataCard } from './MetadataCard'
+export type { MetadataCardConfig, MetadataRow } from './MetadataCard'
+
+export { AICard } from './AICard'
+export type { AICardConfig, AIActionConfig } from './AICard'
+
+export { Timeline } from './Timeline'
+export type { TimelineConfig, TimelineEvent, TimelineTone } from './Timeline'
+
+export { AddressMap } from './AddressMap'
+export type { AddressMapProps } from './AddressMap'

--- a/kelta-ui/app/src/pages/app/ObjectDetailPage/ObjectDetailPage.tsx
+++ b/kelta-ui/app/src/pages/app/ObjectDetailPage/ObjectDetailPage.tsx
@@ -13,7 +13,7 @@
 
 import React, { useState, useCallback, useMemo, useEffect } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
-import { Loader2, AlertCircle, Pencil, Copy, Trash2 } from 'lucide-react'
+import { Loader2, AlertCircle, Pencil, Copy, Trash2, Mail, Phone, MapPin } from 'lucide-react'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import {
   AlertDialog,
@@ -38,8 +38,12 @@ import { FieldRenderer } from '@/components/FieldRenderer'
 import { LayoutFieldSections } from '@/components/LayoutFieldSections'
 import { InsufficientPrivileges } from '@/components/InsufficientPrivileges'
 import { DetailTabBar } from '@/pages/ResourceDetailPage/DetailTabBar'
-import { RecordHeader, FieldSection, Crumb } from '@/components/detail'
-import type { RecordHeaderAction } from '@/components/detail'
+import { RecordHeader, FieldSection, Crumb, MetadataCard } from '@/components/detail'
+import type {
+  RecordHeaderAction,
+  RecordHeaderMetaField,
+  MetadataRow,
+} from '@/components/detail'
 import type { LayoutRelatedListDto } from '@/hooks/usePageLayout'
 import { QuickActionsMenu } from '@/components/QuickActions'
 import { useAnnounce } from '@/components/LiveRegion'
@@ -104,6 +108,110 @@ function getRecordDisplayName(
   }
   // Fall back to ID
   return String(record.id || 'Untitled')
+}
+
+/**
+ * Map a field name (case-insensitive substring) to a Lucide icon for the
+ * record header meta row. Returns null when no icon should be shown.
+ */
+function metaIconFor(fieldName: string): React.ReactNode {
+  const n = fieldName.toLowerCase()
+  if (n.includes('email')) return <Mail className="h-3.5 w-3.5" aria-hidden="true" />
+  if (n.includes('phone') || n === 'mobile') {
+    return <Phone className="h-3.5 w-3.5" aria-hidden="true" />
+  }
+  if (n.includes('city') || n.includes('country') || n.includes('region')) {
+    return <MapPin className="h-3.5 w-3.5" aria-hidden="true" />
+  }
+  return null
+}
+
+/**
+ * Auto-derive a small RecordHeader meta row from common contact-ish fields.
+ * Used when no layout-driven `RecordHeaderConfig.metaFields` is supplied.
+ * Cap at 4 items so the row doesn't wrap on common viewports.
+ */
+function deriveMetaFields(
+  fields: FieldDefinition[],
+  record: Record<string, unknown>
+): RecordHeaderMetaField[] {
+  const candidates: Array<{ key: string; prefix?: string; rank: number }> = []
+  const seen = new Set<string>()
+  const push = (key: string, prefix: string | undefined, rank: number): void => {
+    if (seen.has(key)) return
+    if (record[key] === null || record[key] === undefined || record[key] === '') return
+    seen.add(key)
+    candidates.push({ key, prefix, rank })
+  }
+
+  for (const f of fields) {
+    const n = f.name.toLowerCase()
+    if (f.type === 'email') push(f.name, undefined, 1)
+    else if (f.type === 'phone') push(f.name, undefined, 2)
+    else if (n.includes('city')) push(f.name, undefined, 3)
+    else if (n.includes('country')) push(f.name, undefined, 4)
+  }
+
+  // Joined-at: prefer a domain field like joinedAt/signedUpAt, else fall back to createdAt.
+  const joinedField = fields.find((f) =>
+    /(^|_)joined|signedup|registered|memberSince/i.test(f.name)
+  )
+  if (joinedField && record[joinedField.name]) {
+    push(joinedField.name, 'Joined ', 5)
+  } else if (record.createdAt || record.created_at) {
+    const createdKey = record.createdAt ? 'createdAt' : 'created_at'
+    push(createdKey, 'Joined ', 5)
+  }
+
+  return candidates
+    .sort((a, b) => a.rank - b.rank)
+    .slice(0, 4)
+    .map(({ key, prefix }) => ({ key, prefix, icon: metaIconFor(key) }))
+}
+
+/**
+ * Auto-derive a system-metadata MetadataCard for the right rail. Shows the
+ * record id (monospaced), created/updated timestamps, and resolved author
+ * names when the include map has them.
+ */
+function deriveSystemRows(
+  record: Record<string, unknown>,
+  getUserDisplay: (userId: string) => { name: string; linkTo: string } | null
+): MetadataRow[] {
+  const rows: MetadataRow[] = []
+  rows.push({ label: 'ID', value: String(record.id), mono: true })
+
+  const formatStamp = (raw: unknown): string => {
+    if (!raw) return ''
+    try {
+      return new Intl.DateTimeFormat(undefined, {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+      }).format(new Date(String(raw)))
+    } catch {
+      return String(raw)
+    }
+  }
+
+  const createdAt = record.createdAt ?? record.created_at
+  const updatedAt = record.updatedAt ?? record.updated_at
+  const createdBy = record.createdBy ?? record.created_by
+  const updatedBy = record.updatedBy ?? record.updated_by
+
+  if (createdAt) rows.push({ label: 'Created', value: formatStamp(createdAt) })
+  if (createdBy != null) {
+    const display = getUserDisplay(String(createdBy))
+    rows.push({ label: 'Created by', value: display?.name ?? String(createdBy) })
+  }
+  if (updatedAt) rows.push({ label: 'Updated', value: formatStamp(updatedAt) })
+  if (updatedBy != null) {
+    const display = getUserDisplay(String(updatedBy))
+    rows.push({ label: 'Updated by', value: display?.name ?? String(updatedBy) })
+  }
+  return rows
 }
 
 export function ObjectDetailPage(): React.ReactElement {
@@ -424,6 +532,16 @@ export function ObjectDetailPage(): React.ReactElement {
     return list
   }, [permissions.canEdit, handleEdit])
 
+  const headerMeta = useMemo<RecordHeaderMetaField[]>(
+    () => (record ? deriveMetaFields(fields, record) : []),
+    [fields, record]
+  )
+
+  const systemRows = useMemo(
+    () => (record ? deriveSystemRows(record, getUserDisplay) : []),
+    [record, getUserDisplay]
+  )
+
   // Loading state
   if (isLoading) {
     return (
@@ -493,6 +611,7 @@ export function ObjectDetailPage(): React.ReactElement {
             recordId={recordId || ''}
             collectionLabel={collectionLabel}
             fallbackTitle={recordTitle}
+            config={{ metaFields: headerMeta }}
             actions={headerActions}
             moreMenu={
               <>
@@ -532,72 +651,85 @@ export function ObjectDetailPage(): React.ReactElement {
         </div>
       </div>
 
-      {/* Field Sections — use page layout sections when available, otherwise fall back to generic highlights + details */}
-      {hasLayoutSections ? (
-        <div data-testid="field-values" className="space-y-4">
-          <LayoutFieldSections
-            sections={layout!.sections}
-            schemaFields={fields}
-            record={record}
-            tenantSlug={tenantSlug}
-            lookupDisplayMap={lookupDisplayMap}
-          />
-        </div>
-      ) : (
-        <div data-testid="field-values" className="space-y-4">
-          {/* Highlights Panel (fallback) */}
-          {highlightFields.length > 0 && record && (
-            <Card className="overflow-hidden rounded-xl border border-border bg-card">
-              <CardContent className="py-5">
-                <div className="grid grid-cols-2 gap-x-10 gap-y-5 md:grid-cols-4">
-                  {highlightFields.map((field) => {
-                    const value = record[field.name]
-                    const isRef =
-                      field.type === 'master_detail' ||
-                      field.type === 'lookup' ||
-                      field.type === 'reference'
-                    const displayLabel =
-                      isRef && lookupDisplayMap?.[field.name]
-                        ? lookupDisplayMap[field.name][String(value)] || undefined
-                        : undefined
-
-                    return (
-                      <div key={field.name} className="min-w-0 space-y-1">
-                        <dt className="kelta-field-label">
-                          {field.displayName || field.name}
-                        </dt>
-                        <dd className="text-sm font-medium">
-                          <FieldRenderer
-                            type={field.type}
-                            value={value}
-                            fieldName={field.name}
-                            displayName={field.displayName || field.name}
-                            tenantSlug={tenantSlug}
-                            targetCollection={field.referenceTarget}
-                            displayLabel={displayLabel}
-                            truncate
-                          />
-                        </dd>
-                      </div>
-                    )
-                  })}
-                </div>
-              </CardContent>
-            </Card>
-          )}
-
-          {/* Detail fields section (fallback) */}
-          {detailFields.length > 0 && (
-            <FieldSection
-              title="Details"
-              fields={detailFields}
+      {/* Main + right rail (rail collapses below on narrow screens) */}
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-[minmax(0,1fr)_340px]">
+        {/* Main column: layout sections OR generic highlights + details fallback */}
+        {hasLayoutSections ? (
+          <div data-testid="field-values" className="space-y-4">
+            <LayoutFieldSections
+              sections={layout!.sections}
+              schemaFields={fields}
               record={record}
               tenantSlug={tenantSlug}
               lookupDisplayMap={lookupDisplayMap}
+              persistKeyPrefix={collectionName}
             />
-          )}
-        </div>
-      )}
+          </div>
+        ) : (
+          <div data-testid="field-values" className="space-y-4">
+            {/* Highlights Panel (fallback) */}
+            {highlightFields.length > 0 && record && (
+              <Card className="overflow-hidden rounded-xl border border-border bg-card">
+                <CardContent className="py-5">
+                  <div className="grid grid-cols-2 gap-x-10 gap-y-5 md:grid-cols-4">
+                    {highlightFields.map((field) => {
+                      const value = record[field.name]
+                      const isRef =
+                        field.type === 'master_detail' ||
+                        field.type === 'lookup' ||
+                        field.type === 'reference'
+                      const displayLabel =
+                        isRef && lookupDisplayMap?.[field.name]
+                          ? lookupDisplayMap[field.name][String(value)] || undefined
+                          : undefined
+
+                      return (
+                        <div key={field.name} className="min-w-0 space-y-1">
+                          <dt className="kelta-field-label">
+                            {field.displayName || field.name}
+                          </dt>
+                          <dd className="text-sm font-medium">
+                            <FieldRenderer
+                              type={field.type}
+                              value={value}
+                              fieldName={field.name}
+                              displayName={field.displayName || field.name}
+                              tenantSlug={tenantSlug}
+                              targetCollection={field.referenceTarget}
+                              displayLabel={displayLabel}
+                              truncate
+                            />
+                          </dd>
+                        </div>
+                      )
+                    })}
+                  </div>
+                </CardContent>
+              </Card>
+            )}
+
+            {detailFields.length > 0 && (
+              <FieldSection
+                title="Details"
+                fields={detailFields}
+                record={record}
+                tenantSlug={tenantSlug}
+                lookupDisplayMap={lookupDisplayMap}
+                persistKey={collectionName ? `${collectionName}.details` : undefined}
+              />
+            )}
+          </div>
+        )}
+
+        {/* Right rail — currently auto-derives a single MetadataCard from
+            system fields. StatStrip/ScoreCard/TagsCard/AICard/Timeline blocks
+            land here once the layout-config admin UI ships. */}
+        <aside className="space-y-4">
+          <MetadataCard
+            config={{ title: 'System information', rows: systemRows }}
+          />
+        </aside>
+      </div>
 
       {/* Bottom tab bar: related lists + Notes + Attachments + System Information */}
       {schema && recordId && (


### PR DESCRIPTION
## Summary

Round out the design-handoff "rail block" component family ([design_handoff_kelta_detail_layout/](design_handoff_kelta_detail_layout/README.md)) and ship the ergonomic wins flagged as follow-ups in [#885](https://github.com/cklinker/emf/pull/885).

### New components ([kelta-ui/app/src/components/detail/](kelta-ui/app/src/components/detail/index.ts))

- **`StatStrip`** — 5-col tile strip; trend chips; 1px borders between, no gaps; 12px outer radius.
- **`ScoreCard`** — 0–100 gradient progress bar + status pill + 2×2 sub-metric grid.
- **`TagsCard`** — chip row with tone variants + optional `+` add action.
- **`MetadataCard`** — label/value list separated by 1px dashed dividers; mono values for IDs.
- **`AICard`** — cyan-tinted card with brand-gradient sparkles icon + summary + ghost action buttons.
- **`Timeline`** — generic vertical event feed (28×28 dot + 1px connector + tabular timestamp).
- **`AddressMap`** — composite field section + stylized SVG-only map placeholder.

### `ObjectDetailPage` changes

- Wrap main content + right rail in a 2-col grid (340px rail on `lg`+, collapses below on narrow).
- Auto-derive `RecordHeader.metaFields` from common contact-ish fields (email/phone/city/country + joined-at, capped at 4).
- Auto-derive a system-info `MetadataCard` for the right rail (ID, created/updated timestamps, resolved authors).

### `FieldSection` persistence

- New `persistKey` prop. When set, open/collapsed state survives navigation/reload via `localStorage`. Threaded through `LayoutFieldSections` keyed off `${collection}.${sectionId}`. No backend dependency.

## Deliberate non-goals

- **Real map provider for `AddressMap`** — placeholder is stylized SVG only. Mapbox/Google Maps integration requires provider choice + API key plumbing via `kelta-gateway`. Follow-up.
- **Layout-driven `StatStrip` / `ScoreCard` / `TagsCard` / `AICard` / `Timeline` / `AddressMap`** — component shells are ready, but backend persistence for a `header` block + rail block list on `PageLayoutDto` + admin UI to configure them per-collection is the next milestone.
- **Layout designer chrome** (palette / inspector / Save Layout) — multi-day admin-shell feature, out of scope.
- **Migrate `detail/` into `@kelta/components` shared package** — requires porting shadcn primitives there first.

## Test plan

- [x] `pnpm build` — only the pre-existing `mapPlacementsToFields` TS errors in `LayoutFieldSections` (untouched by this PR).
- [x] `pnpm lint` — clean on all touched files.
- [x] `pnpm test:run src/components/FieldRenderer/FieldRenderer.test.tsx` — 36/36 passing.
- [ ] Manual UI smoke: open a record detail page; verify right rail renders system info; meta row shows email/phone/city; toggle a section closed, reload, state preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)