### PR TITLE
feat(nats): per-subscription consume metrics

### DIFF
--- a/kelta-platform/runtime/runtime-messaging-nats/src/main/java/io/kelta/runtime/messaging/nats/NatsAutoConfiguration.java
+++ b/kelta-platform/runtime/runtime-messaging-nats/src/main/java/io/kelta/runtime/messaging/nats/NatsAutoConfiguration.java
@@ -55,8 +55,10 @@ public class NatsAutoConfiguration {
     @ConditionalOnMissingBean
     public NatsSubscriptionManager natsSubscriptionManager(NatsConnectionManager connectionManager,
                                                             ObjectMapper objectMapper,
-                                                            NatsTracing tracing) {
-        return new NatsSubscriptionManager(connectionManager, objectMapper, tracing);
+                                                            NatsTracing tracing,
+                                                            ObjectProvider<MeterRegistry> meterRegistryProvider) {
+        return new NatsSubscriptionManager(connectionManager, objectMapper, tracing,
+                meterRegistryProvider.getIfAvailable());
     }
 
     @Bean

--- a/kelta-platform/runtime/runtime-messaging-nats/src/main/java/io/kelta/runtime/messaging/nats/NatsSubscriptionManager.java
+++ b/kelta-platform/runtime/runtime-messaging-nats/src/main/java/io/kelta/runtime/messaging/nats/NatsSubscriptionManager.java
@@ -1,6 +1,10 @@
 package io.kelta.runtime.messaging.nats;
 
 import io.kelta.runtime.event.EventSubscription;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.Timer;
 import io.nats.client.Connection;
 import io.nats.client.Dispatcher;
 import io.nats.client.JetStream;
@@ -24,6 +28,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Manages NATS JetStream subscriptions for event handlers.
@@ -45,21 +50,30 @@ public class NatsSubscriptionManager implements DisposableBean {
     private final NatsConnectionManager connectionManager;
     private final ObjectMapper objectMapper;
     private final NatsTracing tracing;
+    private final MeterRegistry meterRegistry;
     private final List<EventSubscription> subscriptions = new ArrayList<>();
     private final List<JetStreamSubscription> activeSubscriptions = new ArrayList<>();
     private final ExecutorService pullExecutor = Executors.newVirtualThreadPerTaskExecutor();
     private volatile boolean running = true;
 
     public NatsSubscriptionManager(NatsConnectionManager connectionManager, ObjectMapper objectMapper) {
-        this(connectionManager, objectMapper, NatsTracing.NOOP);
+        this(connectionManager, objectMapper, NatsTracing.NOOP, null);
     }
 
     public NatsSubscriptionManager(NatsConnectionManager connectionManager,
                                    ObjectMapper objectMapper,
                                    NatsTracing tracing) {
+        this(connectionManager, objectMapper, tracing, null);
+    }
+
+    public NatsSubscriptionManager(NatsConnectionManager connectionManager,
+                                   ObjectMapper objectMapper,
+                                   NatsTracing tracing,
+                                   MeterRegistry meterRegistry) {
         this.connectionManager = connectionManager;
         this.objectMapper = objectMapper;
         this.tracing = tracing != null ? tracing : NatsTracing.NOOP;
+        this.meterRegistry = meterRegistry;
     }
 
     /**
@@ -107,18 +121,22 @@ public class NatsSubscriptionManager implements DisposableBean {
                 try {
                     List<Message> messages = jsSub.fetch(10, Duration.ofSeconds(1));
                     for (Message msg : messages) {
+                        long start = System.nanoTime();
                         try (NatsTracing.Scope ignored = tracing.extractAndOpen(msg.getHeaders())) {
                             String data = new String(msg.getData(), StandardCharsets.UTF_8);
                             if (!tenantEnvelopeValid(sub.name(), msg.getHeaders(), data)) {
                                 msg.ack(); // discard, don't redeliver a poisoned message
+                                recordProcessed(sub.name(), start);
                                 continue;
                             }
                             sub.handler().accept(data);
                             msg.ack();
+                            recordProcessed(sub.name(), start);
                         } catch (Exception e) {
                             log.error("Error processing message in '{}': {}",
                                     sub.name(), e.getMessage(), e);
                             msg.nak();
+                            recordFailed(sub.name(), start);
                         }
                     }
                 } catch (Exception e) {
@@ -151,18 +169,22 @@ public class NatsSubscriptionManager implements DisposableBean {
                 .build();
 
         JetStreamSubscription jsSub = js.subscribe(sub.subject(), dispatcher, msg -> {
+            long start = System.nanoTime();
             try (NatsTracing.Scope ignored = tracing.extractAndOpen(msg.getHeaders())) {
                 String data = new String(msg.getData(), StandardCharsets.UTF_8);
                 if (!tenantEnvelopeValid(sub.name(), msg.getHeaders(), data)) {
                     msg.ack(); // discard, don't redeliver a poisoned message
+                    recordProcessed(sub.name(), start);
                     return;
                 }
                 sub.handler().accept(data);
                 msg.ack();
+                recordProcessed(sub.name(), start);
             } catch (Exception e) {
                 log.error("Error processing broadcast message in '{}': {}",
                         sub.name(), e.getMessage(), e);
                 msg.nak();
+                recordFailed(sub.name(), start);
             }
         }, false, options);
 
@@ -202,6 +224,40 @@ public class NatsSubscriptionManager implements DisposableBean {
                     subscription, e.getMessage());
         }
         return true;
+    }
+
+    void recordProcessed(String subscription, long startNanos) {
+        if (meterRegistry == null) {
+            return;
+        }
+        Tags tags = Tags.of("subscription", subscription);
+        Counter.builder("kelta.nats.consume.processed")
+                .description("NATS messages successfully processed (including poisoned-message drops)")
+                .tags(tags)
+                .register(meterRegistry)
+                .increment();
+        Timer.builder("kelta.nats.consume.latency")
+                .description("End-to-end handler latency from message receipt to ack/nak")
+                .tags(tags)
+                .register(meterRegistry)
+                .record(System.nanoTime() - startNanos, TimeUnit.NANOSECONDS);
+    }
+
+    void recordFailed(String subscription, long startNanos) {
+        if (meterRegistry == null) {
+            return;
+        }
+        Tags tags = Tags.of("subscription", subscription);
+        Counter.builder("kelta.nats.consume.failed")
+                .description("NATS messages whose handler threw and were nak'd for redelivery")
+                .tags(tags)
+                .register(meterRegistry)
+                .increment();
+        Timer.builder("kelta.nats.consume.latency")
+                .description("End-to-end handler latency from message receipt to ack/nak")
+                .tags(tags)
+                .register(meterRegistry)
+                .record(System.nanoTime() - startNanos, TimeUnit.NANOSECONDS);
     }
 
     @Override

--- a/kelta-platform/runtime/runtime-messaging-nats/src/test/java/io/kelta/runtime/messaging/nats/NatsSubscriptionManagerTest.java
+++ b/kelta-platform/runtime/runtime-messaging-nats/src/test/java/io/kelta/runtime/messaging/nats/NatsSubscriptionManagerTest.java
@@ -1,0 +1,84 @@
+package io.kelta.runtime.messaging.nats;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import tools.jackson.databind.ObjectMapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("NatsSubscriptionManager metrics")
+class NatsSubscriptionManagerTest {
+
+    @Mock
+    private NatsConnectionManager connectionManager;
+
+    private ObjectMapper objectMapper;
+    private MeterRegistry meterRegistry;
+    private NatsSubscriptionManager subscriptionManager;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+        meterRegistry = new SimpleMeterRegistry();
+        subscriptionManager = new NatsSubscriptionManager(
+                connectionManager, objectMapper, NatsTracing.NOOP, meterRegistry);
+    }
+
+    @Test
+    @DisplayName("processed records counter and latency tagged by subscription")
+    void processedRecordsCounterAndLatency() {
+        long start = System.nanoTime();
+        subscriptionManager.recordProcessed("collection-events", start);
+
+        assertThat(meterRegistry.find("kelta.nats.consume.processed")
+                .tag("subscription", "collection-events").counter().count()).isEqualTo(1.0);
+        assertThat(meterRegistry.find("kelta.nats.consume.latency")
+                .tag("subscription", "collection-events").timer().count()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("failed records counter and latency tagged by subscription")
+    void failedRecordsCounterAndLatency() {
+        long start = System.nanoTime();
+        subscriptionManager.recordFailed("flow-events", start);
+
+        assertThat(meterRegistry.find("kelta.nats.consume.failed")
+                .tag("subscription", "flow-events").counter().count()).isEqualTo(1.0);
+        assertThat(meterRegistry.find("kelta.nats.consume.latency")
+                .tag("subscription", "flow-events").timer().count()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("no metrics when MeterRegistry is null")
+    void noMetricsWithoutRegistry() {
+        NatsSubscriptionManager noMetrics = new NatsSubscriptionManager(
+                connectionManager, objectMapper, NatsTracing.NOOP, null);
+
+        noMetrics.recordProcessed("sub", System.nanoTime());
+        noMetrics.recordFailed("sub", System.nanoTime());
+
+        // Original registry should remain empty since we constructed with null
+        assertThat(meterRegistry.find("kelta.nats.consume.processed").counter()).isNull();
+    }
+
+    @Test
+    @DisplayName("counters segregate by subscription tag")
+    void countersSegregateBySubscription() {
+        long start = System.nanoTime();
+        subscriptionManager.recordProcessed("sub-a", start);
+        subscriptionManager.recordProcessed("sub-a", start);
+        subscriptionManager.recordProcessed("sub-b", start);
+
+        assertThat(meterRegistry.find("kelta.nats.consume.processed")
+                .tag("subscription", "sub-a").counter().count()).isEqualTo(2.0);
+        assertThat(meterRegistry.find("kelta.nats.consume.processed")
+                .tag("subscription", "sub-b").counter().count()).isEqualTo(1.0);
+    }
+}


### PR DESCRIPTION
> **Stacked on [#920](https://github.com/cklinker/emf/pull/920)** (which now bundles #921 too). Will retarget to `main` automatically when #920 merges.

## Summary
- `kelta.nats.consume.processed` counter per subscription — incremented when handler completes successfully or message is dropped as poisoned. Tag: `subscription`.
- `kelta.nats.consume.failed` counter per subscription — incremented when handler throws and message is nak'd for redelivery. Tag: `subscription`.
- `kelta.nats.consume.latency` timer per subscription — handler runtime from receipt to ack/nak. Tag: `subscription`.
- `MeterRegistry` injected via `ObjectProvider` in `NatsAutoConfiguration` (matches existing pattern for publisher metrics).
- 4 unit tests covering counter + latency for both processed and failed paths, null-registry no-op behavior, per-subscription tag segregation.

## Why
`NatsSubscriptionManager` previously had no observability. Operators could not tell which subscription was healthy, lagging, or silently failing. The "multi-pod NATS rule" (CLAUDE.md) requires config-change events to broadcast and be consumed by every pod — without these metrics, a stuck consumer goes undetected until cache divergence causes a user-visible bug.

## Cardinality
Only the subscription name is tagged. Subscriptions are a bounded set (~10-30 per service), so no per-tenant explosion. Safe to alert/dashboard on.

## Followups (separate PRs, not in scope)
- NATS consumer lag gauge (requires periodic `ConsumerInfo.getNumPending()` poll) — Obs PR-B2.
- AI SSE streaming metrics (active streams gauge, opened counter) — Obs PR-B3.

## Test plan
- [x] `mvn install -f kelta-platform/pom.xml -pl runtime/runtime-messaging-nats` — 12 tests pass (4 new for subscription metrics).
- [x] `mvn verify` passes for kelta-gateway, kelta-worker, kelta-auth, kelta-ai.
- [x] kelta-web lint/typecheck/format/tests pass.
- [ ] Smoke test in dev: drive record changes, observe `kelta.nats.consume.{processed,failed,latency}` increments per subscription; deliberately throw from a handler, observe `failed` counter increment + `latency` still records.

🤖 Generated with [Claude Code](https://claude.com/claude-code)