### PR TITLE
feat(worker): storage quota uses TenantQuotaResolver (tier-aware)

### DIFF
--- a/kelta-worker/src/main/java/io/kelta/worker/controller/AttachmentUploadController.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/controller/AttachmentUploadController.java
@@ -3,6 +3,8 @@ package io.kelta.worker.controller;
 import io.kelta.jsonapi.JsonApiResponseBuilder;
 import io.kelta.worker.repository.GovernorLimitsRepository;
 import io.kelta.worker.service.S3StorageService;
+import io.kelta.worker.service.TenantQuotaResolver;
+import io.kelta.worker.service.TenantTierQuotas;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -65,13 +67,16 @@ public class AttachmentUploadController {
 
     private final S3StorageService storageService;
     private final GovernorLimitsRepository governorLimitsRepository;
+    private final TenantQuotaResolver quotaResolver;
     private final JdbcTemplate jdbcTemplate;
 
     public AttachmentUploadController(S3StorageService storageService,
                                        GovernorLimitsRepository governorLimitsRepository,
+                                       TenantQuotaResolver quotaResolver,
                                        JdbcTemplate jdbcTemplate) {
         this.storageService = storageService;
         this.governorLimitsRepository = governorLimitsRepository;
+        this.quotaResolver = quotaResolver;
         this.jdbcTemplate = jdbcTemplate;
     }
 
@@ -126,21 +131,9 @@ public class AttachmentUploadController {
                             "File size must be between 1 and " + maxFileSize + " bytes"));
         }
 
-        // Check storage governor limit
+        // Check storage governor limit — resolver applies tier defaults and per-tenant overrides.
         long currentStorageBytes = governorLimitsRepository.sumStorageBytes(tenantId);
-        long storageGbLimit = 10; // default
-        try {
-            Optional<Object> limitsOpt = governorLimitsRepository.findTenantLimits(tenantId);
-            if (limitsOpt.isPresent() && limitsOpt.get() instanceof Map<?,?> limitsMap) {
-                Object storageGbObj = limitsMap.get("storageGb");
-                if (storageGbObj instanceof Number num) {
-                    storageGbLimit = num.longValue();
-                }
-            }
-        } catch (Exception e) {
-            log.warn("Failed to read storage limits for tenant {}: {}", tenantId, e.getMessage());
-        }
-
+        long storageGbLimit = quotaResolver.intQuota(tenantId, TenantTierQuotas.KEY_STORAGE_GB);
         long storageLimitBytes = storageGbLimit * BYTES_PER_GB;
         if (currentStorageBytes + fileSize > storageLimitBytes) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).body(

--- a/kelta-worker/src/test/java/io/kelta/worker/controller/AttachmentUploadControllerTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/controller/AttachmentUploadControllerTest.java
@@ -2,6 +2,8 @@ package io.kelta.worker.controller;
 
 import io.kelta.worker.repository.GovernorLimitsRepository;
 import io.kelta.worker.service.S3StorageService;
+import io.kelta.worker.service.TenantQuotaResolver;
+import io.kelta.worker.service.TenantTierQuotas;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -28,6 +30,9 @@ class AttachmentUploadControllerTest {
     private GovernorLimitsRepository governorLimitsRepository;
 
     @Mock
+    private TenantQuotaResolver quotaResolver;
+
+    @Mock
     private JdbcTemplate jdbcTemplate;
 
     private AttachmentUploadController controller;
@@ -37,8 +42,9 @@ class AttachmentUploadControllerTest {
 
     @BeforeEach
     void setUp() {
-        controller = new AttachmentUploadController(storageService, governorLimitsRepository, jdbcTemplate);
+        controller = new AttachmentUploadController(storageService, governorLimitsRepository, quotaResolver, jdbcTemplate);
         lenient().when(storageService.isEnabled()).thenReturn(true);
+        lenient().when(quotaResolver.intQuota(TENANT_ID, TenantTierQuotas.KEY_STORAGE_GB)).thenReturn(10);
     }
 
     private Map<String, Object> validUploadBody() {
@@ -57,7 +63,7 @@ class AttachmentUploadControllerTest {
 
         when(storageService.getMaxFileSize()).thenReturn(52_428_800L);
         when(governorLimitsRepository.sumStorageBytes(TENANT_ID)).thenReturn(0L);
-        when(governorLimitsRepository.findTenantLimits(TENANT_ID)).thenReturn(Optional.empty());
+        // quotaResolver stubbed in setUp
         when(jdbcTemplate.update(anyString(), any(), any(), any(), any(), any(), any(), any(), any(), any()))
                 .thenReturn(1);
         when(storageService.getDefaultExpiry()).thenReturn(Duration.ofMinutes(15));
@@ -119,7 +125,7 @@ class AttachmentUploadControllerTest {
         when(storageService.getMaxFileSize()).thenReturn(52_428_800L);
         // Current usage is 9.99 GB, limit is 10 GB, adding 1 MB would exceed
         when(governorLimitsRepository.sumStorageBytes(TENANT_ID)).thenReturn(10_737_000_000L);
-        when(governorLimitsRepository.findTenantLimits(TENANT_ID)).thenReturn(Optional.empty());
+        // quotaResolver stubbed in setUp
 
         ResponseEntity<Map<String, Object>> response = controller.requestUploadUrl(TENANT_ID, USER_EMAIL, body);
 


### PR DESCRIPTION
> **Stacked on [#929](https://github.com/cklinker/emf/pull/929)**.

## Summary
- [AttachmentUploadController.requestUploadUrl](kelta-worker/src/main/java/io/kelta/worker/controller/AttachmentUploadController.java) had an inline `findTenantLimits` + map walk that hardcoded 10 GB as the default if the JSONB had no override. So a FREE tenant got 10 GB (instead of the 1 GB tier default) and an ENTERPRISE tenant also got 10 GB (instead of 100 GB).
- Replace inline lookup with `quotaResolver.intQuota(tenantId, TenantTierQuotas.KEY_STORAGE_GB)` which already merges tier defaults with per-tenant overrides (matches the other enforcement hooks from #926 and #929).
- 9 controller tests still pass; resolver is mocked in `@BeforeEach`.

## Why
Completes the write-path enforcement coverage: every governor-limits cap (collections, fields, users, flows, reports, storage) now honors `tenant.edition` defaults consistently. The AI request rate cap was already enforced via #919.

🤖 Generated with [Claude Code](https://claude.com/claude-code)