### PR TITLE
feat(worker): enforce maxCollections and maxFieldsPerCollection at write path

### DIFF
--- a/kelta-worker/src/main/java/io/kelta/worker/config/FlowConfig.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/config/FlowConfig.java
@@ -269,6 +269,28 @@ public class FlowConfig {
     }
 
     @Bean
+    public io.kelta.worker.listener.CollectionQuotaEnforcementHook collectionQuotaEnforcementHook(
+            BeforeSaveHookRegistry hookRegistry,
+            io.kelta.worker.service.TenantQuotaResolver quotaResolver,
+            io.kelta.worker.repository.GovernorLimitsRepository governorLimitsRepository) {
+        io.kelta.worker.listener.CollectionQuotaEnforcementHook hook =
+                new io.kelta.worker.listener.CollectionQuotaEnforcementHook(quotaResolver, governorLimitsRepository);
+        hookRegistry.register(hook);
+        return hook;
+    }
+
+    @Bean
+    public io.kelta.worker.listener.FieldQuotaEnforcementHook fieldQuotaEnforcementHook(
+            BeforeSaveHookRegistry hookRegistry,
+            io.kelta.worker.service.TenantQuotaResolver quotaResolver,
+            JdbcTemplate jdbcTemplate) {
+        io.kelta.worker.listener.FieldQuotaEnforcementHook hook =
+                new io.kelta.worker.listener.FieldQuotaEnforcementHook(quotaResolver, jdbcTemplate);
+        hookRegistry.register(hook);
+        return hook;
+    }
+
+    @Bean
     public FieldConfigEventPublisher fieldConfigEventPublisher(
             BeforeSaveHookRegistry hookRegistry,
             PlatformEventPublisher eventPublisher,

--- a/kelta-worker/src/main/java/io/kelta/worker/listener/CollectionQuotaEnforcementHook.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/listener/CollectionQuotaEnforcementHook.java
@@ -1,0 +1,61 @@
+package io.kelta.worker.listener;
+
+import io.kelta.runtime.workflow.BeforeSaveHook;
+import io.kelta.runtime.workflow.BeforeSaveResult;
+import io.kelta.worker.repository.GovernorLimitsRepository;
+import io.kelta.worker.service.TenantQuotaResolver;
+import io.kelta.worker.service.TenantTierQuotas;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+
+/**
+ * Rejects {@code collections} create when the tenant is at or above its
+ * tier-resolved {@code maxCollections} quota. Runs early (order -100) so the
+ * reject happens before any expensive downstream hook (table creation, route
+ * publishing) fires.
+ *
+ * <p>Quota source of truth: {@link TenantQuotaResolver} merges tier defaults
+ * from {@link TenantTierQuotas} with customer-specific overrides from
+ * {@code tenant.limits}.
+ */
+public class CollectionQuotaEnforcementHook implements BeforeSaveHook {
+
+    private static final Logger log = LoggerFactory.getLogger(CollectionQuotaEnforcementHook.class);
+
+    private final TenantQuotaResolver quotaResolver;
+    private final GovernorLimitsRepository repository;
+
+    public CollectionQuotaEnforcementHook(TenantQuotaResolver quotaResolver,
+                                          GovernorLimitsRepository repository) {
+        this.quotaResolver = quotaResolver;
+        this.repository = repository;
+    }
+
+    @Override
+    public String getCollectionName() {
+        return "collections";
+    }
+
+    @Override
+    public int getOrder() {
+        return -100;
+    }
+
+    @Override
+    public BeforeSaveResult beforeCreate(Map<String, Object> record, String tenantId) {
+        if (tenantId == null || tenantId.isBlank()) {
+            return BeforeSaveResult.ok();
+        }
+        int limit = quotaResolver.intQuota(tenantId, TenantTierQuotas.KEY_MAX_COLLECTIONS);
+        int active = repository.countActiveCollections(tenantId);
+        if (active >= limit) {
+            log.info("Rejecting collection create for tenant {} — at quota ({}/{})", tenantId, active, limit);
+            return BeforeSaveResult.error(null,
+                    "Tenant collection quota exceeded (" + active + "/" + limit + "). "
+                            + "Upgrade the tenant tier or raise tenant.limits.maxCollections.");
+        }
+        return BeforeSaveResult.ok();
+    }
+}

--- a/kelta-worker/src/main/java/io/kelta/worker/listener/FieldQuotaEnforcementHook.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/listener/FieldQuotaEnforcementHook.java
@@ -1,0 +1,76 @@
+package io.kelta.worker.listener;
+
+import io.kelta.runtime.workflow.BeforeSaveHook;
+import io.kelta.runtime.workflow.BeforeSaveResult;
+import io.kelta.worker.service.TenantQuotaResolver;
+import io.kelta.worker.service.TenantTierQuotas;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.util.Map;
+
+/**
+ * Rejects {@code fields} create when the parent collection is at or above the
+ * tenant's {@code maxFieldsPerCollection} quota. Runs early (order -100).
+ *
+ * <p>Counts existing fields with the same {@code tenant_id} and
+ * {@code collection_id} to scope the cap per-collection rather than per-tenant.
+ */
+public class FieldQuotaEnforcementHook implements BeforeSaveHook {
+
+    private static final Logger log = LoggerFactory.getLogger(FieldQuotaEnforcementHook.class);
+
+    private static final String COUNT_FIELDS =
+            "SELECT COUNT(*) FROM field WHERE tenant_id = ? AND collection_id = ?";
+
+    private final TenantQuotaResolver quotaResolver;
+    private final JdbcTemplate jdbcTemplate;
+
+    public FieldQuotaEnforcementHook(TenantQuotaResolver quotaResolver, JdbcTemplate jdbcTemplate) {
+        this.quotaResolver = quotaResolver;
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    @Override
+    public String getCollectionName() {
+        return "fields";
+    }
+
+    @Override
+    public int getOrder() {
+        return -100;
+    }
+
+    @Override
+    public BeforeSaveResult beforeCreate(Map<String, Object> record, String tenantId) {
+        if (tenantId == null || tenantId.isBlank()) {
+            return BeforeSaveResult.ok();
+        }
+        Object collectionIdObj = record.get("collectionId");
+        if (collectionIdObj == null) {
+            // Unknown parent — cannot enforce; allow and let downstream validation
+            // surface the missing-required-field error.
+            return BeforeSaveResult.ok();
+        }
+        String collectionId = collectionIdObj.toString();
+        int limit = quotaResolver.intQuota(tenantId, TenantTierQuotas.KEY_MAX_FIELDS_PER_COLLECTION);
+        int active;
+        try {
+            Integer count = jdbcTemplate.queryForObject(COUNT_FIELDS, Integer.class, tenantId, collectionId);
+            active = count != null ? count : 0;
+        } catch (Exception e) {
+            log.warn("Failed to count fields for tenant {} collection {}, allowing: {}",
+                    tenantId, collectionId, e.getMessage());
+            return BeforeSaveResult.ok();
+        }
+        if (active >= limit) {
+            log.info("Rejecting field create for tenant {} collection {} — at quota ({}/{})",
+                    tenantId, collectionId, active, limit);
+            return BeforeSaveResult.error(null,
+                    "Field quota exceeded for this collection (" + active + "/" + limit + "). "
+                            + "Upgrade the tenant tier or raise tenant.limits.maxFieldsPerCollection.");
+        }
+        return BeforeSaveResult.ok();
+    }
+}

--- a/kelta-worker/src/main/java/io/kelta/worker/service/TenantQuotaResolver.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/service/TenantQuotaResolver.java
@@ -1,0 +1,90 @@
+package io.kelta.worker.service;
+
+import io.kelta.worker.repository.GovernorLimitsRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import tools.jackson.databind.ObjectMapper;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Resolves the effective per-tenant quota map by merging tier defaults from
+ * {@link TenantTierQuotas} with customer-specific overrides stored in
+ * {@code tenant.limits}. Used by enforcement hooks ({@code BeforeSaveHook}s)
+ * that need a single source of truth for "what's this tenant's cap?".
+ *
+ * <p>Fails open on lookup errors: a database glitch should not block writes.
+ * The Governor Limits UI surfaces the same numbers and is the operator's
+ * canonical view; the enforcement here is the gate that prevents an
+ * over-limit tenant from creating new resources.
+ */
+@Service
+public class TenantQuotaResolver {
+
+    private static final Logger log = LoggerFactory.getLogger(TenantQuotaResolver.class);
+
+    private final GovernorLimitsRepository repository;
+    private final ObjectMapper objectMapper;
+
+    public TenantQuotaResolver(GovernorLimitsRepository repository, ObjectMapper objectMapper) {
+        this.repository = repository;
+        this.objectMapper = objectMapper;
+    }
+
+    /**
+     * Returns the merged tier-defaults + per-tenant overrides for the tenant.
+     * Returns the PROFESSIONAL tier defaults if the tenant row is missing or
+     * lookup throws.
+     */
+    public Map<String, Object> resolve(String tenantId) {
+        if (tenantId == null || tenantId.isBlank()) {
+            return TenantTierQuotas.defaultsFor(TenantTierQuotas.Tier.PROFESSIONAL);
+        }
+        try {
+            Optional<GovernorLimitsRepository.EditionAndLimits> row =
+                    repository.findEditionAndLimits(tenantId);
+            if (row.isEmpty()) {
+                return TenantTierQuotas.defaultsFor(TenantTierQuotas.Tier.PROFESSIONAL);
+            }
+            TenantTierQuotas.Tier tier = TenantTierQuotas.Tier.fromEdition(row.get().edition());
+            Map<String, Object> overrides = parseLimits(row.get().limits());
+            return TenantTierQuotas.mergeOverrides(tier, overrides);
+        } catch (Exception e) {
+            log.warn("Failed to resolve quotas for tenant {}, falling back to PROFESSIONAL defaults: {}",
+                    tenantId, e.getMessage());
+            return TenantTierQuotas.defaultsFor(TenantTierQuotas.Tier.PROFESSIONAL);
+        }
+    }
+
+    public int intQuota(String tenantId, String key) {
+        Object value = resolve(tenantId).get(key);
+        if (value instanceof Number num) {
+            return num.intValue();
+        }
+        return Integer.MAX_VALUE;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> parseLimits(Object limitsObj) {
+        if (limitsObj == null) {
+            return Map.of();
+        }
+        if (limitsObj instanceof Map<?, ?> m) {
+            return (Map<String, Object>) m;
+        }
+        String limitsStr = limitsObj instanceof String s ? s : limitsObj.toString();
+        if (limitsStr == null || limitsStr.isBlank()) {
+            return Map.of();
+        }
+        try {
+            return objectMapper.readValue(limitsStr,
+                    objectMapper.getTypeFactory().constructMapType(
+                            HashMap.class, String.class, Object.class));
+        } catch (Exception e) {
+            return Map.of();
+        }
+    }
+}

--- a/kelta-worker/src/test/java/io/kelta/worker/listener/CollectionQuotaEnforcementHookTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/listener/CollectionQuotaEnforcementHookTest.java
@@ -1,0 +1,89 @@
+package io.kelta.worker.listener;
+
+import io.kelta.runtime.workflow.BeforeSaveResult;
+import io.kelta.worker.repository.GovernorLimitsRepository;
+import io.kelta.worker.service.TenantQuotaResolver;
+import io.kelta.worker.service.TenantTierQuotas;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CollectionQuotaEnforcementHook")
+class CollectionQuotaEnforcementHookTest {
+
+    @Mock
+    private TenantQuotaResolver resolver;
+
+    @Mock
+    private GovernorLimitsRepository repository;
+
+    private CollectionQuotaEnforcementHook hook;
+
+    @BeforeEach
+    void setUp() {
+        hook = new CollectionQuotaEnforcementHook(resolver, repository);
+    }
+
+    @Test
+    @DisplayName("allows create when active < limit")
+    void allowsBelowLimit() {
+        when(resolver.intQuota("tenant-1", TenantTierQuotas.KEY_MAX_COLLECTIONS)).thenReturn(200);
+        when(repository.countActiveCollections("tenant-1")).thenReturn(199);
+
+        BeforeSaveResult result = hook.beforeCreate(Map.of("name", "new"), "tenant-1");
+
+        assertThat(result.isSuccess()).isTrue();
+    }
+
+    @Test
+    @DisplayName("rejects create when active == limit")
+    void rejectsAtLimit() {
+        when(resolver.intQuota("tenant-1", TenantTierQuotas.KEY_MAX_COLLECTIONS)).thenReturn(10);
+        when(repository.countActiveCollections("tenant-1")).thenReturn(10);
+
+        BeforeSaveResult result = hook.beforeCreate(Map.of("name", "new"), "tenant-1");
+
+        assertThat(result.isSuccess()).isFalse();
+        assertThat(result.getErrors()).hasSize(1);
+        assertThat(result.getErrors().get(0).message()).contains("Tenant collection quota exceeded (10/10)");
+    }
+
+    @Test
+    @DisplayName("rejects when active > limit")
+    void rejectsAboveLimit() {
+        when(resolver.intQuota("tenant-1", TenantTierQuotas.KEY_MAX_COLLECTIONS)).thenReturn(5);
+        when(repository.countActiveCollections("tenant-1")).thenReturn(7);
+
+        BeforeSaveResult result = hook.beforeCreate(Map.of("name", "new"), "tenant-1");
+
+        assertThat(result.isSuccess()).isFalse();
+    }
+
+    @Test
+    @DisplayName("allows when tenantId is missing")
+    void allowsWithoutTenant() {
+        BeforeSaveResult result = hook.beforeCreate(Map.of("name", "new"), null);
+        assertThat(result.isSuccess()).isTrue();
+    }
+
+    @Test
+    @DisplayName("runs early (negative order)")
+    void runsEarly() {
+        assertThat(hook.getOrder()).isNegative();
+    }
+
+    @Test
+    @DisplayName("targets the collections system collection")
+    void targetsCollections() {
+        assertThat(hook.getCollectionName()).isEqualTo("collections");
+    }
+}

--- a/kelta-worker/src/test/java/io/kelta/worker/listener/FieldQuotaEnforcementHookTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/listener/FieldQuotaEnforcementHookTest.java
@@ -1,0 +1,98 @@
+package io.kelta.worker.listener;
+
+import io.kelta.runtime.workflow.BeforeSaveResult;
+import io.kelta.worker.service.TenantQuotaResolver;
+import io.kelta.worker.service.TenantTierQuotas;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("FieldQuotaEnforcementHook")
+class FieldQuotaEnforcementHookTest {
+
+    @Mock
+    private TenantQuotaResolver resolver;
+
+    @Mock
+    private JdbcTemplate jdbcTemplate;
+
+    private FieldQuotaEnforcementHook hook;
+
+    @BeforeEach
+    void setUp() {
+        hook = new FieldQuotaEnforcementHook(resolver, jdbcTemplate);
+    }
+
+    @Test
+    @DisplayName("allows when field count < limit")
+    void allowsBelowLimit() {
+        when(resolver.intQuota("tenant-1", TenantTierQuotas.KEY_MAX_FIELDS_PER_COLLECTION)).thenReturn(500);
+        when(jdbcTemplate.queryForObject(
+                any(String.class), eq(Integer.class), eq("tenant-1"), eq("col-1")))
+                .thenReturn(499);
+
+        BeforeSaveResult result = hook.beforeCreate(
+                Map.of("name", "new", "collectionId", "col-1"), "tenant-1");
+
+        assertThat(result.isSuccess()).isTrue();
+    }
+
+    @Test
+    @DisplayName("rejects at limit")
+    void rejectsAtLimit() {
+        when(resolver.intQuota("tenant-1", TenantTierQuotas.KEY_MAX_FIELDS_PER_COLLECTION)).thenReturn(50);
+        when(jdbcTemplate.queryForObject(
+                any(String.class), eq(Integer.class), eq("tenant-1"), eq("col-1")))
+                .thenReturn(50);
+
+        BeforeSaveResult result = hook.beforeCreate(
+                Map.of("name", "new", "collectionId", "col-1"), "tenant-1");
+
+        assertThat(result.isSuccess()).isFalse();
+        assertThat(result.getErrors().get(0).message()).contains("Field quota exceeded for this collection (50/50)");
+    }
+
+    @Test
+    @DisplayName("allows when collectionId missing (lets downstream validation surface)")
+    void allowsWithoutCollectionId() {
+        BeforeSaveResult result = hook.beforeCreate(Map.of("name", "new"), "tenant-1");
+        assertThat(result.isSuccess()).isTrue();
+        verify(jdbcTemplate, never()).queryForObject(any(String.class), eq(Integer.class), any(), any());
+    }
+
+    @Test
+    @DisplayName("allows without tenant id")
+    void allowsWithoutTenant() {
+        BeforeSaveResult result = hook.beforeCreate(
+                Map.of("name", "new", "collectionId", "col-1"), null);
+        assertThat(result.isSuccess()).isTrue();
+    }
+
+    @Test
+    @DisplayName("allows on DB error (fail-open)")
+    void allowsOnDbError() {
+        when(resolver.intQuota("tenant-1", TenantTierQuotas.KEY_MAX_FIELDS_PER_COLLECTION)).thenReturn(50);
+        when(jdbcTemplate.queryForObject(
+                any(String.class), eq(Integer.class), any(Object.class), any(Object.class)))
+                .thenThrow(new RuntimeException("db down"));
+
+        BeforeSaveResult result = hook.beforeCreate(
+                Map.of("name", "new", "collectionId", "col-1"), "tenant-1");
+
+        assertThat(result.isSuccess()).isTrue();
+    }
+}


### PR DESCRIPTION
> **Stacked on [#925](https://github.com/cklinker/emf/pull/925)**. Will retarget to `main` once #925 merges.

## Summary
- New `TenantQuotaResolver` service merges tier defaults from `TenantTierQuotas` with `tenant.limits` overrides into a single map keyed by quota name; fail-open on lookup errors.
- New `CollectionQuotaEnforcementHook` (BeforeSaveHook on `collections`, order `-100`): rejects `beforeCreate` when active collection count is at or above `maxCollections`.
- New `FieldQuotaEnforcementHook` (BeforeSaveHook on `fields`, order `-100`): rejects when fields-for-this-collection count is at or above `maxFieldsPerCollection`. Scoped per-collection (not per-tenant).
- Both hooks registered as Spring beans in `FlowConfig` so they pick up the `BeforeSaveHookRegistry` on context start.
- 11 new unit tests (6 collection hook, 5 field hook).

## Why
Tier defaults shipped in [#925](https://github.com/cklinker/emf/pull/925) are advisory until a write actually rejects. Without enforcement at the write path, a FREE-tier tenant can still create unlimited collections by ignoring the Governor Limits UI. The `BeforeSaveHook` order `-100` ensures the reject fires before downstream side effects (table creation in `CollectionLifecycleManager`, route publishing in `CollectionConfigEventPublisher`, etc.).

## Out of scope (followup PRs)
Same enforcement pattern needs to land on:
- `users` collection — `maxUsers` (block on user-invite endpoint).
- File upload path — `storageGb` (compare `sumStorageBytes + file.size` against limit).
- `workflows` collection — `maxWorkflows`.
- `reports` collection — `maxReports`.

Each is a small follow-up PR using `TenantQuotaResolver`.

## Test plan
- [x] `mvn verify -f kelta-worker/pom.xml` — full suite passes (worker tests for the new hooks: 11 added).
- [x] kelta-web lint/typecheck/format/tests pass.
- [ ] Smoke test in dev: set a tenant to FREE tier (maxCollections=10), create 10 collections, attempt 11th → 4xx with "Tenant collection quota exceeded (10/10)" message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)