### PR TITLE
feat(nats): propagate W3C trace context through JetStream messages

### DIFF
--- a/kelta-platform/runtime/runtime-messaging-nats/pom.xml
+++ b/kelta-platform/runtime/runtime-messaging-nats/pom.xml
@@ -66,6 +66,18 @@
             <optional>true</optional>
         </dependency>
 
+        <!-- OpenTelemetry API for trace context propagation through NATS messages (optional) -->
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-context</artifactId>
+            <optional>true</optional>
+        </dependency>
+
         <!-- Testing -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -90,6 +102,16 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-testing</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/kelta-platform/runtime/runtime-messaging-nats/src/main/java/io/kelta/runtime/messaging/nats/NatsAutoConfiguration.java
+++ b/kelta-platform/runtime/runtime-messaging-nats/src/main/java/io/kelta/runtime/messaging/nats/NatsAutoConfiguration.java
@@ -15,6 +15,11 @@ import tools.jackson.databind.ObjectMapper;
  * <p>Provides connection management, event publishing, subscription management,
  * stream initialization, and health checking beans.
  *
+ * <p>Trace propagation: the publisher and subscription manager accept a
+ * {@link NatsTracing} SPI bean. {@link NatsTracingAutoConfiguration} wires
+ * {@link OtelNatsTracing} when OpenTelemetry is on the classpath; otherwise this
+ * class falls back to {@link NatsTracing#NOOP}.
+ *
  * @since 1.0.0
  */
 @AutoConfiguration
@@ -28,21 +33,30 @@ public class NatsAutoConfiguration {
     }
 
     @Bean
+    @ConditionalOnMissingBean(NatsTracing.class)
+    public NatsTracing natsTracing() {
+        return NatsTracing.NOOP;
+    }
+
+    @Bean
     @ConditionalOnMissingBean(PlatformEventPublisher.class)
     public NatsEventPublisher natsEventPublisher(NatsConnectionManager connectionManager,
                                                   ObjectMapper objectMapper,
                                                   NatsProperties properties,
+                                                  NatsTracing tracing,
                                                   ObjectProvider<MeterRegistry> meterRegistryProvider) {
         return new NatsEventPublisher(connectionManager, objectMapper,
                 properties.getMaxInflightPublishes(),
-                meterRegistryProvider.getIfAvailable());
+                meterRegistryProvider.getIfAvailable(),
+                tracing);
     }
 
     @Bean
     @ConditionalOnMissingBean
     public NatsSubscriptionManager natsSubscriptionManager(NatsConnectionManager connectionManager,
-                                                            ObjectMapper objectMapper) {
-        return new NatsSubscriptionManager(connectionManager, objectMapper);
+                                                            ObjectMapper objectMapper,
+                                                            NatsTracing tracing) {
+        return new NatsSubscriptionManager(connectionManager, objectMapper, tracing);
     }
 
     @Bean

--- a/kelta-platform/runtime/runtime-messaging-nats/src/main/java/io/kelta/runtime/messaging/nats/NatsEventPublisher.java
+++ b/kelta-platform/runtime/runtime-messaging-nats/src/main/java/io/kelta/runtime/messaging/nats/NatsEventPublisher.java
@@ -54,21 +54,31 @@ public class NatsEventPublisher implements PlatformEventPublisher {
     private final NatsConnectionManager connectionManager;
     private final ObjectMapper objectMapper;
     private final Semaphore inflight;
+    private final NatsTracing tracing;
     private final LongAdder successCount = new LongAdder();
     private final LongAdder failureCount = new LongAdder();
     private final LongAdder droppedCount = new LongAdder();
 
     public NatsEventPublisher(NatsConnectionManager connectionManager, ObjectMapper objectMapper) {
-        this(connectionManager, objectMapper, 1000, null);
+        this(connectionManager, objectMapper, 1000, null, NatsTracing.NOOP);
     }
 
     public NatsEventPublisher(NatsConnectionManager connectionManager,
                               ObjectMapper objectMapper,
                               int maxInflightPublishes,
                               MeterRegistry meterRegistry) {
+        this(connectionManager, objectMapper, maxInflightPublishes, meterRegistry, NatsTracing.NOOP);
+    }
+
+    public NatsEventPublisher(NatsConnectionManager connectionManager,
+                              ObjectMapper objectMapper,
+                              int maxInflightPublishes,
+                              MeterRegistry meterRegistry,
+                              NatsTracing tracing) {
         this.connectionManager = connectionManager;
         this.objectMapper = objectMapper;
         this.inflight = new Semaphore(Math.max(1, maxInflightPublishes));
+        this.tracing = tracing != null ? tracing : NatsTracing.NOOP;
         registerMetrics(meterRegistry, maxInflightPublishes);
     }
 
@@ -112,6 +122,7 @@ public class NatsEventPublisher implements PlatformEventPublisher {
             if (tenantId != null && !tenantId.isBlank()) {
                 headers.add(TENANT_ID_HEADER, tenantId);
             }
+            tracing.inject(headers);
 
             NatsMessage message = NatsMessage.builder()
                     .subject(subject)

--- a/kelta-platform/runtime/runtime-messaging-nats/src/main/java/io/kelta/runtime/messaging/nats/NatsSubscriptionManager.java
+++ b/kelta-platform/runtime/runtime-messaging-nats/src/main/java/io/kelta/runtime/messaging/nats/NatsSubscriptionManager.java
@@ -44,14 +44,22 @@ public class NatsSubscriptionManager implements DisposableBean {
 
     private final NatsConnectionManager connectionManager;
     private final ObjectMapper objectMapper;
+    private final NatsTracing tracing;
     private final List<EventSubscription> subscriptions = new ArrayList<>();
     private final List<JetStreamSubscription> activeSubscriptions = new ArrayList<>();
     private final ExecutorService pullExecutor = Executors.newVirtualThreadPerTaskExecutor();
     private volatile boolean running = true;
 
     public NatsSubscriptionManager(NatsConnectionManager connectionManager, ObjectMapper objectMapper) {
+        this(connectionManager, objectMapper, NatsTracing.NOOP);
+    }
+
+    public NatsSubscriptionManager(NatsConnectionManager connectionManager,
+                                   ObjectMapper objectMapper,
+                                   NatsTracing tracing) {
         this.connectionManager = connectionManager;
         this.objectMapper = objectMapper;
+        this.tracing = tracing != null ? tracing : NatsTracing.NOOP;
     }
 
     /**
@@ -99,7 +107,7 @@ public class NatsSubscriptionManager implements DisposableBean {
                 try {
                     List<Message> messages = jsSub.fetch(10, Duration.ofSeconds(1));
                     for (Message msg : messages) {
-                        try {
+                        try (NatsTracing.Scope ignored = tracing.extractAndOpen(msg.getHeaders())) {
                             String data = new String(msg.getData(), StandardCharsets.UTF_8);
                             if (!tenantEnvelopeValid(sub.name(), msg.getHeaders(), data)) {
                                 msg.ack(); // discard, don't redeliver a poisoned message
@@ -143,7 +151,7 @@ public class NatsSubscriptionManager implements DisposableBean {
                 .build();
 
         JetStreamSubscription jsSub = js.subscribe(sub.subject(), dispatcher, msg -> {
-            try {
+            try (NatsTracing.Scope ignored = tracing.extractAndOpen(msg.getHeaders())) {
                 String data = new String(msg.getData(), StandardCharsets.UTF_8);
                 if (!tenantEnvelopeValid(sub.name(), msg.getHeaders(), data)) {
                     msg.ack(); // discard, don't redeliver a poisoned message

--- a/kelta-platform/runtime/runtime-messaging-nats/src/main/java/io/kelta/runtime/messaging/nats/NatsTracing.java
+++ b/kelta-platform/runtime/runtime-messaging-nats/src/main/java/io/kelta/runtime/messaging/nats/NatsTracing.java
@@ -1,0 +1,41 @@
+package io.kelta.runtime.messaging.nats;
+
+import io.nats.client.impl.Headers;
+
+/**
+ * SPI for propagating distributed-tracing context through NATS messages. Implementations
+ * inject the current trace context into outbound message headers and extract it from
+ * inbound headers to attach the receiving span to its parent span on the publisher.
+ *
+ * <p>The default {@link NoopNatsTracing} disables propagation; the OpenTelemetry-backed
+ * implementation is wired automatically when an {@code OpenTelemetry} bean is present in
+ * the application context (see {@link NatsAutoConfiguration}).
+ */
+public interface NatsTracing {
+
+    NatsTracing NOOP = new NoopNatsTracing();
+
+    /**
+     * Inject the current outgoing trace context into the supplied NATS headers
+     * (e.g. {@code traceparent}, {@code tracestate} for W3C).
+     */
+    void inject(Headers headers);
+
+    /**
+     * Extract the incoming trace context from NATS headers and open a scope that
+     * makes it current on the calling thread. Callers must close the returned
+     * scope when the handler completes.
+     */
+    Scope extractAndOpen(Headers headers);
+
+    /**
+     * A scope returned by {@link #extractAndOpen(Headers)}. Closing the scope
+     * restores the previously-current context. Never null.
+     */
+    interface Scope extends AutoCloseable {
+        Scope NOOP = () -> {};
+
+        @Override
+        void close();
+    }
+}

--- a/kelta-platform/runtime/runtime-messaging-nats/src/main/java/io/kelta/runtime/messaging/nats/NatsTracingAutoConfiguration.java
+++ b/kelta-platform/runtime/runtime-messaging-nats/src/main/java/io/kelta/runtime/messaging/nats/NatsTracingAutoConfiguration.java
@@ -1,0 +1,26 @@
+package io.kelta.runtime.messaging.nats;
+
+import io.opentelemetry.api.OpenTelemetry;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * Wires {@link OtelNatsTracing} as the {@link NatsTracing} bean when the
+ * application provides an {@link OpenTelemetry} instance and the OTel API is on
+ * the classpath. Loaded before {@link NatsAutoConfiguration} so this bean wins
+ * over the no-op fallback registered there.
+ */
+@AutoConfiguration(before = NatsAutoConfiguration.class)
+@ConditionalOnClass(OpenTelemetry.class)
+public class NatsTracingAutoConfiguration {
+
+    @Bean
+    @ConditionalOnBean(OpenTelemetry.class)
+    @ConditionalOnMissingBean(NatsTracing.class)
+    public NatsTracing otelNatsTracing(OpenTelemetry openTelemetry) {
+        return new OtelNatsTracing(openTelemetry);
+    }
+}

--- a/kelta-platform/runtime/runtime-messaging-nats/src/main/java/io/kelta/runtime/messaging/nats/NoopNatsTracing.java
+++ b/kelta-platform/runtime/runtime-messaging-nats/src/main/java/io/kelta/runtime/messaging/nats/NoopNatsTracing.java
@@ -1,0 +1,17 @@
+package io.kelta.runtime.messaging.nats;
+
+import io.nats.client.impl.Headers;
+
+/** No-op tracing — used when OpenTelemetry is not on the classpath / not configured. */
+final class NoopNatsTracing implements NatsTracing {
+
+    @Override
+    public void inject(Headers headers) {
+        // intentionally empty
+    }
+
+    @Override
+    public Scope extractAndOpen(Headers headers) {
+        return Scope.NOOP;
+    }
+}

--- a/kelta-platform/runtime/runtime-messaging-nats/src/main/java/io/kelta/runtime/messaging/nats/OtelNatsTracing.java
+++ b/kelta-platform/runtime/runtime-messaging-nats/src/main/java/io/kelta/runtime/messaging/nats/OtelNatsTracing.java
@@ -1,0 +1,60 @@
+package io.kelta.runtime.messaging.nats;
+
+import io.nats.client.impl.Headers;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.propagation.TextMapGetter;
+import io.opentelemetry.context.propagation.TextMapPropagator;
+import io.opentelemetry.context.propagation.TextMapSetter;
+
+/**
+ * OpenTelemetry-backed implementation of {@link NatsTracing}. Uses the configured
+ * {@link io.opentelemetry.context.propagation.ContextPropagators} (typically W3C
+ * {@code traceparent} + {@code tracestate}) to write outbound headers and read
+ * inbound ones.
+ *
+ * <p>Loaded automatically by {@link NatsAutoConfiguration} when an
+ * {@code OpenTelemetry} bean is available. Direct construction is also valid for
+ * tests.
+ */
+public final class OtelNatsTracing implements NatsTracing {
+
+    private static final TextMapSetter<Headers> SETTER = (carrier, key, value) -> {
+        if (carrier != null) {
+            carrier.put(key, value);
+        }
+    };
+
+    private static final TextMapGetter<Headers> GETTER = new TextMapGetter<>() {
+        @Override
+        public Iterable<String> keys(Headers carrier) {
+            return carrier == null ? java.util.Collections.emptyList() : carrier.keySet();
+        }
+
+        @Override
+        public String get(Headers carrier, String key) {
+            if (carrier == null) {
+                return null;
+            }
+            return carrier.getFirst(key);
+        }
+    };
+
+    private final TextMapPropagator propagator;
+
+    public OtelNatsTracing(OpenTelemetry openTelemetry) {
+        this.propagator = openTelemetry.getPropagators().getTextMapPropagator();
+    }
+
+    @Override
+    public void inject(Headers headers) {
+        propagator.inject(Context.current(), headers, SETTER);
+    }
+
+    @Override
+    public Scope extractAndOpen(Headers headers) {
+        Context extracted = propagator.extract(Context.current(), headers, GETTER);
+        io.opentelemetry.context.Scope otelScope = extracted.makeCurrent();
+        return otelScope::close;
+    }
+}

--- a/kelta-platform/runtime/runtime-messaging-nats/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/kelta-platform/runtime/runtime-messaging-nats/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,1 +1,2 @@
 io.kelta.runtime.messaging.nats.NatsAutoConfiguration
+io.kelta.runtime.messaging.nats.NatsTracingAutoConfiguration

--- a/kelta-platform/runtime/runtime-messaging-nats/src/test/java/io/kelta/runtime/messaging/nats/NatsEventPublisherTest.java
+++ b/kelta-platform/runtime/runtime-messaging-nats/src/test/java/io/kelta/runtime/messaging/nats/NatsEventPublisherTest.java
@@ -3,11 +3,13 @@ package io.kelta.runtime.messaging.nats;
 import io.kelta.runtime.event.PlatformEvent;
 import io.nats.client.JetStream;
 import io.nats.client.api.PublishAck;
+import io.nats.client.impl.Headers;
 import io.nats.client.impl.NatsMessage;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import tools.jackson.databind.ObjectMapper;
@@ -18,6 +20,7 @@ import java.util.concurrent.CompletableFuture;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -93,6 +96,24 @@ class NatsEventPublisherTest {
         assertThat(publisher.droppedCount()).isEqualTo(1L);
         assertThat(publisher.successCount()).isEqualTo(0L);
         assertThat(publisher.availableInflightPermits()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("invokes NatsTracing.inject so trace context propagates to subscribers")
+    void invokesTracingInject() throws Exception {
+        when(connectionManager.jetStream()).thenReturn(jetStream);
+        PublishAck ack = ackStub();
+        when(jetStream.publishAsync(any(NatsMessage.class)))
+                .thenReturn(CompletableFuture.completedFuture(ack));
+        NatsTracing tracing = mock(NatsTracing.class);
+        NatsEventPublisher publisher = new NatsEventPublisher(
+                connectionManager, objectMapper, 10, null, tracing);
+
+        publisher.publish("subject", event());
+
+        ArgumentCaptor<Headers> captor = ArgumentCaptor.forClass(Headers.class);
+        verify(tracing).inject(captor.capture());
+        assertThat(captor.getValue().getFirst("Nats-Msg-Id")).isEqualTo("evt-1");
     }
 
     @Test

--- a/kelta-platform/runtime/runtime-messaging-nats/src/test/java/io/kelta/runtime/messaging/nats/OtelNatsTracingTest.java
+++ b/kelta-platform/runtime/runtime-messaging-nats/src/test/java/io/kelta/runtime/messaging/nats/OtelNatsTracingTest.java
@@ -1,0 +1,90 @@
+package io.kelta.runtime.messaging.nats;
+
+import io.nats.client.impl.Headers;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.context.propagation.ContextPropagators;
+import io.opentelemetry.context.propagation.TextMapPropagator;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("OtelNatsTracing")
+class OtelNatsTracingTest {
+
+    private OpenTelemetry openTelemetry() {
+        TextMapPropagator propagator = W3CTraceContextPropagator.getInstance();
+        return OpenTelemetrySdk.builder()
+                .setTracerProvider(SdkTracerProvider.builder().build())
+                .setPropagators(ContextPropagators.create(propagator))
+                .build();
+    }
+
+    @Test
+    @DisplayName("inject writes a W3C traceparent header derived from the current span")
+    void injectWritesTraceparent() {
+        OpenTelemetry otel = openTelemetry();
+        OtelNatsTracing tracing = new OtelNatsTracing(otel);
+        Tracer tracer = otel.getTracer("test");
+        Span span = tracer.spanBuilder("publish").setSpanKind(SpanKind.PRODUCER).startSpan();
+        Headers headers = new Headers();
+
+        try (Scope ignored = span.makeCurrent()) {
+            tracing.inject(headers);
+        } finally {
+            span.end();
+        }
+
+        String traceparent = headers.getFirst("traceparent");
+        assertThat(traceparent).isNotNull();
+        assertThat(traceparent).contains(span.getSpanContext().getTraceId());
+    }
+
+    @Test
+    @DisplayName("extractAndOpen restores the span context written by inject")
+    void extractRoundTrip() {
+        OpenTelemetry otel = openTelemetry();
+        OtelNatsTracing tracing = new OtelNatsTracing(otel);
+        Tracer tracer = otel.getTracer("test");
+        Span source = tracer.spanBuilder("publish").startSpan();
+        Headers headers = new Headers();
+        try (Scope ignored = source.makeCurrent()) {
+            tracing.inject(headers);
+        } finally {
+            source.end();
+        }
+
+        SpanContext sourceCtx = source.getSpanContext();
+        SpanContext extracted;
+        try (NatsTracing.Scope ignored = tracing.extractAndOpen(headers)) {
+            extracted = Span.fromContext(Context.current()).getSpanContext();
+        }
+
+        assertThat(extracted.getTraceId()).isEqualTo(sourceCtx.getTraceId());
+        assertThat(extracted.getSpanId()).isEqualTo(sourceCtx.getSpanId());
+    }
+
+    @Test
+    @DisplayName("extractAndOpen with empty headers returns an invalid context scope (no parent)")
+    void extractEmptyHeaders() {
+        OpenTelemetry otel = openTelemetry();
+        OtelNatsTracing tracing = new OtelNatsTracing(otel);
+        Headers headers = new Headers();
+
+        SpanContext extracted;
+        try (NatsTracing.Scope ignored = tracing.extractAndOpen(headers)) {
+            extracted = Span.fromContext(Context.current()).getSpanContext();
+        }
+
+        assertThat(extracted.isValid()).isFalse();
+    }
+}


### PR DESCRIPTION
> **Stacked on [#920](https://github.com/cklinker/emf/pull/920)**. Will retarget to `main` automatically when #920 merges.

## Summary
- `NatsTracing` SPI (no OTel deps in the interface) with a no-op default and an OpenTelemetry-backed `OtelNatsTracing` implementation that uses the application's W3C `TextMapPropagator`.
- `NatsEventPublisher.publish` now invokes `tracing.inject(headers)` before `publishAsync` so `traceparent` + `tracestate` land on the wire.
- `NatsSubscriptionManager` wraps both pull and push consumer handler invocations in `tracing.extractAndOpen(headers)`. Receiving spans now attach to the publisher's parent context.
- `NatsTracingAutoConfiguration` registers `OtelNatsTracing` when `OpenTelemetry` is on the classpath; the existing `NatsAutoConfiguration` falls back to `NatsTracing.NOOP` otherwise. `opentelemetry-api` + `opentelemetry-context` declared `<optional>true</optional>` so the lib remains usable in non-OTel contexts.
- Tests: publisher invokes `inject`, `OtelNatsTracing` W3C round-trip (`inject` then `extract` preserves `traceId`/`spanId`, empty headers yield an invalid context).

## Why
Previously NATS messages carried only `Nats-Msg-Id` and `X-Tenant-Id` — trace context was dropped at every NATS hop. Spans on the consuming pod had no parent link back to the request that triggered the publish, leaving config-change broadcasts, record-change events, and Cerbos cache invalidations as unattributable spans in Tempo. With this PR the trace stitches across the gateway → worker → NATS → other-pod boundary.

## Followups (separate PRs)
- `TenantPropagatingExecutors` does not yet propagate OTel `Context` across thread-pool boundaries — virtual-thread submissions still lose trace. (Obs PR-A2.)
- Auth `RestClient` outbound HTTP not verified — Spring Boot auto-instrumentation may not cover the explicit `RestClient.builder()` path. (Obs PR-A3.)

## Test plan
- [x] `mvn install -f kelta-platform/pom.xml -pl runtime/runtime-messaging-nats` — 8 tests pass (3 new for OtelNatsTracing, 1 new for publisher inject, 4 pre-existing).
- [x] `mvn verify` passes for kelta-gateway, kelta-worker, kelta-auth, kelta-ai (downstream consumers — auto-config wires correctly).
- [x] kelta-web lint/typecheck/format/tests pass.
- [ ] Smoke test in dev: trigger a record CRUD in the gateway, confirm the resulting NATS-driven cache invalidation in worker shows up as a child span of the gateway request in Tempo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)