### PR TITLE
fix(ai): unpack tool input_schema + close SSE on error

### DIFF
--- a/kelta-ai/src/main/java/io/kelta/ai/service/ChatService.java
+++ b/kelta-ai/src/main/java/io/kelta/ai/service/ChatService.java
@@ -113,14 +113,20 @@ public class ChatService {
             emitter.complete();
         } catch (Exception e) {
             log.error("Error in chat stream: {}", e.getMessage(), e);
+            // Send the error to the client as an SSE event then close the stream cleanly.
+            // Calling completeWithError(e) would re-throw on Spring's async dispatch and
+            // route the exception to GlobalExceptionHandler, which then fails with
+            // "No converter for LinkedHashMap with preset Content-Type 'text/event-stream'"
+            // because the response is already committed as text/event-stream.
             try {
-                Map<String, Object> errorData = Map.of("code", "AI_PROVIDER_ERROR", "message", e.getMessage());
+                Map<String, Object> errorData = Map.of(
+                        "code", "AI_PROVIDER_ERROR",
+                        "message", e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName());
                 emitter.send(SseEmitter.event().name("error").data(objectMapper.writeValueAsString(errorData)));
-                emitter.completeWithError(e);
             } catch (IOException ex) {
-                log.error("Failed to send error event: {}", ex.getMessage());
-                emitter.completeWithError(e);
+                log.warn("Failed to send error event to client: {}", ex.getMessage());
             }
+            emitter.complete();
         }
     }
 

--- a/kelta-ai/src/main/java/io/kelta/ai/service/tools/ToolRegistry.java
+++ b/kelta-ai/src/main/java/io/kelta/ai/service/tools/ToolRegistry.java
@@ -5,6 +5,7 @@ import com.anthropic.models.messages.Tool;
 import com.anthropic.models.messages.ToolUnion;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -49,10 +50,34 @@ public class ToolRegistry {
         Tool tool = Tool.builder()
                 .name(handler.name())
                 .description(handler.description())
-                .inputSchema(Tool.InputSchema.builder()
-                        .properties(JsonValue.from(handler.inputSchema()))
-                        .build())
+                .inputSchema(buildInputSchema(handler.inputSchema()))
                 .build();
         return ToolUnion.ofTool(tool);
+    }
+
+    private Tool.InputSchema buildInputSchema(Map<String, Object> rawSchema) {
+        Tool.InputSchema.Properties.Builder propertiesBuilder = Tool.InputSchema.Properties.builder();
+        Object propertiesObj = rawSchema.get("properties");
+        if (propertiesObj instanceof Map<?, ?> propertiesMap) {
+            for (Map.Entry<?, ?> entry : propertiesMap.entrySet()) {
+                propertiesBuilder.putAdditionalProperty(
+                        String.valueOf(entry.getKey()),
+                        JsonValue.from(entry.getValue()));
+            }
+        }
+
+        Tool.InputSchema.Builder schemaBuilder = Tool.InputSchema.builder()
+                .properties(propertiesBuilder.build());
+
+        Object requiredObj = rawSchema.get("required");
+        if (requiredObj instanceof List<?> requiredList && !requiredList.isEmpty()) {
+            List<String> required = new ArrayList<>(requiredList.size());
+            for (Object item : requiredList) {
+                required.add(String.valueOf(item));
+            }
+            schemaBuilder.required(required);
+        }
+
+        return schemaBuilder.build();
     }
 }

--- a/kelta-ai/src/test/java/io/kelta/ai/service/tools/ToolRegistryTest.java
+++ b/kelta-ai/src/test/java/io/kelta/ai/service/tools/ToolRegistryTest.java
@@ -1,5 +1,7 @@
 package io.kelta.ai.service.tools;
 
+import com.anthropic.models.messages.Tool;
+import com.anthropic.models.messages.ToolUnion;
 import io.kelta.ai.model.AiProposal;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -66,5 +68,40 @@ class ToolRegistryTest {
     void unknownToolReturnsEmpty() {
         ToolRegistry registry = new ToolRegistry(List.of());
         assertThat(registry.handler("anything")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("unpacks handler schema into Tool.InputSchema properties + required")
+    void unpacksSchemaForAnthropicSdk() {
+        ReadToolHandler handler = new ReadToolHandler() {
+            @Override public String name() { return "query_records"; }
+            @Override public String description() { return "fetch sample"; }
+            @Override public Map<String, Object> inputSchema() {
+                return Map.of(
+                        "type", "object",
+                        "properties", Map.of(
+                                "collectionName", Map.of("type", "string"),
+                                "limit", Map.of("type", "integer")
+                        ),
+                        "required", List.of("collectionName")
+                );
+            }
+            @Override public Object execute(String tenantId, String userId, Map<String, Object> input) {
+                return Map.of();
+            }
+        };
+
+        ToolRegistry registry = new ToolRegistry(List.of(handler));
+        List<ToolUnion> definitions = registry.toolDefinitions();
+        assertThat(definitions).hasSize(1);
+
+        Tool tool = definitions.get(0).tool().orElseThrow();
+        Tool.InputSchema schema = tool.inputSchema();
+
+        Tool.InputSchema.Properties properties = schema.properties().orElseThrow();
+        assertThat(properties._additionalProperties()).containsOnlyKeys("collectionName", "limit");
+        assertThat(properties._additionalProperties()).doesNotContainKeys("type", "properties", "required");
+
+        assertThat(schema.required().orElseThrow()).containsExactly("collectionName");
     }
 }


### PR DESCRIPTION
## Summary

Two AI chat bugs ship together.

**Tool schema (root cause).** `ToolRegistry.toToolUnion` wrapped each handler's full JSON Schema (`{type, properties, required}`) into `Tool.InputSchema.Builder.properties(...)`, which expects only the inner property map. Anthropic rejected every request with:
`400 tools.0.custom.input_schema: JSON schema is invalid. It must match JSON Schema draft 2020-12`.
The new code unpacks `properties` into `Tool.InputSchema.Properties` and feeds `required` to `.required(...)`. `type=object` is implicit.

**SSE error propagation (symptom).** When the streaming request blew up after the response was already committed as `text/event-stream`, `ChatService.chatStream` called `completeWithError(...)`. Spring's async dispatch then routed the exception to `GlobalExceptionHandler`, which tried to serialize a `LinkedHashMap` and failed with `No converter for [class java.util.LinkedHashMap] with preset Content-Type 'text/event-stream'`. We now catch in `chatStream`, emit an `error` SSE event with `{code, message}`, and close the emitter cleanly.

## Test plan

- [x] `mvn -f kelta-ai/pom.xml test` — 72/72 pass
- [x] New `ToolRegistryTest#unpacksSchemaForAnthropicSdk` asserts inner keys land on `Properties` and `required` propagates
- [ ] After merge: hit `/api/ai/chat/stream` in deployed `emf-ai` and confirm no 400 from Anthropic and no `No converter` errors in pod logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)