### PR TITLE
feat(runtime): propagate OTel Context through TenantPropagatingExecutors

### DIFF
--- a/kelta-platform/runtime/runtime-core/pom.xml
+++ b/kelta-platform/runtime/runtime-core/pom.xml
@@ -74,6 +74,13 @@
             <artifactId>json-path</artifactId>
         </dependency>
 
+        <!-- OpenTelemetry context for trace propagation across executors (optional) -->
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-context</artifactId>
+            <optional>true</optional>
+        </dependency>
+
         <!-- Jackson for JSON serialization -->
         <dependency>
             <groupId>tools.jackson.core</groupId>
@@ -85,6 +92,11 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk</artifactId>
             <scope>test</scope>
         </dependency>
         

--- a/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/context/TenantPropagatingExecutors.java
+++ b/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/context/TenantPropagatingExecutors.java
@@ -47,30 +47,37 @@ public final class TenantPropagatingExecutors {
         return () -> snapshot.call(task);
     }
 
-    /** Immutable capture of the submitter's tenant binding, replayed on the worker thread. */
-    private record Snapshot(String tenantId, String tenantSlug) {
+    /**
+     * Immutable capture of the submitter's tenant binding plus OpenTelemetry
+     * context. Replayed on the worker thread so DB queries see the right
+     * tenant AND tracer spans on the worker attach to the submitter's parent
+     * span.
+     */
+    private record Snapshot(String tenantId, String tenantSlug, Object otelContext) {
 
         static Snapshot capture() {
-            return new Snapshot(TenantContext.get(), TenantContext.getSlug());
+            return new Snapshot(TenantContext.get(), TenantContext.getSlug(), OtelBridge.currentContext());
         }
 
         void run(Runnable task) {
+            Runnable wrapped = OtelBridge.wrap(otelContext, task);
             if (!hasBinding()) {
-                task.run();
+                wrapped.run();
                 return;
             }
-            carrier().run(task::run);
+            carrier().run(wrapped);
         }
 
         <T> T call(Callable<T> task) throws Exception {
+            Callable<T> wrapped = OtelBridge.wrap(otelContext, task);
             if (!hasBinding()) {
-                return task.call();
+                return wrapped.call();
             }
             AtomicReference<T> result = new AtomicReference<>();
             AtomicReference<Exception> failure = new AtomicReference<>();
             carrier().run(() -> {
                 try {
-                    result.set(task.call());
+                    result.set(wrapped.call());
                 } catch (Exception e) {
                     failure.set(e);
                 }
@@ -101,6 +108,50 @@ public final class TenantPropagatingExecutors {
 
         private static boolean notBlank(String s) {
             return s != null && !s.isBlank();
+        }
+    }
+
+    /**
+     * Reflection-friendly bridge to {@code io.opentelemetry.context.Context}.
+     * Uses direct types when the OTel API is on the classpath; gracefully
+     * degrades to a no-op when it is not (the dep is declared
+     * {@code <optional>true</optional>} in {@code runtime-core}). The
+     * methods are short enough that JIT erases the indirection.
+     */
+    private static final class OtelBridge {
+
+        private static final boolean OTEL_AVAILABLE = isOtelAvailable();
+
+        private OtelBridge() {}
+
+        private static boolean isOtelAvailable() {
+            try {
+                Class.forName("io.opentelemetry.context.Context");
+                return true;
+            } catch (ClassNotFoundException e) {
+                return false;
+            }
+        }
+
+        static Object currentContext() {
+            if (!OTEL_AVAILABLE) {
+                return null;
+            }
+            return io.opentelemetry.context.Context.current();
+        }
+
+        static Runnable wrap(Object ctx, Runnable task) {
+            if (!OTEL_AVAILABLE || ctx == null) {
+                return task;
+            }
+            return ((io.opentelemetry.context.Context) ctx).wrap(task);
+        }
+
+        static <T> Callable<T> wrap(Object ctx, Callable<T> task) {
+            if (!OTEL_AVAILABLE || ctx == null) {
+                return task;
+            }
+            return ((io.opentelemetry.context.Context) ctx).wrap(task);
         }
     }
 

--- a/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/context/TenantPropagatingExecutorsOtelTest.java
+++ b/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/context/TenantPropagatingExecutorsOtelTest.java
@@ -1,0 +1,76 @@
+package io.kelta.runtime.context;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that {@link TenantPropagatingExecutors} propagates the
+ * OpenTelemetry {@code Context} alongside tenant binding. Without this, a
+ * span started on the worker thread would be a root span instead of a child
+ * of the submitter's request span.
+ */
+@DisplayName("TenantPropagatingExecutors OTel context propagation")
+class TenantPropagatingExecutorsOtelTest {
+
+    private OpenTelemetry otel() {
+        return OpenTelemetrySdk.builder()
+                .setTracerProvider(SdkTracerProvider.builder().build())
+                .build();
+    }
+
+    @Test
+    @DisplayName("captures the current OTel Context and applies it on the worker thread")
+    void propagatesContext() throws Exception {
+        OpenTelemetry sdk = otel();
+        Tracer tracer = sdk.getTracer("test");
+        Span parent = tracer.spanBuilder("parent").startSpan();
+        SpanContext parentCtx = parent.getSpanContext();
+
+        AtomicReference<SpanContext> seenOnWorker = new AtomicReference<>();
+
+        try (Scope ignored = parent.makeCurrent()) {
+            Runnable task = TenantPropagatingExecutors.wrap(() ->
+                    seenOnWorker.set(Span.fromContext(Context.current()).getSpanContext()));
+
+            // Run the wrapped task on a fresh thread to prove the captured
+            // context travels independently of the caller's current scope.
+            Thread t = new Thread(task);
+            t.start();
+            t.join(2000);
+        } finally {
+            parent.end();
+        }
+
+        assertThat(seenOnWorker.get()).isNotNull();
+        assertThat(seenOnWorker.get().getTraceId()).isEqualTo(parentCtx.getTraceId());
+        assertThat(seenOnWorker.get().getSpanId()).isEqualTo(parentCtx.getSpanId());
+    }
+
+    @Test
+    @DisplayName("no current OTel span — worker also has no current span (no NPE)")
+    void noCurrentContextIsSafe() throws Exception {
+        AtomicReference<SpanContext> seenOnWorker = new AtomicReference<>();
+
+        Runnable task = TenantPropagatingExecutors.wrap(() ->
+                seenOnWorker.set(Span.fromContext(Context.current()).getSpanContext()));
+
+        Thread t = new Thread(task);
+        t.start();
+        t.join(2000);
+
+        assertThat(seenOnWorker.get()).isNotNull();
+        assertThat(seenOnWorker.get().isValid()).isFalse();
+    }
+}


### PR DESCRIPTION
## Summary
- Snapshot now captures `io.opentelemetry.context.Context.current()` alongside the tenant binding. On the worker thread, `Context.wrap(runnable)` restores it before the tenant `ScopedValue` carrier runs the task.
- New `OtelBridge` static helper checks `Class.forName("io.opentelemetry.context.Context")` once at class init and degrades to a no-op when the OTel API is absent. No reflection on the hot path.
- `opentelemetry-context` added as `<optional>true</optional>` runtime-core dep; `opentelemetry-sdk` added test-scope.
- 2 new tests: parent→worker trace stitching and the no-current-context safety case.

## Why
Spans started on a virtual-thread submission (e.g. AI chat streaming, scheduled workflow tasks) were previously root spans because `Context.current()` on the worker thread returns the empty root context. Tempo would show two disconnected traces per request. With this PR the worker span attaches to the submitter's parent span.

## Test plan
- [x] `mvn test -f kelta-platform/pom.xml -pl runtime/runtime-core -Dtest=TenantPropagatingExecutorsOtelTest` — 2/2 pass
- [x] Full runtime build green — no regressions to existing 35 events / jsonapi / runtime-core / module tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)