### PR TITLE
feat(maps): per-tenant Mapbox token + admin settings page

### DIFF
--- a/kelta-ui/app/src/App.tsx
+++ b/kelta-ui/app/src/App.tsx
@@ -62,6 +62,7 @@ import {
 import {
   AiSettingsPage,
   EmailSettingsPage,
+  MapSettingsPage,
   DashboardPage,
   CollectionsPage,
   CollectionDetailPage,
@@ -924,6 +925,18 @@ function TenantRoutes(): React.ReactElement {
           <AdminPageRoute>
             <RequirePermission permission="MANAGE_TENANTS">
               <EmailSettingsPage />
+            </RequirePermission>
+          </AdminPageRoute>
+        }
+      />
+
+      {/* Map Settings route — tenant admins configure Mapbox token + style */}
+      <Route
+        path="map-settings"
+        element={
+          <AdminPageRoute>
+            <RequirePermission permission="MANAGE_TENANTS">
+              <MapSettingsPage />
             </RequirePermission>
           </AdminPageRoute>
         }

--- a/kelta-ui/app/src/hooks/useTenantSettings.ts
+++ b/kelta-ui/app/src/hooks/useTenantSettings.ts
@@ -1,0 +1,90 @@
+/**
+ * useTenantSettings
+ *
+ * Read + mutate the current tenant's `settings` JSONB column via the
+ * existing tenants JSON:API surface. Cached per-tenant via react-query so
+ * downstream consumers (AddressMap, integrations panels) don't refetch.
+ */
+
+import { useMemo } from 'react'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { useApi } from '@/context/ApiContext'
+import { useTenant } from '@/context/TenantContext'
+
+export interface TenantSettings {
+  /**
+   * Map / location settings — used by AddressMap. When `token` is empty,
+   * the static-map renderer falls back to the free OSM staticmap service.
+   */
+  map?: {
+    /** Mapbox public access token */
+    token?: string
+    /** Mapbox style id (e.g. `mapbox/dark-v11`) or maplibre style URL */
+    style?: string
+  }
+  /** Free-form bag — other tenant settings live alongside */
+  [key: string]: unknown
+}
+
+interface TenantResource {
+  id: string
+  slug: string
+  name: string
+  settings: TenantSettings | null
+}
+
+const QUERY_KEY = (slug: string): unknown[] => ['tenant-settings', slug]
+
+export function useTenantSettings(): {
+  tenant: TenantResource | null
+  settings: TenantSettings
+  isLoading: boolean
+  error: Error | null
+  save: (next: TenantSettings) => Promise<void>
+  isSaving: boolean
+} {
+  const { apiClient } = useApi()
+  const { tenantSlug } = useTenant()
+  const queryClient = useQueryClient()
+
+  const { data, isLoading, error } = useQuery<TenantResource | null, Error>({
+    queryKey: QUERY_KEY(tenantSlug),
+    queryFn: async () => {
+      const list = await apiClient.getList<TenantResource>(
+        `/api/tenants?filter[slug][eq]=${encodeURIComponent(tenantSlug)}&page[size]=1`
+      )
+      return list[0] ?? null
+    },
+    staleTime: 60 * 1000,
+  })
+
+  const saveMutation = useMutation({
+    mutationFn: async (next: TenantSettings) => {
+      if (!data) throw new Error('Tenant not loaded yet')
+      await apiClient.putResource(`/api/tenants/${data.id}`, {
+        slug: data.slug,
+        name: data.name,
+        settings: next,
+      })
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: QUERY_KEY(tenantSlug) })
+    },
+  })
+
+  const settings = useMemo<TenantSettings>(
+    () => data?.settings ?? {},
+    [data?.settings]
+  )
+
+  return {
+    tenant: data ?? null,
+    settings,
+    isLoading,
+    error: error ?? null,
+    save: async (next) => {
+      await saveMutation.mutateAsync(next)
+    },
+    isSaving: saveMutation.isPending,
+  }
+}

--- a/kelta-ui/app/src/pages/MapSettingsPage/MapSettingsPage.tsx
+++ b/kelta-ui/app/src/pages/MapSettingsPage/MapSettingsPage.tsx
@@ -1,0 +1,140 @@
+/**
+ * MapSettingsPage
+ *
+ * Tenant-level map / location settings. Currently:
+ * - Mapbox public token — when set, AddressMap uses Mapbox Static Images
+ *   (and the optional interactive map style) instead of the OpenStreetMap
+ *   staticmap fallback.
+ * - Mapbox style id / URL — controls the style for both static + interactive
+ *   maps. Defaults to `mapbox/dark-v11` when blank.
+ *
+ * Persists into `tenant.settings.map` JSONB. Future map-related settings
+ * (default zoom, marker tone, attribution overrides) land in the same
+ * sub-object without schema migrations.
+ */
+
+import React, { useState } from 'react'
+import { Map, Save } from 'lucide-react'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { FieldLabel } from '@/components/kelta'
+import { LoadingSpinner, ErrorMessage } from '@/components'
+import { useToast } from '@/components/Toast'
+import { useTenantSettings } from '@/hooks/useTenantSettings'
+
+export interface MapSettingsPageProps {
+  testId?: string
+}
+
+export function MapSettingsPage({
+  testId = 'map-settings-page',
+}: MapSettingsPageProps): React.ReactElement {
+  const { settings, isLoading, error, save, isSaving } = useTenantSettings()
+
+  if (isLoading) return <LoadingSpinner />
+  if (error) return <ErrorMessage error={error} />
+
+  return <MapSettingsForm settings={settings} save={save} isSaving={isSaving} testId={testId} />
+}
+
+interface MapSettingsFormProps {
+  settings: { map?: { token?: string; style?: string }; [key: string]: unknown }
+  save: (next: MapSettingsFormProps['settings']) => Promise<void>
+  isSaving: boolean
+  testId: string
+}
+
+function MapSettingsForm({
+  settings,
+  save,
+  isSaving,
+  testId,
+}: MapSettingsFormProps): React.ReactElement {
+  const { showToast } = useToast()
+  const [token, setToken] = useState<string>(settings.map?.token ?? '')
+  const [style, setStyle] = useState<string>(settings.map?.style ?? '')
+
+  const handleSave = async (): Promise<void> => {
+    const nextMap: Record<string, string> = {}
+    if (token.trim()) nextMap.token = token.trim()
+    if (style.trim()) nextMap.style = style.trim()
+    try {
+      await save({
+        ...settings,
+        map: Object.keys(nextMap).length > 0 ? nextMap : undefined,
+      })
+      showToast('Map settings saved', 'success')
+    } catch (err) {
+      showToast(err instanceof Error ? err.message : 'Save failed', 'error')
+    }
+  }
+
+  return (
+    <div className="space-y-6 p-6" data-testid={testId}>
+      <div className="flex items-center gap-3">
+        <Map className="h-5 w-5 text-muted-foreground" aria-hidden="true" />
+        <h1 className="kelta-page-title">Map settings</h1>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Mapbox</CardTitle>
+          <CardDescription>
+            Configure a Mapbox account for higher-quality static + interactive map tiles. When the
+            token is blank, AddressMap falls back to free OpenStreetMap tiles — no admin action
+            required.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-1">
+            <FieldLabel htmlFor="mapbox-token">Public access token</FieldLabel>
+            <Input
+              id="mapbox-token"
+              type="password"
+              value={token}
+              onChange={(e) => setToken(e.target.value)}
+              placeholder="pk.eyJ1Ijoi…"
+              autoComplete="off"
+              data-testid="mapbox-token-input"
+            />
+            <p className="text-xs text-muted-foreground">
+              Find your public token under{' '}
+              <a
+                href="https://account.mapbox.com/access-tokens/"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-primary hover:underline"
+              >
+                Mapbox → Access tokens
+              </a>
+              . Use a public token; secret tokens leak when embedded in the SPA.
+            </p>
+          </div>
+
+          <div className="space-y-1">
+            <FieldLabel htmlFor="mapbox-style">Style</FieldLabel>
+            <Input
+              id="mapbox-style"
+              value={style}
+              onChange={(e) => setStyle(e.target.value)}
+              placeholder="mapbox/dark-v11"
+              data-testid="mapbox-style-input"
+            />
+            <p className="text-xs text-muted-foreground">
+              Mapbox style id (e.g. <code>mapbox/streets-v12</code>) or a full maplibre style URL.
+              Defaults to <code>mapbox/dark-v11</code> when blank.
+            </p>
+          </div>
+        </CardContent>
+      </Card>
+
+      <div className="flex justify-end">
+        <Button onClick={handleSave} disabled={isSaving} data-testid="save-map-settings">
+          <Save className="mr-2 h-4 w-4" aria-hidden="true" />
+          {isSaving ? 'Saving…' : 'Save changes'}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/kelta-ui/app/src/pages/MapSettingsPage/index.ts
+++ b/kelta-ui/app/src/pages/MapSettingsPage/index.ts
@@ -1,0 +1,2 @@
+export { MapSettingsPage } from './MapSettingsPage'
+export type { MapSettingsPageProps } from './MapSettingsPage'

--- a/kelta-ui/app/src/pages/index.ts
+++ b/kelta-ui/app/src/pages/index.ts
@@ -276,6 +276,10 @@ export type { AiSettingsPageProps } from './AiSettingsPage'
 export { EmailSettingsPage } from './EmailSettingsPage'
 export type { EmailSettingsPageProps } from './EmailSettingsPage'
 
+// MapSettingsPage - tenant Mapbox token + style for AddressMap rendering
+export { MapSettingsPage } from './MapSettingsPage'
+export type { MapSettingsPageProps } from './MapSettingsPage'
+
 // PasswordPolicyPage - Password policy configuration page
 export { PasswordPolicyPanel as PasswordPolicyPage } from './SecuritySettingsPage/PasswordPolicyPanel'
 

--- a/kelta-web/packages/components/src/detail/AddressMap.tsx
+++ b/kelta-web/packages/components/src/detail/AddressMap.tsx
@@ -35,6 +35,16 @@ export interface AddressMapProps<F extends DetailField = DetailField> {
    * consumer to install `maplibre-gl` and import its CSS.
    */
   interactive?: boolean;
+  /**
+   * Mapbox public token. Overrides the build-time `VITE_MAPBOX_TOKEN` env
+   * var. Pass the per-tenant value here when an admin has configured one.
+   */
+  mapboxToken?: string;
+  /**
+   * Mapbox style id (e.g. `mapbox/dark-v11`) or a full maplibre style URL.
+   * Overrides the build-time `VITE_MAPBOX_STYLE` env var.
+   */
+  mapStyle?: string;
 }
 
 interface GeoPoint {
@@ -61,15 +71,21 @@ function extractGeoPoint<F extends DetailField>(
   return { lat, lng };
 }
 
-function staticMapUrl(point: GeoPoint, width: number, height: number): string {
+function staticMapUrl(
+  point: GeoPoint,
+  width: number,
+  height: number,
+  tokenOverride?: string,
+  styleOverride?: string
+): string {
   const env =
     typeof import.meta !== 'undefined' &&
     typeof (import.meta as { env?: Record<string, string | undefined> }).env !== 'undefined'
       ? (import.meta as { env: Record<string, string | undefined> }).env
       : undefined;
-  const mapboxToken = env?.VITE_MAPBOX_TOKEN;
+  const mapboxToken = tokenOverride ?? env?.VITE_MAPBOX_TOKEN;
   if (mapboxToken) {
-    const style = env?.VITE_MAPBOX_STYLE ?? 'mapbox/dark-v11';
+    const style = styleOverride ?? env?.VITE_MAPBOX_STYLE ?? 'mapbox/dark-v11';
     return (
       `https://api.mapbox.com/styles/v1/${style}/static/` +
       `pin-l+3b82f6(${point.lng},${point.lat})/` +
@@ -93,6 +109,8 @@ export function AddressMap<F extends DetailField = DetailField>({
   defaultCollapsed = false,
   renderField,
   interactive = false,
+  mapboxToken,
+  mapStyle,
 }: AddressMapProps<F>): React.ReactElement | null {
   const [isOpen, setIsOpen] = useState(!defaultCollapsed);
   if (fields.length === 0) return null;
@@ -170,7 +188,12 @@ export function AddressMap<F extends DetailField = DetailField>({
                   />
                 </div>
               ) : (
-                <StaticMap point={point} label={mapLabel || 'Address'} />
+                <StaticMap
+                  point={point}
+                  label={mapLabel || 'Address'}
+                  mapboxToken={mapboxToken}
+                  mapStyle={mapStyle}
+                />
               )
             ) : (
               <MapPlaceholder label={mapLabel || 'Address'} />
@@ -182,13 +205,23 @@ export function AddressMap<F extends DetailField = DetailField>({
   );
 }
 
-function StaticMap({ point, label }: { point: GeoPoint; label: string }): React.ReactElement {
+function StaticMap({
+  point,
+  label,
+  mapboxToken,
+  mapStyle,
+}: {
+  point: GeoPoint;
+  label: string;
+  mapboxToken?: string;
+  mapStyle?: string;
+}): React.ReactElement {
   const [errored, setErrored] = useState(false);
   if (errored) return <MapPlaceholder label={label} />;
   return (
     <div className="relative h-[220px] overflow-hidden rounded-[10px] bg-muted">
       <img
-        src={staticMapUrl(point, 600, 220)}
+        src={staticMapUrl(point, 600, 220, mapboxToken, mapStyle)}
         alt={`Map showing ${label}`}
         loading="lazy"
         onError={() => setErrored(true)}


### PR DESCRIPTION
## Summary

Adds a tenant-scoped Mapbox configuration so admins can swap from the free OpenStreetMap fallback to higher-quality Mapbox tiles without a rebuild.

### Backend

- Re-uses the existing `tenant.settings` JSONB column — no migration. Token + style live at `tenant.settings.map.{ token, style }`.

### Frontend

- New [`useTenantSettings`](kelta-ui/app/src/hooks/useTenantSettings.ts) hook: fetches the current tenant's settings via the existing tenants JSON:API surface, exposes a typed `save()` for partial mutations. Cached per-tenant via react-query (`staleTime: 60s`).
- New [`MapSettingsPage`](kelta-ui/app/src/pages/MapSettingsPage/MapSettingsPage.tsx) at `/{tenantSlug}/map-settings` (gated on `MANAGE_TENANTS`). Password-typed token input + a style input with usage hints and a link to the Mapbox console.
- Page is split into a thin loader shell + internal form component so the state-init pattern doesn't trip React's `set-state-in-effect` lint rule.

### `@kelta/components` AddressMap

- New `mapboxToken` + `mapStyle` props. Tenant token plumbed through takes precedence over the build-time `VITE_MAPBOX_TOKEN` env var; both still fall back to OSM staticmap when blank. Threaded through the static-image URL builder.

## Deliberate non-goals

- **Auto-injecting the token via React context.** Consumers pass `mapboxToken` explicitly today. A follow-up adds a `TenantSettingsProvider` for transparent injection once multiple components need the same setting.
- **Mapbox token validation.** We trust admin input; bad tokens result in a tile-load error → fallback to placeholder via `StaticMap`'s `onError` handler.

## Test plan

- [x] `npm run build --workspace=@kelta/components` clean.
- [x] `pnpm build` in `kelta-ui/app` clean.
- [x] `pnpm lint` clean.
- [ ] Manual: navigate to `/{tenant}/map-settings`; paste a valid public Mapbox token; save; verify it round-trips via reload; pass the token to AddressMap; verify the rendered tile uses Mapbox; clear the token; verify OSM fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)