### PR TITLE
chore(gateway): raise Netty + Lettuce pool sizes for scale

### DIFF
--- a/kelta-gateway/src/main/resources/application.yml
+++ b/kelta-gateway/src/main/resources/application.yml
@@ -27,9 +27,10 @@ spring:
       connect-timeout: 2000ms
       lettuce:
         pool:
-          min-idle: 5
-          max-idle: 10
-          max-active: 20
+          min-idle: ${REDIS_POOL_MIN_IDLE:10}
+          max-idle: ${REDIS_POOL_MAX_IDLE:50}
+          max-active: ${REDIS_POOL_MAX_ACTIVE:100}
+          max-wait: ${REDIS_POOL_MAX_WAIT_MS:2000}ms
   
   # Security configuration for JWT validation
   security:
@@ -50,8 +51,9 @@ spring:
         response-timeout: 120s
         max-header-size: 16384     # 16 KB max header size to prevent header-based attacks
         pool:
-          max-connections: 500
-          max-idle-time: 30s
+          max-connections: ${GATEWAY_HTTPCLIENT_MAX_CONNECTIONS:2000}
+          max-idle-time: ${GATEWAY_HTTPCLIENT_MAX_IDLE_TIME:30s}
+          acquire-timeout: ${GATEWAY_HTTPCLIENT_ACQUIRE_TIMEOUT_MS:5000}
 
 
 # Kelta Gateway specific configuration


### PR DESCRIPTION
## Summary
- Reactor Netty HTTP client pool: 500 → 2000 connections (hot path from gateway to worker/auth/ai)
- Lettuce Redis pool: `max-active` 20 → 100, `max-idle` 10 → 50, `min-idle` 5 → 10
- Add explicit `acquire-timeout` (HTTP) and `max-wait` (Redis) so saturated pools fail fast with timeout rather than blocking the reactor thread.

Original sizes are sized for a single-tenant demo. Under load — every request does ≥1 Redis op (rate limit `INCR + EXPIRE`) and ≥1 HTTP call to worker — the pools become the first bottleneck after Hikari ([emf#917](https://github.com/cklinker/emf/pull/917)).

## Overridable via env
| Var | Default |
|-----|---------|
| `GATEWAY_HTTPCLIENT_MAX_CONNECTIONS` | 2000 |
| `GATEWAY_HTTPCLIENT_MAX_IDLE_TIME` | 30s |
| `GATEWAY_HTTPCLIENT_ACQUIRE_TIMEOUT_MS` | 5000 |
| `REDIS_POOL_MAX_ACTIVE` | 100 |
| `REDIS_POOL_MAX_IDLE` | 50 |
| `REDIS_POOL_MIN_IDLE` | 10 |
| `REDIS_POOL_MAX_WAIT_MS` | 2000 |

## Operational note
Single-node Redis at ~100K ops/sec ceiling will still be the next limit at ~50K req/s. Redis Cluster work is Tier-2; this PR removes only the pool bottleneck.

## Test plan
- [x] kelta-gateway `mvn verify` passes
- [x] kelta-worker `mvn verify` passes
- [x] kelta-web lint/typecheck/format/tests pass
- [ ] Smoke test in dev: confirm gateway starts, verify `reactor.netty.connection.provider.total.connections` and `lettuce.command.completion` metrics report new pool sizes under load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)