### PR TITLE
fix(auth): inject Spring-managed RestClient.Builder for OTel auto-instrumentation

### DIFF
--- a/kelta-auth/pom.xml
+++ b/kelta-auth/pom.xml
@@ -36,6 +36,15 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
 
+        <!-- RestClient autoconfig — provides Spring-managed RestClient.Builder
+             bean that OTel/Observation customizers attach to. Spring Boot 4 split
+             this out of spring-boot-autoconfigure; without it RestClient.Builder
+             is not exposed and @Autowired injection fails. -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-restclient</artifactId>
+        </dependency>
+
         <!-- Spring Security -->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/kelta-auth/src/main/java/io/kelta/auth/service/WorkerClient.java
+++ b/kelta-auth/src/main/java/io/kelta/auth/service/WorkerClient.java
@@ -29,6 +29,7 @@ public class WorkerClient {
 
     public WorkerClient(AuthProperties properties,
                         ObjectMapper objectMapper,
+                        RestClient.Builder restClientBuilder,
                         @Value("${kelta.internal.token:}") String internalToken,
                         @Autowired(required = false) @Qualifier("internalWorkerRestClient")
                         @Nullable RestClient internalRestClient) {
@@ -37,11 +38,17 @@ public class WorkerClient {
         // that attaches a bearer token to every /internal/** request. Fall back
         // to a plain RestClient otherwise so the service keeps working while
         // the flag is off or during rollout.
+        //
+        // Both paths now use the Spring-managed RestClient.Builder bean rather
+        // than RestClient.builder() static factory: the managed bean is
+        // auto-instrumented by Spring Boot's OTel starter so outbound calls
+        // get traceparent headers and a CLIENT span. The static factory does
+        // not, which previously broke the gateway→auth→worker trace.
         if (internalRestClient != null) {
             log.info("WorkerClient using OAuth2 client_credentials for /internal/** calls");
             this.restClient = internalRestClient;
         } else {
-            this.restClient = RestClient.builder()
+            this.restClient = restClientBuilder
                     .baseUrl(properties.getWorkerUrl())
                     .build();
         }


### PR DESCRIPTION
## Summary
- [WorkerClient](kelta-auth/src/main/java/io/kelta/auth/service/WorkerClient.java)'s non-internal-auth fallback path called the static `RestClient.builder()` factory. That returns an un-instrumented builder; outbound calls had no `traceparent` header and no client span.
- Inject the Spring-managed `RestClient.Builder` bean instead. Spring Boot's `spring-boot-starter-opentelemetry` auto-configures it with the OTel `RestClient` instrumentation applied.

## Why
Closes the trace propagation gap the audit found: previously a request flowing gateway → auth → worker would show one trace ending at the auth border in Tempo, then a brand-new root span on the worker. This restores the full trace.

Independent of the OAuth2 client_credentials path — that one was already injected and instrumented.

## Test plan
- [x] `mvn verify -f kelta-auth/pom.xml` — full suite passes, no test wires WorkerClient directly.
- [ ] Smoke: hit a flow that requires `WorkerClient.sendEmail` from auth; confirm in Tempo that the auth→worker call shows up as a child span of the auth request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)