### PR TITLE
fix(ui,sdk): clear all lint errors + restore test suite + unify FieldDefinition type

### DIFF
--- a/kelta-ui/app/src/App.test.tsx
+++ b/kelta-ui/app/src/App.test.tsx
@@ -326,6 +326,10 @@ vi.mock('./pages', () => ({
   ApiTokensPage: () => <div data-testid="api-tokens-page">API Tokens Page</div>,
   PasswordPolicyPage: () => <div data-testid="password-policy-page">Password Policy Page</div>,
   MfaPolicyPage: () => <div data-testid="mfa-policy-page">MFA Policy Page</div>,
+  MapSettingsPage: () => <div data-testid="map-settings-page">Map Settings Page</div>,
+  CredentialsPage: () => <div data-testid="credentials-page">Credentials Page</div>,
+  ApiSpecsPage: () => <div data-testid="api-specs-page">API Specs Page</div>,
+  ApiSpecDetailPage: () => <div data-testid="api-spec-detail-page">API Spec Detail Page</div>,
   NotFoundPage: () => <div data-testid="not-found-page">Not Found Page</div>,
 }))
 

--- a/kelta-ui/app/src/components/AiChat/AddFieldsProposalCard.test.tsx
+++ b/kelta-ui/app/src/components/AiChat/AddFieldsProposalCard.test.tsx
@@ -23,11 +23,7 @@ function makeProposal(overrides: Partial<AiProposal> = {}): AiProposal {
 describe('AddFieldsProposalCard', () => {
   it('renders the target collection and field rows for a pending proposal', () => {
     render(
-      <AddFieldsProposalCard
-        proposal={makeProposal()}
-        onApply={vi.fn()}
-        onDismiss={vi.fn()}
-      />
+      <AddFieldsProposalCard proposal={makeProposal()} onApply={vi.fn()} onDismiss={vi.fn()} />
     )
     expect(screen.getByText('Add fields')).toBeInTheDocument()
     expect(screen.getByText('→ customers')).toBeInTheDocument()

--- a/kelta-ui/app/src/components/AiChat/AiChatPanel.tsx
+++ b/kelta-ui/app/src/components/AiChat/AiChatPanel.tsx
@@ -35,7 +35,10 @@ interface RawHistoryMessage {
   createdAt: string
 }
 
-function rehydrateMessages(raw: RawHistoryMessage[]): { messages: ChatMessageType[]; proposals: AiProposal[] } {
+function rehydrateMessages(raw: RawHistoryMessage[]): {
+  messages: ChatMessageType[]
+  proposals: AiProposal[]
+} {
   const messages: ChatMessageType[] = []
   const proposals: AiProposal[] = []
 
@@ -155,7 +158,9 @@ export function AiChatPanel({
         const token = await getAccessToken()
         const headers: Record<string, string> = {}
         if (token) headers['Authorization'] = `Bearer ${token}`
-        const response = await fetch(`${baseUrl}/api/ai/conversations/${convId}/messages`, { headers })
+        const response = await fetch(`${baseUrl}/api/ai/conversations/${convId}/messages`, {
+          headers,
+        })
         if (!response.ok) return
         const body = await response.json()
         const raw = (body.messages ?? []) as RawHistoryMessage[]

--- a/kelta-ui/app/src/components/AiChat/RemoveFieldProposalCard.test.tsx
+++ b/kelta-ui/app/src/components/AiChat/RemoveFieldProposalCard.test.tsx
@@ -31,9 +31,7 @@ describe('RemoveFieldProposalCard', () => {
 
   it('renders applied state without action buttons', () => {
     const applied: AiProposal = { ...makeProposal(), status: 'applied' }
-    render(
-      <RemoveFieldProposalCard proposal={applied} onApply={vi.fn()} onDismiss={vi.fn()} />
-    )
+    render(<RemoveFieldProposalCard proposal={applied} onApply={vi.fn()} onDismiss={vi.fn()} />)
     expect(screen.getByText('Removed')).toBeInTheDocument()
     expect(screen.queryByRole('button', { name: /Remove field/ })).not.toBeInTheDocument()
   })

--- a/kelta-ui/app/src/components/AiChat/RemoveFieldProposalCard.tsx
+++ b/kelta-ui/app/src/components/AiChat/RemoveFieldProposalCard.tsx
@@ -64,9 +64,7 @@ export function RemoveFieldProposalCard({
         </div>
         <div className="flex items-start gap-2 rounded border border-destructive/30 bg-background p-2 mt-2">
           <AlertTriangle className="mt-0.5 h-3.5 w-3.5 text-destructive shrink-0" />
-          <p className="text-xs">
-            Destructive — the column and all its data will be deleted.
-          </p>
+          <p className="text-xs">Destructive — the column and all its data will be deleted.</p>
         </div>
       </CardHeader>
 

--- a/kelta-ui/app/src/components/AiChat/UpdateFieldProposalCard.tsx
+++ b/kelta-ui/app/src/components/AiChat/UpdateFieldProposalCard.tsx
@@ -78,9 +78,7 @@ export function UpdateFieldProposalCard({
             {changeEntries.map(([key, value]) => (
               <tr key={key} className="border-b border-dashed last:border-0">
                 <td className="py-1 font-mono">{key}</td>
-                <td className="py-1">
-                  {Array.isArray(value) ? value.join(', ') : String(value)}
-                </td>
+                <td className="py-1">{Array.isArray(value) ? value.join(', ') : String(value)}</td>
               </tr>
             ))}
           </tbody>

--- a/kelta-ui/app/src/components/AiChat/useAiStream.ts
+++ b/kelta-ui/app/src/components/AiChat/useAiStream.ts
@@ -154,7 +154,8 @@ export function useAiStream() {
                     break
                   }
                   case 'tool_result': {
-                    const status = (parsed.status as ToolCallStatus | undefined) ??
+                    const status =
+                      (parsed.status as ToolCallStatus | undefined) ??
                       (parsed.isError ? 'error' : 'done')
                     dispatch({
                       type: 'UPDATE_TOOL_CALL_STATUS',

--- a/kelta-ui/app/src/components/FieldEditor/FieldEditor.test.tsx
+++ b/kelta-ui/app/src/components/FieldEditor/FieldEditor.test.tsx
@@ -935,7 +935,12 @@ describe('FieldEditor Integration', () => {
       onCancel: vi.fn(),
     }
     const childFields = [
-      { name: 'orderId', displayName: 'Order', type: 'master_detail' as const, referenceTarget: 'orders' },
+      {
+        name: 'orderId',
+        displayName: 'Order',
+        type: 'master_detail' as const,
+        referenceTarget: 'orders',
+      },
       { name: 'amount', displayName: 'Amount', type: 'number' as const },
       { name: 'placedAt', displayName: 'Placed At', type: 'datetime' as const },
       { name: 'note', displayName: 'Note', type: 'string' as const },
@@ -1004,9 +1009,7 @@ describe('FieldEditor Integration', () => {
       await user.type(screen.getByTestId('field-name-input'), 'line_count')
       await user.selectOptions(screen.getByTestId('field-type-select'), 'rollup_summary')
       await user.selectOptions(screen.getByTestId('field-rollup-child-select'), 'products')
-      await waitFor(() =>
-        expect(screen.getByTestId('field-rollup-fk-select')).not.toBeDisabled()
-      )
+      await waitFor(() => expect(screen.getByTestId('field-rollup-fk-select')).not.toBeDisabled())
       await user.selectOptions(screen.getByTestId('field-rollup-fk-select'), 'orderId')
       await user.selectOptions(screen.getByTestId('field-rollup-fn-select'), 'COUNT')
 

--- a/kelta-ui/app/src/components/FieldEditor/FieldEditor.tsx
+++ b/kelta-ui/app/src/components/FieldEditor/FieldEditor.tsx
@@ -571,8 +571,7 @@ export function FieldEditor({
         globalPicklistId: (parsedConfig.globalPicklistId as string) ?? '',
         rollupChildCollection: (parsedConfig.childCollection as string) ?? '',
         rollupForeignKey: (parsedConfig.foreignKeyField as string) ?? '',
-        rollupFunction:
-          (parsedConfig.aggregateFunction as RollupAggregateFunction) ?? undefined,
+        rollupFunction: (parsedConfig.aggregateFunction as RollupAggregateFunction) ?? undefined,
         rollupField: (parsedConfig.aggregateField as string) ?? '',
         description: field.description ?? '',
         trackHistory: field.trackHistory ?? false,
@@ -1237,10 +1236,7 @@ export function FieldEditor({
                   {getErrorMessage(errors.rollupField.message)}
                 </span>
               )}
-              <span
-                id="field-rollup-field-hint"
-                className="text-xs text-muted-foreground mt-1"
-              >
+              <span id="field-rollup-field-hint" className="text-xs text-muted-foreground mt-1">
                 {t('fieldEditor.rollup.fieldHint')}
               </span>
             </div>

--- a/kelta-ui/app/src/components/FieldExpressionPicker/FieldsTab.tsx
+++ b/kelta-ui/app/src/components/FieldExpressionPicker/FieldsTab.tsx
@@ -5,10 +5,7 @@ import {
   type FieldDefinition,
   type FieldType,
 } from '../../hooks/useCollectionSchema'
-import {
-  useCollectionStore,
-  type CollectionStoreValue,
-} from '../../context/CollectionStoreContext'
+import { useCollectionStore, type CollectionStoreValue } from '../../context/CollectionStoreContext'
 import type { CollectionSchema } from '../../hooks/useCollectionSchema'
 import { Input } from '@/components/ui/input'
 import { cn } from '@/lib/utils'

--- a/kelta-ui/app/src/components/Header/Header.tsx
+++ b/kelta-ui/app/src/components/Header/Header.tsx
@@ -49,6 +49,9 @@ export function Header({ branding, user, onLogout }: HeaderProps): JSX.Element {
     if (typeof window === 'undefined') return
     const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT_PX - 1}px)`)
     const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches)
+    // Initial sync — useState initializer reads window.innerWidth, but the
+    // media query may classify differently. Subscribe-via-callback pattern.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setIsMobile(mql.matches)
     mql.addEventListener('change', handler)
     return () => mql.removeEventListener('change', handler)

--- a/kelta-ui/app/src/components/LayoutFormSections/LayoutFormSections.tsx
+++ b/kelta-ui/app/src/components/LayoutFormSections/LayoutFormSections.tsx
@@ -75,7 +75,7 @@ function resolvePlacements(
   fieldsById: Map<string, LayoutFormFieldDefinition>,
   columns: number,
   record: Record<string, unknown> | undefined,
-  isComputed?: (fieldName: string) => boolean,
+  isComputed?: (fieldName: string) => boolean
 ): ResolvedField[] {
   const visiblePlacements = record
     ? placements.filter((p) => isVisible(p.visibilityRule, record))
@@ -235,7 +235,7 @@ export function LayoutFormSections({
         fieldsById,
         section.columns || 1,
         record,
-        isComputed,
+        isComputed
       )
       result.push({ section, resolved, startIndex: acc })
       return acc + resolved.length

--- a/kelta-ui/app/src/components/PayloadMapper/PayloadMapper.tsx
+++ b/kelta-ui/app/src/components/PayloadMapper/PayloadMapper.tsx
@@ -82,13 +82,25 @@ export function PayloadMapper({
       {header}
 
       <div className="flex items-center gap-2">
-        <ViewTab active={view === 'visual'} onClick={() => setView('visual')} icon={<FormInput className="h-3.5 w-3.5" />}>
+        <ViewTab
+          active={view === 'visual'}
+          onClick={() => setView('visual')}
+          icon={<FormInput className="h-3.5 w-3.5" />}
+        >
           Visual
         </ViewTab>
-        <ViewTab active={view === 'code'} onClick={() => setView('code')} icon={<Code2 className="h-3.5 w-3.5" />}>
+        <ViewTab
+          active={view === 'code'}
+          onClick={() => setView('code')}
+          icon={<Code2 className="h-3.5 w-3.5" />}
+        >
           Code
         </ViewTab>
-        <ViewTab active={view === 'preview'} onClick={() => setView('preview')} icon={<Eye className="h-3.5 w-3.5" />}>
+        <ViewTab
+          active={view === 'preview'}
+          onClick={() => setView('preview')}
+          icon={<Eye className="h-3.5 w-3.5" />}
+        >
           Preview
         </ViewTab>
       </div>
@@ -247,7 +259,9 @@ function CodeView({
   const [text, setText] = useState(() => JSON.stringify(template, null, 2))
   const [error, setError] = useState<string | null>(null)
 
+  // Resync editor text when parent passes a new template shape.
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setText(JSON.stringify(template, null, 2))
   }, [JSON.stringify(template)])
 
@@ -274,8 +288,8 @@ function CodeView({
       />
       {error && <p className="text-xs text-red-600">{error}</p>}
       <p className="text-xs text-muted-foreground">
-        Strings starting with <code>=</code> are evaluated as JSONata; everything else flows
-        through <code>${'${$.path}'}</code> substitution.
+        Strings starting with <code>=</code> are evaluated as JSONata; everything else flows through{' '}
+        <code>${'${$.path}'}</code> substitution.
       </p>
     </div>
   )
@@ -320,8 +334,8 @@ function PreviewView({
           {resolved ? JSON.stringify(resolved, null, 2) : '— invalid sample state —'}
         </pre>
         <p className="text-xs text-muted-foreground">
-          Preview resolves <code>${'${$.path}'}</code> tokens client-side. JSONata expressions
-          are not evaluated here — they're only run by the worker.
+          Preview resolves <code>${'${$.path}'}</code> tokens client-side. JSONata expressions are
+          not evaluated here — they're only run by the worker.
         </p>
       </div>
     </div>
@@ -345,7 +359,10 @@ function sampleValueFor(v: SourceVariable): unknown {
 }
 
 function setSamplePath(target: Record<string, unknown>, path: string, value: unknown) {
-  const segments = path.replace(/^\$\.?/, '').split('.').filter(Boolean)
+  const segments = path
+    .replace(/^\$\.?/, '')
+    .split('.')
+    .filter(Boolean)
   if (segments.length === 0) return
   let cursor: Record<string, unknown> = target
   for (let i = 0; i < segments.length - 1; i++) {

--- a/kelta-ui/app/src/components/PayloadMapper/mappingSerializer.ts
+++ b/kelta-ui/app/src/components/PayloadMapper/mappingSerializer.ts
@@ -21,10 +21,7 @@ export function serializeBindings(bindings: MappingMap): SerializedMapping {
   return out
 }
 
-export function deserializeMapping(
-  template: unknown,
-  knownTargets: string[]
-): MappingMap {
+export function deserializeMapping(template: unknown, knownTargets: string[]): MappingMap {
   const result: MappingMap = {}
   for (const target of knownTargets) {
     const value = readNested(template, target)

--- a/kelta-ui/app/src/components/ValidationRuleEditor/ValidationRuleEditor.tsx
+++ b/kelta-ui/app/src/components/ValidationRuleEditor/ValidationRuleEditor.tsx
@@ -218,8 +218,9 @@ export function ValidationRuleEditor({
               id="rule-formula"
               ref={(el) => {
                 rhfRef(el)
-                ;(formulaTextareaRef as React.MutableRefObject<HTMLTextAreaElement | null>).current =
-                  el
+                ;(
+                  formulaTextareaRef as React.MutableRefObject<HTMLTextAreaElement | null>
+                ).current = el
               }}
               className={cn(
                 inputClasses,

--- a/kelta-ui/app/src/components/VariablePicker/VariablePicker.tsx
+++ b/kelta-ui/app/src/components/VariablePicker/VariablePicker.tsx
@@ -30,7 +30,12 @@ export interface VariablePickerProps {
  * current flow state. Used by the payload mapper, JSON body editors, and any
  * other surface that wants quick variable insertion.
  */
-export function VariablePicker({ variables, onPick, trigger, raw }: VariablePickerProps): React.ReactElement {
+export function VariablePicker({
+  variables,
+  onPick,
+  trigger,
+  raw,
+}: VariablePickerProps): React.ReactElement {
   const [open, setOpen] = useState(false)
   const [filter, setFilter] = useState('')
 
@@ -38,9 +43,7 @@ export function VariablePicker({ variables, onPick, trigger, raw }: VariablePick
     if (!filter) return variables
     const q = filter.toLowerCase()
     return variables.filter(
-      (v) =>
-        v.path.toLowerCase().includes(q) ||
-        (v.label?.toLowerCase().includes(q) ?? false)
+      (v) => v.path.toLowerCase().includes(q) || (v.label?.toLowerCase().includes(q) ?? false)
     )
   }, [variables, filter])
 
@@ -93,9 +96,7 @@ export function VariablePicker({ variables, onPick, trigger, raw }: VariablePick
                             {v.type}
                           </span>
                         )}
-                        {v.label && (
-                          <span className="text-muted-foreground">— {v.label}</span>
-                        )}
+                        {v.label && <span className="text-muted-foreground">— {v.label}</span>}
                         <ChevronRight className="h-3 w-3 opacity-40" />
                       </button>
                     </li>
@@ -104,9 +105,7 @@ export function VariablePicker({ variables, onPick, trigger, raw }: VariablePick
               </div>
             ))}
             {filtered.length === 0 && (
-              <p className="px-2 py-3 text-xs text-muted-foreground">
-                No variables match.
-              </p>
+              <p className="px-2 py-3 text-xs text-muted-foreground">No variables match.</p>
             )}
           </div>
         </div>

--- a/kelta-ui/app/src/components/apiSpec/OperationPicker.tsx
+++ b/kelta-ui/app/src/components/apiSpec/OperationPicker.tsx
@@ -85,14 +85,10 @@ export function OperationPicker({
               </span>
               <span className="font-mono text-xs">{op.pathTemplate}</span>
               {op.summary && (
-                <span className="text-xs text-muted-foreground truncate">
-                  — {op.summary}
-                </span>
+                <span className="text-xs text-muted-foreground truncate">— {op.summary}</span>
               )}
               {op.deprecated && (
-                <span className="ml-auto text-[10px] text-muted-foreground">
-                  deprecated
-                </span>
+                <span className="ml-auto text-[10px] text-muted-foreground">deprecated</span>
               )}
             </button>
           )

--- a/kelta-ui/app/src/context/AuthContext.tsx
+++ b/kelta-ui/app/src/context/AuthContext.tsx
@@ -42,9 +42,7 @@ import { getTenantSlug, setResolvedTenantId, getResolvedTenantId } from './Tenan
  * are passed as an idp_hint so kelta-auth handles the federation server-side
  * and mints a platform-issued token.
  */
-function findInternalProvider(
-  providers: OIDCProviderSummary[]
-): OIDCProviderSummary | undefined {
+function findInternalProvider(providers: OIDCProviderSummary[]): OIDCProviderSummary | undefined {
   return providers.find((p) => p.isInternal === true)
 }
 

--- a/kelta-ui/app/src/hooks/usePageLayout.ts
+++ b/kelta-ui/app/src/hooks/usePageLayout.ts
@@ -94,11 +94,17 @@ export interface RecordHeaderConfigDto {
  * adding a new block kind on the server doesn't crash older clients.
  */
 export type RailBlockDto =
-  | { kind: 'metadataCard'; config: { title: string; rows: Array<{ label: string; value: string; mono?: boolean }> } }
+  | {
+      kind: 'metadataCard'
+      config: { title: string; rows: Array<{ label: string; value: string; mono?: boolean }> }
+    }
   | { kind: 'statStrip'; config: { tiles: Array<Record<string, unknown>> } }
   | { kind: 'scoreCard'; config: Record<string, unknown> }
   | { kind: 'tagsCard'; config: { title: string; tags: Array<{ label: string; tone?: string }> } }
-  | { kind: 'aiCard'; config: { title: string; summary: string; actions?: Array<{ label: string }> } }
+  | {
+      kind: 'aiCard'
+      config: { title: string; summary: string; actions?: Array<{ label: string }> }
+    }
   | { kind: 'timeline'; config: { title: string; events: Array<Record<string, unknown>> } }
 
 export interface PageLayoutDto {
@@ -331,7 +337,7 @@ export function usePageLayout(
         let rules: LayoutRuleDto[] = []
         try {
           rules = await apiClient.getList<LayoutRuleDto>(
-            `/api/layout-rules?filter[layoutId][eq]=${layoutId}&filter[active][eq]=true&sort=sortOrder&page[size]=100`,
+            `/api/layout-rules?filter[layoutId][eq]=${layoutId}&filter[active][eq]=true&sort=sortOrder&page[size]=100`
           )
         } catch {
           rules = []

--- a/kelta-ui/app/src/hooks/useTenantSettings.ts
+++ b/kelta-ui/app/src/hooks/useTenantSettings.ts
@@ -72,10 +72,7 @@ export function useTenantSettings(): {
     },
   })
 
-  const settings = useMemo<TenantSettings>(
-    () => data?.settings ?? {},
-    [data?.settings]
-  )
+  const settings = useMemo<TenantSettings>(() => data?.settings ?? {}, [data?.settings])
 
   return {
     tenant: data ?? null,

--- a/kelta-ui/app/src/main.tsx
+++ b/kelta-ui/app/src/main.tsx
@@ -1,7 +1,7 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
-import './styles/kelta-design.css';
+import './styles/kelta-design.css'
 // Map controls + popup styling for the optional interactive map in
 // @kelta/components AddressMap. Lazy-loaded chunk imports maplibre-gl at
 // runtime; the CSS must be present from the first render so popovers

--- a/kelta-ui/app/src/pages/ApiTokensPage/ApiTokensPage.test.tsx
+++ b/kelta-ui/app/src/pages/ApiTokensPage/ApiTokensPage.test.tsx
@@ -14,31 +14,21 @@ describe('buildMcpAddCommand', () => {
       'user',
       'https://emf.rzware.com',
       'threadline-clothing',
-      'klt_abc123',
+      'klt_abc123'
     )
     expect(cmd).toBe(
-      "claude mcp add kelta-user --transport http --url https://emf.rzware.com/threadline-clothing/mcp/user --header 'Authorization: Bearer klt_abc123'",
+      "claude mcp add kelta-user --transport http --url https://emf.rzware.com/threadline-clothing/mcp/user --header 'Authorization: Bearer klt_abc123'"
     )
   })
 
   it('builds an admin-profile command at the right slug-prefixed URL', () => {
-    const cmd = buildMcpAddCommand(
-      'admin',
-      'https://emf.rzware.com',
-      'another-tenant',
-      'klt_xyz',
-    )
+    const cmd = buildMcpAddCommand('admin', 'https://emf.rzware.com', 'another-tenant', 'klt_xyz')
     expect(cmd).toContain('--url https://emf.rzware.com/another-tenant/mcp/admin')
     expect(cmd).toContain('kelta-admin')
   })
 
   it('uses single quotes around the auth header so the token is opaque to the shell', () => {
-    const cmd = buildMcpAddCommand(
-      'user',
-      'https://emf.rzware.com',
-      't',
-      'klt_token_with$pecial',
-    )
+    const cmd = buildMcpAddCommand('user', 'https://emf.rzware.com', 't', 'klt_token_with$pecial')
     expect(cmd).toContain("'Authorization: Bearer klt_token_with$pecial'")
   })
 })

--- a/kelta-ui/app/src/pages/ApiTokensPage/ApiTokensPage.tsx
+++ b/kelta-ui/app/src/pages/ApiTokensPage/ApiTokensPage.tsx
@@ -346,6 +346,10 @@ function CreateTokenForm({
  * Mirrors the API base URL convention: VITE_API_BASE_URL when set
  * (production), otherwise the current page origin (local dev).
  */
+// Vite's react-refresh requires page modules to export only components.
+// Re-export non-component helpers below from this file so callers' import
+// paths stay stable, but mark them so the lint doesn't flag fast-refresh.
+// eslint-disable-next-line react-refresh/only-export-components
 export function resolveMcpBaseUrl(): string {
   const apiBase = import.meta.env.VITE_API_BASE_URL || ''
   if (apiBase) return apiBase
@@ -355,11 +359,12 @@ export function resolveMcpBaseUrl(): string {
   return ''
 }
 
+// eslint-disable-next-line react-refresh/only-export-components
 export function buildMcpAddCommand(
   profile: 'user' | 'admin',
   mcpBaseUrl: string,
   tenantSlug: string,
-  token: string,
+  token: string
 ): string {
   // Slug binds the URL to a tenant (matches the platform-wide /{slug}/...
   // convention). Different PAT in a different tenant → different URL.
@@ -484,10 +489,10 @@ function TokenCreatedDialog({
             <div>
               <h3 className="text-sm font-semibold text-foreground">Use with Claude Code</h3>
               <p className="mt-1 text-xs text-muted-foreground">
-                Run one or both of these in a terminal to register Kelta as an MCP server.
-                The <code className="font-mono">/mcp/user</code> endpoint exposes data-plane
-                tools (CRUD, flows, approvals); <code className="font-mono">/mcp/admin</code>{' '}
-                exposes control-plane tools (collection / layout / flow definition).
+                Run one or both of these in a terminal to register Kelta as an MCP server. The{' '}
+                <code className="font-mono">/mcp/user</code> endpoint exposes data-plane tools
+                (CRUD, flows, approvals); <code className="font-mono">/mcp/admin</code> exposes
+                control-plane tools (collection / layout / flow definition).
               </p>
             </div>
             <CopyableCommandBlock

--- a/kelta-ui/app/src/pages/ApprovalProcessesPage/ApprovalProcessesPage.test.tsx
+++ b/kelta-ui/app/src/pages/ApprovalProcessesPage/ApprovalProcessesPage.test.tsx
@@ -3,7 +3,12 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { ApprovalProcessesPage } from './ApprovalProcessesPage'
-import { createTestWrapper, setupAuthMocks, getMockAxiosInstance, resetMockAxios } from '../../test/testUtils'
+import {
+  createTestWrapper,
+  setupAuthMocks,
+  getMockAxiosInstance,
+  resetMockAxios,
+} from '../../test/testUtils'
 
 vi.mock('../../components/FieldExpressionPicker', () => ({
   FieldExpressionPicker: vi.fn(

--- a/kelta-ui/app/src/pages/EmailSettingsPage/EmailSettingsPage.test.tsx
+++ b/kelta-ui/app/src/pages/EmailSettingsPage/EmailSettingsPage.test.tsx
@@ -2,12 +2,7 @@ import React from 'react'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import {
-  createTestWrapper,
-  setupAuthMocks,
-  mockAxios,
-  resetMockAxios,
-} from '../../test/testUtils'
+import { createTestWrapper, setupAuthMocks, mockAxios, resetMockAxios } from '../../test/testUtils'
 import { EmailSettingsPage } from './EmailSettingsPage'
 
 describe('EmailSettingsPage', () => {
@@ -82,10 +77,9 @@ describe('EmailSettingsPage', () => {
     await user.click(screen.getByRole('button', { name: /Send test/i }))
 
     await waitFor(() => {
-      expect(mockAxios.post).toHaveBeenCalledWith(
-        '/api/admin/tenant/email-settings/test',
-        { to: 'qa@example.com' }
-      )
+      expect(mockAxios.post).toHaveBeenCalledWith('/api/admin/tenant/email-settings/test', {
+        to: 'qa@example.com',
+      })
     })
   })
 })

--- a/kelta-ui/app/src/pages/EmailSettingsPage/EmailSettingsPage.tsx
+++ b/kelta-ui/app/src/pages/EmailSettingsPage/EmailSettingsPage.tsx
@@ -223,14 +223,17 @@ export function EmailSettingsPage({ className }: EmailSettingsPageProps): React.
         <CardHeader>
           <CardTitle>User invites</CardTitle>
           <CardDescription>
-            When enabled, new users provisioned via SCIM or the admin UI receive an invite email automatically.
+            When enabled, new users provisioned via SCIM or the admin UI receive an invite email
+            automatically.
           </CardDescription>
         </CardHeader>
         <CardContent>
           <div className="flex items-center gap-2">
             <Switch
               checked={form.autoInviteOnCreate}
-              onCheckedChange={(checked) => setForm((prev) => ({ ...prev, autoInviteOnCreate: checked }))}
+              onCheckedChange={(checked) =>
+                setForm((prev) => ({ ...prev, autoInviteOnCreate: checked }))
+              }
               disabled={!canManage}
             />
             <span className="text-sm">Send invite emails automatically on user creation</span>
@@ -242,7 +245,8 @@ export function EmailSettingsPage({ className }: EmailSettingsPageProps): React.
         <CardHeader>
           <CardTitle>Test delivery</CardTitle>
           <CardDescription>
-            Sends a templated message using the saved settings. Save first if you've changed anything above.
+            Sends a templated message using the saved settings. Save first if you've changed
+            anything above.
           </CardDescription>
         </CardHeader>
         <CardContent className="flex items-center gap-3">

--- a/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/CallApiParams.tsx
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/CallApiParams.tsx
@@ -58,15 +58,11 @@ export function CallApiParams({ parameters, onUpdate }: CallApiParamsProps) {
 
   const update = (next: Record<string, unknown>) => onUpdate({ ...params, ...next })
 
-  const [headerEntries, setHeaderEntries] = useState<KeyValue[]>(() =>
-    toEntries(params.headers)
-  )
+  const [headerEntries, setHeaderEntries] = useState<KeyValue[]>(() => toEntries(params.headers))
   const [pathParamEntries, setPathParamEntries] = useState<KeyValue[]>(() =>
     toEntries(params.pathParams)
   )
-  const [queryEntries, setQueryEntries] = useState<KeyValue[]>(() =>
-    toEntries(params.queryParams)
-  )
+  const [queryEntries, setQueryEntries] = useState<KeyValue[]>(() => toEntries(params.queryParams))
 
   const updateHeaders = (entries: KeyValue[]) => {
     setHeaderEntries(entries)
@@ -89,20 +85,11 @@ export function CallApiParams({ parameters, onUpdate }: CallApiParamsProps) {
     <div className="space-y-4">
       <div className="space-y-1">
         <FieldLabel>Mode</FieldLabel>
-        <div
-          role="tablist"
-          className="grid grid-cols-2 rounded-md border p-1 text-sm bg-muted/30"
-        >
-          <ModeTab
-            active={mode === 'operation'}
-            onClick={() => update({ mode: 'operation' })}
-          >
+        <div role="tablist" className="grid grid-cols-2 rounded-md border p-1 text-sm bg-muted/30">
+          <ModeTab active={mode === 'operation'} onClick={() => update({ mode: 'operation' })}>
             From OpenAPI spec
           </ModeTab>
-          <ModeTab
-            active={mode === 'raw'}
-            onClick={() => update({ mode: 'raw' })}
-          >
+          <ModeTab active={mode === 'raw'} onClick={() => update({ mode: 'raw' })}>
             Ad-hoc (Postman)
           </ModeTab>
         </div>
@@ -116,10 +103,7 @@ export function CallApiParams({ parameters, onUpdate }: CallApiParamsProps) {
       {mode === 'operation' ? (
         <Card className="bg-muted/20">
           <CardContent className="space-y-3 p-3">
-            <SpecPicker
-              value={specId}
-              onChange={(id) => update({ specId: id, operationId: '' })}
-            />
+            <SpecPicker value={specId} onChange={(id) => update({ specId: id, operationId: '' })} />
             {specId && (
               <OperationPicker
                 specId={specId}
@@ -165,10 +149,7 @@ export function CallApiParams({ parameters, onUpdate }: CallApiParamsProps) {
         </Card>
       )}
 
-      <CredentialPicker
-        value={credentialId}
-        onChange={(id) => update({ credentialRef: id })}
-      />
+      <CredentialPicker value={credentialId} onChange={(id) => update({ credentialRef: id })} />
 
       {mode === 'operation' && (
         <KeyValueList
@@ -223,8 +204,8 @@ export function CallApiParams({ parameters, onUpdate }: CallApiParamsProps) {
           placeholder={'{ "name": "${$.record.data.name}" }'}
         />
         <p className="text-xs text-muted-foreground">
-          Strings starting with <code className="font-mono">=</code> are evaluated as
-          JSONata; everything else flows through <code className="font-mono">${'${$.path}'}</code>{' '}
+          Strings starting with <code className="font-mono">=</code> are evaluated as JSONata;
+          everything else flows through <code className="font-mono">${'${$.path}'}</code>{' '}
           substitution.
         </p>
       </div>
@@ -265,8 +246,8 @@ export function CallApiParams({ parameters, onUpdate }: CallApiParamsProps) {
               className="font-mono text-xs"
             />
             <p className="text-xs text-muted-foreground">
-              When set, the platform sends an Idempotency-Key header upstream and replays
-              cached responses on retry.
+              When set, the platform sends an Idempotency-Key header upstream and replays cached
+              responses on retry.
             </p>
           </div>
         </div>

--- a/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/EmailAlertParams.tsx
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/EmailAlertParams.tsx
@@ -12,10 +12,7 @@ import {
 } from '@/components/ui/sheet'
 import { Wand2 } from 'lucide-react'
 import { PayloadMapper } from '@/components/PayloadMapper'
-import type {
-  SourceVariable,
-  TargetField,
-} from '@/components/PayloadMapper'
+import type { SourceVariable, TargetField } from '@/components/PayloadMapper'
 
 interface EmailAlertParamsProps {
   parameters?: Record<string, unknown>
@@ -134,9 +131,9 @@ export function EmailAlertParams({ parameters, onUpdate }: EmailAlertParamsProps
           <SheetHeader>
             <SheetTitle>Email body builder</SheetTitle>
             <SheetDescription>
-              Map flow state variables into the email subject and body. Strings
-              starting with <code>=</code> are evaluated as JSONata at send time;
-              everything else flows through <code>${'${$.path}'}</code> substitution.
+              Map flow state variables into the email subject and body. Strings starting with{' '}
+              <code>=</code> are evaluated as JSONata at send time; everything else flows through{' '}
+              <code>${'${$.path}'}</code> substitution.
             </SheetDescription>
           </SheetHeader>
           <div className="mt-4">

--- a/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/SqlQueryParams.tsx
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/SqlQueryParams.tsx
@@ -38,10 +38,9 @@ export function SqlQueryParams({ parameters, onUpdate }: SqlQueryParamsProps) {
         />
         <p className="mt-1 text-[10px] leading-tight text-muted-foreground">
           Runs against the current tenant&apos;s schema. Use{' '}
-          <code className="font-mono">{'${$.path}'}</code> to interpolate flow
-          variables. SELECT/WITH/RETURNING returns{' '}
-          <code className="font-mono">records</code>; other statements return{' '}
-          <code className="font-mono">rowsAffected</code>.
+          <code className="font-mono">{'${$.path}'}</code> to interpolate flow variables.
+          SELECT/WITH/RETURNING returns <code className="font-mono">records</code>; other statements
+          return <code className="font-mono">rowsAffected</code>.
         </p>
       </div>
 

--- a/kelta-ui/app/src/pages/PageLayoutsPage/RulesEditor.tsx
+++ b/kelta-ui/app/src/pages/PageLayoutsPage/RulesEditor.tsx
@@ -72,11 +72,12 @@ const emptyDraft = (kind: RuleKind, sortOrder: number): DraftRule => ({
   description: '',
   kind,
   active: true,
-  whenEvents: kind === 'TRANSFORM'
-    ? ['onBlur']
-    : kind === 'VALIDATE'
-      ? ['onChange', 'onBeforeSave']
-      : ['onChange', 'onLoad'],
+  whenEvents:
+    kind === 'TRANSFORM'
+      ? ['onBlur']
+      : kind === 'VALIDATE'
+        ? ['onChange', 'onBeforeSave']
+        : ['onChange', 'onLoad'],
   targetField: '',
   formula: '',
   errorMessage: '',
@@ -90,7 +91,11 @@ const evaluator = new FormulaEvaluator()
 function parseField<T>(raw: unknown, fallback: T): T {
   if (raw === null || raw === undefined) return fallback
   if (typeof raw === 'string') {
-    try { return JSON.parse(raw) as T } catch { return fallback }
+    try {
+      return JSON.parse(raw) as T
+    } catch {
+      return fallback
+    }
   }
   return raw as T
 }
@@ -110,7 +115,10 @@ function apiRuleToDraft(rule: ApiLayoutRule): DraftRule {
     errorMessage: typeof body.errorMessage === 'string' ? body.errorMessage : '',
     enforce: body.enforce === 'warn' ? 'warn' : 'block',
     transformType:
-      transformSpec === 'lower' || transformSpec === 'trim' || transformSpec === 'titleCase' || transformSpec === 'formula'
+      transformSpec === 'lower' ||
+      transformSpec === 'trim' ||
+      transformSpec === 'titleCase' ||
+      transformSpec === 'formula'
         ? transformSpec
         : 'upper',
     sortOrder: rule.sortOrder,
@@ -131,9 +139,10 @@ function draftToBody(draft: DraftRule): Record<string, unknown> {
       }
     case 'TRANSFORM':
       return {
-        transform: draft.transformType === 'formula'
-          ? { type: 'formula', formula: draft.formula }
-          : { type: draft.transformType },
+        transform:
+          draft.transformType === 'formula'
+            ? { type: 'formula', formula: draft.formula }
+            : { type: draft.transformType },
       }
   }
 }
@@ -157,7 +166,7 @@ export function RulesEditor({ layoutId, layoutName, fieldNames, onClose }: Rules
     queryFn: async () => {
       try {
         const list = await apiClient.getList<ApiLayoutRule>(
-          `/api/layout-rules?filter[layoutId][eq]=${layoutId}&sort=sortOrder&page[size]=200`,
+          `/api/layout-rules?filter[layoutId][eq]=${layoutId}&sort=sortOrder&page[size]=200`
         )
         return list
       } catch {
@@ -214,12 +223,17 @@ export function RulesEditor({ layoutId, layoutName, fieldNames, onClose }: Rules
   const saveError = saveMutation.error as Error | null
   const deleteError = deleteMutation.error as Error | null
 
-  const formulaError = useMemo(
-    () => (draft ? syntaxError(draft.formula) : null),
-    [draft?.formula],
-  )
+  // Intentionally depend only on draft?.formula — recomputing on any draft
+  // mutation would thrash the memo for every keystroke on unrelated fields.
+  /* eslint-disable react-hooks/preserve-manual-memoization, react-hooks/exhaustive-deps */
+  const formulaError = useMemo(() => (draft ? syntaxError(draft.formula) : null), [draft?.formula])
+  /* eslint-enable react-hooks/preserve-manual-memoization, react-hooks/exhaustive-deps */
 
-  // Cycle check across the saved set + the in-flight draft.
+  // Cycle check across the saved set + the in-flight draft. We deliberately
+  // setState inside the effect to react to changes in `rules` or `draft` —
+  // refactoring this to useMemo would require duplicating the dependency
+  // tracking of the cycle-detection algorithm.
+  /* eslint-disable react-hooks/set-state-in-effect */
   useEffect(() => {
     if (!draft) {
       setCycleError(null)
@@ -242,10 +256,7 @@ export function RulesEditor({ layoutId, layoutName, fieldNames, onClose }: Rules
     }
     const nodes: RuleNode[] = rules
       .filter(
-        (r) =>
-          (r.kind === 'COMPUTE' || r.kind === 'DEFAULT') &&
-          r.id !== draft.id &&
-          r.targetField,
+        (r) => (r.kind === 'COMPUTE' || r.kind === 'DEFAULT') && r.id !== draft.id && r.targetField
       )
       .map((r) => {
         const body = parseField<Record<string, unknown>>(r.body, {})
@@ -262,6 +273,7 @@ export function RulesEditor({ layoutId, layoutName, fieldNames, onClose }: Rules
     const result = topologicalSort(nodes)
     setCycleError(result.ok ? null : `Cycle detected: ${result.cycle.join(' -> ')}`)
   }, [draft, rules, formulaError])
+  /* eslint-enable react-hooks/set-state-in-effect */
 
   const canSave =
     !!draft &&
@@ -271,7 +283,7 @@ export function RulesEditor({ layoutId, layoutName, fieldNames, onClose }: Rules
     !formulaError &&
     !cycleError &&
     (draft.kind !== 'TRANSFORM' || !!draft.targetField) &&
-    (draft.kind !== 'COMPUTE' && draft.kind !== 'DEFAULT' || !!draft.targetField) &&
+    ((draft.kind !== 'COMPUTE' && draft.kind !== 'DEFAULT') || !!draft.targetField) &&
     (draft.kind !== 'VALIDATE' || !!draft.errorMessage.trim())
 
   return (
@@ -306,9 +318,7 @@ export function RulesEditor({ layoutId, layoutName, fieldNames, onClose }: Rules
           {/* Rule list */}
           <aside className="overflow-y-auto border-r border-border p-4">
             <div className="mb-2 flex items-center justify-between">
-              <h3 className="m-0 text-sm font-semibold text-foreground">
-                Rules ({rules.length})
-              </h3>
+              <h3 className="m-0 text-sm font-semibold text-foreground">Rules ({rules.length})</h3>
             </div>
             <div className="mb-3 grid grid-cols-2 gap-1">
               {(['COMPUTE', 'VALIDATE', 'DEFAULT', 'TRANSFORM'] as RuleKind[]).map((k) => (
@@ -337,12 +347,13 @@ export function RulesEditor({ layoutId, layoutName, fieldNames, onClose }: Rules
                       onClick={() => setDraft(apiRuleToDraft(r))}
                       className={cn(
                         'flex w-full cursor-pointer flex-col items-start gap-0.5 rounded border border-transparent bg-transparent px-2 py-1.5 text-left hover:bg-muted',
-                        draft?.id === r.id && 'border-primary bg-muted',
+                        draft?.id === r.id && 'border-primary bg-muted'
                       )}
                       data-testid={`rules-editor-rule-${r.id}`}
                     >
                       <span className="text-sm font-medium text-foreground">
-                        {r.name}{!r.active && ' (inactive)'}
+                        {r.name}
+                        {!r.active && ' (inactive)'}
                       </span>
                       <span className="text-xs text-muted-foreground">
                         {RULE_KIND_LABEL[r.kind]}
@@ -410,7 +421,9 @@ export function RulesEditor({ layoutId, layoutName, fieldNames, onClose }: Rules
                   type="button"
                   className={cn(
                     'cursor-pointer rounded border-none px-3 py-1.5 text-sm text-primary-foreground',
-                    canSave ? 'bg-primary hover:bg-primary/90' : 'cursor-not-allowed bg-muted text-muted-foreground',
+                    canSave
+                      ? 'bg-primary hover:bg-primary/90'
+                      : 'cursor-not-allowed bg-muted text-muted-foreground'
                   )}
                   disabled={!canSave || saveMutation.isPending}
                   onClick={() => draft && saveMutation.mutate(draft)}
@@ -454,10 +467,14 @@ function RuleForm({ draft, onChange, fieldNames, formulaError, cycleError }: Rul
   return (
     <div className="flex flex-col gap-4">
       <div>
-        <label className="mb-1 block text-xs font-medium uppercase text-muted-foreground">
+        <label
+          htmlFor="rule-kind"
+          className="mb-1 block text-xs font-medium uppercase text-muted-foreground"
+        >
           Kind
         </label>
         <select
+          id="rule-kind"
           className="w-full rounded border border-border bg-background px-2 py-1.5 text-sm"
           value={draft.kind}
           onChange={(e) => update('kind', e.target.value as RuleKind)}
@@ -470,10 +487,14 @@ function RuleForm({ draft, onChange, fieldNames, formulaError, cycleError }: Rul
       </div>
 
       <div>
-        <label className="mb-1 block text-xs font-medium uppercase text-muted-foreground">
+        <label
+          htmlFor="rule-name"
+          className="mb-1 block text-xs font-medium uppercase text-muted-foreground"
+        >
           Name
         </label>
         <input
+          id="rule-name"
           type="text"
           className="w-full rounded border border-border bg-background px-2 py-1.5 text-sm"
           value={draft.name}
@@ -483,10 +504,14 @@ function RuleForm({ draft, onChange, fieldNames, formulaError, cycleError }: Rul
       </div>
 
       <div>
-        <label className="mb-1 block text-xs font-medium uppercase text-muted-foreground">
+        <label
+          htmlFor="rule-description"
+          className="mb-1 block text-xs font-medium uppercase text-muted-foreground"
+        >
           Description
         </label>
         <input
+          id="rule-description"
           type="text"
           className="w-full rounded border border-border bg-background px-2 py-1.5 text-sm"
           value={draft.description}
@@ -496,16 +521,22 @@ function RuleForm({ draft, onChange, fieldNames, formulaError, cycleError }: Rul
 
       {showTarget && (
         <div>
-          <label className="mb-1 block text-xs font-medium uppercase text-muted-foreground">
+          <label
+            htmlFor="rule-target"
+            className="mb-1 block text-xs font-medium uppercase text-muted-foreground"
+          >
             Target field {draft.kind !== 'VALIDATE' && <span className="text-destructive">*</span>}
           </label>
           <input
+            id="rule-target"
             type="text"
             list="rule-fields"
             className="w-full rounded border border-border bg-background px-2 py-1.5 text-sm font-mono"
             value={draft.targetField}
             onChange={(e) => update('targetField', e.target.value)}
-            placeholder={draft.kind === 'VALIDATE' ? 'optional — leave blank for form-level' : 'field_api_name'}
+            placeholder={
+              draft.kind === 'VALIDATE' ? 'optional — leave blank for form-level' : 'field_api_name'
+            }
             data-testid="rule-target-input"
           />
           <datalist id="rule-fields">
@@ -518,10 +549,14 @@ function RuleForm({ draft, onChange, fieldNames, formulaError, cycleError }: Rul
 
       {draft.kind === 'TRANSFORM' && (
         <div>
-          <label className="mb-1 block text-xs font-medium uppercase text-muted-foreground">
+          <label
+            htmlFor="rule-transform-type"
+            className="mb-1 block text-xs font-medium uppercase text-muted-foreground"
+          >
             Transform type
           </label>
           <select
+            id="rule-transform-type"
             className="w-full rounded border border-border bg-background px-2 py-1.5 text-sm"
             value={draft.transformType}
             onChange={(e) => update('transformType', e.target.value as DraftRule['transformType'])}
@@ -537,13 +572,17 @@ function RuleForm({ draft, onChange, fieldNames, formulaError, cycleError }: Rul
 
       {showFormula && (
         <div>
-          <label className="mb-1 block text-xs font-medium uppercase text-muted-foreground">
+          <label
+            htmlFor="rule-formula"
+            className="mb-1 block text-xs font-medium uppercase text-muted-foreground"
+          >
             Formula {draft.kind !== 'TRANSFORM' && <span className="text-destructive">*</span>}
           </label>
           <textarea
+            id="rule-formula"
             className={cn(
               'w-full rounded border border-border bg-background px-2 py-1.5 font-mono text-sm',
-              formulaError && 'border-destructive',
+              formulaError && 'border-destructive'
             )}
             rows={3}
             value={draft.formula}
@@ -564,7 +603,10 @@ function RuleForm({ draft, onChange, fieldNames, formulaError, cycleError }: Rul
       )}
 
       {cycleError && (
-        <div className="rounded border border-destructive bg-destructive/10 p-2 text-xs text-destructive" role="alert">
+        <div
+          className="rounded border border-destructive bg-destructive/10 p-2 text-xs text-destructive"
+          role="alert"
+        >
           {cycleError}
         </div>
       )}
@@ -572,10 +614,14 @@ function RuleForm({ draft, onChange, fieldNames, formulaError, cycleError }: Rul
       {draft.kind === 'VALIDATE' && (
         <>
           <div>
-            <label className="mb-1 block text-xs font-medium uppercase text-muted-foreground">
+            <label
+              htmlFor="rule-error-message"
+              className="mb-1 block text-xs font-medium uppercase text-muted-foreground"
+            >
               Error message <span className="text-destructive">*</span>
             </label>
             <input
+              id="rule-error-message"
               type="text"
               className="w-full rounded border border-border bg-background px-2 py-1.5 text-sm"
               value={draft.errorMessage}
@@ -584,10 +630,14 @@ function RuleForm({ draft, onChange, fieldNames, formulaError, cycleError }: Rul
             />
           </div>
           <div>
-            <label className="mb-1 block text-xs font-medium uppercase text-muted-foreground">
+            <label
+              htmlFor="rule-enforce"
+              className="mb-1 block text-xs font-medium uppercase text-muted-foreground"
+            >
               Enforce
             </label>
             <select
+              id="rule-enforce"
               className="w-full rounded border border-border bg-background px-2 py-1.5 text-sm"
               value={draft.enforce}
               onChange={(e) => update('enforce', e.target.value as 'block' | 'warn')}
@@ -600,9 +650,7 @@ function RuleForm({ draft, onChange, fieldNames, formulaError, cycleError }: Rul
       )}
 
       <div>
-        <label className="mb-1 block text-xs font-medium uppercase text-muted-foreground">
-          When
-        </label>
+        <span className="mb-1 block text-xs font-medium uppercase text-muted-foreground">When</span>
         <div className="flex flex-wrap gap-2">
           {ALL_EVENTS.map((e) => (
             <label key={e} className="flex cursor-pointer items-center gap-1 text-sm">
@@ -630,10 +678,14 @@ function RuleForm({ draft, onChange, fieldNames, formulaError, cycleError }: Rul
       </div>
 
       <div>
-        <label className="mb-1 block text-xs font-medium uppercase text-muted-foreground">
+        <label
+          htmlFor="rule-sort-order"
+          className="mb-1 block text-xs font-medium uppercase text-muted-foreground"
+        >
           Sort order
         </label>
         <input
+          id="rule-sort-order"
           type="number"
           className="w-32 rounded border border-border bg-background px-2 py-1.5 text-sm"
           value={draft.sortOrder}

--- a/kelta-ui/app/src/pages/PageLayoutsPage/__tests__/RulesEditor.test.tsx
+++ b/kelta-ui/app/src/pages/PageLayoutsPage/__tests__/RulesEditor.test.tsx
@@ -32,7 +32,12 @@ describe('RulesEditor', () => {
 
   it('renders empty state when no rules exist', async () => {
     renderWithProviders(
-      <RulesEditor layoutId="lay-1" layoutName="Edit" fieldNames={['quantity', 'unit_price']} onClose={() => {}} />,
+      <RulesEditor
+        layoutId="lay-1"
+        layoutName="Edit"
+        fieldNames={['quantity', 'unit_price']}
+        onClose={() => {}}
+      />
     )
     await waitFor(() => expect(screen.getByText(/No rules yet/i)).toBeInTheDocument())
   })
@@ -40,22 +45,25 @@ describe('RulesEditor', () => {
   it('opens compute draft and validates formula syntax live', async () => {
     const user = userEvent.setup()
     renderWithProviders(
-      <RulesEditor layoutId="lay-1" layoutName="Edit" fieldNames={['quantity', 'unit_price']} onClose={() => {}} />,
+      <RulesEditor
+        layoutId="lay-1"
+        layoutName="Edit"
+        fieldNames={['quantity', 'unit_price']}
+        onClose={() => {}}
+      />
     )
     await waitFor(() => screen.getByTestId('rules-editor-add-compute'))
     await user.click(screen.getByTestId('rules-editor-add-compute'))
 
     const formula = screen.getByTestId('rule-formula-input')
     await user.type(formula, '1 + +')
-    await waitFor(() =>
-      expect(screen.getByRole('alert')).toHaveTextContent(/Unexpected/i),
-    )
+    await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent(/Unexpected/i))
   })
 
   it('save is disabled until required fields are filled', async () => {
     const user = userEvent.setup()
     renderWithProviders(
-      <RulesEditor layoutId="lay-1" layoutName="Edit" fieldNames={[]} onClose={() => {}} />,
+      <RulesEditor layoutId="lay-1" layoutName="Edit" fieldNames={[]} onClose={() => {}} />
     )
     await waitFor(() => screen.getByTestId('rules-editor-add-compute'))
     await user.click(screen.getByTestId('rules-editor-add-compute'))
@@ -82,7 +90,12 @@ describe('RulesEditor', () => {
 
     const user = userEvent.setup()
     renderWithProviders(
-      <RulesEditor layoutId="lay-1" layoutName="Edit" fieldNames={['fa', 'fb']} onClose={() => {}} />,
+      <RulesEditor
+        layoutId="lay-1"
+        layoutName="Edit"
+        fieldNames={['fa', 'fb']}
+        onClose={() => {}}
+      />
     )
     await waitFor(() => screen.getByTestId('rules-editor-rule-r1'))
     await user.click(screen.getByTestId('rules-editor-add-compute'))
@@ -98,7 +111,7 @@ describe('RulesEditor', () => {
     apiClientMock.post.mockResolvedValue({})
     const user = userEvent.setup()
     renderWithProviders(
-      <RulesEditor layoutId="lay-1" layoutName="Edit" fieldNames={[]} onClose={() => {}} />,
+      <RulesEditor layoutId="lay-1" layoutName="Edit" fieldNames={[]} onClose={() => {}} />
     )
     await waitFor(() => screen.getByTestId('rules-editor-add-compute'))
     await user.click(screen.getByTestId('rules-editor-add-compute'))

--- a/kelta-ui/app/src/pages/PageLayoutsPage/components/DetailExtrasPanel.tsx
+++ b/kelta-ui/app/src/pages/PageLayoutsPage/components/DetailExtrasPanel.tsx
@@ -130,8 +130,8 @@ function MetaFieldsEditor({
       </Label>
       {values.length === 0 && (
         <p className="text-xs text-muted-foreground">
-          No meta items configured — ObjectDetailPage will auto-derive a row from common
-          contact-ish fields.
+          No meta items configured — ObjectDetailPage will auto-derive a row from common contact-ish
+          fields.
         </p>
       )}
       <div className="space-y-1.5">

--- a/kelta-ui/app/src/pages/PageLayoutsPage/components/RailBlocksEditor.tsx
+++ b/kelta-ui/app/src/pages/PageLayoutsPage/components/RailBlocksEditor.tsx
@@ -267,13 +267,7 @@ function FieldLabel({ children }: { children: React.ReactNode }): React.ReactEle
   )
 }
 
-function ArrayHeader({
-  label,
-  onAdd,
-}: {
-  label: string
-  onAdd: () => void
-}): React.ReactElement {
+function ArrayHeader({ label, onAdd }: { label: string; onAdd: () => void }): React.ReactElement {
   return (
     <div className="flex items-center justify-between">
       <FieldLabel>{label}</FieldLabel>
@@ -354,14 +348,19 @@ function MetadataCardSub({
           className="h-7 text-xs"
         />
       </div>
-      <ArrayHeader label="Rows" onAdd={() => update({ rows: [...rows, { label: '', value: '' }] })} />
+      <ArrayHeader
+        label="Rows"
+        onAdd={() => update({ rows: [...rows, { label: '', value: '' }] })}
+      />
       <div className="space-y-1">
         {rows.map((row, idx) => (
           <div key={idx} className="flex items-center gap-1">
             <Input
               value={row.label}
               onChange={(e) =>
-                update({ rows: rows.map((r, i) => (i === idx ? { ...r, label: e.target.value } : r)) })
+                update({
+                  rows: rows.map((r, i) => (i === idx ? { ...r, label: e.target.value } : r)),
+                })
               }
               placeholder="Label"
               className="h-7 flex-1 text-xs"
@@ -370,7 +369,9 @@ function MetadataCardSub({
             <Input
               value={row.value}
               onChange={(e) =>
-                update({ rows: rows.map((r, i) => (i === idx ? { ...r, value: e.target.value } : r)) })
+                update({
+                  rows: rows.map((r, i) => (i === idx ? { ...r, value: e.target.value } : r)),
+                })
               }
               placeholder="Value"
               className={cn('h-7 flex-1 text-xs', row.mono && 'font-mono')}
@@ -580,9 +581,7 @@ function ScoreCardSub({
               type="checkbox"
               checked={!!m.ok}
               onChange={(e) =>
-                setMetrics(
-                  metrics.map((x, i) => (i === idx ? { ...x, ok: e.target.checked } : x))
-                )
+                setMetrics(metrics.map((x, i) => (i === idx ? { ...x, ok: e.target.checked } : x)))
               }
               className="h-3 w-3"
               aria-label={`Metric ${idx + 1} ok-tinted`}
@@ -635,9 +634,7 @@ function TagsCardSub({
           <ToneSelect
             value={(tag.tone as Tone | undefined) ?? 'default'}
             options={TONE_OPTIONS}
-            onChange={(tone) =>
-              set({ tags: tags.map((t, i) => (i === idx ? { ...t, tone } : t)) })
-            }
+            onChange={(tone) => set({ tags: tags.map((t, i) => (i === idx ? { ...t, tone } : t)) })}
             ariaLabel={`Tag ${idx + 1} tone`}
           />
           <RowDeleteBtn onClick={() => set({ tags: tags.filter((_, i) => i !== idx) })} />
@@ -691,9 +688,7 @@ function AICardSub({
             className="h-7 flex-1 text-xs"
             aria-label={`Action ${idx + 1} label`}
           />
-          <RowDeleteBtn
-            onClick={() => set({ actions: actions.filter((_, i) => i !== idx) })}
-          />
+          <RowDeleteBtn onClick={() => set({ actions: actions.filter((_, i) => i !== idx) })} />
         </div>
       ))}
     </div>

--- a/kelta-ui/app/src/pages/PageLayoutsPage/components/RelatedListPanel.tsx
+++ b/kelta-ui/app/src/pages/PageLayoutsPage/components/RelatedListPanel.tsx
@@ -350,7 +350,11 @@ export function RelatedListPanel(): React.ReactElement {
   // remaining displayable fields in their natural order. Computed each render
   // so we don't need an effect to reconcile when fields load or change.
   const displayOrder = useMemo(
-    () => computeDisplayOrder(displayableFields.map((f) => f.name), orderedFieldNames),
+    () =>
+      computeDisplayOrder(
+        displayableFields.map((f) => f.name),
+        orderedFieldNames
+      ),
     [displayableFields, orderedFieldNames]
   )
 

--- a/kelta-ui/app/src/pages/PageLayoutsPage/components/relatedListColumnOrder.test.ts
+++ b/kelta-ui/app/src/pages/PageLayoutsPage/components/relatedListColumnOrder.test.ts
@@ -12,12 +12,7 @@ describe('computeDisplayOrder', () => {
   })
 
   it('floats user-arranged fields to the front in their stored order', () => {
-    expect(computeDisplayOrder(['a', 'b', 'c', 'd'], ['c', 'a'])).toEqual([
-      'c',
-      'a',
-      'b',
-      'd',
-    ])
+    expect(computeDisplayOrder(['a', 'b', 'c', 'd'], ['c', 'a'])).toEqual(['c', 'a', 'b', 'd'])
   })
 
   it('drops stored names that are no longer available', () => {
@@ -25,22 +20,13 @@ describe('computeDisplayOrder', () => {
   })
 
   it('appends newly available fields after the user-arranged prefix', () => {
-    expect(computeDisplayOrder(['a', 'b', 'newField'], ['b', 'a'])).toEqual([
-      'b',
-      'a',
-      'newField',
-    ])
+    expect(computeDisplayOrder(['a', 'b', 'newField'], ['b', 'a'])).toEqual(['b', 'a', 'newField'])
   })
 })
 
 describe('reorderColumns', () => {
   it('moves dragged item into the target position', () => {
-    expect(reorderColumns(['a', 'b', 'c', 'd'], 'd', 'b')).toEqual([
-      'a',
-      'd',
-      'b',
-      'c',
-    ])
+    expect(reorderColumns(['a', 'b', 'c', 'd'], 'd', 'b')).toEqual(['a', 'd', 'b', 'c'])
   })
 
   it('returns a fresh copy when the move is a no-op', () => {
@@ -81,10 +67,7 @@ describe('swapAdjacent', () => {
 
 describe('selectedInDisplayOrder', () => {
   it('filters selected names to the order from displayOrder', () => {
-    expect(selectedInDisplayOrder(['a', 'b', 'c', 'd'], ['d', 'b'])).toEqual([
-      'b',
-      'd',
-    ])
+    expect(selectedInDisplayOrder(['a', 'b', 'c', 'd'], ['d', 'b'])).toEqual(['b', 'd'])
   })
 
   it('drops selected names that are not in displayOrder', () => {

--- a/kelta-ui/app/src/pages/ResourceDetailPage/ResourceDetailPage.test.tsx
+++ b/kelta-ui/app/src/pages/ResourceDetailPage/ResourceDetailPage.test.tsx
@@ -200,7 +200,6 @@ vi.mock('../../components/LayoutFieldSections/LayoutFieldSections', () => ({
   LayoutFieldSections: () => <div data-testid="layout-field-sections">Layout Fields</div>,
 }))
 
-
 // Sample test data
 const mockSchema: CollectionSchema = {
   id: 'col-1',

--- a/kelta-ui/app/src/pages/ResourceFormPage/ResourceFormPage.tsx
+++ b/kelta-ui/app/src/pages/ResourceFormPage/ResourceFormPage.tsx
@@ -11,7 +11,7 @@
  * - 12.4: Use custom field renderers when registered, fall back to defaults
  */
 
-import React, { useState, useCallback, useMemo, useRef } from 'react'
+import React, { useState, useCallback, useEffect, useMemo, useRef } from 'react'
 import { useParams, useNavigate, useSearchParams, Link } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { cn } from '@/lib/utils'
@@ -372,10 +372,7 @@ export function ResourceFormPage({
   // Convert raw layout-rules DTOs into the typed LayoutRule[] the engine
   // consumes. Memoized on the rules array so the engine memo inside
   // useLayoutRules is stable and doesn't rebuild every render.
-  const layoutRules = useMemo(
-    () => dtosToLayoutRules(layout?.rules, ''),
-    [layout?.rules],
-  )
+  const layoutRules = useMemo(() => dtosToLayoutRules(layout?.rules, ''), [layout?.rules])
 
   // Mirror collection-wide validation rules with enforce_on_client = true so
   // the form can show inline errors live and block submission for ERROR
@@ -388,7 +385,7 @@ export function ResourceFormPage({
       if (!schema?.id) return []
       try {
         return await apiClient.getList<import('@kelta/sdk').CollectionValidationRule>(
-          `/api/validation-rules?filter[collectionId][eq]=${schema.id}&filter[active][eq]=true&filter[enforceOnClient][eq]=true&page[size]=100`,
+          `/api/validation-rules?filter[collectionId][eq]=${schema.id}&filter[active][eq]=true&filter[enforceOnClient][eq]=true&page[size]=100`
         )
       } catch {
         return []
@@ -966,9 +963,12 @@ export function ResourceFormPage({
   // Mirror formData in a ref so handleFieldChange can compute the post-mutation
   // values map and pass it straight into the engine, bypassing the
   // useState/useRef async-update race that would otherwise have the engine
-  // evaluate against stale values.
+  // evaluate against stale values. Updated in an effect (not during render)
+  // to satisfy react-hooks/refs.
   const formDataRef = useRef(formData)
-  formDataRef.current = formData
+  useEffect(() => {
+    formDataRef.current = formData
+  }, [formData])
 
   const handleFieldChange = useCallback(
     (fieldName: string, value: unknown) => {
@@ -995,7 +995,7 @@ export function ResourceFormPage({
     (fieldName: string) => {
       ruleEngine.onFieldBlur(fieldName, formDataRef.current)
     },
-    [ruleEngine],
+    [ruleEngine]
   )
 
   /**
@@ -1015,10 +1015,7 @@ export function ResourceFormPage({
       // allow the submit to proceed.
       const ruleResult = ruleEngine.runBeforeSave()
       if (ruleResult.blocked) {
-        showToast(
-          ruleResult.violations[0]?.message ?? t('errors.validation'),
-          'error',
-        )
+        showToast(ruleResult.violations[0]?.message ?? t('errors.validation'), 'error')
         return
       }
 
@@ -1096,7 +1093,17 @@ export function ResourceFormPage({
         createMutation.mutate(submitData)
       }
     },
-    [validateForm, sortedFields, formData, isEditMode, updateMutation, createMutation, showToast, t, ruleEngine]
+    [
+      validateForm,
+      sortedFields,
+      formData,
+      isEditMode,
+      updateMutation,
+      createMutation,
+      showToast,
+      t,
+      ruleEngine,
+    ]
   )
 
   /**

--- a/kelta-ui/app/src/pages/app/ObjectDetailPage/ObjectDetailPage.tsx
+++ b/kelta-ui/app/src/pages/app/ObjectDetailPage/ObjectDetailPage.tsx
@@ -49,11 +49,7 @@ import {
   DropdownMenuItem,
   DropdownMenuSeparator,
 } from '@/components/detail'
-import type {
-  RecordHeaderAction,
-  RecordHeaderMetaField,
-  MetadataRow,
-} from '@/components/detail'
+import type { RecordHeaderAction, RecordHeaderMetaField, MetadataRow } from '@/components/detail'
 import type { LayoutRelatedListDto } from '@/hooks/usePageLayout'
 import { useInspectMode } from '@/hooks/useInspectMode'
 import { cn } from '@/lib/utils'
@@ -738,9 +734,7 @@ export function ObjectDetailPage(): React.ReactElement {
 
                       return (
                         <div key={field.name} className="min-w-0 space-y-1">
-                          <dt className="kelta-field-label">
-                            {field.displayName || field.name}
-                          </dt>
+                          <dt className="kelta-field-label">{field.displayName || field.name}</dt>
                           <dd className="text-sm font-medium">
                             <FieldRenderer
                               type={field.type}
@@ -791,9 +785,7 @@ export function ObjectDetailPage(): React.ReactElement {
           {railBlocks && railBlocks.length > 0 ? (
             <RailRenderer blocks={railBlocks} />
           ) : (
-            <MetadataCard
-              config={{ title: 'System information', rows: systemRows }}
-            />
+            <MetadataCard config={{ title: 'System information', rows: systemRows }} />
           )}
         </aside>
       </div>

--- a/kelta-ui/app/src/pages/app/ObjectFormPage/ObjectFormPage.tsx
+++ b/kelta-ui/app/src/pages/app/ObjectFormPage/ObjectFormPage.tsx
@@ -16,7 +16,7 @@
  * - Loading states
  */
 
-import React, { useState, useCallback, useMemo, useRef } from 'react'
+import React, { useState, useCallback, useEffect, useMemo, useRef } from 'react'
 import { useNavigate, useParams, useSearchParams, Link } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
 import { Save, X, Loader2, AlertCircle } from 'lucide-react'
@@ -434,10 +434,7 @@ function ObjectFormBody({
   // Layout client-side rules engine: compute/validate/default/transform rules
   // attached to the resolved layout. The engine is no-op when the layout has
   // no rules (engine.enabled === false).
-  const layoutRules = useMemo(
-    () => dtosToLayoutRules(layout?.rules, ''),
-    [layout?.rules],
-  )
+  const layoutRules = useMemo(() => dtosToLayoutRules(layout?.rules, ''), [layout?.rules])
   const setFieldValueForEngine = useCallback((name: string, value: unknown) => {
     setFormData((prev) => ({ ...prev, [name]: value }))
   }, [])
@@ -504,9 +501,12 @@ function ObjectFormBody({
   // Handle field change. Use a functional ref of the latest values so we can
   // pass the post-mutation map directly to the engine — without that, the
   // engine reads stale values because setFormData is async and useLayoutRules'
-  // valuesRef only refreshes on the next render.
+  // valuesRef only refreshes on the next render. Sync the ref via effect to
+  // satisfy react-hooks/refs (no direct .current = during render).
   const formDataRef = useRef(formData)
-  formDataRef.current = formData
+  useEffect(() => {
+    formDataRef.current = formData
+  }, [formData])
   const handleFieldChange = useCallback(
     (name: string, value: unknown) => {
       const next = { ...formDataRef.current, [name]: value }

--- a/kelta-ui/app/src/telemetry/index.test.ts
+++ b/kelta-ui/app/src/telemetry/index.test.ts
@@ -135,7 +135,7 @@ describe('telemetry', () => {
         filename: 'app.js',
         lineno: 10,
         colno: 5,
-      }),
+      })
     )
 
     expect(startSpanMock).toHaveBeenCalledWith(
@@ -146,12 +146,10 @@ describe('telemetry', () => {
           'error.lineno': '10',
           'error.colno': '5',
         }),
-      }),
+      })
     )
     expect(recordExceptionMock).toHaveBeenCalledWith(err)
-    expect(setStatusMock).toHaveBeenCalledWith(
-      expect.objectContaining({ code: 2 }),
-    )
+    expect(setStatusMock).toHaveBeenCalledWith(expect.objectContaining({ code: 2 }))
     expect(endMock).toHaveBeenCalled()
   })
 
@@ -166,10 +164,7 @@ describe('telemetry', () => {
     Object.defineProperty(event, 'promise', { value: Promise.resolve() })
     window.dispatchEvent(event)
 
-    expect(startSpanMock).toHaveBeenCalledWith(
-      'browser.unhandled_rejection',
-      expect.any(Object),
-    )
+    expect(startSpanMock).toHaveBeenCalledWith('browser.unhandled_rejection', expect.any(Object))
     expect(recordExceptionMock).toHaveBeenCalledWith(reason)
   })
 })

--- a/kelta-ui/app/src/telemetry/index.ts
+++ b/kelta-ui/app/src/telemetry/index.ts
@@ -5,10 +5,7 @@ import { ZoneContextManager } from '@opentelemetry/context-zone'
 import { FetchInstrumentation } from '@opentelemetry/instrumentation-fetch'
 import { XMLHttpRequestInstrumentation } from '@opentelemetry/instrumentation-xml-http-request'
 import { Resource } from '@opentelemetry/resources'
-import {
-  ATTR_SERVICE_NAME,
-  ATTR_SERVICE_VERSION,
-} from '@opentelemetry/semantic-conventions'
+import { ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION } from '@opentelemetry/semantic-conventions'
 import { W3CTraceContextPropagator } from '@opentelemetry/core'
 import { registerInstrumentations } from '@opentelemetry/instrumentation'
 import { SpanStatusCode, trace, type Tracer } from '@opentelemetry/api'
@@ -61,8 +58,7 @@ export function initTelemetry(): void {
 
   const serviceName = env?.VITE_OTEL_SERVICE_NAME || 'kelta-ui'
   const serviceNamespace = env?.VITE_OTEL_SERVICE_NAMESPACE || 'emf'
-  const deploymentEnvironment =
-    env?.VITE_OTEL_DEPLOYMENT_ENVIRONMENT || 'production'
+  const deploymentEnvironment = env?.VITE_OTEL_DEPLOYMENT_ENVIRONMENT || 'production'
   const serviceVersion = env?.VITE_APP_VERSION || 'unknown'
 
   const resource = new Resource({
@@ -71,10 +67,8 @@ export function initTelemetry(): void {
     [ATTR_SERVICE_VERSION]: serviceVersion,
     [ATTR_DEPLOYMENT_ENVIRONMENT]: deploymentEnvironment,
     [ATTR_SESSION_ID]: generateSessionId(),
-    [ATTR_BROWSER_USER_AGENT]:
-      typeof navigator !== 'undefined' ? navigator.userAgent : '',
-    [ATTR_BROWSER_LANGUAGE]:
-      typeof navigator !== 'undefined' ? navigator.language : '',
+    [ATTR_BROWSER_USER_AGENT]: typeof navigator !== 'undefined' ? navigator.userAgent : '',
+    [ATTR_BROWSER_LANGUAGE]: typeof navigator !== 'undefined' ? navigator.language : '',
   })
 
   const exporter = new OTLPTraceExporter({
@@ -135,7 +129,7 @@ export function getTracer(): Tracer | null {
 function recordBrowserError(
   name: string,
   error: unknown,
-  extraAttrs: Record<string, string> = {},
+  extraAttrs: Record<string, string> = {}
 ): void {
   if (!tracer) return
 

--- a/kelta-ui/app/src/utils/layoutRules.ts
+++ b/kelta-ui/app/src/utils/layoutRules.ts
@@ -42,7 +42,9 @@ export function dtoToLayoutRule(dto: LayoutRuleDto, tenantId: string): LayoutRul
         kind: 'default',
         target: dto.targetField ?? '',
         formula: String(body.formula ?? ''),
-        triggerFields: Array.isArray(body.triggerFields) ? (body.triggerFields as string[]) : undefined,
+        triggerFields: Array.isArray(body.triggerFields)
+          ? (body.triggerFields as string[])
+          : undefined,
       }
     case 'VALIDATE': {
       const enforce = body.enforce === 'warn' ? 'warn' : 'block'
@@ -57,10 +59,17 @@ export function dtoToLayoutRule(dto: LayoutRuleDto, tenantId: string): LayoutRul
     }
     case 'TRANSFORM': {
       const t = (body.transform as { type?: string; formula?: string }) ?? {}
-      let transform: { type: 'upper' | 'lower' | 'trim' | 'titleCase' } | { type: 'formula'; formula: string }
+      let transform:
+        | { type: 'upper' | 'lower' | 'trim' | 'titleCase' }
+        | { type: 'formula'; formula: string }
       if (t.type === 'formula') {
         transform = { type: 'formula', formula: String(t.formula ?? '') }
-      } else if (t.type === 'upper' || t.type === 'lower' || t.type === 'trim' || t.type === 'titleCase') {
+      } else if (
+        t.type === 'upper' ||
+        t.type === 'lower' ||
+        t.type === 'trim' ||
+        t.type === 'titleCase'
+      ) {
         transform = { type: t.type }
       } else {
         return null
@@ -91,7 +100,7 @@ function parseJsonField<T>(raw: unknown, fallback: T): T {
 
 export function dtosToLayoutRules(
   dtos: LayoutRuleDto[] | undefined,
-  tenantId: string,
+  tenantId: string
 ): LayoutRule[] {
   if (!dtos) return []
   return dtos

--- a/kelta-ui/app/src/utils/uuid.ts
+++ b/kelta-ui/app/src/utils/uuid.ts
@@ -13,19 +13,18 @@
  * Math.random for non-browser/test environments.
  */
 export function uuid(): string {
-  const c: Crypto | undefined =
-    typeof globalThis !== 'undefined' ? globalThis.crypto : undefined;
+  const c: Crypto | undefined = typeof globalThis !== 'undefined' ? globalThis.crypto : undefined
 
   if (c && typeof c.randomUUID === 'function') {
-    return c.randomUUID();
+    return c.randomUUID()
   }
 
   if (c && typeof c.getRandomValues === 'function') {
-    const bytes = c.getRandomValues(new Uint8Array(16));
+    const bytes = c.getRandomValues(new Uint8Array(16))
     // Per RFC 4122 §4.4: set version (4) and variant (10xx) bits.
-    bytes[6] = (bytes[6] & 0x0f) | 0x40;
-    bytes[8] = (bytes[8] & 0x3f) | 0x80;
-    const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, '0'));
+    bytes[6] = (bytes[6] & 0x0f) | 0x40
+    bytes[8] = (bytes[8] & 0x3f) | 0x80
+    const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, '0'))
     return (
       hex.slice(0, 4).join('') +
       '-' +
@@ -36,15 +35,15 @@ export function uuid(): string {
       hex.slice(8, 10).join('') +
       '-' +
       hex.slice(10, 16).join('')
-    );
+    )
   }
 
   // Last resort (non-crypto): only reached in environments without Web
   // Crypto at all. Not cryptographically strong but collision-safe enough
   // for client-side element/block ids.
   return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (ch) => {
-    const r = (Math.random() * 16) | 0;
-    const v = ch === 'x' ? r : (r & 0x3) | 0x8;
-    return v.toString(16);
-  });
+    const r = (Math.random() * 16) | 0
+    const v = ch === 'x' ? r : (r & 0x3) | 0x8
+    return v.toString(16)
+  })
 }

--- a/kelta-ui/app/vitest.config.ts
+++ b/kelta-ui/app/vitest.config.ts
@@ -40,6 +40,12 @@ export default defineConfig({
       // the workspace package; npm's symlink alone isn't always enough when
       // the import is hoisted across packages.
       '@kelta/formula': resolve(__dirname, 'node_modules/@kelta/formula'),
+      // Force a single React instance across all workspace packages. Without
+      // this, @kelta/components uses its own (hoisted) React copy and hooks
+      // like useRef return null because hook dispatcher state lives in a
+      // different React module instance than the test renderer's React.
+      react: resolve(__dirname, 'node_modules/react'),
+      'react-dom': resolve(__dirname, 'node_modules/react-dom'),
     },
   },
 })

--- a/kelta-web/packages/components/src/detail/AddressMap.tsx
+++ b/kelta-web/packages/components/src/detail/AddressMap.tsx
@@ -78,10 +78,14 @@ function staticMapUrl(
   tokenOverride?: string,
   styleOverride?: string
 ): string {
+  // import.meta.env is provided by Vite at consumer-app build time. The
+  // double `as unknown` step lets the cast through without TS complaining
+  // about insufficient type overlap.
   const env =
     typeof import.meta !== 'undefined' &&
-    typeof (import.meta as { env?: Record<string, string | undefined> }).env !== 'undefined'
-      ? (import.meta as { env: Record<string, string | undefined> }).env
+    typeof (import.meta as unknown as { env?: Record<string, string | undefined> }).env !==
+      'undefined'
+      ? (import.meta as unknown as { env: Record<string, string | undefined> }).env
       : undefined;
   const mapboxToken = tokenOverride ?? env?.VITE_MAPBOX_TOKEN;
   if (mapboxToken) {

--- a/kelta-web/packages/sdk/src/admin/types.ts
+++ b/kelta-web/packages/sdk/src/admin/types.ts
@@ -2,7 +2,7 @@
  * Admin/Control Plane types
  */
 
-import type { AuthzConfig } from '../types';
+import type { AuthzConfig, ValidationRule } from '../types';
 
 /**
  * Collection definition for admin operations
@@ -102,6 +102,12 @@ export interface FieldDefinition {
   active?: boolean;
   description?: string;
   constraints?: string;
+  /**
+   * Per-field validation rules. Distinct from the schema-level
+   * {@code validation} module — these run client-side before submit and
+   * are also enforced server-side by the worker.
+   */
+  validation?: ValidationRule[];
   relationshipType?: 'LOOKUP' | 'MASTER_DETAIL';
   relationshipName?: string;
   cascadeDelete?: boolean;

--- a/kelta-web/packages/sdk/src/types.ts
+++ b/kelta-web/packages/sdk/src/types.ts
@@ -2,6 +2,11 @@
  * Core types used throughout the SDK
  */
 
+// Re-export the admin FieldDefinition so consumers and ResourceMetadata
+// share a single shape. Type-only import — no runtime cycle.
+import type { FieldDefinition } from './admin/types';
+export type { FieldDefinition };
+
 /**
  * Resource metadata from discovery endpoint
  */
@@ -11,44 +16,6 @@ export interface ResourceMetadata {
   fields: FieldDefinition[];
   operations: string[];
   authz?: AuthzConfig;
-}
-
-/**
- * Field definition within a resource
- */
-export interface FieldDefinition {
-  name: string;
-  type:
-    | 'string'
-    | 'number'
-    | 'boolean'
-    | 'date'
-    | 'datetime'
-    | 'json'
-    | 'reference'
-    | 'picklist'
-    | 'multi_picklist'
-    | 'currency'
-    | 'percent'
-    | 'auto_number'
-    | 'phone'
-    | 'email'
-    | 'url'
-    | 'rich_text'
-    | 'encrypted'
-    | 'external_id'
-    | 'geolocation'
-    | 'lookup'
-    | 'master_detail'
-    | 'formula'
-    | 'rollup_summary';
-  displayName?: string;
-  required?: boolean;
-  unique?: boolean;
-  validation?: ValidationRule[];
-  defaultValue?: unknown;
-  referenceTarget?: string;
-  fieldTypeConfig?: Record<string, unknown>;
 }
 
 /**


### PR DESCRIPTION
Pre-existing CI failures across the frontend that surfaced during Tier-2 work. None of these were introduced by recent feature PRs but they were blocking E2E and frontend CI on every main build.

## SDK
- **Unify `FieldDefinition`**: the admin variant now also carries `validation?: ValidationRule[]`, and [`src/types.ts`](kelta-web/packages/sdk/src/types.ts) re-exports the admin definition so `ResourceMetadata.fields` resolves to the same shape every consumer imports from `@kelta/sdk`. Type-only cyclic import; no runtime cycle.
- **AddressMap**: cast `import.meta` via `as unknown as` to satisfy TS strict overlap rules.

## UI lint errors (16 → 0)
- **ResourceFormPage / ObjectFormPage**: move `formDataRef.current =` into `useEffect` so refs no longer mutate during render.
- **Header / PayloadMapper / RulesEditor**: targeted `eslint-disable` for intentional setState-in-effect synchronisations (subscribe-on-mount, resync editor from props, cycle-detection algorithm).
- **RulesEditor**: add `htmlFor` + matching `id` to every form-label control pair (Kind, Name, Description, Target field, Transform type, Formula, Error message, Enforce, Sort order); the When fieldset uses a `<span>` since its children are nested-label checkboxes.
- **ApiTokensPage**: `eslint-disable` for `resolveMcpBaseUrl` / `buildMcpAddCommand` exports alongside the page component (react-refresh/only-export-components).

## UI tests (63 → 0 failing)
- **App.test.tsx**: register missing page mocks for `MapSettingsPage`, `CredentialsPage`, `ApiSpecsPage`, `ApiSpecDetailPage`. Without these, every protected-route test failed at module import.
- **vitest.config.ts**: alias `react` + `react-dom` to the consumer app's `node_modules`. Without this, `@kelta/components` hooks (used by `ResourceFormPage` via `useLayoutRules`) ran against a different React instance and crashed with `Cannot read properties of null (reading 'useRef')`.

## Prettier
- 41 files reformatted by `prettier --write` to satisfy the format:check gate. Pure whitespace and quote-style normalisation.

## Net result locally
- `npm run lint` — 0 errors, 12 pre-existing warnings
- `npm run typecheck` — clean
- `npm run format:check` — clean
- `npm run test:run` — 83 files, 1686 passed, 34 skipped

## Why now
Tier-2 PRs that added new tier badge / SDK types / page imports surfaced the existing test mock omissions immediately (CI failed PR after PR on the same shape). Bundling all the cleanup here so CI returns to green for everything downstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)