### PR TITLE
feat(runtime): tier-3 cell-based routing skeleton

### DIFF
--- a/.claude/docs/cell-architecture.md
+++ b/.claude/docs/cell-architecture.md
@@ -1,0 +1,86 @@
+# Cell-based architecture (Tier 3)
+
+## Why cells
+
+A single-stack deployment — one gateway + one worker + one auth + one ai
+serving every tenant — has hard ceilings:
+
+| Resource | Ceiling | Reached at |
+|----------|--------:|-----------:|
+| Postgres `max_connections` (single primary) | 500-1k | ~3-5 worker pods × 30 connections + auth + ai + cerbos |
+| Postgres write throughput (single primary) | 5-10 KTPS sustained | ~1k active tenants writing concurrently |
+| Redis single-node ops/sec | ~100k | gateway rate limit + cache invalidation traffic at ~50 RPS/tenant × 1k tenants |
+| NATS JetStream subjects | O(subjects × consumers) memory | ~10k subjects (per-tenant per-collection record events) |
+| Cerbos PDP CPU | ~10k decisions/sec single instance | tail of large tenant write load |
+
+Cells shard tenants across N independent stacks so each one is below
+those single-node ceilings. Adding capacity = adding cells. Blast radius
+of an incident = one cell.
+
+## What a cell is
+
+```
+                          ┌──────────────────────────────────────────┐
+                          │ Routing layer                            │
+                          │ (Traefik / ingress NGINX)                │
+                          │ Reads X-Tenant-Slug, looks up tenant→cell│
+                          │ via TenantCellResolver, routes to:       │
+                          └────────┬────────────────────┬────────────┘
+                                   │                    │
+                ┌──────────────────┴───┐    ┌───────────┴──────────────┐
+                │ Cell "default"       │    │ Cell "enterprise-1"      │
+                │  - gateway           │    │  - gateway               │
+                │  - worker (N pods)   │    │  - worker (N pods)       │
+                │  - auth              │    │  - auth                  │
+                │  - ai                │    │  - ai                    │
+                │  - cerbos            │    │  - cerbos                │
+                │  - postgres-default  │    │  - postgres-enterprise-1 │
+                │  - redis-default     │    │  - redis-enterprise-1    │
+                │  - nats-default      │    │  - nats-enterprise-1     │
+                └──────────────────────┘    └──────────────────────────┘
+```
+
+Each cell is a complete platform stack. Tenants are pinned to a single
+cell — there is no cross-cell query path. Operator moves a tenant to a
+new cell by:
+
+1. Stop accepting new writes from the tenant (governor `apiCallsPerDay=0`).
+2. Snapshot the tenant's rows from the source cell's Postgres.
+3. Restore into the destination cell's Postgres.
+4. Set `tenant.cell_id` to the new cell.
+5. Re-open writes.
+
+(A live-migration tool ships in a later phase. For now, plan is
+overnight maintenance windows per tenant.)
+
+## What's in place today (skeleton)
+
+- **V137 migration** adds `tenant.cell_id VARCHAR(64) NOT NULL DEFAULT 'default'` plus an index on the column. Every existing tenant gets `cell_id = 'default'`.
+- **TenantCellResolver interface** in `kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/cell/TenantCellResolver.java`.
+- **JdbcTenantCellResolver** in the same package — reads `tenant.cell_id`, caches indefinitely in process, fail-open to `DEFAULT_CELL_ID` on DB error.
+- **8 unit tests** for the JDBC resolver: default-on-blank, cache hits, missing row, null value, DB error fail-open, invalidate one, invalidate all.
+
+The runtime does not yet read `cell_id` for routing decisions — see "Not yet shipped" below.
+
+## Not yet shipped (follow-up PRs)
+
+1. **Gateway routing layer**: when more than one cell exists, ingress (Traefik or NGINX) needs to read `X-Tenant-Slug` from the incoming request, hit a tenant→cell lookup service (the `TenantCellResolver`), and route to the correct gateway. Today the gateway runs as a single deployment per cluster; we need either a router-in-front-of-gateways or a header-aware gateway that proxies to other gateways.
+2. **Cell-aware ArgoCD apps**: every cell needs its own gateway / worker / auth / ai / DB / Redis / NATS Helm release. Today `homelab-argo/emf/` ships one of each. A `homelab-argo/cells/default/` + `homelab-argo/cells/enterprise-1/` split is the cell-app pattern.
+3. **NATS subject scoping per cell**: `kelta.config.collection.changed.<tenantId>` and `kelta.record.changed.{tenantId}.{collection}` should also include the cell id (`kelta.cell.default.config.collection.changed.<tenantId>`) so cells do not subscribe to each other's events.
+4. **Per-cell observability**: each cell labels its metrics/traces with `cell=<id>` so Grafana can break down per-cell load. Add `OTEL_RESOURCE_ATTRIBUTES=cell=default` to each cell's deployment env.
+5. **Cell rebalancing tool**: operator-driven snapshot/restore between cells, or a streaming logical-replication path.
+6. **NATS-driven cache invalidation** on `JdbcTenantCellResolver`: when a tenant's cell assignment changes, broadcast on a NATS subject and call `invalidate(tenantId)` on every pod's resolver.
+
+## Migration strategy
+
+- **Phase 0 (now)**: skeleton landed. Everyone in cell `default`. No behavioral change.
+- **Phase 1**: ship cell-aware routing layer in the homelab-argo repo with one cell still in use. Validate the routing path with all traffic still hitting `default`.
+- **Phase 2**: stand up `enterprise-1` cell. Move one volunteer tenant. Run dual-cell for a week before adding more.
+- **Phase 3**: cell auto-assignment policy (tier-based: FREE/PROFESSIONAL → `default`, ENTERPRISE/UNLIMITED → dedicated cell). Run for a quarter.
+- **Phase 4**: regional cells (`us-east-1`, `eu-west-1`) for data residency.
+
+## Constraints / risks
+
+- **No cross-cell joins.** Every tenant query must execute entirely inside its cell. Code that today JOINs across the `tenant` table from a different DB cannot survive this split. Audit before shipping cell #2.
+- **Cell directory is the new single point of failure.** The `tenant → cell` mapping (currently the `tenant.cell_id` column on the cell-zero Postgres) becomes a global dependency. Once we ship multi-cell, this lookup must be cached extensively and replicated. Plan to move it to a small dedicated "cell directory" service or Redis layer that all cells consult.
+- **PgBouncer compatibility**: each cell gets its own PgBouncer in front of its Postgres. Session-pool mode applies cell-wide (see `concerns.md` → "Connection Pooler Compatibility").

--- a/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/cell/JdbcTenantCellResolver.java
+++ b/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/cell/JdbcTenantCellResolver.java
@@ -1,0 +1,79 @@
+package io.kelta.runtime.cell;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * JDBC-backed {@link TenantCellResolver}. Reads {@code tenant.cell_id} and
+ * caches the result indefinitely in process. The cache is intentionally
+ * unbounded but the per-tenant memory cost is bytes (UUID string → short
+ * cell id string) so this scales to the active-tenant ceiling of any
+ * single pod.
+ *
+ * <p>Cache invalidation: cell assignment is operator-driven (a tenant is
+ * pinned to a cell when it provisions, rebalanced rarely). When a tenant
+ * moves cells, restart the pods that have cached the old assignment, or
+ * publish a NATS event and call {@link #invalidate(String)}. We don't ship
+ * the eviction listener yet — flagged for the follow-up gateway-side
+ * routing PR.
+ *
+ * @since 1.0.0
+ */
+public final class JdbcTenantCellResolver implements TenantCellResolver {
+
+    private static final Logger log = LoggerFactory.getLogger(JdbcTenantCellResolver.class);
+
+    private static final String SELECT_CELL =
+            "SELECT cell_id FROM tenant WHERE id = ?";
+
+    private final JdbcTemplate jdbcTemplate;
+    private final ConcurrentHashMap<String, String> cache = new ConcurrentHashMap<>();
+
+    public JdbcTenantCellResolver(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    @Override
+    public String cellFor(String tenantId) {
+        if (tenantId == null || tenantId.isBlank()) {
+            return DEFAULT_CELL_ID;
+        }
+        return cache.computeIfAbsent(tenantId, this::lookup);
+    }
+
+    private String lookup(String tenantId) {
+        try {
+            String cellId = jdbcTemplate.queryForObject(SELECT_CELL, String.class, tenantId);
+            return (cellId == null || cellId.isBlank()) ? DEFAULT_CELL_ID : cellId;
+        } catch (Exception e) {
+            // Empty result, DB hiccup, etc. — default cell is safe.
+            log.debug("Cell lookup failed for tenant {} — defaulting to '{}': {}",
+                    tenantId, DEFAULT_CELL_ID, e.getMessage());
+            return DEFAULT_CELL_ID;
+        }
+    }
+
+    /**
+     * Drops a cached entry so the next {@link #cellFor(String)} hits the
+     * database again. Intended for a future NATS-driven invalidation
+     * listener (when an operator rebalances a tenant to a new cell).
+     */
+    public void invalidate(String tenantId) {
+        if (tenantId == null) {
+            return;
+        }
+        cache.remove(tenantId);
+    }
+
+    /** Drop all cached entries. */
+    public void invalidateAll() {
+        cache.clear();
+    }
+
+    int cachedSize() {
+        return cache.size();
+    }
+}

--- a/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/cell/TenantCellResolver.java
+++ b/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/cell/TenantCellResolver.java
@@ -1,0 +1,40 @@
+package io.kelta.runtime.cell;
+
+/**
+ * Resolves the cell (shard) a tenant lives in. Used by routing layers to
+ * direct a request to the cell-local stack (gateway / worker / DB / Redis /
+ * NATS) for that tenant.
+ *
+ * <p><b>Why cells.</b> A single-stack deployment hits per-pod and per-DB
+ * limits at roughly 1-5K active tenants depending on workload mix. Cells
+ * shard tenants across N independent stacks so:
+ * <ul>
+ *   <li>Adding capacity = adding cells, not scaling one stack horizontally
+ *       past Postgres and Redis single-node ceilings.</li>
+ *   <li>Blast radius of an incident is one cell, not the platform.</li>
+ *   <li>Dedicated cells for paid / enterprise tenants isolate noisy
+ *       neighbors from the long tail of free / trial tenants.</li>
+ * </ul>
+ *
+ * <p><b>Current state (Tier 3 skeleton).</b> Every tenant routes to the
+ * {@link #DEFAULT_CELL_ID} cell. The {@code tenant.cell_id} column (V137)
+ * carries the assignment so flipping a tenant to a different cell is a
+ * single UPDATE — but the gateway routing layer doesn't yet read this
+ * field. That ships in the next Tier-3 PR.
+ *
+ * @since 1.0.0
+ */
+public interface TenantCellResolver {
+
+    /** Cell id every tenant lives in until a multi-cell deployment is wired up. */
+    String DEFAULT_CELL_ID = "default";
+
+    /**
+     * Returns the cell id for the given tenant. Implementations may cache.
+     *
+     * @param tenantId the tenant id (UUID string)
+     * @return the cell id; {@link #DEFAULT_CELL_ID} for any tenant whose
+     *         row is missing or whose cell_id column is null
+     */
+    String cellFor(String tenantId);
+}

--- a/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/cell/JdbcTenantCellResolverTest.java
+++ b/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/cell/JdbcTenantCellResolverTest.java
@@ -1,0 +1,121 @@
+package io.kelta.runtime.cell;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("JdbcTenantCellResolver")
+class JdbcTenantCellResolverTest {
+
+    @Mock
+    private JdbcTemplate jdbcTemplate;
+
+    private JdbcTenantCellResolver resolver;
+
+    @BeforeEach
+    void setUp() {
+        resolver = new JdbcTenantCellResolver(jdbcTemplate);
+    }
+
+    @Test
+    @DisplayName("returns DEFAULT_CELL_ID for null or blank tenant id (no DB lookup)")
+    void returnsDefaultForBlank() {
+        assertThat(resolver.cellFor(null)).isEqualTo(TenantCellResolver.DEFAULT_CELL_ID);
+        assertThat(resolver.cellFor("")).isEqualTo(TenantCellResolver.DEFAULT_CELL_ID);
+        assertThat(resolver.cellFor("   ")).isEqualTo(TenantCellResolver.DEFAULT_CELL_ID);
+        assertThat(resolver.cachedSize()).isZero();
+    }
+
+    @Test
+    @DisplayName("returns the cell id from DB on first call")
+    void returnsCellFromDb() {
+        when(jdbcTemplate.queryForObject(anyString(), eq(String.class), eq("tenant-1")))
+                .thenReturn("cell-paid-1");
+
+        assertThat(resolver.cellFor("tenant-1")).isEqualTo("cell-paid-1");
+    }
+
+    @Test
+    @DisplayName("caches lookups — second call same tenant hits cache, no DB")
+    void cachesLookups() {
+        when(jdbcTemplate.queryForObject(anyString(), eq(String.class), eq("tenant-1")))
+                .thenReturn("cell-1");
+
+        resolver.cellFor("tenant-1");
+        resolver.cellFor("tenant-1");
+        resolver.cellFor("tenant-1");
+
+        verify(jdbcTemplate, times(1)).queryForObject(anyString(), eq(String.class), any(Object[].class));
+        assertThat(resolver.cachedSize()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("defaults to DEFAULT_CELL_ID when row missing")
+    void defaultsOnMissingRow() {
+        when(jdbcTemplate.queryForObject(anyString(), eq(String.class), eq("missing")))
+                .thenThrow(new EmptyResultDataAccessException(1));
+
+        assertThat(resolver.cellFor("missing")).isEqualTo(TenantCellResolver.DEFAULT_CELL_ID);
+    }
+
+    @Test
+    @DisplayName("defaults to DEFAULT_CELL_ID when DB returns null")
+    void defaultsOnNullValue() {
+        when(jdbcTemplate.queryForObject(anyString(), eq(String.class), eq("tenant-1")))
+                .thenReturn(null);
+
+        assertThat(resolver.cellFor("tenant-1")).isEqualTo(TenantCellResolver.DEFAULT_CELL_ID);
+    }
+
+    @Test
+    @DisplayName("fail-open on DB error — returns default + does not throw")
+    void failOpenOnDbError() {
+        when(jdbcTemplate.queryForObject(anyString(), eq(String.class), eq("tenant-1")))
+                .thenThrow(new RuntimeException("broker down"));
+
+        assertThat(resolver.cellFor("tenant-1")).isEqualTo(TenantCellResolver.DEFAULT_CELL_ID);
+    }
+
+    @Test
+    @DisplayName("invalidate drops one cache entry; next call re-reads DB")
+    void invalidateDropsEntry() {
+        when(jdbcTemplate.queryForObject(anyString(), eq(String.class), eq("tenant-1")))
+                .thenReturn("cell-1");
+
+        resolver.cellFor("tenant-1");
+        resolver.invalidate("tenant-1");
+        resolver.cellFor("tenant-1");
+
+        verify(jdbcTemplate, times(2)).queryForObject(anyString(), eq(String.class), any(Object[].class));
+    }
+
+    @Test
+    @DisplayName("invalidateAll drops every entry")
+    void invalidateAllDropsEverything() {
+        when(jdbcTemplate.queryForObject(anyString(), eq(String.class), any(Object[].class)))
+                .thenReturn("cell-1");
+
+        resolver.cellFor("a");
+        resolver.cellFor("b");
+        resolver.cellFor("c");
+        assertThat(resolver.cachedSize()).isEqualTo(3);
+
+        resolver.invalidateAll();
+
+        assertThat(resolver.cachedSize()).isZero();
+    }
+}

--- a/kelta-worker/src/main/resources/db/migration/V137__add_tenant_cell_id.sql
+++ b/kelta-worker/src/main/resources/db/migration/V137__add_tenant_cell_id.sql
@@ -1,0 +1,25 @@
+-- V137: add cell_id to tenant for Tier-3 cell-based deployment
+--
+-- Background: at >1k tenants the single-stack model (one gateway + worker
+-- + auth + ai serving everyone) hits per-pod, per-DB, and per-Redis limits.
+-- Cell-based architecture shards tenants across N independent stacks
+-- (cells), each with its own DB / Redis / NATS. Blast radius of an
+-- incident shrinks to one cell instead of the whole platform.
+--
+-- This migration only adds the routing column. Nothing in the runtime
+-- reads it yet — gateway routing changes ship in a follow-up. Defaulting
+-- to 'default' means every existing tenant is in the default cell, so
+-- adding this column is a no-op at runtime until we deploy a second cell.
+
+ALTER TABLE tenant
+    ADD COLUMN IF NOT EXISTS cell_id VARCHAR(64) NOT NULL DEFAULT 'default';
+
+-- Index on cell_id supports the gateway's tenant→cell lookup at request
+-- time. The lookup will be cached, but a missing index would still hurt
+-- on cache-cold pods at startup.
+CREATE INDEX IF NOT EXISTS idx_tenant_cell_id ON tenant(cell_id);
+
+COMMENT ON COLUMN tenant.cell_id IS
+    'Cell (shard) this tenant belongs to. ''default'' for everyone today; '
+    'becomes per-tenant once Tier-3 cell-based deployment ships. '
+    'Routes tenant traffic to a specific cell-local stack (gateway / worker / DB / Redis / NATS).';


### PR DESCRIPTION
## Summary

Phase-0 of the Tier-3 cell-based deployment plan. Lands the routing column + resolver wiring without changing any runtime behavior — every tenant still resolves to the `default` cell.

- **V137 migration** — `tenant.cell_id VARCHAR(64) NOT NULL DEFAULT 'default'` + `idx_tenant_cell_id`. Every existing tenant backfilled to `default`.
- **`TenantCellResolver`** interface (`DEFAULT_CELL_ID` + `cellFor`).
- **`JdbcTenantCellResolver`** — reads `tenant.cell_id`, caches in-process (unbounded, per-tenant cost = bytes), fail-open to `DEFAULT_CELL_ID` on DB error. Exposes `invalidate` / `invalidateAll` for the NATS-driven eviction listener we'll wire in the next PR.
- **8 unit tests** cover blank id, DB hit, cache reuse, missing row, null value, DB error fail-open, single invalidate, invalidateAll.
- **`.claude/docs/cell-architecture.md`** — single-stack ceilings table, cell topology diagram, migration phases 0–4, follow-up PR list, risks (no cross-cell joins, cell directory becomes a new SPOF, PgBouncer per-cell).

## Why now

Single-stack ceilings (one Postgres primary, one Redis, one NATS, one Cerbos PDP) start to matter around 1–5K active tenants depending on workload mix. Cells shard tenants across N independent stacks so adding capacity = adding cells, and the blast radius of an incident is one cell instead of the platform. See the doc for the ceilings table.

## What's NOT in this PR (follow-ups)

1. Gateway / ingress reads `X-Tenant-Slug`, resolves cell, routes to the cell-local gateway.
2. `homelab-argo` split: per-cell Helm releases for gateway / worker / auth / ai / DB / Redis / NATS.
3. NATS subjects scoped by cell id (`kelta.cell.default.config.collection.changed.<tenantId>`).
4. Per-cell observability (`OTEL_RESOURCE_ATTRIBUTES=cell=<id>`).
5. Operator snapshot/restore rebalancing tool.
6. NATS-driven `invalidate(tenantId)` on cell reassignment.

## Test plan

- [x] `mvn install -f kelta-platform/pom.xml -pl runtime/runtime-core -am -B` — BUILD SUCCESS, 8/8 cell tests pass.
- [ ] CI green on full Java + frontend pipeline.
- [ ] V137 applies cleanly on a fresh DB (column + index present, every existing tenant gets `cell_id = 'default'`).
- [ ] Verify no callers of `tenant.*` SELECTs break — column add is additive, but worth a grep before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)