### PR TITLE
fix(auth): gate direct-login at runtime so it survives native-image AOT

### DIFF
--- a/kelta-auth/src/main/java/io/kelta/auth/config/AuthProperties.java
+++ b/kelta-auth/src/main/java/io/kelta/auth/config/AuthProperties.java
@@ -29,6 +29,8 @@ public class AuthProperties {
      */
     private Map<String, InternalClient> internalClients = new LinkedHashMap<>();
 
+    private DirectLogin directLogin = new DirectLogin();
+
     public String getIssuerUri() { return issuerUri; }
     public void setIssuerUri(String issuerUri) { this.issuerUri = issuerUri; }
 
@@ -61,6 +63,11 @@ public class AuthProperties {
         this.internalClients = (internalClients != null) ? internalClients : new LinkedHashMap<>();
     }
 
+    public DirectLogin getDirectLogin() { return directLogin; }
+    public void setDirectLogin(DirectLogin directLogin) {
+        this.directLogin = (directLogin != null) ? directLogin : new DirectLogin();
+    }
+
     /**
      * Credential-carrying record for a single internal service caller. A blank
      * secret disables registration for that client, so the default (empty map)
@@ -70,5 +77,16 @@ public class AuthProperties {
         private String secret;
         public String getSecret() { return secret; }
         public void setSecret(String secret) { this.secret = secret; }
+    }
+
+    /**
+     * Direct-login endpoint toggle. Evaluated at request time so the controller
+     * stays registered in GraalVM native images (Spring AOT prunes beans whose
+     * {@code @ConditionalOnProperty} is unset at build time).
+     */
+    public static class DirectLogin {
+        private boolean enabled;
+        public boolean isEnabled() { return enabled; }
+        public void setEnabled(boolean enabled) { this.enabled = enabled; }
     }
 }

--- a/kelta-auth/src/main/java/io/kelta/auth/controller/DirectLoginController.java
+++ b/kelta-auth/src/main/java/io/kelta/auth/controller/DirectLoginController.java
@@ -5,7 +5,6 @@ import io.kelta.auth.model.KeltaUserDetails;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import jakarta.servlet.http.HttpSession;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -33,11 +32,14 @@ import java.util.UUID;
  * browser-based OIDC authorization code flow. This enables automated testing
  * (e.g. headless Chrome e2e tests) to authenticate without browser redirects.
  * <p>
- * Enabled only when {@code kelta.auth.direct-login.enabled=true}.
+ * Enabled only when {@code kelta.auth.direct-login.enabled=true}. The toggle
+ * is evaluated per-request rather than via {@code @ConditionalOnProperty}
+ * because Spring AOT (GraalVM native image) resolves bean conditions at build
+ * time, where the runtime env var {@code DIRECT_LOGIN_ENABLED} is unset and
+ * the bean would otherwise be pruned from the binary.
  */
 @RestController
 @RequestMapping("/auth/direct-login")
-@ConditionalOnProperty(name = "kelta.auth.direct-login.enabled", havingValue = "true")
 public class DirectLoginController {
 
     private static final Logger log = LoggerFactory.getLogger(DirectLoginController.class);
@@ -59,6 +61,10 @@ public class DirectLoginController {
 
     @PostMapping
     public ResponseEntity<?> login(@RequestBody DirectLoginRequest request, HttpSession session) {
+        if (!authProperties.getDirectLogin().isEnabled()) {
+            return ResponseEntity.notFound().build();
+        }
+
         if (request.username() == null || request.password() == null) {
             return ResponseEntity.badRequest()
                     .body(Map.of("error", "username and password are required"));


### PR DESCRIPTION
## Summary
- Drop `@ConditionalOnProperty` on `DirectLoginController` and gate `kelta.auth.direct-login.enabled` inside the handler (404 when disabled).
- Add nested `DirectLogin` property class on `AuthProperties` so the toggle binds via `@ConfigurationProperties`.

## Why
The kelta-auth image is a GraalVM native binary (`mvn -Pnative native:compile`). Spring AOT resolves `@ConditionalOnProperty` at **build time**, when `DIRECT_LOGIN_ENABLED` is unset → `kelta.auth.direct-login.enabled=false` → `DirectLoginController` is pruned from the binary. Setting the env var at runtime on the Deployment had no effect; `POST /auth/direct-login` fell through to `ResourceHttpRequestHandler` and returned `500 {"errors":[{}]}` with `NoResourceFoundException`. This broke the e2e direct-login fast-path; see [run 26011425617](https://github.com/cklinker/emf/actions/runs/26011425617).

Verified live: `POST /auth/password/change → 403` (controller registered, blocked by CSRF) vs `POST /auth/direct-login → 500 NoResource` (controller missing).

## Test plan
- [ ] CI build & native-image compile succeed.
- [ ] After deploy: `POST /auth/direct-login` returns 401 for bad creds (not 500), 200 for valid e2e admin creds.
- [ ] E2E merge-workflow auth.setup takes the direct-login fast path (no Strategy-2 fallback warning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)