### PR TITLE
feat(platform): migrate domain refs from rzware.com to kelta.io

### DIFF
--- a/.github/workflows/build-and-publish-containers.yml
+++ b/.github/workflows/build-and-publish-containers.yml
@@ -522,8 +522,8 @@ jobs:
         timeout-minutes: 18
         working-directory: e2e-tests
         env:
-          E2E_BASE_URL: https://app.kelta.io
-          E2E_API_BASE_URL: https://api.kelta.io
+          E2E_BASE_URL: https://emf-ui.rzware.com
+          E2E_API_BASE_URL: https://emf.rzware.com
           E2E_TENANT_SLUG: default
           E2E_AUTH_BASE_URL: ${{ secrets.E2E_AUTH_BASE_URL }}
           E2E_AUTHENTIK_URL: ${{ secrets.E2E_AUTHENTIK_URL }}

--- a/.github/workflows/build-and-publish-containers.yml
+++ b/.github/workflows/build-and-publish-containers.yml
@@ -522,8 +522,8 @@ jobs:
         timeout-minutes: 18
         working-directory: e2e-tests
         env:
-          E2E_BASE_URL: https://emf-ui.rzware.com
-          E2E_API_BASE_URL: https://emf.rzware.com
+          E2E_BASE_URL: https://app.kelta.io
+          E2E_API_BASE_URL: https://api.kelta.io
           E2E_TENANT_SLUG: default
           E2E_AUTH_BASE_URL: ${{ secrets.E2E_AUTH_BASE_URL }}
           E2E_AUTHENTIK_URL: ${{ secrets.E2E_AUTHENTIK_URL }}

--- a/kelta-auth/src/main/resources/application.yml
+++ b/kelta-auth/src/main/resources/application.yml
@@ -47,7 +47,7 @@ kelta:
   auth:
     issuer-uri: ${KELTA_AUTH_ISSUER_URI:http://localhost:8080}
     worker-url: ${WORKER_SERVICE_URL:http://localhost:8081}
-    # Cookie domain for SSO across subdomains (e.g., .rzware.com)
+    # Cookie domain for SSO across subdomains (e.g., .kelta.io)
     cookie-domain: ${COOKIE_DOMAIN:localhost}
     # RSA key for JWT signing (JWK JSON format)
     jwk-set: ${JWK_SET:}

--- a/kelta-auth/src/test/java/io/kelta/auth/config/TenantContextFilterTest.java
+++ b/kelta-auth/src/test/java/io/kelta/auth/config/TenantContextFilterTest.java
@@ -40,7 +40,7 @@ class TenantContextFilterTest {
         when(request.getMethod()).thenReturn("GET");
         when(request.getServletPath()).thenReturn("/oauth2/authorize");
         when(request.getParameter("redirect_uri"))
-                .thenReturn("https://app.rzware.com/default/auth/callback");
+                .thenReturn("https://app.kelta.io/default/auth/callback");
         when(request.getSession()).thenReturn(session);
 
         filter.doFilterInternal(request, response, filterChain);
@@ -68,7 +68,7 @@ class TenantContextFilterTest {
         when(request.getMethod()).thenReturn("GET");
         when(request.getServletPath()).thenReturn("/oauth2/authorize");
         when(request.getParameter("redirect_uri"))
-                .thenReturn("https://app.rzware.com/auth/callback");
+                .thenReturn("https://app.kelta.io/auth/callback");
 
         filter.doFilterInternal(request, response, filterChain);
 
@@ -119,7 +119,7 @@ class TenantContextFilterTest {
         when(request.getMethod()).thenReturn("GET");
         when(request.getServletPath()).thenReturn("/oauth2/authorize");
         when(request.getParameter("redirect_uri"))
-                .thenReturn("https://app.rzware.com/default/auth/callback");
+                .thenReturn("https://app.kelta.io/default/auth/callback");
         when(request.getSession()).thenReturn(session);
         when(session.getAttribute("tenantId")).thenReturn("threadline-clothing");
 
@@ -148,7 +148,7 @@ class TenantContextFilterTest {
         when(request.getMethod()).thenReturn("GET");
         when(request.getServletPath()).thenReturn("/oauth2/authorize");
         when(request.getParameter("redirect_uri"))
-                .thenReturn("https://app.rzware.com/default/auth/callback");
+                .thenReturn("https://app.kelta.io/default/auth/callback");
         when(request.getSession()).thenReturn(session);
         when(session.getAttribute("tenantId")).thenReturn("default");
 

--- a/kelta-gateway/src/test/java/io/kelta/gateway/auth/DynamicReactiveJwtDecoderTest.java
+++ b/kelta-gateway/src/test/java/io/kelta/gateway/auth/DynamicReactiveJwtDecoderTest.java
@@ -16,7 +16,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 @DisplayName("DynamicReactiveJwtDecoder")
 class DynamicReactiveJwtDecoderTest {
 
-    private static final String INTERNAL_ISSUER = "https://auth.rzware.com";
+    private static final String INTERNAL_ISSUER = "https://auth.kelta.io";
 
     private DynamicReactiveJwtDecoder decoder;
 

--- a/kelta-ui/Dockerfile
+++ b/kelta-ui/Dockerfile
@@ -43,7 +43,7 @@ COPY kelta-ui/app/src ./src
 COPY kelta-ui/app/public ./public
 
 # Set API base URL for production (frontend calls gateway directly, no nginx proxy)
-ARG VITE_API_BASE_URL=https://emf.rzware.com
+ARG VITE_API_BASE_URL=https://api.kelta.io
 ENV VITE_API_BASE_URL=$VITE_API_BASE_URL
 
 # Build the Vite app (skip tsc — CI validates types separately)

--- a/kelta-ui/app/src/context/AuthContext.tsx
+++ b/kelta-ui/app/src/context/AuthContext.tsx
@@ -438,7 +438,7 @@ export function AuthProvider({
       // All logins authenticate against the internal kelta-auth provider.
       // When the caller picks an external provider, we forward its id as an
       // idp_hint so kelta-auth runs the federation server-side and returns
-      // a platform-issued token (iss=auth.rzware.com).
+      // a platform-issued token (iss=auth.kelta.io).
       const internal = findInternalProvider(providers)
       if (!internal) {
         loginInProgress = false

--- a/kelta-ui/app/src/pages/ApiTokensPage/ApiTokensPage.test.tsx
+++ b/kelta-ui/app/src/pages/ApiTokensPage/ApiTokensPage.test.tsx
@@ -12,23 +12,23 @@ describe('buildMcpAddCommand', () => {
   it('builds a user-profile URL with the slug before /mcp/...', () => {
     const cmd = buildMcpAddCommand(
       'user',
-      'https://emf.rzware.com',
+      'https://api.kelta.io',
       'threadline-clothing',
       'klt_abc123'
     )
     expect(cmd).toBe(
-      "claude mcp add kelta-user --transport http --url https://emf.rzware.com/threadline-clothing/mcp/user --header 'Authorization: Bearer klt_abc123'"
+      "claude mcp add kelta-user --transport http --url https://api.kelta.io/threadline-clothing/mcp/user --header 'Authorization: Bearer klt_abc123'"
     )
   })
 
   it('builds an admin-profile command at the right slug-prefixed URL', () => {
-    const cmd = buildMcpAddCommand('admin', 'https://emf.rzware.com', 'another-tenant', 'klt_xyz')
-    expect(cmd).toContain('--url https://emf.rzware.com/another-tenant/mcp/admin')
+    const cmd = buildMcpAddCommand('admin', 'https://api.kelta.io', 'another-tenant', 'klt_xyz')
+    expect(cmd).toContain('--url https://api.kelta.io/another-tenant/mcp/admin')
     expect(cmd).toContain('kelta-admin')
   })
 
   it('uses single quotes around the auth header so the token is opaque to the shell', () => {
-    const cmd = buildMcpAddCommand('user', 'https://emf.rzware.com', 't', 'klt_token_with$pecial')
+    const cmd = buildMcpAddCommand('user', 'https://api.kelta.io', 't', 'klt_token_with$pecial')
     expect(cmd).toContain("'Authorization: Bearer klt_token_with$pecial'")
   })
 })
@@ -49,8 +49,8 @@ describe('resolveMcpBaseUrl', () => {
   })
 
   it('prefers VITE_API_BASE_URL when set', () => {
-    vi.stubEnv('VITE_API_BASE_URL', 'https://emf.rzware.com')
-    expect(resolveMcpBaseUrl()).toBe('https://emf.rzware.com')
+    vi.stubEnv('VITE_API_BASE_URL', 'https://api.kelta.io')
+    expect(resolveMcpBaseUrl()).toBe('https://api.kelta.io')
   })
 
   it('falls back to window.location.origin when env is empty (local dev)', () => {

--- a/kelta-worker/src/main/java/io/kelta/worker/config/TenantProvisioningConfig.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/config/TenantProvisioningConfig.java
@@ -22,7 +22,7 @@ public class TenantProvisioningConfig {
     public TenantProvisioningHook tenantProvisioningHook(
             BeforeSaveHookRegistry hookRegistry,
             JdbcTemplate jdbcTemplate,
-            @Value("${kelta.auth.issuer-uri:https://auth.rzware.com}") String authIssuerUri) {
+            @Value("${kelta.auth.issuer-uri:https://auth.kelta.io}") String authIssuerUri) {
         TenantProvisioningHook hook = new TenantProvisioningHook(jdbcTemplate, authIssuerUri);
         hookRegistry.register(hook);
         return hook;

--- a/kelta-worker/src/main/resources/application.yml
+++ b/kelta-worker/src/main/resources/application.yml
@@ -50,7 +50,7 @@ kelta:
   encryption:
     key: ${KELTA_ENCRYPTION_KEY:}
   auth:
-    issuer-uri: ${KELTA_AUTH_ISSUER_URI:https://auth.rzware.com}
+    issuer-uri: ${KELTA_AUTH_ISSUER_URI:https://auth.kelta.io}
   external-base-url: ${EXTERNAL_BASE_URL:http://localhost:8080}
   worker:
     id: ${WORKER_ID:}


### PR DESCRIPTION
## Summary
- Default `KELTA_AUTH_ISSUER_URI`, `VITE_API_BASE_URL`, and E2E URLs flip to `kelta.io` subdomains (auth/api/app).
- Test fixtures and code comments updated; external service hosts (Superset, Jaeger, Harbor, IDP, Authentik, S3, Svix) stay on `rzware.com`.
- CI rebuilds emf-ui image with `VITE_API_BASE_URL=https://api.kelta.io`; that image bump auto-flows into homelab-argo via the existing workflow.

## Paired with
- homelab-argo PR (Traefik IngressRoutes, cert SANs, configmaps): https://github.com/cklinker/homelab-argo/pull/new/feature/kelta-io-migration

## Manual ops required before homelab-argo merge
- Route 53 A records for `api/app/auth/mcp.kelta.io` → `71.218.154.60`
- DB on PG `192.168.0.6`:
  ```sql
  UPDATE oidc_providers
     SET issuer    = 'https://auth.kelta.io',
         jwks_uri  = 'https://auth.kelta.io/oauth2/jwks'
   WHERE name = 'Kelta Platform (Internal)';
  ```
- Superset configmap OAuth issuer URL → kelta.io
- Google OAuth console redirect URI (if applicable)

## Test plan
- [ ] CI green (lint + unit + integration)
- [ ] E2E workflow runs against new URLs after homelab-argo merge
- [ ] Login on `https://app.kelta.io/threadline-clothing/login` reaches OIDC discovery without CORS error