### PR TITLE
feat(layouts): persist record-detail header config + rail blocks on page_layout

### DIFF
--- a/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/model/system/SystemCollectionDefinitions.java
+++ b/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/model/system/SystemCollectionDefinitions.java
@@ -296,6 +296,8 @@ public final class SystemCollectionDefinitions {
                 .withDefault("ASC"))
             .addField(FieldDefinition.integer("defaultRowLimit").withColumnName("default_row_limit")
                 .withDefault(50))
+            .addField(FieldDefinition.json("headerConfig").withColumnName("header_config"))
+            .addField(FieldDefinition.json("railBlocks").withColumnName("rail_blocks"))
             .build();
     }
 

--- a/kelta-ui/app/src/components/detail/RailRenderer.tsx
+++ b/kelta-ui/app/src/components/detail/RailRenderer.tsx
@@ -1,0 +1,102 @@
+/**
+ * RailRenderer
+ *
+ * Renders an ordered list of side-rail blocks from a layout config. Each
+ * `RailBlockDto` carries a discriminating `kind` and a `config` payload; we
+ * dispatch on `kind` and silently skip unknown variants so adding a new
+ * server-side kind doesn't crash older clients.
+ */
+
+import React from 'react'
+import type { RailBlockDto } from '@/hooks/usePageLayout'
+import { MetadataCard } from './MetadataCard'
+import { StatStrip } from './StatStrip'
+import { ScoreCard } from './ScoreCard'
+import { TagsCard } from './TagsCard'
+import { AICard } from './AICard'
+import { Timeline } from './Timeline'
+import type { ScoreCardConfig } from './ScoreCard'
+import type { StatTileConfig } from './StatStrip'
+import type { TagTone } from './TagsCard'
+import type { TimelineEvent, TimelineTone } from './Timeline'
+
+export interface RailRendererProps {
+  blocks: RailBlockDto[]
+}
+
+export function RailRenderer({ blocks }: RailRendererProps): React.ReactElement {
+  return (
+    <>
+      {blocks.map((block, idx) => {
+        const key = `${block.kind}-${idx}`
+        switch (block.kind) {
+          case 'metadataCard':
+            return <MetadataCard key={key} config={block.config} />
+          case 'statStrip':
+            return (
+              <StatStrip
+                key={key}
+                tiles={block.config.tiles as unknown as StatTileConfig[]}
+              />
+            )
+          case 'scoreCard':
+            return (
+              <ScoreCard
+                key={key}
+                config={block.config as unknown as ScoreCardConfig}
+              />
+            )
+          case 'tagsCard':
+            return (
+              <TagsCard
+                key={key}
+                config={{
+                  title: block.config.title,
+                  tags: block.config.tags.map((t) => ({
+                    label: t.label,
+                    tone: (t.tone as TagTone | undefined) ?? 'default',
+                  })),
+                }}
+              />
+            )
+          case 'aiCard':
+            return (
+              <AICard
+                key={key}
+                config={{
+                  title: block.config.title,
+                  summary: block.config.summary,
+                  // Server-defined actions are visual-only at this point;
+                  // wire to real handlers when the AI action endpoints land.
+                  actions: (block.config.actions ?? []).map((a) => ({
+                    label: a.label,
+                    onClick: () => undefined,
+                  })),
+                }}
+              />
+            )
+          case 'timeline':
+            return (
+              <Timeline
+                key={key}
+                config={{
+                  title: block.config.title,
+                  events: (block.config.events as unknown[]).map((e) => {
+                    const ev = e as Record<string, unknown>
+                    return {
+                      at: String(ev.at ?? ''),
+                      title: String(ev.title ?? ''),
+                      body: ev.body ? String(ev.body) : undefined,
+                      tone: (ev.tone as TimelineTone | undefined) ?? 'default',
+                    } satisfies TimelineEvent
+                  }),
+                }}
+              />
+            )
+          default:
+            return null
+        }
+      })}
+    </>
+  )
+}

--- a/kelta-ui/app/src/components/detail/index.ts
+++ b/kelta-ui/app/src/components/detail/index.ts
@@ -32,3 +32,6 @@ export type { TimelineConfig, TimelineEvent, TimelineTone } from './Timeline'
 
 export { AddressMap } from './AddressMap'
 export type { AddressMapProps } from './AddressMap'
+
+export { RailRenderer } from './RailRenderer'
+export type { RailRendererProps } from './RailRenderer'

--- a/kelta-ui/app/src/hooks/usePageLayout.ts
+++ b/kelta-ui/app/src/hooks/usePageLayout.ts
@@ -76,6 +76,31 @@ export interface LayoutRuleDto {
   sortOrder: number
 }
 
+/**
+ * Record-detail header configuration (handoff). When NULL on the layout, the
+ * renderer auto-derives sensible defaults from the record's contact-ish
+ * fields. Shape matches `RecordHeaderConfig` in `@/components/detail`.
+ */
+export interface RecordHeaderConfigDto {
+  titleFields?: string[]
+  avatarFrom?: string[]
+  metaFields?: Array<{ key: string; icon?: string; prefix?: string }>
+}
+
+/**
+ * Side-rail block configuration. Each block carries a discriminating `kind`
+ * + a `config` payload matching the corresponding component's props. The
+ * renderer dispatches on `kind` and silently ignores unknown variants so
+ * adding a new block kind on the server doesn't crash older clients.
+ */
+export type RailBlockDto =
+  | { kind: 'metadataCard'; config: { title: string; rows: Array<{ label: string; value: string; mono?: boolean }> } }
+  | { kind: 'statStrip'; config: { tiles: Array<Record<string, unknown>> } }
+  | { kind: 'scoreCard'; config: Record<string, unknown> }
+  | { kind: 'tagsCard'; config: { title: string; tags: Array<{ label: string; tone?: string }> } }
+  | { kind: 'aiCard'; config: { title: string; summary: string; actions?: Array<{ label: string }> } }
+  | { kind: 'timeline'; config: { title: string; events: Array<Record<string, unknown>> } }
+
 export interface PageLayoutDto {
   id: string
   collectionId: string
@@ -86,6 +111,10 @@ export interface PageLayoutDto {
   sections: LayoutSectionDto[]
   relatedLists: LayoutRelatedListDto[]
   rules: LayoutRuleDto[]
+  /** When set, overrides the auto-derived RecordHeader meta row + actions */
+  headerConfig: RecordHeaderConfigDto | null
+  /** When non-empty, replaces the auto-derived rail (system-info MetadataCard) */
+  railBlocks: RailBlockDto[] | null
   createdAt: string
   updatedAt: string
 }

--- a/kelta-ui/app/src/pages/app/ObjectDetailPage/ObjectDetailPage.tsx
+++ b/kelta-ui/app/src/pages/app/ObjectDetailPage/ObjectDetailPage.tsx
@@ -38,7 +38,13 @@ import { FieldRenderer } from '@/components/FieldRenderer'
 import { LayoutFieldSections } from '@/components/LayoutFieldSections'
 import { InsufficientPrivileges } from '@/components/InsufficientPrivileges'
 import { DetailTabBar } from '@/pages/ResourceDetailPage/DetailTabBar'
-import { RecordHeader, FieldSection, Crumb, MetadataCard } from '@/components/detail'
+import {
+  RecordHeader,
+  FieldSection,
+  Crumb,
+  MetadataCard,
+  RailRenderer,
+} from '@/components/detail'
 import type {
   RecordHeaderAction,
   RecordHeaderMetaField,
@@ -532,15 +538,33 @@ export function ObjectDetailPage(): React.ReactElement {
     return list
   }, [permissions.canEdit, handleEdit])
 
-  const headerMeta = useMemo<RecordHeaderMetaField[]>(
-    () => (record ? deriveMetaFields(fields, record) : []),
-    [fields, record]
-  )
+  // Prefer layout-driven header config; fall back to auto-derived meta row
+  // when admins haven't configured one. metaFields on the layout reference
+  // record fields by name, so we attach the same icon-derivation logic that
+  // powers the auto-derive path.
+  const headerMeta = useMemo<RecordHeaderMetaField[]>(() => {
+    if (!record) return []
+    const fromLayout = layout?.headerConfig?.metaFields
+    if (fromLayout && fromLayout.length > 0) {
+      return fromLayout
+        .filter((m) => {
+          const v = record[m.key]
+          return v !== null && v !== undefined && v !== ''
+        })
+        .map((m) => ({ key: m.key, prefix: m.prefix, icon: metaIconFor(m.key) }))
+    }
+    return deriveMetaFields(fields, record)
+  }, [fields, record, layout?.headerConfig])
+
+  const headerTitleFields = layout?.headerConfig?.titleFields
+  const headerAvatarFrom = layout?.headerConfig?.avatarFrom
 
   const systemRows = useMemo(
     () => (record ? deriveSystemRows(record, getUserDisplay) : []),
     [record, getUserDisplay]
   )
+
+  const railBlocks = layout?.railBlocks ?? null
 
   // Loading state
   if (isLoading) {
@@ -611,7 +635,11 @@ export function ObjectDetailPage(): React.ReactElement {
             recordId={recordId || ''}
             collectionLabel={collectionLabel}
             fallbackTitle={recordTitle}
-            config={{ metaFields: headerMeta }}
+            config={{
+              titleFields: headerTitleFields,
+              avatarFrom: headerAvatarFrom,
+              metaFields: headerMeta,
+            }}
             actions={headerActions}
             moreMenu={
               <>
@@ -721,13 +749,16 @@ export function ObjectDetailPage(): React.ReactElement {
           </div>
         )}
 
-        {/* Right rail — currently auto-derives a single MetadataCard from
-            system fields. StatStrip/ScoreCard/TagsCard/AICard/Timeline blocks
-            land here once the layout-config admin UI ships. */}
+        {/* Right rail — layout-configured blocks when present; otherwise a
+            single auto-derived system-info MetadataCard. */}
         <aside className="space-y-4">
-          <MetadataCard
-            config={{ title: 'System information', rows: systemRows }}
-          />
+          {railBlocks && railBlocks.length > 0 ? (
+            <RailRenderer blocks={railBlocks} />
+          ) : (
+            <MetadataCard
+              config={{ title: 'System information', rows: systemRows }}
+            />
+          )}
         </aside>
       </div>
 

--- a/kelta-worker/src/main/resources/db/migration/V136__add_header_config_and_rail_blocks_to_page_layout.sql
+++ b/kelta-worker/src/main/resources/db/migration/V136__add_header_config_and_rail_blocks_to_page_layout.sql
@@ -1,0 +1,20 @@
+-- V136: detail-page header config + rail blocks
+--
+-- Adds two JSONB columns to page_layout for storing the record-detail
+-- design-handoff blocks:
+--
+--   header_config — RecordHeaderConfig (titleFields, avatarFrom, metaFields,
+--                   actions). When NULL, the renderer auto-derives sensible
+--                   defaults from common contact-ish fields on the record.
+--
+--   rail_blocks   — Ordered array of side-rail block configs (StatStrip,
+--                   ScoreCard, TagsCard, MetadataCard, AICard, Timeline).
+--                   Each item is { kind: "...", config: { ... } }. When
+--                   NULL or empty, the renderer falls back to a single
+--                   auto-derived system-info MetadataCard.
+--
+-- Both columns are nullable so existing layouts continue to render unchanged.
+
+ALTER TABLE page_layout
+    ADD COLUMN IF NOT EXISTS header_config JSONB,
+    ADD COLUMN IF NOT EXISTS rail_blocks   JSONB;


### PR DESCRIPTION
## Summary

Adds backend persistence for the two design-handoff blocks that [ObjectDetailPage](kelta-ui/app/src/pages/app/ObjectDetailPage/ObjectDetailPage.tsx) auto-derives today: the RecordHeader meta row and the right-rail block list.

### Backend

- **V136 migration** adds `header_config JSONB` + `rail_blocks JSONB` to the `page_layout` table. Both nullable — existing layouts keep rendering unchanged.
- **`SystemCollectionDefinitions.pageLayouts()`** gains `headerConfig` + `railBlocks` JSON fields so `DynamicCollectionRouter` exposes them through JSON:API automatically.

### Frontend

- **`PageLayoutDto`** ([usePageLayout.ts](kelta-ui/app/src/hooks/usePageLayout.ts)) gets `headerConfig` + `railBlocks` with discriminating TS types for the six rail-block kinds (`metadataCard`, `statStrip`, `scoreCard`, `tagsCard`, `aiCard`, `timeline`).
- **`RailRenderer`** dispatches on `kind` and silently skips unknown variants — new server-side kinds don't crash older clients.
- **`ObjectDetailPage`** now prefers layout-driven config when present:
  - `headerConfig.metaFields` overrides the auto-derived contact-ish row.
  - `headerConfig.titleFields` / `avatarFrom` flow through to `RecordHeader`.
  - `railBlocks` replaces the auto-derived system-info `MetadataCard` when non-empty; admins regain that card by adding a `metadataCard` block.

### Deliberate non-goals

- **Admin UI for editing `headerConfig` + `railBlocks`** — deferred to a separate change set. Admins set values via the existing page-layouts JSON:API endpoint or directly in SQL for now.
- **`AddressMap` real map provider** — still placeholder. Provider choice + API key plumbing is a follow-up.

## Test plan

- [x] `mvn compile` clean on `kelta-platform/runtime-core` + `kelta-worker`.
- [x] `pnpm build` clean on touched frontend files.
- [x] `pnpm lint` clean on touched files.
- [x] `pnpm test:run FieldRenderer.test.tsx` — 36/36 passing.
- [ ] Manual: apply migration locally, `INSERT` a header_config JSON on a layout, verify the meta row picks it up; same for a `railBlocks` array.

🤖 Generated with [Claude Code](https://claude.com/claude-code)