### PR TITLE
feat(nats): consumer lag gauge per subscription

### DIFF
--- a/kelta-platform/runtime/runtime-messaging-nats/src/main/java/io/kelta/runtime/messaging/nats/NatsSubscriptionManager.java
+++ b/kelta-platform/runtime/runtime-messaging-nats/src/main/java/io/kelta/runtime/messaging/nats/NatsSubscriptionManager.java
@@ -2,6 +2,7 @@ package io.kelta.runtime.messaging.nats;
 
 import io.kelta.runtime.event.EventSubscription;
 import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.Timer;
@@ -13,6 +14,7 @@ import io.nats.client.Message;
 import io.nats.client.PullSubscribeOptions;
 import io.nats.client.PushSubscribeOptions;
 import io.nats.client.api.ConsumerConfiguration;
+import io.nats.client.api.ConsumerInfo;
 import io.nats.client.api.DeliverPolicy;
 import io.nats.client.impl.Headers;
 import org.slf4j.Logger;
@@ -26,9 +28,12 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Manages NATS JetStream subscriptions for event handlers.
@@ -53,7 +58,14 @@ public class NatsSubscriptionManager implements DisposableBean {
     private final MeterRegistry meterRegistry;
     private final List<EventSubscription> subscriptions = new ArrayList<>();
     private final List<JetStreamSubscription> activeSubscriptions = new ArrayList<>();
+    private final ConcurrentHashMap<String, JetStreamSubscription> subsByName = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, AtomicLong> lagByName = new ConcurrentHashMap<>();
     private final ExecutorService pullExecutor = Executors.newVirtualThreadPerTaskExecutor();
+    private final ScheduledExecutorService lagPoller = Executors.newSingleThreadScheduledExecutor(r -> {
+        Thread t = new Thread(r, "nats-consumer-lag-poller");
+        t.setDaemon(true);
+        return t;
+    });
     private volatile boolean running = true;
 
     public NatsSubscriptionManager(NatsConnectionManager connectionManager, ObjectMapper objectMapper) {
@@ -96,6 +108,10 @@ public class NatsSubscriptionManager implements DisposableBean {
                         sub.name(), sub.subject(), e.getMessage(), e);
             }
         }
+        // Schedule consumer-lag polling after all subscriptions are registered.
+        if (meterRegistry != null && !subsByName.isEmpty()) {
+            lagPoller.scheduleAtFixedRate(this::pollLagOnce, 30, 30, TimeUnit.SECONDS);
+        }
     }
 
     private void startPullConsumer(EventSubscription sub) throws Exception {
@@ -114,6 +130,7 @@ public class NatsSubscriptionManager implements DisposableBean {
 
         JetStreamSubscription jsSub = js.subscribe(sub.subject(), options);
         activeSubscriptions.add(jsSub);
+        registerForLagPolling(sub.name(), jsSub);
 
         pullExecutor.submit(() -> {
             log.info("Pull consumer '{}' started on subject '{}'", sub.name(), sub.subject());
@@ -189,7 +206,43 @@ public class NatsSubscriptionManager implements DisposableBean {
         }, false, options);
 
         activeSubscriptions.add(jsSub);
+        registerForLagPolling(sub.name(), jsSub);
         log.info("Push consumer '{}' started on subject '{}'", sub.name(), sub.subject());
+    }
+
+    /**
+     * Track this subscription for periodic lag polling and register a gauge
+     * backed by the {@link AtomicLong} we update each tick. Idempotent —
+     * second registration with the same name replaces the prior gauge.
+     */
+    void registerForLagPolling(String name, JetStreamSubscription jsSub) {
+        if (meterRegistry == null) {
+            return;
+        }
+        subsByName.put(name, jsSub);
+        AtomicLong lag = lagByName.computeIfAbsent(name, k -> new AtomicLong(0L));
+        Gauge.builder("kelta.nats.consume.lag", lag, AtomicLong::doubleValue)
+                .description("NATS JetStream consumer pending message count (lag)")
+                .tags("subscription", name)
+                .register(meterRegistry);
+    }
+
+    /** Polls each tracked subscription for ConsumerInfo and updates lag gauges. */
+    void pollLagOnce() {
+        for (var entry : subsByName.entrySet()) {
+            String name = entry.getKey();
+            JetStreamSubscription sub = entry.getValue();
+            try {
+                ConsumerInfo info = sub.getConsumerInfo();
+                long pending = info.getNumPending();
+                AtomicLong lag = lagByName.get(name);
+                if (lag != null) {
+                    lag.set(pending);
+                }
+            } catch (Exception e) {
+                log.debug("Lag poll failed for subscription '{}': {}", name, e.getMessage());
+            }
+        }
     }
 
     /**
@@ -263,6 +316,7 @@ public class NatsSubscriptionManager implements DisposableBean {
     @Override
     public void destroy() {
         running = false;
+        lagPoller.shutdownNow();
         for (JetStreamSubscription sub : activeSubscriptions) {
             try {
                 sub.drain(Duration.ofSeconds(5));

--- a/kelta-platform/runtime/runtime-messaging-nats/src/test/java/io/kelta/runtime/messaging/nats/NatsSubscriptionManagerLagTest.java
+++ b/kelta-platform/runtime/runtime-messaging-nats/src/test/java/io/kelta/runtime/messaging/nats/NatsSubscriptionManagerLagTest.java
@@ -1,0 +1,86 @@
+package io.kelta.runtime.messaging.nats;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.nats.client.JetStreamSubscription;
+import io.nats.client.api.ConsumerInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import tools.jackson.databind.ObjectMapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("NatsSubscriptionManager consumer lag gauge")
+class NatsSubscriptionManagerLagTest {
+
+    @Mock
+    private NatsConnectionManager connectionManager;
+
+    @Mock
+    private JetStreamSubscription jsSub;
+
+    private MeterRegistry registry;
+    private NatsSubscriptionManager mgr;
+
+    @BeforeEach
+    void setUp() {
+        registry = new SimpleMeterRegistry();
+        mgr = new NatsSubscriptionManager(connectionManager, new ObjectMapper(), NatsTracing.NOOP, registry);
+    }
+
+    @Test
+    @DisplayName("registerForLagPolling exposes a gauge tagged by subscription")
+    void registerExposesGauge() {
+        mgr.registerForLagPolling("sub-a", jsSub);
+
+        assertThat(registry.find("kelta.nats.consume.lag")
+                .tag("subscription", "sub-a").gauge()).isNotNull();
+        assertThat(registry.find("kelta.nats.consume.lag")
+                .tag("subscription", "sub-a").gauge().value()).isZero();
+    }
+
+    @Test
+    @DisplayName("pollLagOnce reads ConsumerInfo.getNumPending and updates gauge")
+    void pollUpdatesGauge() throws Exception {
+        ConsumerInfo info = mock(ConsumerInfo.class);
+        when(info.getNumPending()).thenReturn(42L);
+        when(jsSub.getConsumerInfo()).thenReturn(info);
+
+        mgr.registerForLagPolling("sub-a", jsSub);
+        mgr.pollLagOnce();
+
+        assertThat(registry.find("kelta.nats.consume.lag")
+                .tag("subscription", "sub-a").gauge().value()).isEqualTo(42.0);
+    }
+
+    @Test
+    @DisplayName("pollLagOnce silently skips when ConsumerInfo lookup throws")
+    void pollSilentlyHandlesFailure() throws Exception {
+        when(jsSub.getConsumerInfo()).thenThrow(new RuntimeException("broker down"));
+
+        mgr.registerForLagPolling("sub-a", jsSub);
+        // Should not propagate
+        mgr.pollLagOnce();
+
+        assertThat(registry.find("kelta.nats.consume.lag")
+                .tag("subscription", "sub-a").gauge().value()).isZero();
+    }
+
+    @Test
+    @DisplayName("no MeterRegistry => no gauge registration on registerForLagPolling")
+    void noMetricsWithoutRegistry() {
+        NatsSubscriptionManager noMetrics = new NatsSubscriptionManager(
+                connectionManager, new ObjectMapper(), NatsTracing.NOOP, null);
+
+        noMetrics.registerForLagPolling("sub-a", jsSub);
+
+        assertThat(registry.find("kelta.nats.consume.lag").gauge()).isNull();
+    }
+}


### PR DESCRIPTION
## Summary
- Track active JetStream subscriptions in a name-keyed map alongside the existing list so a poller can look them up.
- Single-threaded daemon `ScheduledExecutorService` polls `ConsumerInfo.getNumPending()` per subscription every 30s and updates an `AtomicLong`-backed Micrometer gauge `kelta.nats.consume.lag{subscription=...}`.
- Poll failures swallowed (debug log) — broker hiccup does not spam errors. Lag stays at the last known value until next successful poll.
- Scheduler only starts when a `MeterRegistry` is wired AND at least one subscription registered.
- 4 unit tests: register exposes gauge, poll updates value, poll silently handles failure, no-registry no-op.

## Why
Alert rules in [homelab-argo#93](https://github.com/cklinker/homelab-argo/pull/93) reference `kelta_nats_consume_failed_total` and `processed` counters but had no signal for a stuck-but-not-failing consumer — messages accumulate in the stream, the handler runs fine on the rare delivery, and lag grows unnoticed. This gauge closes that gap.

Cardinality unchanged: only the `subscription` tag (bounded set of ~10-30 per service).

## Test plan
- [x] `mvn verify -f kelta-platform/pom.xml -pl runtime/runtime-messaging-nats -am` — 16 tests pass (4 new).
- [ ] After deploy, add a Prometheus rule for `kelta.nats.consume.lag > 1000 for 10m` and verify it fires when broker is paused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)