### PR TITLE
feat(worker): per-tenant request concurrency cap to block noisy neighbors

### DIFF
--- a/kelta-worker/src/main/java/io/kelta/worker/filter/TenantConcurrencyFilter.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/filter/TenantConcurrencyFilter.java
@@ -1,0 +1,76 @@
+package io.kelta.worker.filter;
+
+import io.kelta.runtime.context.TenantContext;
+import io.kelta.worker.service.TenantConcurrencyLimiter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+/**
+ * Per-tenant concurrency cap: a single tenant can have at most N concurrent
+ * in-flight requests per worker pod. Excess requests get 503 with
+ * {@code Retry-After}, protecting the HikariCP pool from a noisy neighbor.
+ *
+ * <p>Runs after {@link TenantContextFilter} (order +10) so the tenant is bound
+ * when {@link TenantConcurrencyLimiter#tryAcquire(String)} is called.
+ * Skips actuator probes and the governor-limits endpoint so health + quota
+ * pages stay responsive under load.
+ */
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE + 15)
+public class TenantConcurrencyFilter extends OncePerRequestFilter {
+
+    private static final Logger log = LoggerFactory.getLogger(TenantConcurrencyFilter.class);
+
+    private final TenantConcurrencyLimiter limiter;
+
+    public TenantConcurrencyFilter(TenantConcurrencyLimiter limiter) {
+        this.limiter = limiter;
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String path = request.getRequestURI();
+        return path.startsWith("/actuator/")
+                || path.startsWith("/internal/")
+                || path.equals("/api/governor-limits");
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String tenantId = TenantContext.get();
+        if (tenantId == null || tenantId.isBlank()) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        if (!limiter.tryAcquire(tenantId)) {
+            log.info("Tenant {} concurrency limit reached ({} in flight) — rejecting request",
+                    tenantId, limiter.inUsePermits(tenantId));
+            response.setStatus(503);
+            response.setHeader("Retry-After", "1");
+            response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+            response.getWriter().write("""
+                {"errors":[{"status":"503","code":"TENANT_CONCURRENCY_LIMIT","title":"Too many concurrent requests for this tenant; retry shortly"}]}
+                """);
+            return;
+        }
+
+        try {
+            filterChain.doFilter(request, response);
+        } finally {
+            limiter.release(tenantId);
+        }
+    }
+}

--- a/kelta-worker/src/main/java/io/kelta/worker/service/TenantConcurrencyLimiter.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/service/TenantConcurrencyLimiter.java
@@ -1,0 +1,93 @@
+package io.kelta.worker.service;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Semaphore;
+
+/**
+ * Per-tenant request concurrency limiter for the worker. Bounds the number of
+ * concurrent in-flight requests per tenant per pod so a single noisy tenant
+ * cannot saturate the HikariCP pool and starve every other tenant.
+ *
+ * <p>Default cap of 10 per tenant per pod is intentionally generous for SMB
+ * tenants; tune via {@code kelta.worker.tenant-concurrency-limit}. Semaphores
+ * are created lazily on first request for a tenant and never expire — the
+ * memory footprint per tenant is on the order of bytes, so this is fine even
+ * for thousands of active tenants per pod.
+ *
+ * <p>{@link #tryAcquire(String)} returns {@code true} immediately if a permit
+ * is available; {@code false} otherwise. Callers must call {@link #release(String)}
+ * exactly once for each successful acquire, regardless of how the request ends.
+ */
+@Service
+public class TenantConcurrencyLimiter {
+
+    private final ConcurrentHashMap<String, Semaphore> semaphores = new ConcurrentHashMap<>();
+    private final int defaultPermits;
+    private final MeterRegistry meterRegistry;
+
+    public TenantConcurrencyLimiter(
+            @Value("${kelta.worker.tenant-concurrency-limit:10}") int defaultPermits,
+            MeterRegistry meterRegistry) {
+        this.defaultPermits = Math.max(1, defaultPermits);
+        this.meterRegistry = meterRegistry;
+    }
+
+    public boolean tryAcquire(String tenantId) {
+        if (tenantId == null || tenantId.isBlank()) {
+            return true;
+        }
+        Semaphore sem = semaphoreFor(tenantId);
+        boolean acquired = sem.tryAcquire();
+        if (!acquired) {
+            counter("kelta.worker.tenant.concurrency.rejected", tenantId).increment();
+        }
+        return acquired;
+    }
+
+    public void release(String tenantId) {
+        if (tenantId == null || tenantId.isBlank()) {
+            return;
+        }
+        Semaphore sem = semaphores.get(tenantId);
+        if (sem != null) {
+            sem.release();
+        }
+    }
+
+    /** Returns currently in-use permits for a tenant; for tests + diagnostics. */
+    public int inUsePermits(String tenantId) {
+        Semaphore sem = semaphores.get(tenantId);
+        return sem == null ? 0 : defaultPermits - sem.availablePermits();
+    }
+
+    private Semaphore semaphoreFor(String tenantId) {
+        return semaphores.computeIfAbsent(tenantId, k -> new Semaphore(defaultPermits, true));
+    }
+
+    private Counter counter(String name, String tenantId) {
+        // Tenant tag is bounded only by tenant count; capped via a single-counter
+        // sample per tenant. For very high tenant counts, switch to a global
+        // counter with no tag and rely on rejection logs for per-tenant context.
+        Tags tags = Tags.of("tenant", tenantId);
+        return Counter.builder(name)
+                .description("Worker requests rejected because the per-tenant concurrency limit was reached")
+                .tags(tags)
+                .register(meterRegistry);
+    }
+
+    /** Per-pod default permits, exposed for tests + config diagnostics. */
+    public int defaultPermits() {
+        return defaultPermits;
+    }
+
+    public Map<String, Semaphore> semaphoreSnapshot() {
+        return Map.copyOf(semaphores);
+    }
+}

--- a/kelta-worker/src/test/java/io/kelta/worker/service/TenantConcurrencyLimiterTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/service/TenantConcurrencyLimiterTest.java
@@ -1,0 +1,98 @@
+package io.kelta.worker.service;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("TenantConcurrencyLimiter")
+class TenantConcurrencyLimiterTest {
+
+    private MeterRegistry registry;
+    private TenantConcurrencyLimiter limiter;
+
+    @BeforeEach
+    void setUp() {
+        registry = new SimpleMeterRegistry();
+        limiter = new TenantConcurrencyLimiter(3, registry);
+    }
+
+    @Test
+    @DisplayName("allows up to the default permit count per tenant")
+    void allowsUpToLimit() {
+        assertThat(limiter.tryAcquire("tenant-1")).isTrue();
+        assertThat(limiter.tryAcquire("tenant-1")).isTrue();
+        assertThat(limiter.tryAcquire("tenant-1")).isTrue();
+        assertThat(limiter.tryAcquire("tenant-1")).isFalse();
+    }
+
+    @Test
+    @DisplayName("release restores a permit for the same tenant")
+    void releaseRestoresPermit() {
+        limiter.tryAcquire("tenant-1");
+        limiter.tryAcquire("tenant-1");
+        limiter.tryAcquire("tenant-1");
+        assertThat(limiter.tryAcquire("tenant-1")).isFalse();
+
+        limiter.release("tenant-1");
+
+        assertThat(limiter.tryAcquire("tenant-1")).isTrue();
+    }
+
+    @Test
+    @DisplayName("tenants are isolated — one tenant at-limit does not block another")
+    void tenantsIsolated() {
+        limiter.tryAcquire("tenant-1");
+        limiter.tryAcquire("tenant-1");
+        limiter.tryAcquire("tenant-1");
+
+        assertThat(limiter.tryAcquire("tenant-2")).isTrue();
+        assertThat(limiter.tryAcquire("tenant-2")).isTrue();
+    }
+
+    @Test
+    @DisplayName("rejection increments the per-tenant counter")
+    void rejectionCounted() {
+        limiter.tryAcquire("tenant-1");
+        limiter.tryAcquire("tenant-1");
+        limiter.tryAcquire("tenant-1");
+        limiter.tryAcquire("tenant-1");
+        limiter.tryAcquire("tenant-1");
+
+        assertThat(registry.find("kelta.worker.tenant.concurrency.rejected")
+                .tag("tenant", "tenant-1")
+                .counter().count()).isEqualTo(2.0);
+    }
+
+    @Test
+    @DisplayName("null/blank tenant always allowed and never tracked")
+    void blankTenantAllowed() {
+        assertThat(limiter.tryAcquire(null)).isTrue();
+        assertThat(limiter.tryAcquire("")).isTrue();
+        assertThat(limiter.tryAcquire("   ")).isTrue();
+
+        assertThat(registry.find("kelta.worker.tenant.concurrency.rejected").counter()).isNull();
+    }
+
+    @Test
+    @DisplayName("release on unknown tenant is a no-op")
+    void releaseUnknownTenant() {
+        limiter.release("never-seen");
+        // No exception, no permit change for any other tenant
+        assertThat(limiter.tryAcquire("tenant-1")).isTrue();
+    }
+
+    @Test
+    @DisplayName("inUsePermits reflects current acquires")
+    void inUsePermitsReflection() {
+        assertThat(limiter.inUsePermits("tenant-1")).isZero();
+        limiter.tryAcquire("tenant-1");
+        limiter.tryAcquire("tenant-1");
+        assertThat(limiter.inUsePermits("tenant-1")).isEqualTo(2);
+        limiter.release("tenant-1");
+        assertThat(limiter.inUsePermits("tenant-1")).isEqualTo(1);
+    }
+}


### PR DESCRIPTION
## Summary
- New [TenantConcurrencyLimiter](kelta-worker/src/main/java/io/kelta/worker/service/TenantConcurrencyLimiter.java) service: in-process `ConcurrentHashMap<tenantId, Semaphore>`, fair acquisition. Lazy semaphore creation per tenant; bytes per tenant. Rejection increments `kelta.worker.tenant.concurrency.rejected` counter tagged by tenant.
- New [TenantConcurrencyFilter](kelta-worker/src/main/java/io/kelta/worker/filter/TenantConcurrencyFilter.java) servlet filter, ordered `HIGHEST_PRECEDENCE+15` (after `TenantContextFilter`). Returns `HTTP 503` + `Retry-After: 1` when the cap is reached. Skips actuator, `/internal/`, and `/api/governor-limits` so health + quota pages stay responsive under load.
- Default cap **10 concurrent requests per tenant per pod** (env-overridable via `kelta.worker.tenant-concurrency-limit`). Generous for SMB tenants.
- 7 unit tests covering per-tenant cap, release restores permit, tenant isolation, rejection counter, null/blank tenant bypass, release-unknown no-op, `inUsePermits` reflection.

## Why
A single tenant under burst load could saturate the worker HikariCP pool (raised to 30 in [emf#917](https://github.com/cklinker/emf/pull/917)), starving every other tenant's request even though their quota allowed it. Pre-quota enforcement at the filter stops the noisy tenant before it monopolizes shared connection capacity.

This is in-process per-pod for simplicity. Across 3 worker pods × default cap 10 = 30 simultaneous requests system-wide per tenant before back-pressure surfaces.

## Cardinality note
`kelta.worker.tenant.concurrency.rejected` is tagged by tenant. Bounded by active-tenant count. For very high tenant counts (>5k), drop the tag and rely on logs for per-tenant context. Tunable in [TenantConcurrencyLimiter.counter()](kelta-worker/src/main/java/io/kelta/worker/service/TenantConcurrencyLimiter.java) when needed.

## Test plan
- [x] `mvn verify -f kelta-worker/pom.xml` — 1136 tests pass (7 new for `TenantConcurrencyLimiter`).
- [x] kelta-web lint/typecheck/format/tests pass.
- [ ] Smoke test in dev: hammer a single tenant with `hey -c 50` against a worker endpoint, observe 503 with `Retry-After: 1` after the 10th in-flight; concurrent traffic to a second tenant unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)