### PR TITLE
fix(worker): force runtime init for protobuf JavaFeaturesProto in native-image

### DIFF
--- a/kelta-worker/pom.xml
+++ b/kelta-worker/pom.xml
@@ -244,6 +244,14 @@
                                   registration (which uses reflection) runs during the build.
                                 -->
                                 <buildArg>--initialize-at-build-time=com.google.protobuf</buildArg>
+                                <!-- Protobuf 4.x JavaFeaturesProto + DescriptorProtos pull in
+                                     com.google.protobuf.GeneratedMessage$GeneratedExtension
+                                     accessors via static blocks that call getDescriptor() before
+                                     internalInit() has run when initialized at build time. Force
+                                     them to runtime init — the more-specific rule overrides the
+                                     com.google.protobuf package-level build-time rule above. -->
+                                <buildArg>--initialize-at-run-time=com.google.protobuf.JavaFeaturesProto</buildArg>
+                                <buildArg>--initialize-at-run-time=com.google.protobuf.DescriptorProtos</buildArg>
                                 <buildArg>--initialize-at-build-time=com.google.api</buildArg>
                                 <buildArg>--initialize-at-build-time=com.google.gson</buildArg>
                                 <buildArg>--initialize-at-build-time=dev.cerbos</buildArg>


### PR DESCRIPTION
## The failure
Main's native-image build fails ([run 26677521606](https://github.com/cklinker/emf/actions/runs/26677521606)):

```
Error: Class initialization of com.google.protobuf.JavaFeaturesProto failed. Use the option
    '--initialize-at-run-time=com.google.protobuf.JavaFeaturesProto'
to explicitly request initialization of this class at run time.
Caused by: java.lang.IllegalStateException: getDescriptor() called before internalInit()
    at com.google.protobuf.GeneratedMessage$GeneratedExtension.getDescriptor(GeneratedMessage.java:1880)
    at com.google.protobuf.ExtensionRegistry.newExtensionInfo(ExtensionRegistry.java:212)
    at com.google.protobuf.Descriptors.getJavaEditionDefaults(Descriptors.java:97)
    at com.google.protobuf.DescriptorProtos.<clinit>(DescriptorProtos.java:48728)
    at com.google.protobuf.JavaFeaturesProto.<clinit>(JavaFeaturesProto.java:1564)
```

## The fix
Add the two specific classes to `--initialize-at-run-time=`. The more-specific rule overrides the existing package-level `--initialize-at-build-time=com.google.protobuf` rule. GraalVM's diagnostic literally tells us to do this.

## Why now
This started failing after a Maven dependency resolution upgraded protobuf-java to 4.x at some point in the last few merges. The 4.x family added `JavaFeaturesProto` (proto editions feature) whose static block reaches into descriptor state too early. Not caused by any specific recent PR — it would have surfaced on the first native build using the new protobuf transitively.

## Test plan
- [ ] Can't reproduce locally (no GraalVM in dev environment). CI's worker native build is the validation.
- [ ] If still failing, may need to also add `--initialize-at-run-time=com.google.protobuf.ExtensionRegistry` per the secondary stack frame.

🤖 Generated with [Claude Code](https://claude.com/claude-code)