### PR TITLE
feat(ai): SSE stream metrics for chat endpoint

### DIFF
--- a/kelta-ai/src/main/java/io/kelta/ai/controller/ChatController.java
+++ b/kelta-ai/src/main/java/io/kelta/ai/controller/ChatController.java
@@ -1,6 +1,7 @@
 package io.kelta.ai.controller;
 
 import io.kelta.ai.config.AiConfigProperties;
+import io.kelta.ai.service.AiSseMetrics;
 import io.kelta.ai.service.ChatService;
 import io.kelta.runtime.context.TenantPropagatingExecutors;
 import org.slf4j.Logger;
@@ -21,10 +22,12 @@ public class ChatController {
 
     private final ChatService chatService;
     private final AiConfigProperties config;
+    private final AiSseMetrics sseMetrics;
 
-    public ChatController(ChatService chatService, AiConfigProperties config) {
+    public ChatController(ChatService chatService, AiConfigProperties config, AiSseMetrics sseMetrics) {
         this.chatService = chatService;
         this.config = config;
+        this.sseMetrics = sseMetrics;
     }
 
     @PostMapping
@@ -65,6 +68,10 @@ public class ChatController {
         log.info("Stream chat request from tenant {} user {}", tenantId, userId);
 
         SseEmitter emitter = new SseEmitter(config.sseTimeoutMs());
+        sseMetrics.streamOpened();
+        emitter.onCompletion(() -> sseMetrics.streamClosed(AiSseMetrics.CloseReason.COMPLETION));
+        emitter.onTimeout(() -> sseMetrics.streamClosed(AiSseMetrics.CloseReason.TIMEOUT));
+        emitter.onError(ex -> sseMetrics.streamClosed(AiSseMetrics.CloseReason.ERROR));
 
         // Run the streaming on a virtual thread; propagate the caller's tenant
         // ScopedValue so downstream DB queries see the right app.current_tenant_id.

--- a/kelta-ai/src/main/java/io/kelta/ai/service/AiSseMetrics.java
+++ b/kelta-ai/src/main/java/io/kelta/ai/service/AiSseMetrics.java
@@ -1,0 +1,67 @@
+package io.kelta.ai.service;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * SSE-streaming observability for the AI chat endpoint. Exposes:
+ * <ul>
+ *   <li>{@code kelta.ai.sse.active} — gauge of currently-open SSE emitters
+ *   <li>{@code kelta.ai.sse.opened} — counter of total streams opened
+ *   <li>{@code kelta.ai.sse.closed} — counter of streams closed, tagged
+ *       {@code reason=completion|timeout|error}
+ * </ul>
+ *
+ * <p>No per-tenant tagging — cardinality is bounded by close-reason enum.
+ */
+@Service
+public class AiSseMetrics {
+
+    public enum CloseReason {
+        COMPLETION, TIMEOUT, ERROR;
+
+        public String tag() {
+            return name().toLowerCase();
+        }
+    }
+
+    private final AtomicInteger activeStreams = new AtomicInteger();
+    private final Counter openedCounter;
+
+    public AiSseMetrics(MeterRegistry meterRegistry) {
+        Gauge.builder("kelta.ai.sse.active", activeStreams, AtomicInteger::get)
+                .description("Current number of open AI SSE streams")
+                .register(meterRegistry);
+        this.openedCounter = Counter.builder("kelta.ai.sse.opened")
+                .description("Total AI SSE streams opened")
+                .register(meterRegistry);
+        for (CloseReason reason : CloseReason.values()) {
+            Counter.builder("kelta.ai.sse.closed")
+                    .description("Total AI SSE streams closed by reason")
+                    .tags(Tags.of("reason", reason.tag()))
+                    .register(meterRegistry);
+        }
+        this.meterRegistry = meterRegistry;
+    }
+
+    private final MeterRegistry meterRegistry;
+
+    public void streamOpened() {
+        activeStreams.incrementAndGet();
+        openedCounter.increment();
+    }
+
+    public void streamClosed(CloseReason reason) {
+        activeStreams.decrementAndGet();
+        meterRegistry.counter("kelta.ai.sse.closed", "reason", reason.tag()).increment();
+    }
+
+    int activeStreamCount() {
+        return activeStreams.get();
+    }
+}

--- a/kelta-ai/src/test/java/io/kelta/ai/controller/ChatControllerTest.java
+++ b/kelta-ai/src/test/java/io/kelta/ai/controller/ChatControllerTest.java
@@ -1,7 +1,9 @@
 package io.kelta.ai.controller;
 
 import io.kelta.ai.config.AiConfigProperties;
+import io.kelta.ai.service.AiSseMetrics;
 import io.kelta.ai.service.ChatService;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -38,7 +40,7 @@ class ChatControllerTest {
                 "http://localhost:8080",
                 30000L
         );
-        controller = new ChatController(chatService, config);
+        controller = new ChatController(chatService, config, new AiSseMetrics(new SimpleMeterRegistry()));
     }
 
     @Nested

--- a/kelta-ai/src/test/java/io/kelta/ai/service/AiSseMetricsTest.java
+++ b/kelta-ai/src/test/java/io/kelta/ai/service/AiSseMetricsTest.java
@@ -1,0 +1,62 @@
+package io.kelta.ai.service;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("AiSseMetrics")
+class AiSseMetricsTest {
+
+    private MeterRegistry registry;
+    private AiSseMetrics metrics;
+
+    @BeforeEach
+    void setUp() {
+        registry = new SimpleMeterRegistry();
+        metrics = new AiSseMetrics(registry);
+    }
+
+    @Test
+    @DisplayName("streamOpened increments active gauge and opened counter")
+    void streamOpened() {
+        metrics.streamOpened();
+        metrics.streamOpened();
+
+        assertThat(metrics.activeStreamCount()).isEqualTo(2);
+        assertThat(registry.find("kelta.ai.sse.opened").counter().count()).isEqualTo(2.0);
+        assertThat(registry.find("kelta.ai.sse.active").gauge().value()).isEqualTo(2.0);
+    }
+
+    @Test
+    @DisplayName("streamClosed decrements gauge and increments closed counter tagged by reason")
+    void streamClosed() {
+        metrics.streamOpened();
+        metrics.streamOpened();
+        metrics.streamOpened();
+        metrics.streamClosed(AiSseMetrics.CloseReason.COMPLETION);
+        metrics.streamClosed(AiSseMetrics.CloseReason.TIMEOUT);
+        metrics.streamClosed(AiSseMetrics.CloseReason.ERROR);
+
+        assertThat(metrics.activeStreamCount()).isZero();
+        assertThat(registry.find("kelta.ai.sse.closed").tag("reason", "completion").counter().count())
+                .isEqualTo(1.0);
+        assertThat(registry.find("kelta.ai.sse.closed").tag("reason", "timeout").counter().count())
+                .isEqualTo(1.0);
+        assertThat(registry.find("kelta.ai.sse.closed").tag("reason", "error").counter().count())
+                .isEqualTo(1.0);
+    }
+
+    @Test
+    @DisplayName("all close-reason counters registered up front for stable dashboards")
+    void closeReasonsPreregistered() {
+        for (AiSseMetrics.CloseReason reason : AiSseMetrics.CloseReason.values()) {
+            assertThat(registry.find("kelta.ai.sse.closed").tag("reason", reason.tag()).counter())
+                    .as("counter for reason=%s should exist before any close happens", reason.tag())
+                    .isNotNull();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- New `AiSseMetrics` service registering three meters at startup:
  - `kelta.ai.sse.active` gauge — currently open SSE emitters.
  - `kelta.ai.sse.opened` counter — total streams opened.
  - `kelta.ai.sse.closed` counter — closed streams, tagged `reason=completion|timeout|error`.
- [ChatController.chatStream](kelta-ai/src/main/java/io/kelta/ai/controller/ChatController.java) wires the metrics around the emitter lifecycle: increment on open, register `onCompletion` / `onTimeout` / `onError` callbacks to decrement and attribute the close reason.
- All three close-reason counters are pre-registered on `AiSseMetrics` construction so Grafana panels show 0-rate series before the first close happens.
- 3 unit tests cover open/close, gauge math, and the pre-registration guarantee.

## Why
The streaming endpoint spawns virtual threads holding `SseEmitter`s but had no observability. A leaked emitter, a stuck virtual thread, or a flood of timeouts produced no signal — operators learned about problems from user reports. With `kelta.ai.sse.active` we can alert on emitter leaks (active stays high while no new opens come in) and on timeout/error rate spikes.

## Cardinality
Only the `reason` enum (3 values) is tagged. No per-tenant tag — keeps the series count constant regardless of tenant growth.

## Test plan
- [x] `mvn verify -f kelta-ai/pom.xml` — 75 tests pass (3 new for `AiSseMetrics`).
- [x] kelta-web lint/typecheck/format/tests pass.
- [ ] Smoke test in dev: open a chat stream, watch `kelta.ai.sse.active` go to 1; finish the stream, watch it return to 0 and `kelta.ai.sse.closed{reason="completion"}` increment. Force a timeout by setting `AI_SSE_TIMEOUT_MS=2000` and idling, watch `reason="timeout"` increment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)