### PR TITLE
feat(ai): tool registry, multi-turn tool loop, read + mutate tools

### DIFF
--- a/kelta-ai/src/main/java/io/kelta/ai/controller/ChatHistoryController.java
+++ b/kelta-ai/src/main/java/io/kelta/ai/controller/ChatHistoryController.java
@@ -9,6 +9,11 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.*;
 
+/**
+ * Read endpoints for AI conversation history. The {@code /messages} endpoint
+ * returns full content_blocks so the React panel can rehydrate a conversation
+ * after a page refresh.
+ */
 @RestController
 @RequestMapping("/api/ai/conversations")
 public class ChatHistoryController {
@@ -28,8 +33,7 @@ public class ChatHistoryController {
             @RequestHeader(value = "X-User-Id", required = false) String userId,
             @RequestParam(defaultValue = "50") int limit) {
 
-        List<Conversation> conversations = conversationRepository.findByUser(
-                tenantId, userId, limit);
+        List<Conversation> conversations = conversationRepository.findByUser(tenantId, userId, limit);
 
         List<Map<String, Object>> data = conversations.stream()
                 .map(c -> {
@@ -50,27 +54,13 @@ public class ChatHistoryController {
             @RequestHeader("X-Tenant-ID") String tenantId,
             @PathVariable UUID id) {
 
-        Conversation conversation = conversationRepository.findById(id, tenantId)
-                .orElse(null);
+        Conversation conversation = conversationRepository.findById(id, tenantId).orElse(null);
         if (conversation == null) {
             return ResponseEntity.notFound().build();
         }
 
-        List<ChatMessage> messages = messageRepository.findByConversation(id, tenantId);
-
-        List<Map<String, Object>> messageData = messages.stream()
-                .map(m -> {
-                    Map<String, Object> item = new LinkedHashMap<>();
-                    item.put("id", m.id().toString());
-                    item.put("role", m.role());
-                    item.put("content", m.content());
-                    item.put("proposalJson", m.proposalJson());
-                    item.put("tokensInput", m.tokensInput());
-                    item.put("tokensOutput", m.tokensOutput());
-                    item.put("createdAt", m.createdAt().toString());
-                    return item;
-                })
-                .toList();
+        List<Map<String, Object>> messageData = messageRepository.findByConversation(id, tenantId)
+                .stream().map(this::toMessageDto).toList();
 
         Map<String, Object> data = new LinkedHashMap<>();
         data.put("id", conversation.id().toString());
@@ -80,5 +70,37 @@ public class ChatHistoryController {
         data.put("messages", messageData);
 
         return ResponseEntity.ok(Map.of("data", data));
+    }
+
+    @GetMapping("/{id}/messages")
+    public ResponseEntity<Map<String, Object>> getMessages(
+            @RequestHeader("X-Tenant-ID") String tenantId,
+            @PathVariable UUID id) {
+
+        Conversation conversation = conversationRepository.findById(id, tenantId).orElse(null);
+        if (conversation == null) {
+            return ResponseEntity.notFound().build();
+        }
+
+        List<Map<String, Object>> messageData = messageRepository.findByConversation(id, tenantId)
+                .stream().map(this::toMessageDto).toList();
+
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("conversationId", conversation.id().toString());
+        result.put("messages", messageData);
+        return ResponseEntity.ok(result);
+    }
+
+    private Map<String, Object> toMessageDto(ChatMessage m) {
+        Map<String, Object> item = new LinkedHashMap<>();
+        item.put("id", m.id().toString());
+        item.put("role", m.role());
+        item.put("contentBlocks", m.contentBlocks() != null ? m.contentBlocks() : List.of());
+        item.put("content", m.displayText());
+        item.put("proposalJson", m.legacyProposalJson());
+        item.put("tokensInput", m.tokensInput());
+        item.put("tokensOutput", m.tokensOutput());
+        item.put("createdAt", m.createdAt().toString());
+        return item;
     }
 }

--- a/kelta-ai/src/main/java/io/kelta/ai/model/ChatMessage.java
+++ b/kelta-ai/src/main/java/io/kelta/ai/model/ChatMessage.java
@@ -1,26 +1,51 @@
 package io.kelta.ai.model;
 
 import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 public record ChatMessage(
         UUID id,
         String tenantId,
         UUID conversationId,
         String role,
-        String content,
-        String proposalJson,
+        List<Map<String, Object>> contentBlocks,
+        String legacyContent,
+        String legacyProposalJson,
         int tokensInput,
         int tokensOutput,
         Instant createdAt
 ) {
+
     public static ChatMessage user(String tenantId, UUID conversationId, String content) {
-        return new ChatMessage(UUID.randomUUID(), tenantId, conversationId, "user", content, null, 0, 0, Instant.now());
+        Map<String, Object> textBlock = new LinkedHashMap<>();
+        textBlock.put("type", "text");
+        textBlock.put("text", content);
+        return new ChatMessage(UUID.randomUUID(), tenantId, conversationId, "user",
+                List.of(textBlock), content, null, 0, 0, Instant.now());
     }
 
-    public static ChatMessage assistant(String tenantId, UUID conversationId, String content,
-                                         String proposalJson, int tokensInput, int tokensOutput) {
-        return new ChatMessage(UUID.randomUUID(), tenantId, conversationId, "assistant", content,
-                proposalJson, tokensInput, tokensOutput, Instant.now());
+    public static ChatMessage user(String tenantId, UUID conversationId, List<Map<String, Object>> blocks) {
+        return new ChatMessage(UUID.randomUUID(), tenantId, conversationId, "user",
+                List.copyOf(blocks), null, null, 0, 0, Instant.now());
+    }
+
+    public static ChatMessage assistant(String tenantId, UUID conversationId,
+                                         List<Map<String, Object>> blocks,
+                                         int tokensInput, int tokensOutput) {
+        return new ChatMessage(UUID.randomUUID(), tenantId, conversationId, "assistant",
+                List.copyOf(blocks), null, null, tokensInput, tokensOutput, Instant.now());
+    }
+
+    /** Plain text for UI summary views. Concatenates all text blocks. */
+    public String displayText() {
+        if (contentBlocks == null) return legacyContent != null ? legacyContent : "";
+        return contentBlocks.stream()
+                .filter(b -> "text".equals(b.get("type")))
+                .map(b -> String.valueOf(b.getOrDefault("text", "")))
+                .collect(Collectors.joining("\n"));
     }
 }

--- a/kelta-ai/src/main/java/io/kelta/ai/repository/ChatMessageRepository.java
+++ b/kelta-ai/src/main/java/io/kelta/ai/repository/ChatMessageRepository.java
@@ -3,34 +3,50 @@ package io.kelta.ai.repository;
 import io.kelta.ai.model.ChatMessage;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
 @Repository
 public class ChatMessageRepository {
 
-    private final JdbcTemplate jdbc;
+    private static final TypeReference<List<Map<String, Object>>> BLOCK_LIST_TYPE = new TypeReference<>() {
+    };
 
-    public ChatMessageRepository(JdbcTemplate jdbc) {
+    private final JdbcTemplate jdbc;
+    private final ObjectMapper objectMapper;
+
+    public ChatMessageRepository(JdbcTemplate jdbc, ObjectMapper objectMapper) {
         this.jdbc = jdbc;
+        this.objectMapper = objectMapper;
     }
 
     public void save(ChatMessage message) {
+        String contentBlocksJson = serializeBlocks(message.contentBlocks());
+        String legacyContent = message.legacyContent() != null ? message.legacyContent() : message.displayText();
+        String legacyProposalJson = message.legacyProposalJson();
+        if (legacyProposalJson == null) {
+            legacyProposalJson = firstProposalJson(message.contentBlocks());
+        }
+
         jdbc.update("""
-                INSERT INTO ai_message (id, tenant_id, conversation_id, role, content, proposal_json, tokens_input, tokens_output, created_at)
-                VALUES (?, ?, ?, ?, ?, ?::jsonb, ?, ?, ?)
-                """,
+                        INSERT INTO ai_message (id, tenant_id, conversation_id, role, content, proposal_json, content_blocks, tokens_input, tokens_output, created_at)
+                        VALUES (?, ?, ?, ?, ?, ?::jsonb, ?::jsonb, ?, ?, ?)
+                        """,
                 message.id(),
                 message.tenantId(),
                 message.conversationId(),
                 message.role(),
-                message.content(),
-                message.proposalJson(),
+                legacyContent,
+                legacyProposalJson,
+                contentBlocksJson,
                 message.tokensInput(),
                 message.tokensOutput(),
                 Timestamp.from(message.createdAt()));
@@ -50,23 +66,83 @@ public class ChatMessageRepository {
     }
 
     public Optional<ChatMessage> findByProposalId(UUID proposalId, String tenantId) {
-        // Proposal ID is stored inside the proposal_json JSONB
-        List<ChatMessage> results = jdbc.query(
-                "SELECT * FROM ai_message WHERE tenant_id = ? AND proposal_json->>'id' = ? LIMIT 1",
-                this::mapRow, tenantId, proposalId.toString());
+        String containment = "[{\"proposalId\":\"" + proposalId + "\"}]";
+        List<ChatMessage> results = jdbc.query("""
+                        SELECT * FROM ai_message
+                         WHERE tenant_id = ?
+                           AND (content_blocks @> ?::jsonb OR proposal_json->>'id' = ?)
+                         LIMIT 1
+                        """,
+                this::mapRow, tenantId, containment, proposalId.toString());
         return results.isEmpty() ? Optional.empty() : Optional.of(results.getFirst());
     }
 
     private ChatMessage mapRow(ResultSet rs, int rowNum) throws SQLException {
+        String contentBlocksJson = rs.getString("content_blocks");
+        List<Map<String, Object>> blocks = deserializeBlocks(contentBlocksJson);
         return new ChatMessage(
                 rs.getObject("id", UUID.class),
                 rs.getString("tenant_id"),
                 rs.getObject("conversation_id", UUID.class),
                 rs.getString("role"),
+                blocks,
                 rs.getString("content"),
                 rs.getString("proposal_json"),
                 rs.getInt("tokens_input"),
                 rs.getInt("tokens_output"),
                 rs.getTimestamp("created_at").toInstant());
+    }
+
+    private String serializeBlocks(List<Map<String, Object>> blocks) {
+        if (blocks == null) return "[]";
+        try {
+            return objectMapper.writeValueAsString(blocks);
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to serialize content_blocks", e);
+        }
+    }
+
+    private List<Map<String, Object>> deserializeBlocks(String json) {
+        if (json == null || json.isBlank()) return List.of();
+        try {
+            List<Map<String, Object>> parsed = objectMapper.readValue(json, BLOCK_LIST_TYPE);
+            return parsed != null ? parsed : List.of();
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to deserialize content_blocks", e);
+        }
+    }
+
+    private String firstProposalJson(List<Map<String, Object>> blocks) {
+        if (blocks == null) return null;
+        for (Map<String, Object> b : blocks) {
+            Object proposalId = b.get("proposalId");
+            Object name = b.get("name");
+            if (proposalId != null && "tool_use".equals(b.get("type"))
+                    && name != null && String.valueOf(name).startsWith("propose_")) {
+                try {
+                    return objectMapper.writeValueAsString(Map.of(
+                            "id", proposalId,
+                            "type", inferTypeFromName(String.valueOf(name)),
+                            "status", "pending",
+                            "data", b.get("input")
+                    ));
+                } catch (Exception ignored) {
+                    return null;
+                }
+            }
+        }
+        return null;
+    }
+
+    private static String inferTypeFromName(String toolName) {
+        return switch (toolName) {
+            case "propose_collection" -> "collection";
+            case "propose_layout" -> "layout";
+            case "propose_add_fields" -> "add_fields";
+            case "propose_update_field" -> "update_field";
+            case "propose_remove_field" -> "remove_field";
+            case "propose_picklist" -> "picklist";
+            default -> "unknown";
+        };
     }
 }

--- a/kelta-ai/src/main/java/io/kelta/ai/service/AnthropicService.java
+++ b/kelta-ai/src/main/java/io/kelta/ai/service/AnthropicService.java
@@ -5,16 +5,17 @@ import com.anthropic.core.http.StreamResponse;
 import com.anthropic.models.messages.*;
 import io.kelta.ai.config.AiConfigProperties;
 import io.kelta.ai.repository.AiConfigRepository;
+import io.kelta.ai.service.tools.ToolRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.Map;
 
 /**
  * Wraps the Anthropic Java SDK for sending messages to Claude.
  * Resolves model selection from tenant config with fallback chain.
+ * Tool definitions are supplied by {@link ToolRegistry}.
  */
 @Service
 public class AnthropicService {
@@ -24,12 +25,14 @@ public class AnthropicService {
     private final AnthropicClient client;
     private final AiConfigProperties config;
     private final AiConfigRepository aiConfigRepository;
+    private final ToolRegistry toolRegistry;
 
     public AnthropicService(AnthropicClient client, AiConfigProperties config,
-                             AiConfigRepository aiConfigRepository) {
+                             AiConfigRepository aiConfigRepository, ToolRegistry toolRegistry) {
         this.client = client;
         this.config = config;
         this.aiConfigRepository = aiConfigRepository;
+        this.toolRegistry = toolRegistry;
     }
 
     public MessageCreateParams.Builder buildRequest(String tenantId, String systemPrompt,
@@ -42,13 +45,11 @@ public class AnthropicService {
                 .maxTokens((long) maxTokens)
                 .system(systemPrompt);
 
-        // Add messages
         for (MessageParam msg : messages) {
             builder.addMessage(msg);
         }
 
-        // Add tool definitions
-        for (ToolUnion tool : getToolDefinitions()) {
+        for (ToolUnion tool : toolRegistry.toolDefinitions()) {
             builder.addTool(tool);
         }
 
@@ -76,62 +77,5 @@ public class AnthropicService {
                 .map(Integer::parseInt)
                 .or(() -> aiConfigRepository.getConfig("0", "anthropic.maxTokens").map(Integer::parseInt))
                 .orElse(config.anthropic().defaultMaxTokens());
-    }
-
-    private List<ToolUnion> getToolDefinitions() {
-        Tool collectionTool = Tool.builder()
-                .name("propose_collection")
-                .description("Propose creating a new collection (data model) with fields. " +
-                        "Use this when the user wants to create a new collection or entity type.")
-                .inputSchema(Tool.InputSchema.builder()
-                        .properties(com.anthropic.core.JsonValue.from(getCollectionToolSchema()))
-                        .build())
-                .build();
-
-        Tool layoutTool = Tool.builder()
-                .name("propose_layout")
-                .description("Propose creating a page layout for a collection. " +
-                        "Use this when the user wants to create or customize how a collection's records are displayed.")
-                .inputSchema(Tool.InputSchema.builder()
-                        .properties(com.anthropic.core.JsonValue.from(getLayoutToolSchema()))
-                        .build())
-                .build();
-
-        return List.of(
-                ToolUnion.ofTool(collectionTool),
-                ToolUnion.ofTool(layoutTool)
-        );
-    }
-
-    private Object getCollectionToolSchema() {
-        return Map.of(
-                "name", Map.of("type", "string", "description", "Collection name (lowercase, alphanumeric, underscores)"),
-                "displayName", Map.of("type", "string", "description", "Human-readable collection name"),
-                "description", Map.of("type", "string", "description", "Collection description"),
-                "displayFieldName", Map.of("type", "string", "description", "Name of the field used as record label"),
-                "fields", Map.of(
-                        "type", "array",
-                        "description", "Fields for the collection",
-                        "items", Map.of("type", "object")
-                )
-        );
-    }
-
-    private Object getLayoutToolSchema() {
-        return Map.of(
-                "collectionName", Map.of("type", "string", "description", "Name of the collection this layout is for"),
-                "name", Map.of("type", "string", "description", "Layout name"),
-                "layoutType", Map.of("type", "string", "description", "Layout type: DETAIL, EDIT, MINI, or LIST"),
-                "sections", Map.of(
-                        "type", "array",
-                        "description", "Layout sections with field placements",
-                        "items", Map.of("type", "object")
-                ),
-                "relatedLists", Map.of(
-                        "type", "array",
-                        "description", "Related list configurations",
-                        "items", Map.of("type", "object")
-                )
-        );
     }
 }

--- a/kelta-ai/src/main/java/io/kelta/ai/service/ChatService.java
+++ b/kelta-ai/src/main/java/io/kelta/ai/service/ChatService.java
@@ -1,175 +1,108 @@
 package io.kelta.ai.service;
 
+import com.anthropic.core.JsonValue;
 import com.anthropic.core.http.StreamResponse;
 import com.anthropic.models.messages.*;
-import tools.jackson.databind.ObjectMapper;
 import io.kelta.ai.model.AiProposal;
 import io.kelta.ai.model.ChatMessage;
 import io.kelta.ai.model.Conversation;
 import io.kelta.ai.repository.ChatMessageRepository;
 import io.kelta.ai.repository.ConversationRepository;
+import io.kelta.ai.service.tools.DispatchResult;
+import io.kelta.ai.service.tools.ToolDispatcher;
+import io.kelta.ai.service.tools.ToolRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import tools.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
 /**
- * Orchestrates the AI chat flow: builds context, sends to Anthropic,
- * processes tool calls, persists messages, and streams responses.
+ * Orchestrates the AI chat flow: builds context, drives Anthropic's multi-turn
+ * tool-use loop with real tool_result content blocks, persists each turn, and
+ * streams results to the client.
  */
 @Service
 public class ChatService {
 
     private static final Logger log = LoggerFactory.getLogger(ChatService.class);
+    private static final int MAX_TOOL_ITERATIONS = 8;
+    private static final long TOKEN_BUDGET = 100_000L;
 
     private final AnthropicService anthropicService;
     private final SystemPromptService systemPromptService;
-    private final ProposalService proposalService;
+    private final ToolDispatcher toolDispatcher;
+    private final ToolRegistry toolRegistry;
     private final TokenTrackingService tokenTrackingService;
     private final ConversationRepository conversationRepository;
     private final ChatMessageRepository messageRepository;
     private final ObjectMapper objectMapper;
 
-    public ChatService(AnthropicService anthropicService, SystemPromptService systemPromptService,
-                        ProposalService proposalService, TokenTrackingService tokenTrackingService,
-                        ConversationRepository conversationRepository, ChatMessageRepository messageRepository,
+    public ChatService(AnthropicService anthropicService,
+                        SystemPromptService systemPromptService,
+                        ToolDispatcher toolDispatcher,
+                        ToolRegistry toolRegistry,
+                        TokenTrackingService tokenTrackingService,
+                        ConversationRepository conversationRepository,
+                        ChatMessageRepository messageRepository,
                         ObjectMapper objectMapper) {
         this.anthropicService = anthropicService;
         this.systemPromptService = systemPromptService;
-        this.proposalService = proposalService;
+        this.toolDispatcher = toolDispatcher;
+        this.toolRegistry = toolRegistry;
         this.tokenTrackingService = tokenTrackingService;
         this.conversationRepository = conversationRepository;
         this.messageRepository = messageRepository;
         this.objectMapper = objectMapper;
     }
 
-    /**
-     * Handles a synchronous chat request. Returns the full response.
-     */
-    @SuppressWarnings("unchecked")
     public Map<String, Object> chat(String tenantId, String userId, UUID conversationId,
                                      String userMessage, String contextType, String contextId) {
         Conversation conversation = getOrCreateConversation(tenantId, userId, conversationId, userMessage);
+        messageRepository.save(ChatMessage.user(tenantId, conversation.id(), userMessage));
 
-        ChatMessage userMsg = ChatMessage.user(tenantId, conversation.id(), userMessage);
-        messageRepository.save(userMsg);
+        String systemPrompt = systemPromptService.buildSystemPrompt(tenantId, contextType, contextId);
+        List<MessageParam> conversationParams = new ArrayList<>(buildMessageHistory(conversation.id(), tenantId));
 
-        String systemPrompt = systemPromptService.buildSystemPrompt(
-                tenantId, contextType, contextId);
+        List<AiProposal> proposals = new ArrayList<>();
+        int[] tokenCounts = {0, 0};
+        StringBuilder lastText = new StringBuilder();
 
-        List<MessageParam> messages = buildMessageHistory(conversation.id(), tenantId);
+        runSyncToolLoop(tenantId, userId, conversation, systemPrompt, conversationParams,
+                proposals, tokenCounts, lastText);
 
-        MessageCreateParams params = anthropicService.buildRequest(tenantId, systemPrompt, messages).build();
-        Message response = anthropicService.sendMessage(params);
+        conversationRepository.updateTimestamp(conversation.id(), tenantId);
 
-        return processResponse(tenantId, conversation, response);
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("conversationId", conversation.id().toString());
+        result.put("content", lastText.toString());
+        result.put("proposals", proposals);
+        result.put("tokensUsed", Map.of("input", tokenCounts[0], "output", tokenCounts[1]));
+        return result;
     }
 
-    /**
-     * Handles a streaming chat request. Sends SSE events as Claude generates output.
-     */
     public void chatStream(String tenantId, String userId, UUID conversationId,
                             String userMessage, String contextType, String contextId,
                             SseEmitter emitter) {
         try {
             Conversation conversation = getOrCreateConversation(tenantId, userId, conversationId, userMessage);
+            messageRepository.save(ChatMessage.user(tenantId, conversation.id(), userMessage));
 
-            ChatMessage userMsg = ChatMessage.user(tenantId, conversation.id(), userMessage);
-            messageRepository.save(userMsg);
+            String systemPrompt = systemPromptService.buildSystemPrompt(tenantId, contextType, contextId);
+            List<MessageParam> conversationParams = new ArrayList<>(buildMessageHistory(conversation.id(), tenantId));
 
-            String systemPrompt = systemPromptService.buildSystemPrompt(
-                    tenantId, contextType, contextId);
-
-            List<MessageParam> messages = buildMessageHistory(conversation.id(), tenantId);
-
-            StringBuilder fullText = new StringBuilder();
             List<AiProposal> proposals = new ArrayList<>();
-            int[] tokenCounts = {0, 0}; // input, output
-            String[] stopReason = {null};
+            int[] tokenCounts = {0, 0};
 
-            // Tool use continuation loop: Claude may stop after each tool call
-            // expecting a tool result. We send back "Proposal recorded" and continue.
-            int maxIterations = 5; // Safety limit
-            MessageCreateParams.Builder requestBuilder = anthropicService.buildRequest(tenantId, systemPrompt, messages);
-
-            for (int iteration = 0; iteration < maxIterations; iteration++) {
-                MessageCreateParams params = requestBuilder.build();
-
-                // Track current tool use across stream events
-                String[] currentToolName = {null};
-                String[] currentToolId = {null};
-                StringBuilder toolInputJson = new StringBuilder();
-
-                try (StreamResponse<RawMessageStreamEvent> stream = anthropicService.streamMessage(params)) {
-                    stream.stream().forEach(event -> {
-                        try {
-                            processStreamEvent(event, emitter, fullText, proposals, tokenCounts,
-                                    currentToolName, currentToolId, toolInputJson, stopReason);
-                        } catch (Exception e) {
-                            log.error("Error processing stream event: {}", e.getMessage());
-                        }
-                    });
-                }
-
-                tokenTrackingService.recordUsage(tenantId, tokenCounts[0], tokenCounts[1]);
-
-                // If Claude stopped because of tool use, continue with tool results
-                if ("tool_use".equals(stopReason[0]) && !proposals.isEmpty()) {
-                    log.info("Claude stopped for tool use (iteration {}), continuing with tool results", iteration);
-
-                    // Build list of already-proposed collection names
-                    String alreadyProposed = proposals.stream()
-                            .map(p -> "'" + p.data().getOrDefault("name", p.data().getOrDefault("displayName", "unknown")) + "'")
-                            .collect(java.util.stream.Collectors.joining(", "));
-
-                    List<MessageParam> continuationMessages = new ArrayList<>(messages);
-
-                    AiProposal lastProposal = proposals.getLast();
-                    continuationMessages.add(MessageParam.builder()
-                            .role(MessageParam.Role.ASSISTANT)
-                            .content(fullText.toString() + "\n[Called propose_collection for " +
-                                    lastProposal.data().getOrDefault("displayName", "") + "]")
-                            .build());
-                    continuationMessages.add(MessageParam.builder()
-                            .role(MessageParam.Role.USER)
-                            .content("Proposal recorded. The following collections have ALREADY been proposed — do NOT propose them again: " +
-                                    alreadyProposed + ". " +
-                                    "If there are remaining collections you mentioned that are NOT in this list, " +
-                                    "call propose_collection for each one now. If all collections have been proposed, " +
-                                    "just respond with a brief summary.")
-                            .build());
-
-                    requestBuilder = anthropicService.buildRequest(tenantId, systemPrompt, continuationMessages);
-                    fullText.setLength(0); // Reset for next iteration
-                    stopReason[0] = null;
-                } else {
-                    // Normal end or max tokens — stop looping
-                    break;
-                }
-            }
-
-            // Save each proposal as a separate message so they can all be found by ID
-            if (proposals.isEmpty()) {
-                ChatMessage assistantMsg = ChatMessage.assistant(
-                        tenantId, conversation.id(), fullText.toString(),
-                        null, tokenCounts[0], tokenCounts[1]);
-                messageRepository.save(assistantMsg);
-            } else {
-                for (int i = 0; i < proposals.size(); i++) {
-                    String pJson = objectMapper.writeValueAsString(proposals.get(i));
-                    // First message gets the text content, rest are proposal-only
-                    String content = (i == 0) ? fullText.toString() : "";
-                    int inputTok = (i == 0) ? tokenCounts[0] : 0;
-                    int outputTok = (i == 0) ? tokenCounts[1] : 0;
-                    ChatMessage proposalMsg = ChatMessage.assistant(
-                            tenantId, conversation.id(), content,
-                            pJson, inputTok, outputTok);
-                    messageRepository.save(proposalMsg);
-                }
-            }
+            runStreamingToolLoop(tenantId, userId, conversation, systemPrompt, conversationParams,
+                    emitter, proposals, tokenCounts);
 
             conversationRepository.updateTimestamp(conversation.id(), tenantId);
 
@@ -178,7 +111,6 @@ public class ChatService {
             doneData.put("tokensUsed", Map.of("input", tokenCounts[0], "output", tokenCounts[1]));
             emitter.send(SseEmitter.event().name("done").data(objectMapper.writeValueAsString(doneData)));
             emitter.complete();
-
         } catch (Exception e) {
             log.error("Error in chat stream: {}", e.getMessage(), e);
             try {
@@ -192,143 +124,302 @@ public class ChatService {
         }
     }
 
-    @SuppressWarnings("unchecked")
-    private void processStreamEvent(RawMessageStreamEvent event, SseEmitter emitter,
-                                     StringBuilder fullText, List<AiProposal> proposals,
-                                     int[] tokenCounts, String[] currentToolName,
-                                     String[] currentToolId, StringBuilder toolInputJson,
-                                     String[] stopReason) throws IOException {
-        // Handle content block delta (text or tool input JSON)
-        event.contentBlockDelta().ifPresent(delta -> {
-            // Text delta — stream to client
-            delta.delta().text().ifPresent(textDelta -> {
-                String text = textDelta.text();
-                fullText.append(text);
-                try {
-                    Map<String, Object> deltaData = Map.of("text", text);
-                    emitter.send(SseEmitter.event().name("delta").data(objectMapper.writeValueAsString(deltaData)));
-                } catch (IOException e) {
-                    log.error("Failed to send delta event: {}", e.getMessage());
-                }
-            });
+    // =========================================================================
+    // Tool-loop drivers
+    // =========================================================================
 
-            // Tool input JSON delta — accumulate chunks
-            delta.delta().inputJson().ifPresent(inputJsonDelta -> {
-                toolInputJson.append(inputJsonDelta.partialJson());
-            });
-        });
+    private void runStreamingToolLoop(String tenantId, String userId, Conversation conversation,
+                                       String systemPrompt, List<MessageParam> conversationParams,
+                                       SseEmitter emitter, List<AiProposal> proposals,
+                                       int[] tokenCounts) throws IOException {
+        for (int i = 0; i < MAX_TOOL_ITERATIONS; i++) {
+            StreamAssembler assembler = new StreamAssembler(emitter, objectMapper, toolRegistry);
+            MessageCreateParams params = anthropicService
+                    .buildRequest(tenantId, systemPrompt, conversationParams).build();
 
-        // Handle content block start (tool use detection)
-        event.contentBlockStart().ifPresent(blockStart -> {
-            blockStart.contentBlock().toolUse().ifPresent(toolUse -> {
-                currentToolName[0] = toolUse.name();
-                currentToolId[0] = toolUse.id();
-                toolInputJson.setLength(0); // Reset for new tool
-                try {
-                    Map<String, Object> toolData = Map.of("name", toolUse.name(), "id", toolUse.id());
-                    emitter.send(SseEmitter.event().name("tool_use").data(objectMapper.writeValueAsString(toolData)));
-                } catch (IOException e) {
-                    log.error("Failed to send tool_use event: {}", e.getMessage());
-                }
-            });
-        });
-
-        // Handle content block stop — finalize tool use and emit proposal
-        event.contentBlockStop().ifPresent(stop -> {
-            if (currentToolName[0] != null && toolInputJson.length() > 0) {
-                try {
-                    Map<String, Object> toolInput = objectMapper.readValue(
-                            toolInputJson.toString(), Map.class);
-                    String proposalType = "propose_collection".equals(currentToolName[0])
-                            ? "collection" : "layout";
-                    AiProposal proposal = proposalService.createProposal(proposalType, toolInput);
-                    proposals.add(proposal);
-
-                    String proposalJson = objectMapper.writeValueAsString(proposal);
-                    emitter.send(SseEmitter.event().name("proposal").data(proposalJson));
-                    log.info("Emitted {} proposal: {}", proposalType, proposal.id());
-                } catch (Exception e) {
-                    log.error("Failed to process tool result: {}", e.getMessage());
-                }
-                currentToolName[0] = null;
-                toolInputJson.setLength(0);
+            try (StreamResponse<RawMessageStreamEvent> stream = anthropicService.streamMessage(params)) {
+                stream.stream().forEach(assembler::accept);
             }
-        });
 
-        // Handle message delta (output token count and stop reason)
-        event.messageDelta().ifPresent(msgDelta -> {
-            tokenCounts[1] = (int) msgDelta.usage().outputTokens();
-            // Track stop reason to know if we need to continue for more tool calls
-            try {
-                var delta = msgDelta.delta();
-                var sr = delta.stopReason();
-                if (sr.isPresent()) {
-                    stopReason[0] = sr.get().toString().toLowerCase().replace("\"", "");
-                    log.info("Stream stop reason: {}", stopReason[0]);
-                }
-            } catch (Exception e) {
-                log.debug("Could not extract stop reason: {}", e.getMessage());
+            tokenTrackingService.recordUsage(tenantId, assembler.inputTokens(), assembler.outputTokens());
+            tokenCounts[0] += assembler.inputTokens();
+            tokenCounts[1] += assembler.outputTokens();
+
+            boolean hasTools = !assembler.toolUses().isEmpty();
+            List<DispatchResult> dispatched = hasTools
+                    ? dispatchAll(tenantId, userId, assembler.toolUses(), emitter, proposals)
+                    : List.of();
+
+            enrichAssistantBlocksWithProposalIds(assembler.assistantBlocks(), dispatched);
+
+            messageRepository.save(ChatMessage.assistant(
+                    tenantId, conversation.id(), assembler.assistantBlocks(),
+                    assembler.inputTokens(), assembler.outputTokens()));
+            conversationParams.add(toAssistantMessageParam(assembler.assistantBlocks()));
+
+            if (!"tool_use".equals(assembler.stopReason()) || !hasTools) break;
+            if (tokenCounts[0] + tokenCounts[1] > TOKEN_BUDGET) {
+                emitter.send(SseEmitter.event().name("error").data(objectMapper.writeValueAsString(
+                        Map.of("code", "TOKEN_BUDGET_EXCEEDED",
+                                "message", "Tool loop exceeded token budget — stopped after " + (i + 1) + " iterations"))));
+                break;
             }
-        });
 
-        // Handle message start (input token count)
-        event.messageStart().ifPresent(msgStart -> {
-            tokenCounts[0] = (int) msgStart.message().usage().inputTokens();
-        });
+            List<Map<String, Object>> resultBlocks = buildToolResultBlocks(dispatched);
+            messageRepository.save(ChatMessage.user(tenantId, conversation.id(), resultBlocks));
+            conversationParams.add(toUserMessageParam(resultBlocks));
+        }
+    }
+
+    private void runSyncToolLoop(String tenantId, String userId, Conversation conversation,
+                                  String systemPrompt, List<MessageParam> conversationParams,
+                                  List<AiProposal> proposals, int[] tokenCounts,
+                                  StringBuilder lastText) {
+        for (int i = 0; i < MAX_TOOL_ITERATIONS; i++) {
+            MessageCreateParams params = anthropicService
+                    .buildRequest(tenantId, systemPrompt, conversationParams).build();
+            Message response = anthropicService.sendMessage(params);
+
+            int inTok = (int) response.usage().inputTokens();
+            int outTok = (int) response.usage().outputTokens();
+            tokenTrackingService.recordUsage(tenantId, inTok, outTok);
+            tokenCounts[0] += inTok;
+            tokenCounts[1] += outTok;
+
+            List<Map<String, Object>> assistantBlocks = new ArrayList<>();
+            List<StreamAssembler.ToolUseRecord> toolUses = new ArrayList<>();
+            StringBuilder textBuf = new StringBuilder();
+            for (ContentBlock block : response.content()) {
+                block.text().ifPresent(t -> {
+                    Map<String, Object> b = new LinkedHashMap<>();
+                    b.put("type", "text");
+                    b.put("text", t.text());
+                    assistantBlocks.add(b);
+                    textBuf.append(t.text());
+                });
+                block.toolUse().ifPresent(t -> {
+                    Map<String, Object> input = convertToolInput(t._input());
+                    Map<String, Object> b = new LinkedHashMap<>();
+                    b.put("type", "tool_use");
+                    b.put("id", t.id());
+                    b.put("name", t.name());
+                    b.put("input", input);
+                    assistantBlocks.add(b);
+                    toolUses.add(new StreamAssembler.ToolUseRecord(t.id(), t.name(), input));
+                });
+            }
+            lastText.setLength(0);
+            lastText.append(textBuf);
+
+            boolean hasTools = !toolUses.isEmpty();
+            List<DispatchResult> dispatched = hasTools
+                    ? dispatchAll(tenantId, userId, toolUses, null, proposals)
+                    : List.of();
+
+            enrichAssistantBlocksWithProposalIds(assistantBlocks, dispatched);
+
+            messageRepository.save(ChatMessage.assistant(
+                    tenantId, conversation.id(), assistantBlocks, inTok, outTok));
+            conversationParams.add(toAssistantMessageParam(assistantBlocks));
+
+            String stopReason = response.stopReason()
+                    .map(sr -> sr.toString().toLowerCase().replace("\"", ""))
+                    .orElse(null);
+            if (!"tool_use".equals(stopReason) || !hasTools) break;
+            if (tokenCounts[0] + tokenCounts[1] > TOKEN_BUDGET) {
+                log.warn("Sync tool loop exceeded token budget for conversation {}", conversation.id());
+                break;
+            }
+
+            List<Map<String, Object>> resultBlocks = buildToolResultBlocks(dispatched);
+            messageRepository.save(ChatMessage.user(tenantId, conversation.id(), resultBlocks));
+            conversationParams.add(toUserMessageParam(resultBlocks));
+        }
+    }
+
+    // =========================================================================
+    // Dispatch + persistence helpers
+    // =========================================================================
+
+    private List<DispatchResult> dispatchAll(String tenantId, String userId,
+                                              List<StreamAssembler.ToolUseRecord> toolUses,
+                                              SseEmitter emitter, List<AiProposal> proposalsOut) {
+        List<DispatchResult> results = new ArrayList<>(toolUses.size());
+        for (StreamAssembler.ToolUseRecord tu : toolUses) {
+            DispatchResult result = toolDispatcher.dispatch(tenantId, userId, tu.id(), tu.name(), tu.input());
+            results.add(result);
+            emitDispatchEvent(emitter, result);
+            if (result.proposal() != null) {
+                proposalsOut.add(result.proposal());
+            }
+        }
+        return results;
+    }
+
+    private void emitDispatchEvent(SseEmitter emitter, DispatchResult result) {
+        if (emitter == null) return;
+        try {
+            if (result.proposal() != null) {
+                emitter.send(SseEmitter.event().name("proposal")
+                        .data(objectMapper.writeValueAsString(result.proposal())));
+            } else {
+                Map<String, Object> payload = new LinkedHashMap<>();
+                payload.put("toolUseId", result.toolUseId());
+                payload.put("name", result.toolName());
+                payload.put("isError", result.isError());
+                payload.put("status", result.isError() ? "error" : "done");
+                emitter.send(SseEmitter.event().name("tool_result")
+                        .data(objectMapper.writeValueAsString(payload)));
+            }
+        } catch (IOException e) {
+            log.error("Failed to emit dispatch event: {}", e.getMessage());
+        }
+    }
+
+    private void enrichAssistantBlocksWithProposalIds(List<Map<String, Object>> blocks,
+                                                       List<DispatchResult> dispatched) {
+        if (blocks == null || dispatched == null || dispatched.isEmpty()) return;
+        Map<String, UUID> proposalByToolUseId = new LinkedHashMap<>();
+        for (DispatchResult r : dispatched) {
+            if (r.proposal() != null) {
+                proposalByToolUseId.put(r.toolUseId(), r.proposal().id());
+            }
+        }
+        for (Map<String, Object> b : blocks) {
+            if ("tool_use".equals(b.get("type"))) {
+                UUID pid = proposalByToolUseId.get(String.valueOf(b.get("id")));
+                if (pid != null) b.put("proposalId", pid.toString());
+            }
+        }
+    }
+
+    private List<Map<String, Object>> buildToolResultBlocks(List<DispatchResult> dispatched) {
+        List<Map<String, Object>> blocks = new ArrayList<>(dispatched.size());
+        for (DispatchResult r : dispatched) {
+            Map<String, Object> b = new LinkedHashMap<>();
+            b.put("type", "tool_result");
+            b.put("tool_use_id", r.toolUseId());
+            b.put("content", r.resultJson());
+            b.put("is_error", r.isError());
+            blocks.add(b);
+        }
+        return blocks;
+    }
+
+    // =========================================================================
+    // History reconstruction
+    // =========================================================================
+
+    private List<MessageParam> buildMessageHistory(UUID conversationId, String tenantId) {
+        List<ChatMessage> history = messageRepository.findByConversation(conversationId, tenantId);
+        List<MessageParam> messages = new ArrayList<>(history.size());
+        for (ChatMessage msg : history) {
+            if ("system".equals(msg.role())) continue;
+            MessageParam.Role role = "user".equals(msg.role())
+                    ? MessageParam.Role.USER : MessageParam.Role.ASSISTANT;
+            List<ContentBlockParam> blocks = toContentBlockParams(msg);
+            if (blocks.isEmpty()) continue;
+            messages.add(MessageParam.builder()
+                    .role(role)
+                    .contentOfBlockParams(blocks)
+                    .build());
+        }
+        return messages;
+    }
+
+    private List<ContentBlockParam> toContentBlockParams(ChatMessage msg) {
+        List<ContentBlockParam> result = new ArrayList<>();
+        List<Map<String, Object>> blocks = msg.contentBlocks();
+        if (blocks == null || blocks.isEmpty()) {
+            String text = msg.legacyContent();
+            if (text != null && !text.isEmpty()) {
+                result.add(ContentBlockParam.ofText(TextBlockParam.builder().text(text).build()));
+            }
+            return result;
+        }
+        for (Map<String, Object> block : blocks) {
+            ContentBlockParam param = convertPersistedBlock(block);
+            if (param != null) result.add(param);
+        }
+        return result;
     }
 
     @SuppressWarnings("unchecked")
-    private Map<String, Object> processResponse(String tenantId, Conversation conversation, Message response) {
-        int inputTokens = (int) response.usage().inputTokens();
-        int outputTokens = (int) response.usage().outputTokens();
-
-        tokenTrackingService.recordUsage(tenantId, inputTokens, outputTokens);
-
-        StringBuilder textContent = new StringBuilder();
-        List<AiProposal> proposals = new ArrayList<>();
-
-        for (ContentBlock block : response.content()) {
-            block.text().ifPresent(textBlock -> textContent.append(textBlock.text()));
-
-            block.toolUse().ifPresent(toolUse -> {
-                String toolName = toolUse.name();
-                // Get the raw input as a JsonValue and convert to Map
-                Object rawInput = toolUse._input();
-                Map<String, Object> input;
-                if (rawInput instanceof Map) {
-                    input = (Map<String, Object>) rawInput;
-                } else {
-                    input = objectMapper.convertValue(rawInput, Map.class);
+    private ContentBlockParam convertPersistedBlock(Map<String, Object> block) {
+        String type = String.valueOf(block.getOrDefault("type", ""));
+        return switch (type) {
+            case "text" -> ContentBlockParam.ofText(TextBlockParam.builder()
+                    .text(String.valueOf(block.getOrDefault("text", "")))
+                    .build());
+            case "tool_use" -> {
+                ToolUseBlockParam.Input.Builder inputBuilder = ToolUseBlockParam.Input.builder();
+                Object rawInput = block.get("input");
+                if (rawInput instanceof Map<?, ?> m) {
+                    for (Map.Entry<?, ?> e : m.entrySet()) {
+                        inputBuilder.putAdditionalProperty(String.valueOf(e.getKey()), JsonValue.from(e.getValue()));
+                    }
                 }
+                yield ContentBlockParam.ofToolUse(ToolUseBlockParam.builder()
+                        .id(String.valueOf(block.get("id")))
+                        .name(String.valueOf(block.get("name")))
+                        .input(inputBuilder.build())
+                        .build());
+            }
+            case "tool_result" -> ContentBlockParam.ofToolResult(ToolResultBlockParam.builder()
+                    .toolUseId(String.valueOf(block.get("tool_use_id")))
+                    .content(String.valueOf(block.getOrDefault("content", "")))
+                    .isError(Boolean.TRUE.equals(block.get("is_error")))
+                    .build());
+            // Skip legacy proposals — they have no matching tool_result and would
+            // fail Anthropic validation when replayed.
+            case "tool_use_legacy" -> null;
+            default -> null;
+        };
+    }
 
-                String proposalType = "propose_collection".equals(toolName) ? "collection" : "layout";
-                AiProposal proposal = proposalService.createProposal(proposalType, input);
-                proposals.add(proposal);
-            });
+    // =========================================================================
+    // Block ↔ MessageParam conversion
+    // =========================================================================
+
+    private MessageParam toAssistantMessageParam(List<Map<String, Object>> blocks) {
+        List<ContentBlockParam> params = new ArrayList<>();
+        for (Map<String, Object> b : blocks) {
+            ContentBlockParam p = convertPersistedBlock(b);
+            if (p != null) params.add(p);
         }
+        return MessageParam.builder()
+                .role(MessageParam.Role.ASSISTANT)
+                .contentOfBlockParams(params)
+                .build();
+    }
 
-        String proposalJson = null;
+    private MessageParam toUserMessageParam(List<Map<String, Object>> blocks) {
+        List<ContentBlockParam> params = new ArrayList<>();
+        for (Map<String, Object> b : blocks) {
+            ContentBlockParam p = convertPersistedBlock(b);
+            if (p != null) params.add(p);
+        }
+        return MessageParam.builder()
+                .role(MessageParam.Role.USER)
+                .contentOfBlockParams(params)
+                .build();
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> convertToolInput(Object rawInput) {
+        if (rawInput instanceof Map<?, ?> m) {
+            Map<String, Object> result = new LinkedHashMap<>();
+            for (Map.Entry<?, ?> e : m.entrySet()) {
+                result.put(String.valueOf(e.getKey()), e.getValue());
+            }
+            return result;
+        }
         try {
-            proposalJson = proposals.isEmpty() ? null :
-                    objectMapper.writeValueAsString(proposals.getFirst());
+            return objectMapper.convertValue(rawInput, Map.class);
         } catch (Exception e) {
-            log.error("Failed to serialize proposal: {}", e.getMessage());
+            log.error("Failed to convert tool input: {}", e.getMessage());
+            return Map.of();
         }
-
-        ChatMessage assistantMsg = ChatMessage.assistant(
-                tenantId, conversation.id(), textContent.toString(),
-                proposalJson, inputTokens, outputTokens);
-        messageRepository.save(assistantMsg);
-
-        conversationRepository.updateTimestamp(conversation.id(), tenantId);
-
-        Map<String, Object> result = new LinkedHashMap<>();
-        result.put("conversationId", conversation.id().toString());
-        result.put("content", textContent.toString());
-        result.put("proposals", proposals);
-        result.put("tokensUsed", Map.of("input", inputTokens, "output", outputTokens));
-
-        return result;
     }
 
     private Conversation getOrCreateConversation(String tenantId, String userId,
@@ -337,28 +428,9 @@ public class ChatService {
             return conversationRepository.findById(conversationId, tenantId)
                     .orElseThrow(() -> new IllegalArgumentException("Conversation not found: " + conversationId));
         }
-
         String title = userMessage.length() > 100 ? userMessage.substring(0, 100) + "..." : userMessage;
         Conversation conversation = Conversation.create(tenantId, userId, title);
         conversationRepository.save(conversation);
         return conversation;
-    }
-
-    private List<MessageParam> buildMessageHistory(UUID conversationId, String tenantId) {
-        List<ChatMessage> history = messageRepository.findByConversation(conversationId, tenantId);
-        List<MessageParam> messages = new ArrayList<>();
-        for (ChatMessage msg : history) {
-            if ("system".equals(msg.role())) continue;
-
-            MessageParam.Role role = "user".equals(msg.role())
-                    ? MessageParam.Role.USER
-                    : MessageParam.Role.ASSISTANT;
-
-            messages.add(MessageParam.builder()
-                    .role(role)
-                    .content(msg.content())
-                    .build());
-        }
-        return messages;
     }
 }

--- a/kelta-ai/src/main/java/io/kelta/ai/service/ProposalService.java
+++ b/kelta-ai/src/main/java/io/kelta/ai/service/ProposalService.java
@@ -40,6 +40,50 @@ public class ProposalService {
         return AiProposal.pending(type, data);
     }
 
+    /**
+     * Reconstruct an AiProposal from a persisted message. New messages store
+     * the proposal info inside a {@code tool_use} content block (with
+     * {@code proposalId}); legacy messages store it in the {@code proposalJson}
+     * column.
+     */
+    @SuppressWarnings("unchecked")
+    private AiProposal extractProposal(ChatMessage message, UUID proposalId) {
+        if (message.contentBlocks() != null) {
+            for (Map<String, Object> block : message.contentBlocks()) {
+                if (!"tool_use".equals(block.get("type"))) continue;
+                Object pid = block.get("proposalId");
+                if (pid == null || !proposalId.toString().equals(String.valueOf(pid))) continue;
+                String toolName = String.valueOf(block.get("name"));
+                String type = proposalTypeFromToolName(toolName);
+                Map<String, Object> data = block.get("input") instanceof Map<?, ?> m
+                        ? new java.util.LinkedHashMap<>((Map<String, Object>) m)
+                        : Map.of();
+                return new AiProposal(proposalId, type, "pending", data, message.createdAt());
+            }
+        }
+
+        if (message.legacyProposalJson() != null) {
+            try {
+                return objectMapper.readValue(message.legacyProposalJson(), AiProposal.class);
+            } catch (JacksonException e) {
+                throw new RuntimeException("Failed to deserialize proposal", e);
+            }
+        }
+        throw new IllegalArgumentException("Proposal not found in message: " + proposalId);
+    }
+
+    private static String proposalTypeFromToolName(String toolName) {
+        return switch (toolName) {
+            case "propose_collection" -> "collection";
+            case "propose_layout" -> "layout";
+            case "propose_add_fields" -> "add_fields";
+            case "propose_update_field" -> "update_field";
+            case "propose_remove_field" -> "remove_field";
+            case "propose_picklist" -> "picklist";
+            default -> "unknown";
+        };
+    }
+
     public String serializeProposal(AiProposal proposal) {
         try {
             return objectMapper.writeValueAsString(proposal);
@@ -57,12 +101,7 @@ public class ProposalService {
         ChatMessage message = messageRepository.findByProposalId(proposalId, tenantId)
                 .orElseThrow(() -> new IllegalArgumentException("Proposal not found: " + proposalId));
 
-        AiProposal proposal;
-        try {
-            proposal = objectMapper.readValue(message.proposalJson(), AiProposal.class);
-        } catch (JacksonException e) {
-            throw new RuntimeException("Failed to deserialize proposal", e);
-        }
+        AiProposal proposal = extractProposal(message, proposalId);
 
         if (!"pending".equals(proposal.status())) {
             throw new IllegalStateException("Proposal has already been " + proposal.status());
@@ -71,8 +110,120 @@ public class ProposalService {
         return switch (proposal.type()) {
             case "collection" -> applyCollectionProposal(tenantId, userId, proposal.data());
             case "layout" -> applyLayoutProposal(tenantId, userId, proposal.data());
+            case "add_fields" -> applyAddFieldsProposal(tenantId, userId, proposal.data());
+            case "update_field" -> applyUpdateFieldProposal(tenantId, userId, proposal.data());
+            case "remove_field" -> applyRemoveFieldProposal(tenantId, userId, proposal.data());
+            case "picklist" -> applyPicklistProposal(tenantId, userId, proposal.data());
             default -> throw new IllegalArgumentException("Unknown proposal type: " + proposal.type());
         };
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> applyAddFieldsProposal(String tenantId, String userId, Map<String, Object> data) {
+        String collectionName = String.valueOf(data.get("collectionName"));
+        Map<String, Object> collection = workerApiClient.getCollectionByName(tenantId, collectionName)
+                .orElseThrow(() -> new IllegalArgumentException("Collection not found: " + collectionName));
+        String collectionId = String.valueOf(collection.get("id"));
+
+        List<Map<String, Object>> fields = (List<Map<String, Object>>) data.getOrDefault("fields", List.of());
+        if (fields.isEmpty()) {
+            throw new IllegalArgumentException("No fields specified to add");
+        }
+
+        List<String> warnings = new java.util.ArrayList<>();
+        warnings.addAll(createPicklistsForFields(tenantId, userId, fields));
+        warnings.addAll(workerApiClient.createFields(tenantId, userId, collectionId, fields));
+
+        Map<String, Object> result = new java.util.LinkedHashMap<>();
+        result.put("collectionId", collectionId);
+        result.put("collectionName", collectionName);
+        result.put("fieldsAdded", fields.size() - warnings.size());
+        if (!warnings.isEmpty()) result.put("_warnings", warnings);
+        return result;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> applyUpdateFieldProposal(String tenantId, String userId, Map<String, Object> data) {
+        String collectionName = String.valueOf(data.get("collectionName"));
+        String fieldName = String.valueOf(data.get("fieldName"));
+        Map<String, Object> changes = (Map<String, Object>) data.getOrDefault("changes", Map.of());
+
+        if (changes.containsKey("type")) {
+            throw new IllegalArgumentException("Type changes are not supported via propose_update_field. " +
+                    "Use propose_remove_field then propose_add_fields.");
+        }
+
+        String fieldId = findFieldId(tenantId, collectionName, fieldName);
+        return workerApiClient.updateField(tenantId, userId, fieldId, changes);
+    }
+
+    private Map<String, Object> applyRemoveFieldProposal(String tenantId, String userId, Map<String, Object> data) {
+        String collectionName = String.valueOf(data.get("collectionName"));
+        String fieldName = String.valueOf(data.get("fieldName"));
+        String fieldId = findFieldId(tenantId, collectionName, fieldName);
+
+        workerApiClient.deleteField(tenantId, userId, fieldId);
+
+        Map<String, Object> result = new java.util.LinkedHashMap<>();
+        result.put("status", "deleted");
+        result.put("collectionName", collectionName);
+        result.put("fieldName", fieldName);
+        return result;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> applyPicklistProposal(String tenantId, String userId, Map<String, Object> data) {
+        Map<String, Object> picklistData = new java.util.LinkedHashMap<>();
+        picklistData.put("name", data.get("name"));
+        picklistData.put("description", data.get("description"));
+        picklistData.put("restricted", data.getOrDefault("restricted", false));
+        picklistData.put("sorted", false);
+        picklistData.entrySet().removeIf(e -> e.getValue() == null);
+
+        Map<String, Object> created = workerApiClient.createGlobalPicklist(tenantId, userId, picklistData);
+        Object plData = created.get("data");
+        String picklistId = (plData instanceof Map)
+                ? String.valueOf(((Map<String, Object>) plData).get("id"))
+                : null;
+
+        if (picklistId == null) {
+            throw new IllegalStateException("Could not extract picklist ID from worker response");
+        }
+
+        List<Map<String, Object>> values = (List<Map<String, Object>>) data.getOrDefault("values", List.of());
+        List<Map<String, Object>> formatted = new java.util.ArrayList<>();
+        for (int i = 0; i < values.size(); i++) {
+            Map<String, Object> raw = values.get(i);
+            Map<String, Object> v = new java.util.LinkedHashMap<>();
+            v.put("value", raw.get("value"));
+            v.put("label", raw.getOrDefault("label", raw.get("value")));
+            v.put("sortOrder", raw.getOrDefault("sortOrder", i));
+            v.put("isActive", true);
+            v.put("isDefault", i == 0);
+            formatted.add(v);
+        }
+        workerApiClient.createPicklistValues(tenantId, userId, picklistId, formatted);
+
+        Map<String, Object> result = new java.util.LinkedHashMap<>();
+        result.put("picklistId", picklistId);
+        result.put("name", data.get("name"));
+        result.put("valuesCreated", formatted.size());
+        return result;
+    }
+
+    @SuppressWarnings("unchecked")
+    private String findFieldId(String tenantId, String collectionName, String fieldName) {
+        Map<String, Object> collection = workerApiClient.getCollectionByName(tenantId, collectionName)
+                .orElseThrow(() -> new IllegalArgumentException("Collection not found: " + collectionName));
+        String collectionId = String.valueOf(collection.get("id"));
+
+        for (Map<String, Object> field : workerApiClient.listFields(tenantId, collectionId)) {
+            Map<String, Object> attrs = (Map<String, Object>) field.getOrDefault("attributes", field);
+            if (fieldName.equals(attrs.get("name"))) {
+                return String.valueOf(field.get("id"));
+            }
+        }
+        throw new IllegalArgumentException("Field '" + fieldName + "' not found on collection " + collectionName);
     }
 
     @SuppressWarnings("unchecked")

--- a/kelta-ai/src/main/java/io/kelta/ai/service/StreamAssembler.java
+++ b/kelta-ai/src/main/java/io/kelta/ai/service/StreamAssembler.java
@@ -1,0 +1,180 @@
+package io.kelta.ai.service;
+
+import com.anthropic.models.messages.RawMessageStreamEvent;
+import io.kelta.ai.service.tools.ToolRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import tools.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Assembles a streamed Anthropic message into structured content blocks
+ * (text + tool_use). Emits SSE events to the client as content arrives,
+ * and exposes the final assembled blocks once the stream completes.
+ *
+ * SSE event vocabulary emitted here:
+ *  - delta       : text token (text blocks)
+ *  - tool_call   : tool invocation start (READ tool — transient UI indicator)
+ *  - tool_use    : tool invocation start (PROPOSE tool — back-compat)
+ */
+public class StreamAssembler {
+
+    private static final Logger log = LoggerFactory.getLogger(StreamAssembler.class);
+
+    private final SseEmitter emitter;
+    private final ObjectMapper objectMapper;
+    private final ToolRegistry toolRegistry;
+
+    // Final assembled state — read after stream completes
+    private final List<Map<String, Object>> assistantBlocks = new ArrayList<>();
+    private final List<ToolUseRecord> toolUses = new ArrayList<>();
+
+    // Per-block accumulation state
+    private final StringBuilder currentText = new StringBuilder();
+    private final StringBuilder currentToolInputJson = new StringBuilder();
+    private String currentToolId;
+    private String currentToolName;
+
+    // Per-message state
+    private int inputTokens;
+    private int outputTokens;
+    private String stopReason;
+
+    public StreamAssembler(SseEmitter emitter, ObjectMapper objectMapper, ToolRegistry toolRegistry) {
+        this.emitter = emitter;
+        this.objectMapper = objectMapper;
+        this.toolRegistry = toolRegistry;
+    }
+
+    public void accept(RawMessageStreamEvent event) {
+        try {
+            handleMessageStart(event);
+            handleContentBlockStart(event);
+            handleContentBlockDelta(event);
+            handleContentBlockStop(event);
+            handleMessageDelta(event);
+        } catch (Exception e) {
+            log.error("Error processing stream event: {}", e.getMessage(), e);
+        }
+    }
+
+    public List<Map<String, Object>> assistantBlocks() {
+        return assistantBlocks;
+    }
+
+    public List<ToolUseRecord> toolUses() {
+        return toolUses;
+    }
+
+    public int inputTokens() {
+        return inputTokens;
+    }
+
+    public int outputTokens() {
+        return outputTokens;
+    }
+
+    public String stopReason() {
+        return stopReason;
+    }
+
+    private void handleMessageStart(RawMessageStreamEvent event) {
+        event.messageStart().ifPresent(msgStart ->
+                inputTokens = (int) msgStart.message().usage().inputTokens());
+    }
+
+    private void handleContentBlockStart(RawMessageStreamEvent event) {
+        event.contentBlockStart().ifPresent(blockStart -> {
+            blockStart.contentBlock().toolUse().ifPresent(toolUse -> {
+                currentToolId = toolUse.id();
+                currentToolName = toolUse.name();
+                currentToolInputJson.setLength(0);
+
+                String eventName = toolRegistry.isReadTool(currentToolName) ? "tool_call" : "tool_use";
+                emit(eventName, Map.of(
+                        "toolUseId", currentToolId,
+                        "name", currentToolName,
+                        "status", "pending"
+                ));
+            });
+        });
+    }
+
+    private void handleContentBlockDelta(RawMessageStreamEvent event) {
+        event.contentBlockDelta().ifPresent(delta -> {
+            delta.delta().text().ifPresent(textDelta -> {
+                String text = textDelta.text();
+                currentText.append(text);
+                emit("delta", Map.of("text", text));
+            });
+            delta.delta().inputJson().ifPresent(inputJsonDelta ->
+                    currentToolInputJson.append(inputJsonDelta.partialJson()));
+        });
+    }
+
+    @SuppressWarnings("unchecked")
+    private void handleContentBlockStop(RawMessageStreamEvent event) {
+        event.contentBlockStop().ifPresent(stop -> {
+            if (currentToolId != null) {
+                Map<String, Object> input = parseToolInput();
+                Map<String, Object> block = new LinkedHashMap<>();
+                block.put("type", "tool_use");
+                block.put("id", currentToolId);
+                block.put("name", currentToolName);
+                block.put("input", input);
+                assistantBlocks.add(block);
+                toolUses.add(new ToolUseRecord(currentToolId, currentToolName, input));
+                currentToolId = null;
+                currentToolName = null;
+                currentToolInputJson.setLength(0);
+            } else if (currentText.length() > 0) {
+                Map<String, Object> block = new LinkedHashMap<>();
+                block.put("type", "text");
+                block.put("text", currentText.toString());
+                assistantBlocks.add(block);
+                currentText.setLength(0);
+            }
+        });
+    }
+
+    private void handleMessageDelta(RawMessageStreamEvent event) {
+        event.messageDelta().ifPresent(msgDelta -> {
+            outputTokens = (int) msgDelta.usage().outputTokens();
+            try {
+                msgDelta.delta().stopReason().ifPresent(sr ->
+                        stopReason = sr.toString().toLowerCase().replace("\"", ""));
+            } catch (Exception e) {
+                log.debug("Could not extract stop reason: {}", e.getMessage());
+            }
+        });
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> parseToolInput() {
+        if (currentToolInputJson.isEmpty()) return Map.of();
+        try {
+            return objectMapper.readValue(currentToolInputJson.toString(), Map.class);
+        } catch (Exception e) {
+            log.error("Failed to parse tool input JSON for {}: {}", currentToolName, e.getMessage());
+            return Map.of();
+        }
+    }
+
+    private void emit(String name, Object data) {
+        if (emitter == null) return;
+        try {
+            emitter.send(SseEmitter.event().name(name).data(objectMapper.writeValueAsString(data)));
+        } catch (IOException e) {
+            log.error("Failed to send {} event: {}", name, e.getMessage());
+        }
+    }
+
+    public record ToolUseRecord(String id, String name, Map<String, Object> input) {
+    }
+}

--- a/kelta-ai/src/main/java/io/kelta/ai/service/SystemPromptService.java
+++ b/kelta-ai/src/main/java/io/kelta/ai/service/SystemPromptService.java
@@ -10,10 +10,14 @@ import java.util.Map;
 /**
  * Builds the system prompt for Claude with platform domain knowledge.
  * Combines static knowledge about field types and schemas with dynamic
- * context about the tenant's current collections.
+ * context about the tenant's current collections. For tenants with few
+ * collections (≤ {@link #AUTO_INLINE_THRESHOLD}), inlines full field
+ * tables to avoid round-trips on get_collection_schema.
  */
 @Service
 public class SystemPromptService {
+
+    static final int AUTO_INLINE_THRESHOLD = 8;
 
     private static final Logger log = LoggerFactory.getLogger(SystemPromptService.class);
 
@@ -27,7 +31,6 @@ public class SystemPromptService {
         StringBuilder sb = new StringBuilder();
         sb.append(getStaticPrompt());
 
-        // Add dynamic tenant context
         try {
             String tenantContext = buildTenantContext(tenantId, contextType, contextId);
             sb.append("\n\n").append(tenantContext);
@@ -41,160 +44,98 @@ public class SystemPromptService {
     private String getStaticPrompt() {
         return """
                 You are an AI assistant for the Kelta platform, a multi-tenant data management system.
-                You help users create and configure collections (data models) and page layouts.
+                You help users design and modify collections (data models), fields, picklists, and page layouts.
 
-                ## Your Capabilities
+                ## Tool Usage Patterns
 
-                You can propose:
-                1. **New collections** with fields - using the `propose_collection` tool
-                2. **Page layouts** for collections - using the `propose_layout` tool
+                You have READ tools to inspect the existing tenant — use them liberally before recommending changes:
+                - `get_collection_schema(collectionName)` — fields, types, references on an existing collection
+                - `query_records(collectionName, limit)` — sample 1–20 records to see actual data
+                - `list_picklists()` / `get_picklist(name)` — picklist values
+                - `list_validation_rules(collectionName)` — rules in effect
+                - `list_page_layouts(collectionName)` — existing layouts
 
-                Always use the appropriate tool to make proposals. Never output raw JSON.
-                When proposing changes, explain what you're creating and why.
+                You have PROPOSE tools that require user approval:
+                - `propose_collection` — create a new collection with fields
+                - `propose_layout` — create a page layout
+                - `propose_add_fields` — add new fields to an EXISTING collection
+                - `propose_update_field` — update a field's metadata (NOT its type)
+                - `propose_remove_field` — destructive; remove a field. Include a reason.
+                - `propose_picklist` — create a new global picklist
+
+                Rules:
+                1. Before recommending fields for an existing collection, ALWAYS call `get_collection_schema` first.
+                2. If the user states "products has X" and you don't see X in context, call `get_collection_schema` to verify
+                   rather than asking them to retype it.
+                3. `propose_update_field` cannot change a field's type. To replace a field, use `propose_remove_field`
+                   then `propose_add_fields`.
+                4. Call read tools freely — they're internal. Propose tools surface a card the user must approve, so
+                   explain what each proposal does when you call it.
+                5. Never output raw JSON to the user. Always go through tools.
 
                 ## Platform Built-in Features
 
                 The Kelta platform already provides these features out of the box via system collections.
                 Do NOT create collections for any of these — they already exist and are managed by the platform:
 
-                - **User Management**: `platform_user` — user accounts, authentication, login tracking, profiles
-                - **Roles & Permissions**: `roles`, `policies`, `profiles` — role-based access control, field-level and object-level permissions
-                - **Tenants**: `tenants` — multi-tenant management with governor limits
-                - **Schema Management**: `collections`, `fields` — the metadata system itself
-                - **Page Layouts**: `page_layouts`, `layout_sections`, `layout_fields`, `layout_assignments` — UI layout configuration
-                - **Navigation**: `ui_menus`, `ui_menu_items`, `ui_pages` — menu and page management
-                - **Picklists**: `global_picklists`, `picklist_values` — reusable value sets
-                - **Validation Rules**: `validation_rules` — custom field validation
-                - **Record Types**: `record_types` — record type management with picklist overrides
-                - **Sharing & Security**: `sharing_rules`, `org_wide_defaults` — record-level sharing
-                - **Workflows**: `workflow_rules`, `approval_processes`, `flows` — automation
-                - **Scheduled Jobs**: `scheduled_jobs` — background job scheduling
-                - **Email**: `email_templates`, `email_logs` — email templating and delivery
-                - **Webhooks & Integrations**: `connected_apps`, `webhook_endpoints` — external integrations
-                - **Analytics**: Embedded Superset dashboards and reports
-                - **Audit Trail**: `setup_audit_trail` — change tracking for setup
+                - User Management, Roles & Permissions, Tenants, Schema Management
+                - Page Layouts, Navigation, Picklists, Validation Rules, Record Types
+                - Sharing & Security, Workflows, Scheduled Jobs, Email, Webhooks & Integrations
+                - Analytics (embedded Superset), Audit Trail
 
                 When a user asks for "user management" or "authentication", explain that the platform already handles this.
-                Only create collections for the user's **domain-specific data** (e.g., products, orders, customers, recipes, songs).
+                Only create collections for the user's domain-specific data (products, orders, customers, etc.).
 
                 If the user's domain needs to reference platform users (e.g., "assigned_to" on a task), use a STRING field
                 to store the user ID — do not create a MASTER_DETAIL to the system user collection.
 
-                **Built-in record features (do NOT add these as fields):**
-                - **Notes** — Every record automatically supports notes/comments. Do NOT add a `notes` field.
-                - **Attachments** — Every record automatically supports file attachments. Do NOT add attachment/file fields.
-                - **Created/Updated timestamps** — Automatically tracked. Do NOT add `created_at`, `updated_at`, `created_date`, `modified_date` fields.
-                - **Created/Updated by** — Automatically tracked. Do NOT add `created_by`, `updated_by` fields.
-                - **Record ID** — Auto-generated UUID. Do NOT add an `id` field.
-                - **Active/Inactive** — Managed by the platform. Do NOT add `is_active` or `active` fields.
+                Built-in record features (do NOT add these as fields):
+                - Notes, Attachments, created/updated timestamps, created/updated by, record ID, active/inactive flag.
 
                 ## Collection Rules
 
-                - Collection names must be lowercase alphanumeric with underscores only (pattern: `^[a-z][a-z0-9_]*$`)
-                - Maximum 50 characters for collection name
-                - Every collection should have a meaningful `displayName`
-                - Always suggest a `displayFieldName` (the field shown as the record's label)
-                - The following names are RESERVED and will fail validation: users, roles, permissions, tenants, collections, fields, profiles, ui_pages, ui_menus, ui_menu_items, page_layouts, layout_sections, layout_fields, layout_assignments, global_picklists, picklist_values, validation_rules, record_types, sharing_rules, workflows, approval_processes, platform_user, connected_apps, scheduled_jobs, email_templates, email_logs, setup_audit_trail, webhook_endpoints, flow_definitions, flow_executions, bulk_jobs
+                - Collection names must match `^[a-z][a-z0-9_]*$`, max 50 chars
+                - Every collection needs a meaningful `displayName` and a `displayFieldName`
+                - Reserved names that will fail validation: users, roles, permissions, tenants, collections, fields,
+                  profiles, ui_pages, ui_menus, ui_menu_items, page_layouts, layout_sections, layout_fields,
+                  layout_assignments, global_picklists, picklist_values, validation_rules, record_types,
+                  sharing_rules, workflows, approval_processes, platform_user, connected_apps, scheduled_jobs,
+                  email_templates, email_logs, setup_audit_trail, webhook_endpoints, flow_definitions,
+                  flow_executions, bulk_jobs
 
-                ## Available Field Types
+                ## Field Types
 
-                Basic types:
-                - `STRING` - Text values (default max 255 chars)
-                - `INTEGER` - Whole numbers
-                - `LONG` - Large whole numbers
-                - `DOUBLE` - Decimal numbers
-                - `BOOLEAN` - True/false values
-                - `DATE` - Date only (no time)
-                - `DATETIME` - Date and time with timezone
-                - `JSON` - Arbitrary JSON data
+                Basic: STRING, INTEGER, LONG, DOUBLE, BOOLEAN, DATE, DATETIME, JSON
+                Picklist: PICKLIST, MULTI_PICKLIST (require `enumValues`)
+                Specialized: CURRENCY, PERCENT, AUTO_NUMBER, PHONE, EMAIL, URL, RICH_TEXT, ENCRYPTED,
+                EXTERNAL_ID, GEOLOCATION
+                Relationship: MASTER_DETAIL (the only relationship type — requires `referenceConfig`
+                with `targetCollection` and `relationshipName`)
+                Computed: FORMULA, ROLLUP_SUMMARY
 
-                Picklist types:
-                - `PICKLIST` - Single selection from predefined values (requires `enumValues`)
-                - `MULTI_PICKLIST` - Multiple selections from predefined values (requires `enumValues`)
-
-                Specialized types:
-                - `CURRENCY` - Monetary values (requires `fieldTypeConfig` with `currencyCode`)
-                - `PERCENT` - Percentage values
-                - `AUTO_NUMBER` - Auto-incrementing number (requires `fieldTypeConfig` with `prefix`, `startNumber`)
-                - `PHONE` - Phone number with validation
-                - `EMAIL` - Email address with validation
-                - `URL` - URL with validation
-                - `RICH_TEXT` - HTML/rich text content
-                - `ENCRYPTED` - Encrypted field (stored encrypted at rest)
-                - `EXTERNAL_ID` - External system identifier
-                - `GEOLOCATION` - Geographic coordinates (lat/lng)
-
-                Relationship types:
-                - `MASTER_DETAIL` - Relationship to another collection. Use this for ALL relationships (foreign keys). Requires `referenceConfig` with `targetCollection` and `relationshipName`. Do NOT use REFERENCE or LOOKUP — they are deprecated. Always use MASTER_DETAIL for any field that links to another collection.
-
-                Computed types:
-                - `FORMULA` - Calculated field based on a formula expression
-                - `ROLLUP_SUMMARY` - Aggregation of child records
-
-                ## Field Properties
-
-                Each field can have:
-                - `name` (required) - Field name (lowercase alphanumeric with underscores)
-                - `type` (required) - One of the field types above
-                - `nullable` - Whether the field can be null (default: true)
-                - `unique` - Whether values must be unique (default: false)
-                - `defaultValue` - Default value for new records
-                - `validationRules` - Array of validation rules with `type` (min, max, pattern, email, url, custom) and `value`
-                - `enumValues` - Array of allowed values (for PICKLIST and MULTI_PICKLIST)
-                - `referenceConfig` - Configuration for relationship fields (`targetCollection`, `relationshipName`, `cascadeDelete`)
-                - `fieldTypeConfig` - Type-specific configuration (e.g., `currencyCode` for CURRENCY, `prefix` for AUTO_NUMBER)
+                Field properties: name, type, nullable, unique, defaultValue, validationRules, enumValues,
+                referenceConfig, fieldTypeConfig.
 
                 ## Page Layout Structure
 
-                Layout types: `DETAIL`, `EDIT`, `MINI`, `LIST`
+                Layout types: DETAIL, EDIT, MINI, LIST. Each layout has sections; each section has heading,
+                columns (1-3), style (DEFAULT/COLLAPSIBLE/CARD), fieldPlacements (fieldName, columnNumber,
+                sortOrder). Layouts can have `relatedLists` for child records.
 
-                Each layout has sections, and each section has:
-                - `heading` - Section title
-                - `columns` - Number of columns (1, 2, or 3)
-                - `style` - `DEFAULT`, `COLLAPSIBLE`, or `CARD`
-                - `fieldPlacements` - Array of fields placed in this section with:
-                  - `fieldName` - Name of the field
-                  - `columnNumber` - Which column (1-based)
-                  - `sortOrder` - Display order within the column
+                ## Relational Design
 
-                Layouts can also have `relatedLists` for showing child/related records.
-
-                ## Relational Database Design Rules — CRITICAL
-
-                You MUST follow proper relational database design principles:
-
-                1. **Normalize data into multiple collections.** NEVER put everything in one collection.
-                   - Orders need an `orders` collection AND an `order_lines` collection
-                   - Recipes need a `recipes` collection AND a `recipe_ingredients` collection
-                   - Invoices need an `invoices` collection AND an `invoice_items` collection
-                   - Courses need a `courses` collection AND a `course_modules` collection
-
-                2. **Use MASTER_DETAIL relationships** to connect parent-child collections.
-                   - The child collection (e.g., `order_lines`) has a MASTER_DETAIL field pointing to the parent (`orders`)
-                   - Always include `referenceConfig` with `targetCollection` and `relationshipName`
-
-                3. **Create ALL related collections in a single response** using multiple `propose_collection` tool calls.
-                   - When asked for "an order management system", call `propose_collection` MULTIPLE TIMES in the SAME response:
-                     first `orders`, then `order_items` with a MASTER_DETAIL to `orders`
-                   - You MUST call the tool once per collection — do NOT stop after the first collection
-                   - The user should see ALL proposed collections at once to review together
-                   - IMPORTANT: Always call propose_collection for EVERY collection you describe. If you say you'll create
-                     orders AND order items, you MUST call propose_collection twice — once for each.
-
-                4. **Junction tables** for many-to-many relationships.
-                   - e.g., `playlist_tracks` connecting `playlists` and `tracks`
-
-                5. **Avoid storing lists in a single field.** If something has multiple values (ingredients, line items, tags),
-                   create a separate collection with a MASTER_DETAIL back to the parent.
+                Normalize data into multiple collections (orders + order_lines, recipes + recipe_ingredients).
+                Use MASTER_DETAIL on the child pointing to the parent. Avoid storing lists in a single field.
+                When designing a multi-collection system, call `propose_collection` once per collection
+                across iterations — you do NOT need to do it all in one response.
 
                 ## Best Practices
 
-                1. Always include a display field (usually `name` or `title`)
-                2. Use appropriate field types (EMAIL for emails, PHONE for phone numbers, etc.)
-                3. Use PICKLIST for fields with a known set of values (e.g., status, priority) — include `enumValues`
-                4. When creating relationships, the target collection must be proposed first or already exist
-                5. Propose collections in dependency order: parent collections first, then children
-                6. Include `displayFieldName` to set which field represents the record's label
+                - Include a display field (usually `name` or `title`)
+                - Use type-specific fields (EMAIL for emails, PHONE for phones)
+                - PICKLIST for known value sets; include `enumValues`
+                - Target collections must exist or be proposed first
+                - Propose parents before children
                 """;
     }
 
@@ -203,7 +144,6 @@ public class SystemPromptService {
         StringBuilder sb = new StringBuilder();
         sb.append("## Current Tenant Context\n\n");
 
-        // Fetch existing collections
         List<Map<String, Object>> collections = workerApiClient.listCollections(tenantId);
 
         if (collections.isEmpty()) {
@@ -212,37 +152,80 @@ public class SystemPromptService {
             sb.append("Existing collections in this tenant:\n\n");
             for (Map<String, Object> collection : collections) {
                 Map<String, Object> attrs = (Map<String, Object>) collection.get("attributes");
-                if (attrs != null) {
-                    sb.append("- **").append(attrs.getOrDefault("displayName", attrs.get("name")))
-                            .append("** (`").append(attrs.get("name")).append("`)")
-                            .append(": ").append(attrs.getOrDefault("description", "")).append("\n");
+                if (attrs == null) continue;
+                sb.append("- **").append(attrs.getOrDefault("displayName", attrs.get("name")))
+                        .append("** (`").append(attrs.get("name")).append("`)");
+                Object desc = attrs.get("description");
+                if (desc != null && !String.valueOf(desc).isBlank()) {
+                    sb.append(": ").append(desc);
                 }
+                sb.append("\n");
+            }
+
+            if (collections.size() <= AUTO_INLINE_THRESHOLD) {
+                appendInlineFieldTables(tenantId, collections, sb);
+            } else {
+                sb.append("\nTenant has ").append(collections.size())
+                        .append(" collections — use `get_collection_schema` to inspect fields on demand.\n");
             }
         }
 
-        // If viewing a specific collection, fetch its fields
         if ("collection".equals(contextType) && contextId != null) {
-            sb.append("\n### Currently Viewing Collection\n\n");
-            try {
-                List<Map<String, Object>> fields = workerApiClient.listFields(tenantId, contextId);
-                if (!fields.isEmpty()) {
-                    sb.append("Fields in this collection:\n\n");
-                    sb.append("| Field | Type | Required |\n|-------|------|----------|\n");
-                    for (Map<String, Object> field : fields) {
-                        Map<String, Object> attrs = (Map<String, Object>) field.get("attributes");
-                        if (attrs != null) {
-                            sb.append("| ").append(attrs.get("name"))
-                                    .append(" | ").append(attrs.get("type"))
-                                    .append(" | ").append(Boolean.TRUE.equals(attrs.get("required")) ? "Yes" : "No")
-                                    .append(" |\n");
-                        }
-                    }
-                }
-            } catch (Exception e) {
-                log.warn("Failed to fetch fields for collection {}: {}", contextId, e.getMessage());
-            }
+            appendCurrentCollectionFields(tenantId, contextId, sb);
         }
 
         return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    private void appendInlineFieldTables(String tenantId, List<Map<String, Object>> collections,
+                                          StringBuilder sb) {
+        sb.append("\n### Schemas (auto-loaded — tenant has few collections)\n");
+        for (Map<String, Object> collection : collections) {
+            Map<String, Object> attrs = (Map<String, Object>) collection.get("attributes");
+            if (attrs == null) continue;
+            String name = String.valueOf(attrs.get("name"));
+            String collectionId = String.valueOf(collection.get("id"));
+
+            sb.append("\n#### `").append(name).append("`\n\n");
+            try {
+                List<Map<String, Object>> fields = workerApiClient.listFields(tenantId, collectionId);
+                appendFieldTable(fields, sb);
+            } catch (Exception e) {
+                log.warn("Failed to fetch fields for {}: {}", name, e.getMessage());
+                sb.append("_(failed to load fields — use `get_collection_schema('").append(name).append("')`)_\n");
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void appendCurrentCollectionFields(String tenantId, String contextId, StringBuilder sb) {
+        sb.append("\n### Currently Viewing Collection\n\n");
+        try {
+            List<Map<String, Object>> fields = workerApiClient.listFields(tenantId, contextId);
+            appendFieldTable(fields, sb);
+        } catch (Exception e) {
+            log.warn("Failed to fetch fields for collection {}: {}", contextId, e.getMessage());
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void appendFieldTable(List<Map<String, Object>> fields, StringBuilder sb) {
+        if (fields.isEmpty()) {
+            sb.append("_(no fields yet)_\n");
+            return;
+        }
+        sb.append("| Field | Type | Required | Notes |\n|-------|------|----------|-------|\n");
+        for (Map<String, Object> field : fields) {
+            Map<String, Object> attrs = (Map<String, Object>) field.get("attributes");
+            if (attrs == null) continue;
+            sb.append("| `").append(attrs.getOrDefault("name", ""))
+                    .append("` | ").append(attrs.getOrDefault("type", ""))
+                    .append(" | ").append(Boolean.TRUE.equals(attrs.get("required")) ? "Yes" : "No")
+                    .append(" | ");
+            Object refTarget = attrs.get("referenceTarget");
+            if (refTarget != null) sb.append("→ ").append(refTarget);
+            sb.append(" |\n");
+        }
     }
 }

--- a/kelta-ai/src/main/java/io/kelta/ai/service/WorkerApiClient.java
+++ b/kelta-ai/src/main/java/io/kelta/ai/service/WorkerApiClient.java
@@ -7,8 +7,10 @@ import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * HTTP client for calling the kelta-worker APIs.
@@ -347,6 +349,169 @@ public class WorkerApiClient {
                 .bodyValue(jsonApiBody)
                 .retrieve()
                 .bodyToMono(Map.class)
+                .block();
+    }
+
+    // =========================================================================
+    // Read helpers (used by AI read tools)
+    // =========================================================================
+
+    @SuppressWarnings("unchecked")
+    public Optional<Map<String, Object>> getCollectionByName(String tenantId, String name) {
+        if (name == null || name.isBlank()) return Optional.empty();
+        String needle = name.toLowerCase();
+        return listCollections(tenantId).stream()
+                .filter(c -> {
+                    Map<String, Object> attrs = (Map<String, Object>) c.get("attributes");
+                    if (attrs == null) return false;
+                    Object n = attrs.get("name");
+                    return n != null && needle.equals(String.valueOf(n).toLowerCase());
+                })
+                .findFirst();
+    }
+
+    @SuppressWarnings("unchecked")
+    public List<Map<String, Object>> listPicklists(String tenantId) {
+        Map<String, Object> response = webClient.get()
+                .uri("/api/global-picklists?page[size]=200")
+                .header("X-Tenant-ID", tenantId)
+                .retrieve()
+                .bodyToMono(Map.class)
+                .block();
+        if (response != null && response.containsKey("data")) {
+            return (List<Map<String, Object>>) response.get("data");
+        }
+        return List.of();
+    }
+
+    @SuppressWarnings("unchecked")
+    public Optional<Map<String, Object>> getPicklist(String tenantId, String idOrName) {
+        if (idOrName == null || idOrName.isBlank()) return Optional.empty();
+        Map<String, Object> response = webClient.get()
+                .uri(uri -> uri.path("/api/global-picklists")
+                        .queryParam("include", "picklist-values")
+                        .queryParam("filter[name][EQ]", idOrName)
+                        .queryParam("page[size]", 1)
+                        .build())
+                .header("X-Tenant-ID", tenantId)
+                .retrieve()
+                .bodyToMono(Map.class)
+                .block();
+        if (response == null) return Optional.empty();
+        List<Map<String, Object>> data = (List<Map<String, Object>>) response.get("data");
+        if (data == null || data.isEmpty()) {
+            return Optional.empty();
+        }
+        Map<String, Object> picklist = data.getFirst();
+        Object included = response.get("included");
+        if (included instanceof List<?> incList) {
+            List<Map<String, Object>> values = incList.stream()
+                    .filter(o -> o instanceof Map)
+                    .map(o -> (Map<String, Object>) o)
+                    .filter(o -> "picklist-values".equals(o.get("type")))
+                    .toList();
+            Map<String, Object> withValues = new LinkedHashMap<>(picklist);
+            withValues.put("values", values);
+            return Optional.of(withValues);
+        }
+        return Optional.of(picklist);
+    }
+
+    @SuppressWarnings("unchecked")
+    public List<Map<String, Object>> listValidationRules(String tenantId, String collectionId) {
+        Map<String, Object> response = webClient.get()
+                .uri(uri -> uri.path("/api/validation-rules")
+                        .queryParam("filter[collectionId][EQ]", collectionId)
+                        .queryParam("page[size]", 200)
+                        .build())
+                .header("X-Tenant-ID", tenantId)
+                .retrieve()
+                .bodyToMono(Map.class)
+                .block();
+        if (response != null && response.containsKey("data")) {
+            return (List<Map<String, Object>>) response.get("data");
+        }
+        return List.of();
+    }
+
+    @SuppressWarnings("unchecked")
+    public List<Map<String, Object>> listPageLayouts(String tenantId, String collectionId) {
+        Map<String, Object> response = webClient.get()
+                .uri(uri -> uri.path("/api/page-layouts")
+                        .queryParam("filter[collectionId][EQ]", collectionId)
+                        .queryParam("page[size]", 50)
+                        .build())
+                .header("X-Tenant-ID", tenantId)
+                .retrieve()
+                .bodyToMono(Map.class)
+                .block();
+        if (response != null && response.containsKey("data")) {
+            return (List<Map<String, Object>>) response.get("data");
+        }
+        return List.of();
+    }
+
+    @SuppressWarnings("unchecked")
+    public Map<String, Object> sampleRecords(String tenantId, String collectionName,
+                                              int limit, List<String> fields,
+                                              Map<String, Object> filter) {
+        int safeLimit = Math.max(1, Math.min(20, limit));
+        Map<String, Object> response = webClient.get()
+                .uri(uri -> {
+                    var b = uri.path("/api/" + collectionName)
+                            .queryParam("page[size]", safeLimit);
+                    if (fields != null && !fields.isEmpty()) {
+                        b.queryParam("fields[" + collectionName + "]", String.join(",", fields));
+                    }
+                    if (filter != null) {
+                        for (Map.Entry<String, Object> e : filter.entrySet()) {
+                            if (e.getValue() != null) {
+                                b.queryParam("filter[" + e.getKey() + "][EQ]", String.valueOf(e.getValue()));
+                            }
+                        }
+                    }
+                    return b.build();
+                })
+                .header("X-Tenant-ID", tenantId)
+                .retrieve()
+                .onStatus(status -> status.is4xxClientError() || status.is5xxServerError(),
+                        resp -> resp.bodyToMono(String.class)
+                                .map(body -> new RuntimeException(parseWorkerError(body))))
+                .bodyToMono(Map.class)
+                .block();
+        if (response == null) return Map.of("data", List.of());
+        return response;
+    }
+
+    public Map<String, Object> updateField(String tenantId, String userId, String fieldId,
+                                            Map<String, Object> attrs) {
+        Map<String, Object> jsonApiBody = Map.of(
+                "data", Map.of("type", "fields", "id", fieldId, "attributes", attrs));
+
+        return webClient.patch()
+                .uri("/api/fields/{fieldId}", fieldId)
+                .header("X-Tenant-ID", tenantId)
+                .header("X-User-Id", userId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(jsonApiBody)
+                .retrieve()
+                .onStatus(status -> status.is4xxClientError() || status.is5xxServerError(),
+                        resp -> resp.bodyToMono(String.class)
+                                .map(body -> new RuntimeException(parseWorkerError(body))))
+                .bodyToMono(Map.class)
+                .block();
+    }
+
+    public void deleteField(String tenantId, String userId, String fieldId) {
+        webClient.delete()
+                .uri("/api/fields/{fieldId}", fieldId)
+                .header("X-Tenant-ID", tenantId)
+                .header("X-User-Id", userId)
+                .retrieve()
+                .onStatus(status -> status.is4xxClientError() || status.is5xxServerError(),
+                        resp -> resp.bodyToMono(String.class)
+                                .map(body -> new RuntimeException(parseWorkerError(body))))
+                .bodyToMono(Void.class)
                 .block();
     }
 }

--- a/kelta-ai/src/main/java/io/kelta/ai/service/tools/DispatchResult.java
+++ b/kelta-ai/src/main/java/io/kelta/ai/service/tools/DispatchResult.java
@@ -1,0 +1,19 @@
+package io.kelta.ai.service.tools;
+
+import io.kelta.ai.model.AiProposal;
+
+public record DispatchResult(
+        String toolUseId,
+        String toolName,
+        String resultJson,
+        boolean isError,
+        AiProposal proposal
+) {
+    public static DispatchResult readResult(String toolUseId, String toolName, String resultJson, boolean isError) {
+        return new DispatchResult(toolUseId, toolName, resultJson, isError, null);
+    }
+
+    public static DispatchResult proposalQueued(String toolUseId, String toolName, String ackJson, AiProposal proposal) {
+        return new DispatchResult(toolUseId, toolName, ackJson, false, proposal);
+    }
+}

--- a/kelta-ai/src/main/java/io/kelta/ai/service/tools/ProposeToolHandler.java
+++ b/kelta-ai/src/main/java/io/kelta/ai/service/tools/ProposeToolHandler.java
@@ -1,0 +1,15 @@
+package io.kelta.ai.service.tools;
+
+import io.kelta.ai.model.AiProposal;
+
+import java.util.Map;
+
+public non-sealed interface ProposeToolHandler extends ToolHandler {
+
+    AiProposal buildProposal(Map<String, Object> input);
+
+    @Override
+    default ToolKind kind() {
+        return ToolKind.PROPOSE;
+    }
+}

--- a/kelta-ai/src/main/java/io/kelta/ai/service/tools/ReadToolHandler.java
+++ b/kelta-ai/src/main/java/io/kelta/ai/service/tools/ReadToolHandler.java
@@ -1,0 +1,13 @@
+package io.kelta.ai.service.tools;
+
+import java.util.Map;
+
+public non-sealed interface ReadToolHandler extends ToolHandler {
+
+    Object execute(String tenantId, String userId, Map<String, Object> input);
+
+    @Override
+    default ToolKind kind() {
+        return ToolKind.READ;
+    }
+}

--- a/kelta-ai/src/main/java/io/kelta/ai/service/tools/ToolDispatcher.java
+++ b/kelta-ai/src/main/java/io/kelta/ai/service/tools/ToolDispatcher.java
@@ -1,0 +1,78 @@
+package io.kelta.ai.service.tools;
+
+import io.kelta.ai.model.AiProposal;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import tools.jackson.databind.ObjectMapper;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Service
+public class ToolDispatcher {
+
+    private static final Logger log = LoggerFactory.getLogger(ToolDispatcher.class);
+
+    private final ToolRegistry registry;
+    private final ObjectMapper objectMapper;
+
+    public ToolDispatcher(ToolRegistry registry, ObjectMapper objectMapper) {
+        this.registry = registry;
+        this.objectMapper = objectMapper;
+    }
+
+    public DispatchResult dispatch(String tenantId, String userId,
+                                    String toolUseId, String toolName,
+                                    Map<String, Object> input) {
+        ToolHandler handler = registry.handler(toolName)
+                .orElseThrow(() -> new IllegalArgumentException("Unknown tool: " + toolName));
+
+        return switch (handler) {
+            case ReadToolHandler r -> dispatchRead(r, tenantId, userId, toolUseId, toolName, input);
+            case ProposeToolHandler p -> dispatchPropose(p, toolUseId, toolName, input);
+        };
+    }
+
+    private DispatchResult dispatchRead(ReadToolHandler handler, String tenantId, String userId,
+                                         String toolUseId, String toolName, Map<String, Object> input) {
+        try {
+            Object data = handler.execute(tenantId, userId, input);
+            String json = objectMapper.writeValueAsString(data);
+            return DispatchResult.readResult(toolUseId, toolName, json, false);
+        } catch (IllegalArgumentException e) {
+            log.warn("Tool '{}' rejected input: {}", toolName, e.getMessage());
+            return DispatchResult.readResult(toolUseId, toolName, errorJson("invalid_input", e.getMessage()), true);
+        } catch (Exception e) {
+            log.error("Tool '{}' failed: {}", toolName, e.getMessage(), e);
+            return DispatchResult.readResult(toolUseId, toolName, errorJson(e.getClass().getSimpleName(), e.getMessage()), true);
+        }
+    }
+
+    private DispatchResult dispatchPropose(ProposeToolHandler handler, String toolUseId,
+                                            String toolName, Map<String, Object> input) {
+        try {
+            AiProposal proposal = handler.buildProposal(input);
+            Map<String, Object> ack = new LinkedHashMap<>();
+            ack.put("status", "queued");
+            ack.put("proposalId", proposal.id().toString());
+            ack.put("message", "Proposal queued for user approval. Continue with any other tool calls or summarize.");
+            String ackJson = objectMapper.writeValueAsString(ack);
+            return DispatchResult.proposalQueued(toolUseId, toolName, ackJson, proposal);
+        } catch (IllegalArgumentException e) {
+            log.warn("Propose tool '{}' rejected input: {}", toolName, e.getMessage());
+            return DispatchResult.readResult(toolUseId, toolName, errorJson("invalid_input", e.getMessage()), true);
+        } catch (Exception e) {
+            log.error("Propose tool '{}' failed: {}", toolName, e.getMessage(), e);
+            return DispatchResult.readResult(toolUseId, toolName, errorJson(e.getClass().getSimpleName(), e.getMessage()), true);
+        }
+    }
+
+    private String errorJson(String code, String message) {
+        try {
+            return objectMapper.writeValueAsString(Map.of("error", code, "message", message != null ? message : ""));
+        } catch (Exception e) {
+            return "{\"error\":\"serialization_failed\"}";
+        }
+    }
+}

--- a/kelta-ai/src/main/java/io/kelta/ai/service/tools/ToolHandler.java
+++ b/kelta-ai/src/main/java/io/kelta/ai/service/tools/ToolHandler.java
@@ -1,0 +1,14 @@
+package io.kelta.ai.service.tools;
+
+import java.util.Map;
+
+public sealed interface ToolHandler permits ReadToolHandler, ProposeToolHandler {
+
+    String name();
+
+    String description();
+
+    Map<String, Object> inputSchema();
+
+    ToolKind kind();
+}

--- a/kelta-ai/src/main/java/io/kelta/ai/service/tools/ToolKind.java
+++ b/kelta-ai/src/main/java/io/kelta/ai/service/tools/ToolKind.java
@@ -1,0 +1,6 @@
+package io.kelta.ai.service.tools;
+
+public enum ToolKind {
+    READ,
+    PROPOSE
+}

--- a/kelta-ai/src/main/java/io/kelta/ai/service/tools/ToolRegistry.java
+++ b/kelta-ai/src/main/java/io/kelta/ai/service/tools/ToolRegistry.java
@@ -1,0 +1,58 @@
+package io.kelta.ai.service.tools;
+
+import com.anthropic.core.JsonValue;
+import com.anthropic.models.messages.Tool;
+import com.anthropic.models.messages.ToolUnion;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@Component
+public class ToolRegistry {
+
+    private final Map<String, ToolHandler> handlers;
+
+    public ToolRegistry(List<ToolHandler> handlers) {
+        Map<String, ToolHandler> byName = new HashMap<>();
+        for (ToolHandler h : handlers) {
+            byName.put(h.name(), h);
+        }
+        this.handlers = Map.copyOf(byName);
+    }
+
+    public Optional<ToolHandler> handler(String name) {
+        return Optional.ofNullable(handlers.get(name));
+    }
+
+    public boolean isReadTool(String name) {
+        return handler(name).map(h -> h.kind() == ToolKind.READ).orElse(false);
+    }
+
+    public boolean isProposeTool(String name) {
+        return handler(name).map(h -> h.kind() == ToolKind.PROPOSE).orElse(false);
+    }
+
+    public List<ToolUnion> toolDefinitions() {
+        return handlers.values().stream()
+                .map(this::toToolUnion)
+                .toList();
+    }
+
+    public int size() {
+        return handlers.size();
+    }
+
+    private ToolUnion toToolUnion(ToolHandler handler) {
+        Tool tool = Tool.builder()
+                .name(handler.name())
+                .description(handler.description())
+                .inputSchema(Tool.InputSchema.builder()
+                        .properties(JsonValue.from(handler.inputSchema()))
+                        .build())
+                .build();
+        return ToolUnion.ofTool(tool);
+    }
+}

--- a/kelta-ai/src/main/java/io/kelta/ai/service/tools/handlers/GetCollectionSchemaHandler.java
+++ b/kelta-ai/src/main/java/io/kelta/ai/service/tools/handlers/GetCollectionSchemaHandler.java
@@ -1,0 +1,91 @@
+package io.kelta.ai.service.tools.handlers;
+
+import io.kelta.ai.service.WorkerApiClient;
+import io.kelta.ai.service.tools.ReadToolHandler;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class GetCollectionSchemaHandler implements ReadToolHandler {
+
+    private final WorkerApiClient workerApiClient;
+
+    public GetCollectionSchemaHandler(WorkerApiClient workerApiClient) {
+        this.workerApiClient = workerApiClient;
+    }
+
+    @Override
+    public String name() {
+        return "get_collection_schema";
+    }
+
+    @Override
+    public String description() {
+        return "Retrieve the full schema (all fields, types, picklist values, references, validations) for an existing collection. " +
+                "CALL THIS before recommending fields for an existing collection so you can see what already exists. " +
+                "Do not guess field names from memory.";
+    }
+
+    @Override
+    public Map<String, Object> inputSchema() {
+        return Map.of(
+                "type", "object",
+                "properties", Map.of(
+                        "collectionName", Map.of(
+                                "type", "string",
+                                "description", "Collection name (lowercase, alphanumeric, underscores), e.g. \"products\""
+                        )
+                ),
+                "required", List.of("collectionName")
+        );
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Object execute(String tenantId, String userId, Map<String, Object> input) {
+        String collectionName = String.valueOf(input.get("collectionName"));
+        if (collectionName.isBlank() || "null".equals(collectionName)) {
+            throw new IllegalArgumentException("collectionName is required");
+        }
+
+        Map<String, Object> collection = workerApiClient.getCollectionByName(tenantId, collectionName)
+                .orElseThrow(() -> new IllegalArgumentException("Collection not found: " + collectionName));
+
+        Map<String, Object> attrs = (Map<String, Object>) collection.getOrDefault("attributes", Map.of());
+        String collectionId = String.valueOf(collection.get("id"));
+
+        List<Map<String, Object>> rawFields = workerApiClient.listFields(tenantId, collectionId);
+        List<Map<String, Object>> fields = new ArrayList<>();
+        for (Map<String, Object> field : rawFields) {
+            Map<String, Object> fAttrs = (Map<String, Object>) field.getOrDefault("attributes", Map.of());
+            Map<String, Object> summary = new LinkedHashMap<>();
+            putIfPresent(summary, "name", fAttrs.get("name"));
+            putIfPresent(summary, "displayName", fAttrs.get("displayName"));
+            putIfPresent(summary, "type", fAttrs.get("type"));
+            putIfPresent(summary, "required", fAttrs.get("required"));
+            putIfPresent(summary, "unique", fAttrs.get("uniqueConstraint"));
+            putIfPresent(summary, "description", fAttrs.get("description"));
+            putIfPresent(summary, "referenceTarget", fAttrs.get("referenceTarget"));
+            putIfPresent(summary, "relationshipName", fAttrs.get("relationshipName"));
+            putIfPresent(summary, "fieldTypeConfig", fAttrs.get("fieldTypeConfig"));
+            fields.add(summary);
+        }
+
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("name", attrs.get("name"));
+        result.put("displayName", attrs.get("displayName"));
+        result.put("description", attrs.get("description"));
+        result.put("displayFieldName", attrs.get("displayFieldName"));
+        result.put("fieldCount", fields.size());
+        result.put("fields", fields);
+        return result;
+    }
+
+    private static void putIfPresent(Map<String, Object> map, String key, Object value) {
+        if (value != null) map.put(key, value);
+    }
+}

--- a/kelta-ai/src/main/java/io/kelta/ai/service/tools/handlers/GetPicklistHandler.java
+++ b/kelta-ai/src/main/java/io/kelta/ai/service/tools/handlers/GetPicklistHandler.java
@@ -1,0 +1,77 @@
+package io.kelta.ai.service.tools.handlers;
+
+import io.kelta.ai.service.WorkerApiClient;
+import io.kelta.ai.service.tools.ReadToolHandler;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class GetPicklistHandler implements ReadToolHandler {
+
+    private final WorkerApiClient workerApiClient;
+
+    public GetPicklistHandler(WorkerApiClient workerApiClient) {
+        this.workerApiClient = workerApiClient;
+    }
+
+    @Override
+    public String name() {
+        return "get_picklist";
+    }
+
+    @Override
+    public String description() {
+        return "Get the values of a global picklist by name. Useful when proposing fields that should reuse an existing picklist.";
+    }
+
+    @Override
+    public Map<String, Object> inputSchema() {
+        return Map.of(
+                "type", "object",
+                "properties", Map.of(
+                        "name", Map.of("type", "string", "description", "Picklist name, e.g. \"priority\"")
+                ),
+                "required", List.of("name")
+        );
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Object execute(String tenantId, String userId, Map<String, Object> input) {
+        String name = String.valueOf(input.get("name"));
+        if (name.isBlank() || "null".equals(name)) {
+            throw new IllegalArgumentException("name is required");
+        }
+        Map<String, Object> picklist = workerApiClient.getPicklist(tenantId, name)
+                .orElseThrow(() -> new IllegalArgumentException("Picklist not found: " + name));
+
+        Map<String, Object> attrs = (Map<String, Object>) picklist.getOrDefault("attributes", Map.of());
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("id", picklist.get("id"));
+        result.put("name", attrs.get("name"));
+        if (attrs.get("description") != null) result.put("description", attrs.get("description"));
+        if (attrs.get("restricted") != null) result.put("restricted", attrs.get("restricted"));
+
+        List<Map<String, Object>> values = new ArrayList<>();
+        Object rawValues = picklist.get("values");
+        if (rawValues instanceof List<?> list) {
+            for (Object o : list) {
+                if (o instanceof Map<?, ?> raw) {
+                    Map<String, Object> vAttrs = (Map<String, Object>) ((Map<String, Object>) raw).getOrDefault("attributes", raw);
+                    Map<String, Object> v = new LinkedHashMap<>();
+                    v.put("value", vAttrs.get("value"));
+                    v.put("label", vAttrs.get("label"));
+                    if (vAttrs.get("sortOrder") != null) v.put("sortOrder", vAttrs.get("sortOrder"));
+                    if (vAttrs.get("isActive") != null) v.put("isActive", vAttrs.get("isActive"));
+                    values.add(v);
+                }
+            }
+        }
+        result.put("values", values);
+        return result;
+    }
+}

--- a/kelta-ai/src/main/java/io/kelta/ai/service/tools/handlers/ListPageLayoutsHandler.java
+++ b/kelta-ai/src/main/java/io/kelta/ai/service/tools/handlers/ListPageLayoutsHandler.java
@@ -1,0 +1,67 @@
+package io.kelta.ai.service.tools.handlers;
+
+import io.kelta.ai.service.WorkerApiClient;
+import io.kelta.ai.service.tools.ReadToolHandler;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class ListPageLayoutsHandler implements ReadToolHandler {
+
+    private final WorkerApiClient workerApiClient;
+
+    public ListPageLayoutsHandler(WorkerApiClient workerApiClient) {
+        this.workerApiClient = workerApiClient;
+    }
+
+    @Override
+    public String name() {
+        return "list_page_layouts";
+    }
+
+    @Override
+    public String description() {
+        return "List page layouts (DETAIL, EDIT, MINI, LIST) defined for a collection. " +
+                "Useful before proposing a new layout to avoid duplication.";
+    }
+
+    @Override
+    public Map<String, Object> inputSchema() {
+        return Map.of(
+                "type", "object",
+                "properties", Map.of(
+                        "collectionName", Map.of("type", "string", "description", "Collection name")
+                ),
+                "required", List.of("collectionName")
+        );
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Object execute(String tenantId, String userId, Map<String, Object> input) {
+        String collectionName = String.valueOf(input.get("collectionName"));
+        if (collectionName.isBlank() || "null".equals(collectionName)) {
+            throw new IllegalArgumentException("collectionName is required");
+        }
+        Map<String, Object> collection = workerApiClient.getCollectionByName(tenantId, collectionName)
+                .orElseThrow(() -> new IllegalArgumentException("Collection not found: " + collectionName));
+        String collectionId = String.valueOf(collection.get("id"));
+
+        List<Map<String, Object>> raw = workerApiClient.listPageLayouts(tenantId, collectionId);
+        List<Map<String, Object>> result = new ArrayList<>(raw.size());
+        for (Map<String, Object> layout : raw) {
+            Map<String, Object> attrs = (Map<String, Object>) layout.getOrDefault("attributes", Map.of());
+            Map<String, Object> summary = new LinkedHashMap<>();
+            summary.put("id", layout.get("id"));
+            summary.put("name", attrs.get("name"));
+            summary.put("layoutType", attrs.get("layoutType"));
+            if (attrs.get("isDefault") != null) summary.put("isDefault", attrs.get("isDefault"));
+            result.add(summary);
+        }
+        return result;
+    }
+}

--- a/kelta-ai/src/main/java/io/kelta/ai/service/tools/handlers/ListPicklistsHandler.java
+++ b/kelta-ai/src/main/java/io/kelta/ai/service/tools/handlers/ListPicklistsHandler.java
@@ -1,0 +1,56 @@
+package io.kelta.ai.service.tools.handlers;
+
+import io.kelta.ai.service.WorkerApiClient;
+import io.kelta.ai.service.tools.ReadToolHandler;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class ListPicklistsHandler implements ReadToolHandler {
+
+    private final WorkerApiClient workerApiClient;
+
+    public ListPicklistsHandler(WorkerApiClient workerApiClient) {
+        this.workerApiClient = workerApiClient;
+    }
+
+    @Override
+    public String name() {
+        return "list_picklists";
+    }
+
+    @Override
+    public String description() {
+        return "List global picklists available in this tenant. " +
+                "Useful when proposing a PICKLIST or MULTI_PICKLIST field to see if a reusable picklist already exists.";
+    }
+
+    @Override
+    public Map<String, Object> inputSchema() {
+        return Map.of(
+                "type", "object",
+                "properties", Map.of()
+        );
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Object execute(String tenantId, String userId, Map<String, Object> input) {
+        List<Map<String, Object>> raw = workerApiClient.listPicklists(tenantId);
+        List<Map<String, Object>> result = new ArrayList<>(raw.size());
+        for (Map<String, Object> p : raw) {
+            Map<String, Object> attrs = (Map<String, Object>) p.getOrDefault("attributes", Map.of());
+            Map<String, Object> summary = new LinkedHashMap<>();
+            summary.put("id", p.get("id"));
+            summary.put("name", attrs.get("name"));
+            if (attrs.get("description") != null) summary.put("description", attrs.get("description"));
+            if (attrs.get("restricted") != null) summary.put("restricted", attrs.get("restricted"));
+            result.add(summary);
+        }
+        return result;
+    }
+}

--- a/kelta-ai/src/main/java/io/kelta/ai/service/tools/handlers/ListValidationRulesHandler.java
+++ b/kelta-ai/src/main/java/io/kelta/ai/service/tools/handlers/ListValidationRulesHandler.java
@@ -1,0 +1,68 @@
+package io.kelta.ai.service.tools.handlers;
+
+import io.kelta.ai.service.WorkerApiClient;
+import io.kelta.ai.service.tools.ReadToolHandler;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class ListValidationRulesHandler implements ReadToolHandler {
+
+    private final WorkerApiClient workerApiClient;
+
+    public ListValidationRulesHandler(WorkerApiClient workerApiClient) {
+        this.workerApiClient = workerApiClient;
+    }
+
+    @Override
+    public String name() {
+        return "list_validation_rules";
+    }
+
+    @Override
+    public String description() {
+        return "List validation rules that apply to a collection. " +
+                "Use when the user asks about constraints, or before proposing changes that may interact with existing rules.";
+    }
+
+    @Override
+    public Map<String, Object> inputSchema() {
+        return Map.of(
+                "type", "object",
+                "properties", Map.of(
+                        "collectionName", Map.of("type", "string", "description", "Collection name")
+                ),
+                "required", List.of("collectionName")
+        );
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Object execute(String tenantId, String userId, Map<String, Object> input) {
+        String collectionName = String.valueOf(input.get("collectionName"));
+        if (collectionName.isBlank() || "null".equals(collectionName)) {
+            throw new IllegalArgumentException("collectionName is required");
+        }
+        Map<String, Object> collection = workerApiClient.getCollectionByName(tenantId, collectionName)
+                .orElseThrow(() -> new IllegalArgumentException("Collection not found: " + collectionName));
+        String collectionId = String.valueOf(collection.get("id"));
+
+        List<Map<String, Object>> raw = workerApiClient.listValidationRules(tenantId, collectionId);
+        List<Map<String, Object>> result = new ArrayList<>(raw.size());
+        for (Map<String, Object> rule : raw) {
+            Map<String, Object> attrs = (Map<String, Object>) rule.getOrDefault("attributes", Map.of());
+            Map<String, Object> summary = new LinkedHashMap<>();
+            summary.put("id", rule.get("id"));
+            summary.put("name", attrs.get("name"));
+            if (attrs.get("formula") != null) summary.put("formula", attrs.get("formula"));
+            if (attrs.get("errorMessage") != null) summary.put("errorMessage", attrs.get("errorMessage"));
+            if (attrs.get("active") != null) summary.put("active", attrs.get("active"));
+            result.add(summary);
+        }
+        return result;
+    }
+}

--- a/kelta-ai/src/main/java/io/kelta/ai/service/tools/handlers/ProposeAddFieldsHandler.java
+++ b/kelta-ai/src/main/java/io/kelta/ai/service/tools/handlers/ProposeAddFieldsHandler.java
@@ -1,0 +1,45 @@
+package io.kelta.ai.service.tools.handlers;
+
+import io.kelta.ai.model.AiProposal;
+import io.kelta.ai.service.tools.ProposeToolHandler;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class ProposeAddFieldsHandler implements ProposeToolHandler {
+
+    @Override
+    public String name() {
+        return "propose_add_fields";
+    }
+
+    @Override
+    public String description() {
+        return "Propose adding one or more new fields to an existing collection. " +
+                "Use this when the user wants to extend a collection — do NOT recreate the whole collection. " +
+                "Call get_collection_schema first to confirm which fields are missing.";
+    }
+
+    @Override
+    public Map<String, Object> inputSchema() {
+        return Map.of(
+                "type", "object",
+                "properties", Map.of(
+                        "collectionName", Map.of("type", "string", "description", "Existing collection name"),
+                        "fields", Map.of(
+                                "type", "array",
+                                "description", "Fields to add — same schema as propose_collection.fields[]",
+                                "items", Map.of("type", "object")
+                        )
+                ),
+                "required", List.of("collectionName", "fields")
+        );
+    }
+
+    @Override
+    public AiProposal buildProposal(Map<String, Object> input) {
+        return AiProposal.pending("add_fields", input);
+    }
+}

--- a/kelta-ai/src/main/java/io/kelta/ai/service/tools/handlers/ProposeCollectionHandler.java
+++ b/kelta-ai/src/main/java/io/kelta/ai/service/tools/handlers/ProposeCollectionHandler.java
@@ -1,0 +1,47 @@
+package io.kelta.ai.service.tools.handlers;
+
+import io.kelta.ai.model.AiProposal;
+import io.kelta.ai.service.tools.ProposeToolHandler;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class ProposeCollectionHandler implements ProposeToolHandler {
+
+    @Override
+    public String name() {
+        return "propose_collection";
+    }
+
+    @Override
+    public String description() {
+        return "Propose creating a new collection (data model) with fields. " +
+                "Use this when the user wants to create a new collection or entity type that does not already exist.";
+    }
+
+    @Override
+    public Map<String, Object> inputSchema() {
+        return Map.of(
+                "type", "object",
+                "properties", Map.of(
+                        "name", Map.of("type", "string", "description", "Collection name (lowercase, alphanumeric, underscores)"),
+                        "displayName", Map.of("type", "string", "description", "Human-readable collection name"),
+                        "description", Map.of("type", "string", "description", "Collection description"),
+                        "displayFieldName", Map.of("type", "string", "description", "Name of the field used as record label"),
+                        "fields", Map.of(
+                                "type", "array",
+                                "description", "Fields for the collection",
+                                "items", Map.of("type", "object")
+                        )
+                ),
+                "required", List.of("name", "fields")
+        );
+    }
+
+    @Override
+    public AiProposal buildProposal(Map<String, Object> input) {
+        return AiProposal.pending("collection", input);
+    }
+}

--- a/kelta-ai/src/main/java/io/kelta/ai/service/tools/handlers/ProposeLayoutHandler.java
+++ b/kelta-ai/src/main/java/io/kelta/ai/service/tools/handlers/ProposeLayoutHandler.java
@@ -1,0 +1,51 @@
+package io.kelta.ai.service.tools.handlers;
+
+import io.kelta.ai.model.AiProposal;
+import io.kelta.ai.service.tools.ProposeToolHandler;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class ProposeLayoutHandler implements ProposeToolHandler {
+
+    @Override
+    public String name() {
+        return "propose_layout";
+    }
+
+    @Override
+    public String description() {
+        return "Propose creating a page layout for a collection. " +
+                "Use this when the user wants to create or customize how a collection's records are displayed.";
+    }
+
+    @Override
+    public Map<String, Object> inputSchema() {
+        return Map.of(
+                "type", "object",
+                "properties", Map.of(
+                        "collectionName", Map.of("type", "string", "description", "Name of the collection this layout is for"),
+                        "name", Map.of("type", "string", "description", "Layout name"),
+                        "layoutType", Map.of("type", "string", "description", "Layout type: DETAIL, EDIT, MINI, or LIST"),
+                        "sections", Map.of(
+                                "type", "array",
+                                "description", "Layout sections with field placements",
+                                "items", Map.of("type", "object")
+                        ),
+                        "relatedLists", Map.of(
+                                "type", "array",
+                                "description", "Related list configurations",
+                                "items", Map.of("type", "object")
+                        )
+                ),
+                "required", List.of("collectionName", "name", "layoutType", "sections")
+        );
+    }
+
+    @Override
+    public AiProposal buildProposal(Map<String, Object> input) {
+        return AiProposal.pending("layout", input);
+    }
+}

--- a/kelta-ai/src/main/java/io/kelta/ai/service/tools/handlers/ProposePicklistHandler.java
+++ b/kelta-ai/src/main/java/io/kelta/ai/service/tools/handlers/ProposePicklistHandler.java
@@ -1,0 +1,53 @@
+package io.kelta.ai.service.tools.handlers;
+
+import io.kelta.ai.model.AiProposal;
+import io.kelta.ai.service.tools.ProposeToolHandler;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class ProposePicklistHandler implements ProposeToolHandler {
+
+    @Override
+    public String name() {
+        return "propose_picklist";
+    }
+
+    @Override
+    public String description() {
+        return "Propose creating a new global picklist that can be reused across collections. " +
+                "Call list_picklists first to avoid duplicating an existing one.";
+    }
+
+    @Override
+    public Map<String, Object> inputSchema() {
+        return Map.of(
+                "type", "object",
+                "properties", Map.of(
+                        "name", Map.of("type", "string", "description", "Picklist name (lowercase, alphanumeric, underscores)"),
+                        "description", Map.of("type", "string"),
+                        "restricted", Map.of("type", "boolean", "description", "If true, only listed values are allowed"),
+                        "values", Map.of(
+                                "type", "array",
+                                "description", "Picklist values",
+                                "items", Map.of(
+                                        "type", "object",
+                                        "properties", Map.of(
+                                                "value", Map.of("type", "string"),
+                                                "label", Map.of("type", "string"),
+                                                "sortOrder", Map.of("type", "integer")
+                                        )
+                                )
+                        )
+                ),
+                "required", List.of("name", "values")
+        );
+    }
+
+    @Override
+    public AiProposal buildProposal(Map<String, Object> input) {
+        return AiProposal.pending("picklist", input);
+    }
+}

--- a/kelta-ai/src/main/java/io/kelta/ai/service/tools/handlers/ProposeRemoveFieldHandler.java
+++ b/kelta-ai/src/main/java/io/kelta/ai/service/tools/handlers/ProposeRemoveFieldHandler.java
@@ -1,0 +1,41 @@
+package io.kelta.ai.service.tools.handlers;
+
+import io.kelta.ai.model.AiProposal;
+import io.kelta.ai.service.tools.ProposeToolHandler;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class ProposeRemoveFieldHandler implements ProposeToolHandler {
+
+    @Override
+    public String name() {
+        return "propose_remove_field";
+    }
+
+    @Override
+    public String description() {
+        return "Propose removing a field from a collection. DESTRUCTIVE — surface this clearly to the user. " +
+                "Always include a short reason explaining why.";
+    }
+
+    @Override
+    public Map<String, Object> inputSchema() {
+        return Map.of(
+                "type", "object",
+                "properties", Map.of(
+                        "collectionName", Map.of("type", "string"),
+                        "fieldName", Map.of("type", "string"),
+                        "reason", Map.of("type", "string", "description", "Why this field should be removed")
+                ),
+                "required", List.of("collectionName", "fieldName", "reason")
+        );
+    }
+
+    @Override
+    public AiProposal buildProposal(Map<String, Object> input) {
+        return AiProposal.pending("remove_field", input);
+    }
+}

--- a/kelta-ai/src/main/java/io/kelta/ai/service/tools/handlers/ProposeUpdateFieldHandler.java
+++ b/kelta-ai/src/main/java/io/kelta/ai/service/tools/handlers/ProposeUpdateFieldHandler.java
@@ -1,0 +1,60 @@
+package io.kelta.ai.service.tools.handlers;
+
+import io.kelta.ai.model.AiProposal;
+import io.kelta.ai.service.tools.ProposeToolHandler;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class ProposeUpdateFieldHandler implements ProposeToolHandler {
+
+    @Override
+    public String name() {
+        return "propose_update_field";
+    }
+
+    @Override
+    public String description() {
+        return "Propose updating properties of an existing field — displayName, required, unique, description, enumValues, validationRules. " +
+                "TYPE CHANGES ARE NOT SUPPORTED. To replace a field, use propose_remove_field followed by propose_add_fields.";
+    }
+
+    @Override
+    public Map<String, Object> inputSchema() {
+        return Map.of(
+                "type", "object",
+                "properties", Map.of(
+                        "collectionName", Map.of("type", "string"),
+                        "fieldName", Map.of("type", "string"),
+                        "changes", Map.of(
+                                "type", "object",
+                                "description", "Only these properties may change: displayName, required, unique, description, enumValues, validationRules. " +
+                                        "Do NOT include 'type' — type changes are rejected.",
+                                "properties", Map.of(
+                                        "displayName", Map.of("type", "string"),
+                                        "required", Map.of("type", "boolean"),
+                                        "unique", Map.of("type", "boolean"),
+                                        "description", Map.of("type", "string"),
+                                        "enumValues", Map.of("type", "array", "items", Map.of("type", "string")),
+                                        "validationRules", Map.of("type", "array", "items", Map.of("type", "object"))
+                                )
+                        )
+                ),
+                "required", List.of("collectionName", "fieldName", "changes")
+        );
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public AiProposal buildProposal(Map<String, Object> input) {
+        Object changes = input.get("changes");
+        if (changes instanceof Map<?, ?> m && m.containsKey("type")) {
+            throw new IllegalArgumentException(
+                    "Type changes are not supported by propose_update_field. " +
+                            "Use propose_remove_field then propose_add_fields to replace the field.");
+        }
+        return AiProposal.pending("update_field", input);
+    }
+}

--- a/kelta-ai/src/main/java/io/kelta/ai/service/tools/handlers/QueryRecordsHandler.java
+++ b/kelta-ai/src/main/java/io/kelta/ai/service/tools/handlers/QueryRecordsHandler.java
@@ -1,0 +1,127 @@
+package io.kelta.ai.service.tools.handlers;
+
+import io.kelta.ai.service.WorkerApiClient;
+import io.kelta.ai.service.tools.ReadToolHandler;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class QueryRecordsHandler implements ReadToolHandler {
+
+    private static final int MAX_LIMIT = 20;
+    private static final int VALUE_TRUNCATE_AT = 500;
+
+    private final WorkerApiClient workerApiClient;
+
+    public QueryRecordsHandler(WorkerApiClient workerApiClient) {
+        this.workerApiClient = workerApiClient;
+    }
+
+    @Override
+    public String name() {
+        return "query_records";
+    }
+
+    @Override
+    public String description() {
+        return "Fetch a small sample (max 20) of records from a collection so you can see what the data actually looks like. " +
+                "Use this to understand value formats, distributions, or to ground recommendations in real data. " +
+                "Do NOT use for large data exports — for that direct the user to the data export feature.";
+    }
+
+    @Override
+    public Map<String, Object> inputSchema() {
+        return Map.of(
+                "type", "object",
+                "properties", Map.of(
+                        "collectionName", Map.of("type", "string", "description", "Collection name, e.g. \"orders\""),
+                        "limit", Map.of("type", "integer", "description", "Max records to return (1-20, default 5)"),
+                        "fields", Map.of(
+                                "type", "array",
+                                "description", "Restrict returned columns to keep tokens down",
+                                "items", Map.of("type", "string")
+                        ),
+                        "filter", Map.of(
+                                "type", "object",
+                                "description", "Simple equality filters, e.g. {\"status\":\"active\"}"
+                        )
+                ),
+                "required", List.of("collectionName")
+        );
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Object execute(String tenantId, String userId, Map<String, Object> input) {
+        String collectionName = String.valueOf(input.get("collectionName"));
+        if (collectionName.isBlank() || "null".equals(collectionName)) {
+            throw new IllegalArgumentException("collectionName is required");
+        }
+
+        int limit = 5;
+        Object limitObj = input.get("limit");
+        if (limitObj instanceof Number n) {
+            limit = n.intValue();
+        }
+        limit = Math.max(1, Math.min(MAX_LIMIT, limit));
+
+        List<String> fields = null;
+        Object fieldsObj = input.get("fields");
+        if (fieldsObj instanceof List<?> list) {
+            fields = list.stream().map(String::valueOf).toList();
+        }
+
+        Map<String, Object> filter = null;
+        Object filterObj = input.get("filter");
+        if (filterObj instanceof Map<?, ?> m) {
+            filter = new LinkedHashMap<>();
+            for (Map.Entry<?, ?> e : m.entrySet()) {
+                filter.put(String.valueOf(e.getKey()), e.getValue());
+            }
+        }
+
+        Map<String, Object> response = workerApiClient.sampleRecords(tenantId, collectionName, limit, fields, filter);
+
+        List<Map<String, Object>> records = new ArrayList<>();
+        Object data = response.get("data");
+        if (data instanceof List<?> list) {
+            for (Object o : list) {
+                if (o instanceof Map<?, ?> row) {
+                    records.add(truncateValues((Map<String, Object>) row));
+                }
+            }
+        }
+
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("collection", collectionName);
+        result.put("count", records.size());
+        result.put("records", records);
+        return result;
+    }
+
+    private static Map<String, Object> truncateValues(Map<String, Object> row) {
+        Map<String, Object> attrs = new LinkedHashMap<>();
+        Object id = row.get("id");
+        if (id != null) attrs.put("id", id);
+        Object inner = row.get("attributes");
+        if (inner instanceof Map<?, ?> m) {
+            for (Map.Entry<?, ?> e : m.entrySet()) {
+                attrs.put(String.valueOf(e.getKey()), truncate(e.getValue()));
+            }
+        }
+        return attrs;
+    }
+
+    private static Object truncate(Object value) {
+        if (value == null) return null;
+        String s = String.valueOf(value);
+        if (s.length() > VALUE_TRUNCATE_AT) {
+            return s.substring(0, VALUE_TRUNCATE_AT) + "…(truncated)";
+        }
+        return value;
+    }
+}

--- a/kelta-ai/src/main/resources/db/migration/V3__add_content_blocks_to_ai_message.sql
+++ b/kelta-ai/src/main/resources/db/migration/V3__add_content_blocks_to_ai_message.sql
@@ -1,0 +1,34 @@
+-- Add content_blocks JSONB column to ai_message to hold the full Anthropic
+-- content-block sequence (text + tool_use + tool_result) for a single turn.
+-- Backfill: convert legacy content + proposal_json into a content_blocks array.
+-- Old proposals become "tool_use_legacy" blocks that buildMessageHistory will
+-- skip when replaying history to Claude (no matching tool_result would break
+-- Anthropic validation).
+
+ALTER TABLE ai_message
+    ADD COLUMN content_blocks JSONB;
+
+UPDATE ai_message
+SET content_blocks = (
+    CASE
+        WHEN content IS NOT NULL AND content <> '' THEN
+            jsonb_build_array(jsonb_build_object('type', 'text', 'text', content))
+        ELSE '[]'::jsonb
+    END
+) || (
+    CASE
+        WHEN proposal_json IS NOT NULL THEN
+            jsonb_build_array(jsonb_build_object(
+                'type', 'tool_use_legacy',
+                'proposal', proposal_json::jsonb,
+                'proposalId', proposal_json::jsonb ->> 'id'
+            ))
+        ELSE '[]'::jsonb
+    END
+)
+WHERE content_blocks IS NULL;
+
+ALTER TABLE ai_message ALTER COLUMN content_blocks SET DEFAULT '[]'::jsonb;
+ALTER TABLE ai_message ALTER COLUMN content_blocks SET NOT NULL;
+
+CREATE INDEX idx_ai_message_content_blocks_gin ON ai_message USING gin (content_blocks);

--- a/kelta-ai/src/test/java/io/kelta/ai/TestFixtures.java
+++ b/kelta-ai/src/test/java/io/kelta/ai/TestFixtures.java
@@ -5,6 +5,8 @@ import io.kelta.ai.model.AiProposal;
 import io.kelta.ai.model.ChatMessage;
 import io.kelta.ai.model.Conversation;
 
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -37,15 +39,23 @@ public final class TestFixtures {
 
     public static ChatMessage assistantMessage() {
         return ChatMessage.assistant(TENANT_ID, UUID.randomUUID(),
-                "I'll help you with that.", null, 100, 50);
+                List.of(textBlock("I'll help you with that.")), 100, 50);
     }
 
     public static ChatMessage assistantMessage(UUID conversationId, String content) {
-        return ChatMessage.assistant(TENANT_ID, conversationId, content, null, 100, 50);
+        return ChatMessage.assistant(TENANT_ID, conversationId,
+                List.of(textBlock(content)), 100, 50);
+    }
+
+    public static Map<String, Object> textBlock(String text) {
+        Map<String, Object> block = new LinkedHashMap<>();
+        block.put("type", "text");
+        block.put("text", text);
+        return block;
     }
 
     public static AiProposal proposal() {
-        return AiProposal.pending("create_collection", Map.of(
+        return AiProposal.pending("collection", Map.of(
                 "name", "customers",
                 "fields", Map.of("name", "string", "email", "string")
         ));

--- a/kelta-ai/src/test/java/io/kelta/ai/controller/ChatHistoryControllerTest.java
+++ b/kelta-ai/src/test/java/io/kelta/ai/controller/ChatHistoryControllerTest.java
@@ -88,8 +88,7 @@ class ChatHistoryControllerTest {
             Instant now = Instant.now();
             Conversation conv = new Conversation(convId, "tenant-1", "user-1", "Test", now, now);
 
-            ChatMessage msg = new ChatMessage(UUID.randomUUID(), "tenant-1", convId,
-                    "user", "Hello", null, 0, 0, now);
+            ChatMessage msg = ChatMessage.user("tenant-1", convId, "Hello");
 
             when(conversationRepository.findById(convId, "tenant-1")).thenReturn(Optional.of(conv));
             when(messageRepository.findByConversation(convId, "tenant-1")).thenReturn(List.of(msg));
@@ -116,6 +115,45 @@ class ChatHistoryControllerTest {
 
             ResponseEntity<Map<String, Object>> response =
                     controller.getConversation("tenant-1", id);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        }
+    }
+
+    @Nested
+    @DisplayName("getMessages")
+    class GetMessages {
+
+        @Test
+        @DisplayName("returns messages with contentBlocks for rehydration")
+        void returnsContentBlocks() {
+            UUID convId = UUID.randomUUID();
+            Instant now = Instant.now();
+            Conversation conv = new Conversation(convId, "tenant-1", "user-1", "Test", now, now);
+            ChatMessage msg = ChatMessage.user("tenant-1", convId, "Hello");
+
+            when(conversationRepository.findById(convId, "tenant-1")).thenReturn(Optional.of(conv));
+            when(messageRepository.findByConversation(convId, "tenant-1")).thenReturn(List.of(msg));
+
+            ResponseEntity<Map<String, Object>> response =
+                    controller.getMessages("tenant-1", convId);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(response.getBody().get("conversationId")).isEqualTo(convId.toString());
+            @SuppressWarnings("unchecked")
+            List<Map<String, Object>> messages = (List<Map<String, Object>>) response.getBody().get("messages");
+            assertThat(messages).hasSize(1);
+            assertThat(messages.getFirst().get("role")).isEqualTo("user");
+            assertThat(messages.getFirst().get("contentBlocks")).isNotNull();
+        }
+
+        @Test
+        @DisplayName("returns 404 when conversation not found")
+        void returns404() {
+            UUID id = UUID.randomUUID();
+            when(conversationRepository.findById(id, "tenant-1")).thenReturn(Optional.empty());
+
+            ResponseEntity<Map<String, Object>> response = controller.getMessages("tenant-1", id);
 
             assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
         }

--- a/kelta-ai/src/test/java/io/kelta/ai/service/AnthropicServiceTest.java
+++ b/kelta-ai/src/test/java/io/kelta/ai/service/AnthropicServiceTest.java
@@ -5,6 +5,7 @@ import com.anthropic.models.messages.*;
 import com.anthropic.services.blocking.MessageService;
 import io.kelta.ai.config.AiConfigProperties;
 import io.kelta.ai.repository.AiConfigRepository;
+import io.kelta.ai.service.tools.ToolRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -33,6 +34,9 @@ class AnthropicServiceTest {
     @Mock
     private AiConfigRepository aiConfigRepository;
 
+    @Mock
+    private ToolRegistry toolRegistry;
+
     private AnthropicService service;
 
     @BeforeEach
@@ -40,7 +44,7 @@ class AnthropicServiceTest {
         AiConfigProperties config = new AiConfigProperties(
                 new AiConfigProperties.AnthropicProperties("test-key", "claude-sonnet-4-20250514", 4096, 0.7),
                 "http://localhost:8080", 30000L);
-        service = new AnthropicService(client, config, aiConfigRepository);
+        service = new AnthropicService(client, config, aiConfigRepository, toolRegistry);
     }
 
     private MessageParam userMessage(String text) {
@@ -61,6 +65,7 @@ class AnthropicServiceTest {
                     .thenReturn(Optional.of("claude-opus-4-20250514"));
             when(aiConfigRepository.getConfig("tenant-1", "anthropic.maxTokens"))
                     .thenReturn(Optional.of("8192"));
+            when(toolRegistry.toolDefinitions()).thenReturn(List.of());
 
             List<MessageParam> messages = List.of(userMessage("Hello"));
 
@@ -82,6 +87,7 @@ class AnthropicServiceTest {
                     .thenReturn(Optional.empty());
             when(aiConfigRepository.getConfig("0", "anthropic.maxTokens"))
                     .thenReturn(Optional.empty());
+            when(toolRegistry.toolDefinitions()).thenReturn(List.of());
 
             List<MessageParam> messages = List.of(userMessage("Hello"));
 
@@ -93,23 +99,25 @@ class AnthropicServiceTest {
         }
 
         @Test
-        @DisplayName("includes tool definitions in request")
-        void includesToolDefinitions() {
-            when(aiConfigRepository.getConfig("tenant-1", "anthropic.model"))
-                    .thenReturn(Optional.empty());
-            when(aiConfigRepository.getConfig("0", "anthropic.model"))
-                    .thenReturn(Optional.empty());
-            when(aiConfigRepository.getConfig("tenant-1", "anthropic.maxTokens"))
-                    .thenReturn(Optional.empty());
-            when(aiConfigRepository.getConfig("0", "anthropic.maxTokens"))
-                    .thenReturn(Optional.empty());
+        @DisplayName("injects tool definitions from registry")
+        void injectsToolDefinitions() {
+            when(aiConfigRepository.getConfig(anyString(), anyString())).thenReturn(Optional.empty());
+
+            Tool fake = Tool.builder()
+                    .name("fake_tool")
+                    .description("test")
+                    .inputSchema(Tool.InputSchema.builder()
+                            .properties(com.anthropic.core.JsonValue.from(java.util.Map.of()))
+                            .build())
+                    .build();
+            when(toolRegistry.toolDefinitions()).thenReturn(List.of(ToolUnion.ofTool(fake)));
 
             MessageCreateParams params = service.buildRequest(
                     "tenant-1", "System", List.of(userMessage("Hello"))
             ).build();
 
             assertThat(params.tools()).isPresent();
-            assertThat(params.tools().get()).hasSize(2);
+            assertThat(params.tools().get()).hasSize(1);
         }
     }
 

--- a/kelta-ai/src/test/java/io/kelta/ai/service/tools/ToolDispatcherTest.java
+++ b/kelta-ai/src/test/java/io/kelta/ai/service/tools/ToolDispatcherTest.java
@@ -1,0 +1,119 @@
+package io.kelta.ai.service.tools;
+
+import io.kelta.ai.model.AiProposal;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import tools.jackson.databind.ObjectMapper;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ToolDispatcher")
+class ToolDispatcherTest {
+
+    @Mock
+    private ToolRegistry registry;
+
+    @Mock
+    private ReadToolHandler readHandler;
+
+    @Mock
+    private ProposeToolHandler proposeHandler;
+
+    private ToolDispatcher dispatcher;
+
+    @BeforeEach
+    void setUp() {
+        dispatcher = new ToolDispatcher(registry, new ObjectMapper());
+    }
+
+    @Test
+    @DisplayName("returns JSON tool_result for a successful read tool")
+    void readToolSuccess() {
+        when(registry.handler("get_x")).thenReturn(Optional.of(readHandler));
+        when(readHandler.execute("t", "u", Map.of("a", 1))).thenReturn(Map.of("ok", true));
+
+        DispatchResult result = dispatcher.dispatch("t", "u", "toolu_1", "get_x", Map.of("a", 1));
+
+        assertThat(result.proposal()).isNull();
+        assertThat(result.isError()).isFalse();
+        assertThat(result.resultJson()).contains("\"ok\":true");
+        assertThat(result.toolUseId()).isEqualTo("toolu_1");
+        assertThat(result.toolName()).isEqualTo("get_x");
+    }
+
+    @Test
+    @DisplayName("read tool exception becomes isError tool_result")
+    void readToolFailure() {
+        when(registry.handler("get_x")).thenReturn(Optional.of(readHandler));
+        when(readHandler.execute("t", "u", Map.of())).thenThrow(new RuntimeException("boom"));
+
+        DispatchResult result = dispatcher.dispatch("t", "u", "toolu_1", "get_x", Map.of());
+
+        assertThat(result.isError()).isTrue();
+        assertThat(result.resultJson()).contains("\"message\":\"boom\"");
+    }
+
+    @Test
+    @DisplayName("invalid input becomes invalid_input error")
+    void invalidInput() {
+        when(registry.handler("get_x")).thenReturn(Optional.of(readHandler));
+        when(readHandler.execute("t", "u", Map.of()))
+                .thenThrow(new IllegalArgumentException("collectionName is required"));
+
+        DispatchResult result = dispatcher.dispatch("t", "u", "toolu_1", "get_x", Map.of());
+
+        assertThat(result.isError()).isTrue();
+        assertThat(result.resultJson()).contains("invalid_input");
+    }
+
+    @Test
+    @DisplayName("propose tool returns proposal queued ack with proposal attached")
+    void proposeToolSuccess() {
+        when(registry.handler("propose_x")).thenReturn(Optional.of(proposeHandler));
+        AiProposal proposal = AiProposal.pending("fake", Map.of("a", 1));
+        when(proposeHandler.buildProposal(Map.of("a", 1))).thenReturn(proposal);
+
+        DispatchResult result = dispatcher.dispatch("t", "u", "toolu_2", "propose_x", Map.of("a", 1));
+
+        assertThat(result.proposal()).isEqualTo(proposal);
+        assertThat(result.isError()).isFalse();
+        assertThat(result.resultJson()).contains("queued");
+        assertThat(result.resultJson()).contains(proposal.id().toString());
+    }
+
+    @Test
+    @DisplayName("propose tool rejection becomes invalid_input error without proposal")
+    void proposeToolRejection() {
+        when(registry.handler("propose_x")).thenReturn(Optional.of(proposeHandler));
+        when(proposeHandler.buildProposal(Map.of()))
+                .thenThrow(new IllegalArgumentException("Type changes are not supported"));
+
+        DispatchResult result = dispatcher.dispatch("t", "u", "toolu_2", "propose_x", Map.of());
+
+        assertThat(result.proposal()).isNull();
+        assertThat(result.isError()).isTrue();
+        assertThat(result.resultJson()).contains("Type changes are not supported");
+    }
+
+    @Test
+    @DisplayName("unknown tool throws IllegalArgumentException")
+    void unknownTool() {
+        when(registry.handler("missing")).thenReturn(Optional.empty());
+
+        org.junit.jupiter.api.Assertions.assertThrows(IllegalArgumentException.class, () ->
+                dispatcher.dispatch("t", "u", "toolu_3", "missing", Map.of()));
+    }
+
+    @SuppressWarnings("unused")
+    private static List<String> reserved() { return List.of(); }
+}

--- a/kelta-ai/src/test/java/io/kelta/ai/service/tools/ToolRegistryTest.java
+++ b/kelta-ai/src/test/java/io/kelta/ai/service/tools/ToolRegistryTest.java
@@ -1,0 +1,70 @@
+package io.kelta.ai.service.tools;
+
+import io.kelta.ai.model.AiProposal;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("ToolRegistry")
+class ToolRegistryTest {
+
+    private static class FakeReadHandler implements ReadToolHandler {
+        private final String name;
+        FakeReadHandler(String name) { this.name = name; }
+        @Override public String name() { return name; }
+        @Override public String description() { return "read " + name; }
+        @Override public Map<String, Object> inputSchema() { return Map.of("type", "object"); }
+        @Override public Object execute(String tenantId, String userId, Map<String, Object> input) {
+            return Map.of("ok", true);
+        }
+    }
+
+    private static class FakeProposeHandler implements ProposeToolHandler {
+        private final String name;
+        FakeProposeHandler(String name) { this.name = name; }
+        @Override public String name() { return name; }
+        @Override public String description() { return "propose " + name; }
+        @Override public Map<String, Object> inputSchema() { return Map.of("type", "object"); }
+        @Override public AiProposal buildProposal(Map<String, Object> input) {
+            return AiProposal.pending("fake", input);
+        }
+    }
+
+    @Test
+    @DisplayName("registers handlers by name and exposes tool definitions")
+    void registersHandlers() {
+        ToolRegistry registry = new ToolRegistry(List.of(
+                new FakeReadHandler("read_one"),
+                new FakeProposeHandler("propose_one")
+        ));
+        assertThat(registry.size()).isEqualTo(2);
+        assertThat(registry.toolDefinitions()).hasSize(2);
+        assertThat(registry.handler("read_one")).isPresent();
+        assertThat(registry.handler("propose_one")).isPresent();
+    }
+
+    @Test
+    @DisplayName("isReadTool / isProposeTool classify handlers correctly")
+    void classifiesHandlers() {
+        ToolRegistry registry = new ToolRegistry(List.of(
+                new FakeReadHandler("get_x"),
+                new FakeProposeHandler("propose_x")
+        ));
+        assertThat(registry.isReadTool("get_x")).isTrue();
+        assertThat(registry.isProposeTool("get_x")).isFalse();
+        assertThat(registry.isProposeTool("propose_x")).isTrue();
+        assertThat(registry.isReadTool("propose_x")).isFalse();
+        assertThat(registry.isReadTool("missing")).isFalse();
+    }
+
+    @Test
+    @DisplayName("returns empty Optional for unknown tool name")
+    void unknownToolReturnsEmpty() {
+        ToolRegistry registry = new ToolRegistry(List.of());
+        assertThat(registry.handler("anything")).isEmpty();
+    }
+}

--- a/kelta-ai/src/test/java/io/kelta/ai/service/tools/handlers/GetCollectionSchemaHandlerTest.java
+++ b/kelta-ai/src/test/java/io/kelta/ai/service/tools/handlers/GetCollectionSchemaHandlerTest.java
@@ -1,0 +1,99 @@
+package io.kelta.ai.service.tools.handlers;
+
+import io.kelta.ai.service.WorkerApiClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GetCollectionSchemaHandler")
+class GetCollectionSchemaHandlerTest {
+
+    @Mock
+    private WorkerApiClient workerApiClient;
+
+    private GetCollectionSchemaHandler handler;
+
+    @BeforeEach
+    void setUp() {
+        handler = new GetCollectionSchemaHandler(workerApiClient);
+    }
+
+    @Test
+    @DisplayName("returns collection schema with fields summary")
+    @SuppressWarnings("unchecked")
+    void returnsSchema() {
+        Map<String, Object> collection = Map.of(
+                "id", "col-1",
+                "attributes", Map.of(
+                        "name", "products",
+                        "displayName", "Products",
+                        "description", "Sellable items",
+                        "displayFieldName", "name"
+                )
+        );
+        when(workerApiClient.getCollectionByName("tenant-1", "products"))
+                .thenReturn(Optional.of(collection));
+
+        Map<String, Object> field = Map.of(
+                "id", "f1",
+                "attributes", Map.of(
+                        "name", "sku",
+                        "type", "STRING",
+                        "required", true,
+                        "uniqueConstraint", true
+                )
+        );
+        when(workerApiClient.listFields("tenant-1", "col-1")).thenReturn(List.of(field));
+
+        Object result = handler.execute("tenant-1", "user-1", Map.of("collectionName", "products"));
+
+        Map<String, Object> map = (Map<String, Object>) result;
+        assertThat(map.get("name")).isEqualTo("products");
+        assertThat(map.get("displayName")).isEqualTo("Products");
+        assertThat(map.get("fieldCount")).isEqualTo(1);
+        List<Map<String, Object>> fields = (List<Map<String, Object>>) map.get("fields");
+        assertThat(fields).hasSize(1);
+        assertThat(fields.getFirst()).containsEntry("name", "sku");
+        assertThat(fields.getFirst()).containsEntry("type", "STRING");
+        assertThat(fields.getFirst()).containsEntry("required", true);
+        assertThat(fields.getFirst()).containsEntry("unique", true);
+    }
+
+    @Test
+    @DisplayName("throws when collectionName missing")
+    void requiresName() {
+        assertThatThrownBy(() -> handler.execute("tenant-1", "user-1", Map.of()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("collectionName");
+    }
+
+    @Test
+    @DisplayName("throws when collection not found")
+    void throwsWhenMissing() {
+        when(workerApiClient.getCollectionByName("tenant-1", "missing"))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> handler.execute("tenant-1", "user-1", Map.of("collectionName", "missing")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Collection not found");
+    }
+
+    @Test
+    @DisplayName("declares get_collection_schema as its name")
+    void declaresName() {
+        assertThat(handler.name()).isEqualTo("get_collection_schema");
+        assertThat(handler.inputSchema()).containsKey("properties");
+    }
+}

--- a/kelta-ai/src/test/java/io/kelta/ai/service/tools/handlers/ProposeUpdateFieldHandlerTest.java
+++ b/kelta-ai/src/test/java/io/kelta/ai/service/tools/handlers/ProposeUpdateFieldHandlerTest.java
@@ -1,0 +1,40 @@
+package io.kelta.ai.service.tools.handlers;
+
+import io.kelta.ai.model.AiProposal;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("ProposeUpdateFieldHandler")
+class ProposeUpdateFieldHandlerTest {
+
+    private final ProposeUpdateFieldHandler handler = new ProposeUpdateFieldHandler();
+
+    @Test
+    @DisplayName("accepts metadata-only changes")
+    void acceptsMetadataChanges() {
+        AiProposal proposal = handler.buildProposal(Map.of(
+                "collectionName", "products",
+                "fieldName", "price",
+                "changes", Map.of("displayName", "List Price", "required", true)
+        ));
+        assertThat(proposal.type()).isEqualTo("update_field");
+        assertThat(proposal.status()).isEqualTo("pending");
+    }
+
+    @Test
+    @DisplayName("rejects type changes with a clear message")
+    void rejectsTypeChange() {
+        assertThatThrownBy(() -> handler.buildProposal(Map.of(
+                "collectionName", "products",
+                "fieldName", "price",
+                "changes", Map.of("type", "STRING")
+        ))).isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Type changes are not supported")
+                .hasMessageContaining("propose_remove_field");
+    }
+}

--- a/kelta-ui/app/src/components/AiChat/AddFieldsProposalCard.test.tsx
+++ b/kelta-ui/app/src/components/AiChat/AddFieldsProposalCard.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { AddFieldsProposalCard } from './AddFieldsProposalCard'
+import type { AiProposal } from './types'
+
+function makeProposal(overrides: Partial<AiProposal> = {}): AiProposal {
+  return {
+    id: 'p1',
+    type: 'add_fields',
+    status: 'pending',
+    data: {
+      collectionName: 'customers',
+      fields: [
+        { name: 'loyalty_points', type: 'INTEGER', nullable: false },
+        { name: 'marketing_consent', type: 'BOOLEAN' },
+      ],
+    },
+    createdAt: new Date().toISOString(),
+    ...overrides,
+  }
+}
+
+describe('AddFieldsProposalCard', () => {
+  it('renders the target collection and field rows for a pending proposal', () => {
+    render(
+      <AddFieldsProposalCard
+        proposal={makeProposal()}
+        onApply={vi.fn()}
+        onDismiss={vi.fn()}
+      />
+    )
+    expect(screen.getByText('Add fields')).toBeInTheDocument()
+    expect(screen.getByText('→ customers')).toBeInTheDocument()
+    expect(screen.getByText('loyalty_points')).toBeInTheDocument()
+    expect(screen.getByText('marketing_consent')).toBeInTheDocument()
+  })
+
+  it('calls onApply with the proposal id', () => {
+    const onApply = vi.fn()
+    render(
+      <AddFieldsProposalCard proposal={makeProposal()} onApply={onApply} onDismiss={vi.fn()} />
+    )
+    fireEvent.click(screen.getByText('Apply'))
+    expect(onApply).toHaveBeenCalledWith('p1')
+  })
+
+  it('renders collapsed view when applied', () => {
+    render(
+      <AddFieldsProposalCard
+        proposal={makeProposal({ status: 'applied' })}
+        onApply={vi.fn()}
+        onDismiss={vi.fn()}
+      />
+    )
+    expect(screen.getByText('Applied')).toBeInTheDocument()
+    expect(screen.queryByText('Apply')).not.toBeInTheDocument()
+  })
+})

--- a/kelta-ui/app/src/components/AiChat/AddFieldsProposalCard.tsx
+++ b/kelta-ui/app/src/components/AiChat/AddFieldsProposalCard.tsx
@@ -1,0 +1,111 @@
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { Check, X, PlusCircle, CheckCircle, XCircle } from 'lucide-react'
+import type { AiProposal, ProposedField } from './types'
+
+interface AddFieldsProposalCardProps {
+  proposal: AiProposal
+  onApply: (proposalId: string) => void
+  onDismiss: (proposalId: string) => void
+  isApplying?: boolean
+}
+
+export function AddFieldsProposalCard({
+  proposal,
+  onApply,
+  onDismiss,
+  isApplying,
+}: AddFieldsProposalCardProps) {
+  const data = proposal.data
+  const fields = (data.fields as ProposedField[]) || []
+  const collectionName = data.collectionName as string
+  const isApplied = proposal.status === 'applied'
+  const isDismissed = proposal.status === 'dismissed'
+  const isResolved = isApplied || isDismissed
+
+  if (isResolved) {
+    return (
+      <div className="mx-4 my-2 flex items-center gap-2 rounded-lg border border-dashed px-3 py-2 text-xs text-muted-foreground">
+        {isApplied ? (
+          <CheckCircle className="h-3.5 w-3.5 text-green-600 shrink-0" />
+        ) : (
+          <XCircle className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+        )}
+        <PlusCircle className="h-3.5 w-3.5 shrink-0" />
+        <span className="font-medium text-foreground">{fields.length} field(s)</span>
+        <span>to</span>
+        <Badge variant="outline" className="text-[10px] px-1 py-0">
+          {collectionName}
+        </Badge>
+        <span className="ml-auto">
+          {isApplied ? (
+            <Badge className="bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300 text-[10px]">
+              Applied
+            </Badge>
+          ) : (
+            <Badge variant="secondary" className="text-[10px]">
+              Dismissed
+            </Badge>
+          )}
+        </span>
+      </div>
+    )
+  }
+
+  return (
+    <Card className="mx-4 my-2 border-primary/20">
+      <CardHeader className="pb-3">
+        <div className="flex items-center gap-2">
+          <PlusCircle className="h-4 w-4 text-primary" />
+          <CardTitle className="text-sm font-semibold">Add fields</CardTitle>
+          <Badge variant="outline" className="text-xs">
+            → {collectionName}
+          </Badge>
+        </div>
+      </CardHeader>
+
+      <CardContent className="pb-3">
+        <table className="w-full text-xs">
+          <thead>
+            <tr className="border-b">
+              <th className="pb-1 text-left font-medium">Field</th>
+              <th className="pb-1 text-left font-medium">Type</th>
+              <th className="pb-1 text-center font-medium">Req</th>
+            </tr>
+          </thead>
+          <tbody>
+            {fields.map((field, idx) => (
+              <tr key={idx} className="border-b border-dashed last:border-0">
+                <td className="py-1 font-mono">{field.name}</td>
+                <td className="py-1">{field.type}</td>
+                <td className="py-1 text-center">
+                  {field.nullable === false ? (
+                    <Check className="mx-auto h-3 w-3 text-green-600" />
+                  ) : (
+                    ''
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </CardContent>
+
+      <CardFooter className="gap-2 pt-0">
+        <Button size="sm" onClick={() => onApply(proposal.id)} disabled={isApplying}>
+          {isApplying ? 'Applying...' : 'Apply'}
+        </Button>
+        <Button
+          size="sm"
+          variant="ghost"
+          onClick={() => onDismiss(proposal.id)}
+          disabled={isApplying}
+        >
+          <X className="mr-1 h-3 w-3" />
+          Dismiss
+        </Button>
+      </CardFooter>
+    </Card>
+  )
+}

--- a/kelta-ui/app/src/components/AiChat/AiChatContext.tsx
+++ b/kelta-ui/app/src/components/AiChat/AiChatContext.tsx
@@ -1,5 +1,11 @@
 import React, { createContext, useContext, useReducer, useCallback } from 'react'
-import type { ChatMessage, AiProposal, ConversationSummary, AiChatState } from './types'
+import type {
+  ChatMessage,
+  AiProposal,
+  ConversationSummary,
+  AiChatState,
+  ToolCallStatus,
+} from './types'
 
 type AiChatAction =
   | { type: 'TOGGLE_PANEL' }
@@ -9,12 +15,14 @@ type AiChatAction =
   | { type: 'SET_ACTIVE_CONVERSATION'; id: string | null }
   | { type: 'SET_CONVERSATION_ID'; id: string }
   | { type: 'SET_MESSAGES'; messages: ChatMessage[] }
+  | { type: 'LOAD_CONVERSATION_HISTORY'; messages: ChatMessage[]; proposals: AiProposal[] }
   | { type: 'ADD_MESSAGE'; message: ChatMessage }
   | { type: 'SET_STREAMING'; isStreaming: boolean }
   | { type: 'APPEND_STREAMING_TEXT'; text: string }
   | { type: 'CLEAR_STREAMING_TEXT' }
   | { type: 'ADD_PROPOSAL'; proposal: AiProposal }
   | { type: 'UPDATE_PROPOSAL_STATUS'; id: string; status: AiProposal['status'] }
+  | { type: 'UPDATE_TOOL_CALL_STATUS'; toolUseId: string; status: ToolCallStatus; summary?: string }
   | { type: 'SET_TOKEN_USAGE'; usage: { used: number; limit: number } | null }
 
 const initialState: AiChatState = {
@@ -50,6 +58,13 @@ function reducer(state: AiChatState, action: AiChatAction): AiChatState {
       return { ...state, activeConversationId: action.id }
     case 'SET_MESSAGES':
       return { ...state, messages: action.messages }
+    case 'LOAD_CONVERSATION_HISTORY':
+      return {
+        ...state,
+        messages: action.messages,
+        proposals: action.proposals,
+        streamingText: '',
+      }
     case 'ADD_MESSAGE':
       return { ...state, messages: [...state.messages, action.message] }
     case 'SET_STREAMING':
@@ -66,7 +81,6 @@ function reducer(state: AiChatState, action: AiChatAction): AiChatState {
         proposals: state.proposals.map((p) =>
           p.id === action.id ? { ...p, status: action.status } : p
         ),
-        // Also update the proposal embedded in messages
         messages: state.messages.map((msg) =>
           msg.proposals
             ? {
@@ -74,6 +88,18 @@ function reducer(state: AiChatState, action: AiChatAction): AiChatState {
                 proposals: msg.proposals.map((p) =>
                   p.id === action.id ? { ...p, status: action.status } : p
                 ),
+              }
+            : msg
+        ),
+      }
+    case 'UPDATE_TOOL_CALL_STATUS':
+      return {
+        ...state,
+        messages: state.messages.map((msg) =>
+          msg.toolCall && msg.toolCall.id === action.toolUseId
+            ? {
+                ...msg,
+                toolCall: { ...msg.toolCall, status: action.status, summary: action.summary },
               }
             : msg
         ),

--- a/kelta-ui/app/src/components/AiChat/AiChatPanel.tsx
+++ b/kelta-ui/app/src/components/AiChat/AiChatPanel.tsx
@@ -10,14 +10,116 @@ import { ChatMessage, StreamingMessage } from './ChatMessage'
 import { ChatInput } from './ChatInput'
 import { CollectionProposalCard } from './CollectionProposalCard'
 import { LayoutProposalCard } from './LayoutProposalCard'
+import { AddFieldsProposalCard } from './AddFieldsProposalCard'
+import { UpdateFieldProposalCard } from './UpdateFieldProposalCard'
+import { RemoveFieldProposalCard } from './RemoveFieldProposalCard'
+import { PicklistProposalCard } from './PicklistProposalCard'
+import { ToolCallIndicator } from './ToolCallIndicator'
 import { TokenUsageBadge } from './TokenUsageBadge'
-import type { AiProposal } from './types'
+import type { AiProposal, ChatMessage as ChatMessageType, ToolCallState } from './types'
 
 interface AiChatPanelProps {
   baseUrl?: string
   contextType?: string
   contextId?: string
   contextLabel?: string
+}
+
+interface RawHistoryMessage {
+  id: string
+  role: 'user' | 'assistant'
+  contentBlocks?: Array<Record<string, unknown>>
+  content?: string
+  tokensInput?: number
+  tokensOutput?: number
+  createdAt: string
+}
+
+function rehydrateMessages(raw: RawHistoryMessage[]): { messages: ChatMessageType[]; proposals: AiProposal[] } {
+  const messages: ChatMessageType[] = []
+  const proposals: AiProposal[] = []
+
+  for (const m of raw) {
+    const blocks = m.contentBlocks ?? []
+    let textBuffer = ''
+
+    for (const block of blocks) {
+      const type = block.type as string | undefined
+
+      if (type === 'text') {
+        textBuffer += (block.text as string) ?? ''
+        continue
+      }
+
+      if (type === 'tool_use') {
+        if (textBuffer.trim()) {
+          messages.push({
+            id: uuid(),
+            role: m.role,
+            content: textBuffer,
+            createdAt: m.createdAt,
+          })
+          textBuffer = ''
+        }
+        const name = block.name as string
+        const toolUseId = block.id as string
+        const proposalId = block.proposalId as string | undefined
+        const input = block.input as Record<string, unknown> | undefined
+
+        if (proposalId && name?.startsWith('propose_')) {
+          const proposal: AiProposal = {
+            id: proposalId,
+            type: name.replace(/^propose_/, '') as AiProposal['type'],
+            status: 'applied',
+            data: input ?? {},
+            createdAt: m.createdAt,
+          }
+          proposals.push(proposal)
+          messages.push({
+            id: `proposal-${proposalId}`,
+            role: 'assistant',
+            content: '',
+            proposals: [proposal],
+            createdAt: m.createdAt,
+          })
+        } else {
+          const toolCall: ToolCallState = {
+            id: toolUseId,
+            name,
+            status: 'done',
+          }
+          messages.push({
+            id: `toolcall-${toolUseId}`,
+            role: 'assistant',
+            content: '',
+            toolCall,
+            createdAt: m.createdAt,
+          })
+        }
+      }
+    }
+
+    if (textBuffer.trim()) {
+      messages.push({
+        id: uuid(),
+        role: m.role,
+        content: textBuffer,
+        createdAt: m.createdAt,
+      })
+    }
+
+    // Fallback for legacy rows where contentBlocks is empty
+    if (blocks.length === 0 && m.content) {
+      messages.push({
+        id: uuid(),
+        role: m.role,
+        content: m.content,
+        createdAt: m.createdAt,
+      })
+    }
+  }
+
+  return { messages, proposals }
 }
 
 export function AiChatPanel({
@@ -31,17 +133,52 @@ export function AiChatPanel({
   const { sendStreamMessage, cancelStream } = useAiStream()
   const messagesEndRef = useRef<HTMLDivElement>(null)
   const [applyingId, setApplyingId] = useState<string | null>(null)
+  const hydratedConvIdRef = useRef<string | null>(null)
 
-  // Auto-scroll to bottom on new messages or streaming text
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
   }, [state.messages, state.streamingText, state.proposals])
+
+  // Rehydrate conversation history on mount when an activeConversationId is set
+  // (e.g. user reopens a saved conversation or refreshes the page).
+  useEffect(() => {
+    const convId = state.activeConversationId
+    if (!convId || hydratedConvIdRef.current === convId) return
+    if (state.messages.length > 0) {
+      hydratedConvIdRef.current = convId
+      return
+    }
+
+    let cancelled = false
+    const load = async () => {
+      try {
+        const token = await getAccessToken()
+        const headers: Record<string, string> = {}
+        if (token) headers['Authorization'] = `Bearer ${token}`
+        const response = await fetch(`${baseUrl}/api/ai/conversations/${convId}/messages`, { headers })
+        if (!response.ok) return
+        const body = await response.json()
+        const raw = (body.messages ?? []) as RawHistoryMessage[]
+        if (cancelled) return
+        const { messages, proposals } = rehydrateMessages(raw)
+        dispatch({ type: 'LOAD_CONVERSATION_HISTORY', messages, proposals })
+        hydratedConvIdRef.current = convId
+      } catch (err) {
+        console.error('Failed to rehydrate conversation:', err)
+      }
+    }
+    load()
+    return () => {
+      cancelled = true
+    }
+  }, [state.activeConversationId, state.messages.length, baseUrl, dispatch, getAccessToken])
 
   const handleSend = useCallback(
     (message: string) => {
       sendStreamMessage(baseUrl, message, state.activeConversationId, contextType, contextId, {
         onDone: (conversationId) => {
           dispatch({ type: 'SET_CONVERSATION_ID', id: conversationId })
+          hydratedConvIdRef.current = conversationId
         },
       })
     },
@@ -51,6 +188,7 @@ export function AiChatPanel({
   const handleNewChat = useCallback(() => {
     dispatch({ type: 'SET_ACTIVE_CONVERSATION', id: null })
     dispatch({ type: 'SET_MESSAGES', messages: [] })
+    hydratedConvIdRef.current = null
   }, [dispatch])
 
   const handleApply = useCallback(
@@ -67,7 +205,6 @@ export function AiChatPanel({
         })
         if (response.ok) {
           dispatch({ type: 'UPDATE_PROPOSAL_STATUS', id: proposalId, status: 'applied' })
-          // Check for warnings (partial failures)
           try {
             const body = await response.json()
             const warnings = body.warnings as string[] | undefined
@@ -75,13 +212,13 @@ export function AiChatPanel({
               const warningMsg = {
                 id: uuid(),
                 role: 'assistant' as const,
-                content: `Collection created with ${warnings.length} warning(s):\n${warnings.map((w: string) => `- ${w}`).join('\n')}`,
+                content: `Applied with ${warnings.length} warning(s):\n${warnings.map((w: string) => `- ${w}`).join('\n')}`,
                 createdAt: new Date().toISOString(),
               }
               dispatch({ type: 'ADD_MESSAGE', message: warningMsg })
             }
           } catch {
-            /* ignore parse error */
+            /* ignore */
           }
         } else {
           let errorMsg = `Apply failed (${response.status})`
@@ -120,26 +257,28 @@ export function AiChatPanel({
   )
 
   const renderProposal = (proposal: AiProposal) => {
-    if (proposal.type === 'collection') {
-      return (
-        <CollectionProposalCard
-          key={proposal.id}
-          proposal={proposal}
-          onApply={handleApply}
-          onDismiss={handleDismiss}
-          isApplying={applyingId === proposal.id}
-        />
-      )
+    const props = {
+      proposal,
+      onApply: handleApply,
+      onDismiss: handleDismiss,
+      isApplying: applyingId === proposal.id,
     }
-    return (
-      <LayoutProposalCard
-        key={proposal.id}
-        proposal={proposal}
-        onApply={handleApply}
-        onDismiss={handleDismiss}
-        isApplying={applyingId === proposal.id}
-      />
-    )
+    switch (proposal.type) {
+      case 'collection':
+        return <CollectionProposalCard key={proposal.id} {...props} />
+      case 'layout':
+        return <LayoutProposalCard key={proposal.id} {...props} />
+      case 'add_fields':
+        return <AddFieldsProposalCard key={proposal.id} {...props} />
+      case 'update_field':
+        return <UpdateFieldProposalCard key={proposal.id} {...props} />
+      case 'remove_field':
+        return <RemoveFieldProposalCard key={proposal.id} {...props} />
+      case 'picklist':
+        return <PicklistProposalCard key={proposal.id} {...props} />
+      default:
+        return null
+    }
   }
 
   return (
@@ -165,7 +304,6 @@ export function AiChatPanel({
           </div>
         </SheetHeader>
 
-        {/* Messages & Proposals — rendered inline */}
         <div className="flex-1 overflow-y-auto">
           {state.messages.length === 0 && !state.isStreaming && state.proposals.length === 0 && (
             <div className="flex h-full items-center justify-center p-8">
@@ -173,16 +311,18 @@ export function AiChatPanel({
                 <Bot className="mx-auto mb-3 h-12 w-12 text-muted-foreground/30" />
                 <h3 className="text-sm font-medium text-muted-foreground">How can I help?</h3>
                 <p className="mt-1 text-xs text-muted-foreground/60">
-                  I can create collections and layouts for you.
+                  Ask me to review or extend your collections.
                   <br />
-                  Try: &quot;Create a customer collection&quot;
+                  Try: &quot;Review the fields in products&quot;
                 </p>
               </div>
             </div>
           )}
 
           {state.messages.map((msg) => {
-            // If message has proposals, render them instead of the text
+            if (msg.toolCall) {
+              return <ToolCallIndicator key={msg.id} call={msg.toolCall} />
+            }
             if (msg.proposals && msg.proposals.length > 0) {
               return msg.proposals.map(renderProposal)
             }
@@ -194,7 +334,6 @@ export function AiChatPanel({
           <div ref={messagesEndRef} />
         </div>
 
-        {/* Input */}
         <ChatInput
           onSend={handleSend}
           onCancel={cancelStream}

--- a/kelta-ui/app/src/components/AiChat/PicklistProposalCard.tsx
+++ b/kelta-ui/app/src/components/AiChat/PicklistProposalCard.tsx
@@ -1,0 +1,96 @@
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { List, X, CheckCircle, XCircle } from 'lucide-react'
+import type { AiProposal, ProposedPicklistValue } from './types'
+
+interface PicklistProposalCardProps {
+  proposal: AiProposal
+  onApply: (proposalId: string) => void
+  onDismiss: (proposalId: string) => void
+  isApplying?: boolean
+}
+
+export function PicklistProposalCard({
+  proposal,
+  onApply,
+  onDismiss,
+  isApplying,
+}: PicklistProposalCardProps) {
+  const data = proposal.data
+  const name = data.name as string
+  const values = (data.values as ProposedPicklistValue[]) || []
+  const restricted = data.restricted === true
+  const isApplied = proposal.status === 'applied'
+  const isDismissed = proposal.status === 'dismissed'
+  const isResolved = isApplied || isDismissed
+
+  if (isResolved) {
+    return (
+      <div className="mx-4 my-2 flex items-center gap-2 rounded-lg border border-dashed px-3 py-2 text-xs text-muted-foreground">
+        {isApplied ? (
+          <CheckCircle className="h-3.5 w-3.5 text-green-600 shrink-0" />
+        ) : (
+          <XCircle className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+        )}
+        <List className="h-3.5 w-3.5 shrink-0" />
+        <span className="font-medium text-foreground">{name}</span>
+        <Badge variant="outline" className="text-[10px] px-1 py-0">
+          {values.length} values
+        </Badge>
+        <span className="ml-auto">
+          {isApplied ? (
+            <Badge className="bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300 text-[10px]">
+              Applied
+            </Badge>
+          ) : (
+            <Badge variant="secondary" className="text-[10px]">
+              Dismissed
+            </Badge>
+          )}
+        </span>
+      </div>
+    )
+  }
+
+  return (
+    <Card className="mx-4 my-2 border-primary/20">
+      <CardHeader className="pb-3">
+        <div className="flex items-center gap-2">
+          <List className="h-4 w-4 text-primary" />
+          <CardTitle className="text-sm font-semibold">{name}</CardTitle>
+          {restricted && (
+            <Badge variant="outline" className="text-xs">
+              Restricted
+            </Badge>
+          )}
+        </div>
+      </CardHeader>
+
+      <CardContent className="pb-3">
+        <div className="flex flex-wrap gap-1">
+          {values.map((v, idx) => (
+            <Badge key={idx} variant="secondary" className="text-xs">
+              {v.label ?? v.value}
+            </Badge>
+          ))}
+        </div>
+      </CardContent>
+
+      <CardFooter className="gap-2 pt-0">
+        <Button size="sm" onClick={() => onApply(proposal.id)} disabled={isApplying}>
+          {isApplying ? 'Applying...' : 'Apply'}
+        </Button>
+        <Button
+          size="sm"
+          variant="ghost"
+          onClick={() => onDismiss(proposal.id)}
+          disabled={isApplying}
+        >
+          <X className="mr-1 h-3 w-3" />
+          Dismiss
+        </Button>
+      </CardFooter>
+    </Card>
+  )
+}

--- a/kelta-ui/app/src/components/AiChat/RemoveFieldProposalCard.test.tsx
+++ b/kelta-ui/app/src/components/AiChat/RemoveFieldProposalCard.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { RemoveFieldProposalCard } from './RemoveFieldProposalCard'
+import type { AiProposal } from './types'
+
+function makeProposal(): AiProposal {
+  return {
+    id: 'p1',
+    type: 'remove_field',
+    status: 'pending',
+    data: {
+      collectionName: 'products',
+      fieldName: 'old_sku',
+      reason: 'Replaced by sku',
+    },
+    createdAt: new Date().toISOString(),
+  }
+}
+
+describe('RemoveFieldProposalCard', () => {
+  it('renders title, target field, destructive warning, and reason', () => {
+    render(
+      <RemoveFieldProposalCard proposal={makeProposal()} onApply={vi.fn()} onDismiss={vi.fn()} />
+    )
+    // Header title and primary action both say "Remove field" — disambiguate via roles.
+    expect(screen.getAllByText(/Remove field/).length).toBeGreaterThanOrEqual(1)
+    expect(screen.getByText('products.old_sku')).toBeInTheDocument()
+    expect(screen.getByText(/data will be deleted/i)).toBeInTheDocument()
+    expect(screen.getByText(/Replaced by sku/)).toBeInTheDocument()
+  })
+
+  it('renders applied state without action buttons', () => {
+    const applied: AiProposal = { ...makeProposal(), status: 'applied' }
+    render(
+      <RemoveFieldProposalCard proposal={applied} onApply={vi.fn()} onDismiss={vi.fn()} />
+    )
+    expect(screen.getByText('Removed')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Remove field/ })).not.toBeInTheDocument()
+  })
+})

--- a/kelta-ui/app/src/components/AiChat/RemoveFieldProposalCard.tsx
+++ b/kelta-ui/app/src/components/AiChat/RemoveFieldProposalCard.tsx
@@ -1,0 +1,100 @@
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { Trash2, X, AlertTriangle, CheckCircle, XCircle } from 'lucide-react'
+import type { AiProposal } from './types'
+
+interface RemoveFieldProposalCardProps {
+  proposal: AiProposal
+  onApply: (proposalId: string) => void
+  onDismiss: (proposalId: string) => void
+  isApplying?: boolean
+}
+
+export function RemoveFieldProposalCard({
+  proposal,
+  onApply,
+  onDismiss,
+  isApplying,
+}: RemoveFieldProposalCardProps) {
+  const data = proposal.data
+  const collectionName = data.collectionName as string
+  const fieldName = data.fieldName as string
+  const reason = data.reason as string | undefined
+  const isApplied = proposal.status === 'applied'
+  const isDismissed = proposal.status === 'dismissed'
+  const isResolved = isApplied || isDismissed
+
+  if (isResolved) {
+    return (
+      <div className="mx-4 my-2 flex items-center gap-2 rounded-lg border border-dashed px-3 py-2 text-xs text-muted-foreground">
+        {isApplied ? (
+          <CheckCircle className="h-3.5 w-3.5 text-green-600 shrink-0" />
+        ) : (
+          <XCircle className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+        )}
+        <Trash2 className="h-3.5 w-3.5 shrink-0" />
+        <span className="font-medium text-foreground">
+          {collectionName}.{fieldName}
+        </span>
+        <span className="ml-auto">
+          {isApplied ? (
+            <Badge className="bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-300 text-[10px]">
+              Removed
+            </Badge>
+          ) : (
+            <Badge variant="secondary" className="text-[10px]">
+              Dismissed
+            </Badge>
+          )}
+        </span>
+      </div>
+    )
+  }
+
+  return (
+    <Card className="mx-4 my-2 border-destructive/40 bg-destructive/5">
+      <CardHeader className="pb-3">
+        <div className="flex items-center gap-2">
+          <Trash2 className="h-4 w-4 text-destructive" />
+          <CardTitle className="text-sm font-semibold">Remove field</CardTitle>
+          <Badge variant="outline" className="text-xs">
+            {collectionName}.{fieldName}
+          </Badge>
+        </div>
+        <div className="flex items-start gap-2 rounded border border-destructive/30 bg-background p-2 mt-2">
+          <AlertTriangle className="mt-0.5 h-3.5 w-3.5 text-destructive shrink-0" />
+          <p className="text-xs">
+            Destructive — the column and all its data will be deleted.
+          </p>
+        </div>
+      </CardHeader>
+
+      {reason && (
+        <CardContent className="pb-3 text-xs text-muted-foreground">
+          <span className="font-medium text-foreground">Reason:</span> {reason}
+        </CardContent>
+      )}
+
+      <CardFooter className="gap-2 pt-0">
+        <Button
+          size="sm"
+          variant="destructive"
+          onClick={() => onApply(proposal.id)}
+          disabled={isApplying}
+        >
+          {isApplying ? 'Removing...' : 'Remove field'}
+        </Button>
+        <Button
+          size="sm"
+          variant="ghost"
+          onClick={() => onDismiss(proposal.id)}
+          disabled={isApplying}
+        >
+          <X className="mr-1 h-3 w-3" />
+          Dismiss
+        </Button>
+      </CardFooter>
+    </Card>
+  )
+}

--- a/kelta-ui/app/src/components/AiChat/ToolCallIndicator.test.tsx
+++ b/kelta-ui/app/src/components/AiChat/ToolCallIndicator.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ToolCallIndicator } from './ToolCallIndicator'
+
+describe('ToolCallIndicator', () => {
+  it('renders a friendly label for known tools', () => {
+    render(
+      <ToolCallIndicator
+        call={{ id: 'toolu_1', name: 'get_collection_schema', status: 'pending' }}
+      />
+    )
+    expect(screen.getByText(/Inspecting collection/i)).toBeInTheDocument()
+  })
+
+  it('falls back to the tool name for unknown tools', () => {
+    render(<ToolCallIndicator call={{ id: 'toolu_2', name: 'foo_bar', status: 'pending' }} />)
+    expect(screen.getByText('foo_bar')).toBeInTheDocument()
+  })
+
+  it('includes summary text when provided', () => {
+    render(
+      <ToolCallIndicator
+        call={{ id: 'toolu_3', name: 'query_records', status: 'done', summary: '5 rows' }}
+      />
+    )
+    expect(screen.getByText(/5 rows/)).toBeInTheDocument()
+  })
+
+  it('shows error state visually', () => {
+    const { container } = render(
+      <ToolCallIndicator call={{ id: 'toolu_4', name: 'get_picklist', status: 'error' }} />
+    )
+    expect(container.firstChild).toHaveClass('text-destructive')
+  })
+})

--- a/kelta-ui/app/src/components/AiChat/ToolCallIndicator.tsx
+++ b/kelta-ui/app/src/components/AiChat/ToolCallIndicator.tsx
@@ -1,0 +1,37 @@
+import { Loader2, Check, AlertCircle } from 'lucide-react'
+import type { ToolCallState } from './types'
+
+interface ToolCallIndicatorProps {
+  call: ToolCallState
+}
+
+const TOOL_LABELS: Record<string, string> = {
+  get_collection_schema: 'Inspecting collection',
+  query_records: 'Sampling records',
+  list_picklists: 'Listing picklists',
+  get_picklist: 'Loading picklist',
+  list_validation_rules: 'Loading validation rules',
+  list_page_layouts: 'Loading page layouts',
+}
+
+export function ToolCallIndicator({ call }: ToolCallIndicatorProps) {
+  const label = TOOL_LABELS[call.name] ?? call.name
+  const colorClass =
+    call.status === 'error'
+      ? 'border-destructive/40 text-destructive'
+      : call.status === 'done'
+        ? 'border-green-500/30 text-green-700 dark:text-green-400'
+        : 'border-muted-foreground/30 text-muted-foreground'
+
+  return (
+    <div
+      className={`mx-4 my-1 inline-flex items-center gap-2 rounded-full border px-2.5 py-1 text-xs ${colorClass}`}
+    >
+      {call.status === 'pending' && <Loader2 className="h-3 w-3 animate-spin" />}
+      {call.status === 'done' && <Check className="h-3 w-3" />}
+      {call.status === 'error' && <AlertCircle className="h-3 w-3" />}
+      <span>{label}</span>
+      {call.summary && <span className="opacity-70">— {call.summary}</span>}
+    </div>
+  )
+}

--- a/kelta-ui/app/src/components/AiChat/UpdateFieldProposalCard.tsx
+++ b/kelta-ui/app/src/components/AiChat/UpdateFieldProposalCard.tsx
@@ -1,0 +1,106 @@
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { Pencil, X, CheckCircle, XCircle } from 'lucide-react'
+import type { AiProposal, ProposedFieldChange } from './types'
+
+interface UpdateFieldProposalCardProps {
+  proposal: AiProposal
+  onApply: (proposalId: string) => void
+  onDismiss: (proposalId: string) => void
+  isApplying?: boolean
+}
+
+export function UpdateFieldProposalCard({
+  proposal,
+  onApply,
+  onDismiss,
+  isApplying,
+}: UpdateFieldProposalCardProps) {
+  const data = proposal.data
+  const collectionName = data.collectionName as string
+  const fieldName = data.fieldName as string
+  const changes = (data.changes as ProposedFieldChange) || {}
+  const isApplied = proposal.status === 'applied'
+  const isDismissed = proposal.status === 'dismissed'
+  const isResolved = isApplied || isDismissed
+
+  if (isResolved) {
+    return (
+      <div className="mx-4 my-2 flex items-center gap-2 rounded-lg border border-dashed px-3 py-2 text-xs text-muted-foreground">
+        {isApplied ? (
+          <CheckCircle className="h-3.5 w-3.5 text-green-600 shrink-0" />
+        ) : (
+          <XCircle className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+        )}
+        <Pencil className="h-3.5 w-3.5 shrink-0" />
+        <span className="font-medium text-foreground">
+          {collectionName}.{fieldName}
+        </span>
+        <span className="ml-auto">
+          {isApplied ? (
+            <Badge className="bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300 text-[10px]">
+              Applied
+            </Badge>
+          ) : (
+            <Badge variant="secondary" className="text-[10px]">
+              Dismissed
+            </Badge>
+          )}
+        </span>
+      </div>
+    )
+  }
+
+  const changeEntries = Object.entries(changes).filter(([, v]) => v !== undefined)
+
+  return (
+    <Card className="mx-4 my-2 border-primary/20">
+      <CardHeader className="pb-3">
+        <div className="flex items-center gap-2">
+          <Pencil className="h-4 w-4 text-primary" />
+          <CardTitle className="text-sm font-semibold">Update field</CardTitle>
+          <Badge variant="outline" className="text-xs">
+            {collectionName}.{fieldName}
+          </Badge>
+        </div>
+      </CardHeader>
+
+      <CardContent className="pb-3">
+        <table className="w-full text-xs">
+          <thead>
+            <tr className="border-b">
+              <th className="pb-1 text-left font-medium">Property</th>
+              <th className="pb-1 text-left font-medium">New value</th>
+            </tr>
+          </thead>
+          <tbody>
+            {changeEntries.map(([key, value]) => (
+              <tr key={key} className="border-b border-dashed last:border-0">
+                <td className="py-1 font-mono">{key}</td>
+                <td className="py-1">
+                  {Array.isArray(value) ? value.join(', ') : String(value)}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </CardContent>
+
+      <CardFooter className="gap-2 pt-0">
+        <Button size="sm" onClick={() => onApply(proposal.id)} disabled={isApplying}>
+          {isApplying ? 'Applying...' : 'Apply'}
+        </Button>
+        <Button
+          size="sm"
+          variant="ghost"
+          onClick={() => onDismiss(proposal.id)}
+          disabled={isApplying}
+        >
+          <X className="mr-1 h-3 w-3" />
+          Dismiss
+        </Button>
+      </CardFooter>
+    </Card>
+  )
+}

--- a/kelta-ui/app/src/components/AiChat/types.ts
+++ b/kelta-ui/app/src/components/AiChat/types.ts
@@ -1,16 +1,35 @@
+export type ToolCallStatus = 'pending' | 'done' | 'error'
+
+export interface ToolCallState {
+  id: string
+  name: string
+  status: ToolCallStatus
+  summary?: string
+}
+
 export interface ChatMessage {
   id: string
   role: 'user' | 'assistant'
   content: string
   proposals?: AiProposal[]
+  toolCall?: ToolCallState
+  contentBlocks?: Array<Record<string, unknown>>
   tokensInput?: number
   tokensOutput?: number
   createdAt: string
 }
 
+export type AiProposalType =
+  | 'collection'
+  | 'layout'
+  | 'add_fields'
+  | 'update_field'
+  | 'remove_field'
+  | 'picklist'
+
 export interface AiProposal {
   id: string
-  type: 'collection' | 'layout'
+  type: AiProposalType
   status: 'pending' | 'applied' | 'dismissed'
   data: Record<string, unknown>
   createdAt: string
@@ -63,4 +82,19 @@ export interface ProposedSection {
     columnNumber: number
     sortOrder: number
   }>
+}
+
+export interface ProposedFieldChange {
+  displayName?: string
+  required?: boolean
+  unique?: boolean
+  description?: string
+  enumValues?: string[]
+  validationRules?: Array<{ type: string; value: string }>
+}
+
+export interface ProposedPicklistValue {
+  value: string
+  label?: string
+  sortOrder?: number
 }

--- a/kelta-ui/app/src/components/AiChat/useAiStream.ts
+++ b/kelta-ui/app/src/components/AiChat/useAiStream.ts
@@ -2,11 +2,15 @@ import { useCallback, useRef } from 'react'
 import { uuid } from '@/utils/uuid'
 import { useAuth } from '../../context/AuthContext'
 import { useAiChat } from './AiChatContext'
-import type { AiProposal, ChatMessage } from './types'
+import type { AiProposal, ChatMessage, ToolCallStatus } from './types'
 
 interface StreamCallbacks {
   onDone?: (conversationId: string) => void
   onError?: (error: string) => void
+}
+
+function toolCallMessageId(toolUseId: string): string {
+  return `toolcall-${toolUseId}`
 }
 
 export function useAiStream() {
@@ -23,7 +27,6 @@ export function useAiStream() {
       contextId?: string,
       callbacks?: StreamCallbacks
     ) => {
-      // Abort any existing stream
       abortControllerRef.current?.abort()
       const abortController = new AbortController()
       abortControllerRef.current = abortController
@@ -31,7 +34,6 @@ export function useAiStream() {
       dispatch({ type: 'SET_STREAMING', isStreaming: true })
       dispatch({ type: 'CLEAR_STREAMING_TEXT' })
 
-      // Add user message immediately
       const userMsg: ChatMessage = {
         id: uuid(),
         role: 'user',
@@ -41,9 +43,7 @@ export function useAiStream() {
       dispatch({ type: 'ADD_MESSAGE', message: userMsg })
 
       try {
-        // Get auth token
         const token = await getAccessToken()
-
         const headers: Record<string, string> = {
           'Content-Type': 'application/json',
         }
@@ -73,8 +73,6 @@ export function useAiStream() {
           } catch {
             // ignore parse error
           }
-
-          // Add error as assistant message so it's visible in the chat
           const errorChatMsg: ChatMessage = {
             id: uuid(),
             role: 'assistant',
@@ -95,6 +93,20 @@ export function useAiStream() {
         let buffer = ''
         let fullText = ''
         let currentEvent = ''
+
+        const flushStreamingText = () => {
+          if (fullText.trim()) {
+            const textMsg: ChatMessage = {
+              id: uuid(),
+              role: 'assistant',
+              content: fullText,
+              createdAt: new Date().toISOString(),
+            }
+            dispatch({ type: 'ADD_MESSAGE', message: textMsg })
+            dispatch({ type: 'CLEAR_STREAMING_TEXT' })
+            fullText = ''
+          }
+        }
 
         let done = false
         while (!done) {
@@ -120,23 +132,42 @@ export function useAiStream() {
                     dispatch({ type: 'APPEND_STREAMING_TEXT', text: parsed.text as string })
                     break
                   case 'tool_use':
-                    // When tool use starts, finalize any accumulated text as a message
-                    if (fullText.trim()) {
-                      const textMsg: ChatMessage = {
-                        id: uuid(),
-                        role: 'assistant',
-                        content: fullText,
-                        createdAt: new Date().toISOString(),
-                      }
-                      dispatch({ type: 'ADD_MESSAGE', message: textMsg })
-                      dispatch({ type: 'CLEAR_STREAMING_TEXT' })
-                      fullText = ''
-                    }
+                    // Propose tools — finalize streaming text; the proposal event will follow.
+                    flushStreamingText()
                     break
+                  case 'tool_call': {
+                    // Read tool — render a transient pill.
+                    flushStreamingText()
+                    const toolUseId = parsed.toolUseId as string
+                    const callMsg: ChatMessage = {
+                      id: toolCallMessageId(toolUseId),
+                      role: 'assistant',
+                      content: '',
+                      toolCall: {
+                        id: toolUseId,
+                        name: parsed.name as string,
+                        status: 'pending',
+                      },
+                      createdAt: new Date().toISOString(),
+                    }
+                    dispatch({ type: 'ADD_MESSAGE', message: callMsg })
+                    break
+                  }
+                  case 'tool_result': {
+                    const status = (parsed.status as ToolCallStatus | undefined) ??
+                      (parsed.isError ? 'error' : 'done')
+                    dispatch({
+                      type: 'UPDATE_TOOL_CALL_STATUS',
+                      toolUseId: parsed.toolUseId as string,
+                      status,
+                      summary: parsed.summary as string | undefined,
+                    })
+                    break
+                  }
                   case 'proposal': {
+                    flushStreamingText()
                     const proposal = parsed as AiProposal
                     dispatch({ type: 'ADD_PROPOSAL', proposal })
-                    // Add as a message so it appears inline in the chat flow
                     const proposalMsg: ChatMessage = {
                       id: `proposal-${proposal.id}`,
                       role: 'assistant',
@@ -176,7 +207,6 @@ export function useAiStream() {
           }
         }
 
-        // Finalize: add the complete assistant message
         if (fullText) {
           const assistantMsg: ChatMessage = {
             id: uuid(),
@@ -189,7 +219,6 @@ export function useAiStream() {
       } catch (err) {
         if ((err as Error).name !== 'AbortError') {
           const errorMsg = (err as Error).message
-          // Show error in the chat UI
           const errorChatMsg: ChatMessage = {
             id: uuid(),
             role: 'assistant',


### PR DESCRIPTION
## Summary

The AI chat assistant was nearly useless — it had only two write tools (`propose_collection`, `propose_layout`) and no way to inspect existing collections/fields/data. When a user said "products already has those fields", the AI had to ask them to retype the schema. This PR fixes that by introducing a real Anthropic tool-use loop with 6 read tools, 6 propose tools, persisted multi-block message history, and matching frontend affordances.

### Tools added

**Read** (return real data to Claude inside `tool_result` blocks):
- `get_collection_schema(collectionName)` — fields, types, references, picklist values
- `query_records(collectionName, limit, fields, filter)` — sample 1–20 records
- `list_picklists` / `get_picklist`
- `list_validation_rules(collectionName)`
- `list_page_layouts(collectionName)`

**Propose** (queue user-approved proposals):
- `propose_collection`, `propose_layout` (existing)
- `propose_add_fields`, `propose_update_field` (type changes rejected at the schema level), `propose_remove_field`, `propose_picklist`

### Architecture

- New `service/tools/` package with `ToolKind`, sealed `ToolHandler` (`ReadToolHandler` + `ProposeToolHandler`), `ToolRegistry` (Spring discovery), `ToolDispatcher`. Adding a tool now means dropping a new `@Component` in `handlers/`.
- `AnthropicService` no longer hardcodes tool definitions — pulls them from `ToolRegistry`.
- `ChatService` runs a real multi-turn loop (max 8 iterations, 100K-token budget) with proper `tool_use` → `tool_result` content blocks.
- `StreamAssembler` extracts the SSE state machine that builds content blocks from raw stream events.
- `ChatMessage` + V3 migration store interleaved content blocks as JSONB. Legacy columns retained for back-compat; legacy rows backfilled into `content_blocks` at migration time.
- `findByProposalId` now uses JSONB containment with legacy `proposal_json` fallback.
- `SystemPromptService` trims the static prompt, adds a Tool Usage Patterns section, and auto-inlines field tables when a tenant has ≤8 collections.
- `ProposalService` routes the new proposal types to `add_fields` / `update_field` / `remove_field` / `picklist` apply paths.
- `ChatHistoryController` exposes `GET /api/ai/conversations/{id}/messages` returning `contentBlocks` for frontend rehydration.

### Frontend

- New SSE events handled in `useAiStream`: `tool_call` (read-tool start, transient pill) + `tool_result` (resolve pill state).
- New `ToolCallIndicator` plus `AddFields` / `UpdateField` / `RemoveField` / `Picklist` proposal cards.
- `AiChatPanel` rehydrates conversation history from `contentBlocks` on mount when an `activeConversationId` is set.

## Test plan

- [ ] `cd kelta-ai && mvn test` — 71 tests pass (5 new under `service/tools/**`)
- [ ] `cd kelta-ui/app && npm run test:run -- src/components/AiChat` — 9 tests pass across 3 files
- [ ] `cd kelta-ui/app && npx tsc --noEmit` — clean
- [ ] `cd kelta-ui/app && npx eslint src/components/AiChat` — clean
- [ ] **Migration smoke**: start kelta-ai locally; verify V3 applies and an `ai_message` row has `content_blocks` populated
- [ ] **Sample dialogue** in a tenant with a `products` collection: ask "Review the fields in products and recommend what's missing" — AI calls `get_collection_schema`, UI shows "Inspecting collection..." pill, AI returns recommendations that reference actual existing fields
- [ ] **Add fields flow**: ask "Add a `loyalty_points` integer field to customers" — AI calls `get_collection_schema('customers')` then `propose_add_fields`, UI renders `AddFieldsProposalCard`, Apply succeeds
- [ ] **Type-change rejected**: ask "Change products.price from CURRENCY to STRING" — AI surfaces the rejection from `propose_update_field` and suggests remove + add
- [ ] **Conversation reload**: send a few messages, refresh the page with the conversation ID in the URL — messages and proposal cards reappear from `contentBlocks`
- [ ] **Tool loop bounds**: stress with "inspect every collection and recommend changes" — loop exits cleanly at 8 iterations or 100K tokens with a single `error` SSE event

🤖 Generated with [Claude Code](https://claude.com/claude-code)