### PR TITLE
fix(ai): re-enable Flyway auto-config under Spring Boot 4

### DIFF
--- a/kelta-ai/pom.xml
+++ b/kelta-ai/pom.xml
@@ -87,10 +87,17 @@
             <scope>runtime</scope>
         </dependency>
 
-        <!-- Flyway Database Migrations -->
+        <!-- Flyway Database Migrations.
+             Spring Boot 4.x modularized auto-configuration — FlywayAutoConfiguration
+             moved from spring-boot-autoconfigure to spring-boot-flyway. The starter
+             pulls in that module so Flyway actually runs on startup. -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-flyway</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.flywaydb</groupId>
-            <artifactId>flyway-core</artifactId>
+            <artifactId>flyway-database-postgresql</artifactId>
         </dependency>
 
         <!-- Jackson 3 -->


### PR DESCRIPTION
## Summary

Spring Boot 4.x modularized auto-configuration — `FlywayAutoConfiguration` moved from `spring-boot-autoconfigure` into the new `spring-boot-flyway` module. After the Boot 4 upgrade (#628), `kelta-ai/pom.xml` kept only `flyway-core`, so the auto-config bean is never registered and Flyway silently no-ops on startup.

V3 (`content_blocks` column on `ai_message` from #914) therefore never applied, breaking every chat message INSERT:

```
PSQLException: ERROR: column "content_blocks" of relation "ai_message" does not exist
  at io.kelta.ai.repository.ChatMessageRepository.save(ChatMessageRepository.java:39)
```

`kelta-worker` already does this correctly — pom comment there explicitly calls out the Boot 4 modularization. This brings `kelta-ai` in line.

### Changes

- Replace `flyway-core` with `spring-boot-starter-flyway` (pulls in the relocated auto-config module).
- Add `flyway-database-postgresql` (required by Flyway 10+ for Postgres support).

### What happens on next pod start

V1 and V2 are already recorded in `ai_flyway_schema_history` from the Boot 3 era (when `flyway-core` alone was enough to trigger auto-config). Flyway will boot, see history table populated through V2, find V3 pending, and apply it — adding the `content_blocks` column and backfilling legacy rows.

## Test plan

- [ ] `cd kelta-ai && mvn -DskipTests package` — clean build with new deps
- [ ] Deploy to homelab; tail pod logs for `Migrating schema "public" to version "3"` line
- [ ] `\d ai_message` in `kelta_control_plane` shows `content_blocks JSONB NOT NULL DEFAULT '[]'::jsonb`
- [ ] Send a new AI chat message — succeeds (no SQL grammar error)
- [ ] Existing chat history still loads via `GET /api/ai/conversations/{id}/messages`

🤖 Generated with [Claude Code](https://claude.com/claude-code)