### PR TITLE
docs(worker): flag PgBouncer txn-pool incompatibility with RLS

### DIFF
--- a/.claude/docs/concerns.md
+++ b/.claude/docs/concerns.md
@@ -53,6 +53,23 @@
 
 - Multiple BOM version overrides in worker POM increase transitive conflict risk (`kelta-worker/pom.xml`)
 
+## Connection Pooler Compatibility
+
+**RLS tenant variable is session-scoped, not transaction-scoped:**
+- `TenantAwareDataSourceConfig` issues `SET app.current_tenant_id = '<id>'` on every connection borrowed from HikariCP. This is a Postgres **session** setting that persists until the connection is closed or reset.
+- File: `kelta-worker/src/main/java/io/kelta/worker/config/TenantAwareDataSourceConfig.java` (line 89)
+- Also: `kelta-ai/src/main/resources/application.yml` (`hikari.connection-init-sql: SET app.current_tenant_id = ''`)
+
+**Impact under PgBouncer transaction-pool mode:**
+- PgBouncer's `pool_mode = transaction` returns a different physical Postgres connection per transaction. Session state set on a prior transaction is lost — RLS `current_setting('app.current_tenant_id', true)` returns the empty default, and the `admin_bypass` policy hits, returning rows for **all tenants**.
+- This is a tenant-isolation correctness bug, not just a perf issue.
+
+**Required configuration when deploying PgBouncer:**
+- Set `pool_mode = session` for all kelta workloads (worker, auth, ai). Lower pooling efficiency than transaction mode but preserves session state. Or:
+- Migrate every tenant-scoped DB callsite to issue `SET LOCAL app.current_tenant_id = '<id>'` inside an explicit transaction (requires refactor of all `JdbcTemplate` auto-commit calls + audit of `@Transactional` boundaries).
+
+**Followup**: dedicated rewrite to `SET LOCAL`-inside-transaction is tracked under Tier-2 DB scaling work.
+
 ## Test Coverage Gaps
 
 - Federated user provisioning (`FederatedUserMapper`) — no tests

--- a/kelta-worker/src/main/java/io/kelta/worker/config/TenantAwareDataSourceConfig.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/config/TenantAwareDataSourceConfig.java
@@ -32,6 +32,27 @@ import java.sql.Statement;
  * circular dependency issues that arise from declaring a {@code @Primary @Bean} DataSource
  * that injects another DataSource.
  *
+ * <h2>WARNING: PgBouncer transaction-pool incompatibility</h2>
+ * <p>The {@code SET app.current_tenant_id} issued here is a Postgres <b>session</b>
+ * setting. Under PgBouncer's {@code pool_mode = transaction} the underlying physical
+ * connection is recycled per transaction, so the session variable is lost — RLS then
+ * sees the empty default and the {@code admin_bypass} policy lets a query return rows
+ * for <b>all tenants</b>. This is a tenant-isolation correctness bug, not just a perf
+ * issue.
+ *
+ * <p>When deploying PgBouncer (or any other transaction-level pooler) in front of
+ * Postgres, you must either:
+ * <ul>
+ *   <li>Configure {@code pool_mode = session} (lower pooling efficiency but preserves
+ *       session state — current default for kelta workloads), or
+ *   <li>Migrate every tenant-scoped callsite to issue
+ *       {@code SET LOCAL app.current_tenant_id = '...'} inside an explicit transaction.
+ *       This requires rewriting all {@code JdbcTemplate} auto-commit calls and auditing
+ *       {@code @Transactional} boundaries (tracked as Tier-2 DB scaling work).
+ * </ul>
+ *
+ * <p>See {@code .claude/docs/concerns.md} → "Connection Pooler Compatibility".
+ *
  * @since 1.0.0
  */
 @Configuration


### PR DESCRIPTION
## Summary
- Add a prominent WARNING block to [TenantAwareDataSourceConfig](kelta-worker/src/main/java/io/kelta/worker/config/TenantAwareDataSourceConfig.java) javadoc spelling out the PgBouncer transaction-pool incompatibility and the two safe configurations.
- New "Connection Pooler Compatibility" section in [.claude/docs/concerns.md](.claude/docs/concerns.md) with file/line refs and the Tier-2 follow-up plan.

## The problem (audit finding)
`TenantAwareDataSourceConfig` issues `SET app.current_tenant_id = '<id>'` as a Postgres **session** setting on every connection borrowed from HikariCP. Under PgBouncer `pool_mode = transaction` the underlying physical connection is recycled per transaction → session variable lost → RLS falls through to `admin_bypass` policy → query returns rows for **all tenants**, not just the caller's.

This is a tenant-isolation **correctness** bug, not a perf issue. It will not surface in dev (no pooler) and will surface as data leakage in prod the first time PgBouncer is deployed in transaction mode.

## Safe configurations
1. **`pool_mode = session`** in PgBouncer — lower pooling efficiency than transaction mode but preserves session state. Recommended default for kelta workloads.
2. **Rewrite to `SET LOCAL app.current_tenant_id` inside an explicit transaction** — requires refactor of every tenant-scoped `JdbcTemplate` auto-commit call + audit of `@Transactional` boundaries. Tracked as DB-C follow-up.

## Scope
Doc-only. No code change. The proper `SET LOCAL` rewrite is its own PR.

## Test plan
- [x] Diff is doc + javadoc only — no Maven build needed.
- [ ] Reviewer sanity check: the warning is impossible to miss before someone deploys PgBouncer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)