### PR TITLE
chore(infra): tune HikariCP pools for scale

### DIFF
--- a/kelta-ai/src/main/resources/application.yml
+++ b/kelta-ai/src/main/resources/application.yml
@@ -15,6 +15,13 @@ spring:
     driver-class-name: org.postgresql.Driver
     hikari:
       connection-init-sql: SET app.current_tenant_id = ''
+      maximum-pool-size: ${DB_POOL_MAX:15}
+      minimum-idle: ${DB_POOL_MIN_IDLE:3}
+      connection-timeout: ${DB_POOL_CONNECTION_TIMEOUT_MS:5000}
+      idle-timeout: ${DB_POOL_IDLE_TIMEOUT_MS:600000}
+      max-lifetime: ${DB_POOL_MAX_LIFETIME_MS:1800000}
+      leak-detection-threshold: ${DB_POOL_LEAK_DETECTION_MS:30000}
+      pool-name: kelta-ai-pool
   flyway:
     enabled: true
     baseline-on-migrate: true

--- a/kelta-auth/src/main/resources/application.yml
+++ b/kelta-auth/src/main/resources/application.yml
@@ -13,8 +13,13 @@ spring:
     username: ${DB_USERNAME:kelta}
     password: ${DB_PASSWORD:kelta}
     hikari:
-      maximum-pool-size: 10
-      minimum-idle: 2
+      maximum-pool-size: ${DB_POOL_MAX:15}
+      minimum-idle: ${DB_POOL_MIN_IDLE:3}
+      connection-timeout: ${DB_POOL_CONNECTION_TIMEOUT_MS:5000}
+      idle-timeout: ${DB_POOL_IDLE_TIMEOUT_MS:600000}
+      max-lifetime: ${DB_POOL_MAX_LIFETIME_MS:1800000}
+      leak-detection-threshold: ${DB_POOL_LEAK_DETECTION_MS:30000}
+      pool-name: kelta-auth-pool
 
   data:
     redis:

--- a/kelta-worker/src/main/resources/application.yml
+++ b/kelta-worker/src/main/resources/application.yml
@@ -13,6 +13,14 @@ spring:
     username: ${SPRING_DATASOURCE_USERNAME:kelta}
     password: ${SPRING_DATASOURCE_PASSWORD:kelta}
     driver-class-name: org.postgresql.Driver
+    hikari:
+      maximum-pool-size: ${DB_POOL_MAX:30}
+      minimum-idle: ${DB_POOL_MIN_IDLE:5}
+      connection-timeout: ${DB_POOL_CONNECTION_TIMEOUT_MS:5000}
+      idle-timeout: ${DB_POOL_IDLE_TIMEOUT_MS:600000}
+      max-lifetime: ${DB_POOL_MAX_LIFETIME_MS:1800000}
+      leak-detection-threshold: ${DB_POOL_LEAK_DETECTION_MS:30000}
+      pool-name: kelta-worker-pool
   flyway:
     enabled: false   # migrations run via K8s PreSync Job (application-migrate.yml re-enables)
     baseline-on-migrate: true


### PR DESCRIPTION
## Summary
- Set explicit HikariCP `maximum-pool-size`, `minimum-idle`, `connection-timeout`, `idle-timeout`, `max-lifetime`, `leak-detection-threshold`, and named `pool-name` on worker, auth, and ai datasources.
- Spring default of 10 connections saturates at modest concurrency; tier-1 scaling work to keep DB pool from being first bottleneck under load.
- All values overridable via env vars (`DB_POOL_MAX`, `DB_POOL_MIN_IDLE`, `DB_POOL_CONNECTION_TIMEOUT_MS`, `DB_POOL_IDLE_TIMEOUT_MS`, `DB_POOL_MAX_LIFETIME_MS`, `DB_POOL_LEAK_DETECTION_MS`) so per-environment tuning needs no rebuild.

## Defaults
| Service | max | min-idle |
|---------|-----|----------|
| kelta-worker | 30 | 5 |
| kelta-auth   | 15 | 3 |
| kelta-ai     | 15 | 3 |

Shared timeouts: `connection-timeout=5s`, `idle-timeout=10m`, `max-lifetime=30m`, `leak-detection-threshold=30s`.

## Operational note
Postgres `max_connections` must accommodate `sum(pool_max × replicas) + migration headroom` before scaling pod count. Default Postgres `max_connections=100` will be exhausted at ~3 worker pods + 1 auth + 1 ai. Raise to `200+` or add PgBouncer (separate work — PgBouncer txn-mode also needs `SET LOCAL` audit on `app.current_tenant_id` in [TenantAwareDataSourceConfig.java:89](kelta-worker/src/main/java/io/kelta/worker/config/TenantAwareDataSourceConfig.java#L89)).

## Test plan
- [x] Runtime modules built
- [x] kelta-worker `mvn verify` passes
- [x] kelta-auth `mvn verify` passes
- [x] kelta-ai `mvn verify` passes
- [x] kelta-gateway `mvn verify` passes
- [x] kelta-web lint/typecheck/format/tests pass
- [ ] Smoke test in dev after merge: confirm services start, check `/actuator/metrics/hikaricp.connections` for `kelta-worker-pool`/`kelta-auth-pool`/`kelta-ai-pool`

🤖 Generated with [Claude Code](https://claude.com/claude-code)