### PR TITLE
fix(auth): migrate oidc_provider and platform client redirect URI to kelta.io

### DIFF
--- a/kelta-auth/src/main/java/io/kelta/auth/config/ConnectedAppRegistrar.java
+++ b/kelta-auth/src/main/java/io/kelta/auth/config/ConnectedAppRegistrar.java
@@ -53,10 +53,6 @@ public class ConnectedAppRegistrar implements ApplicationRunner {
         String clientId = "kelta-platform";
 
         RegisteredClient existing = clientRepository.findByClientId(clientId);
-        if (existing != null) {
-            log.info("Platform OAuth2 client '{}' already registered (id={})", clientId, existing.getId());
-            return;
-        }
 
         String uiBaseUrl = properties.getUiBaseUrl();
         if (uiBaseUrl == null || uiBaseUrl.isBlank()) {
@@ -67,7 +63,16 @@ public class ConnectedAppRegistrar implements ApplicationRunner {
             uiBaseUrl = uiBaseUrl.substring(0, uiBaseUrl.length() - 1);
         }
 
-        RegisteredClient platformClient = RegisteredClient.withId(UUID.randomUUID().toString())
+        String registrationId = existing != null ? existing.getId() : UUID.randomUUID().toString();
+        String expectedRedirectUri = uiBaseUrl + "/auth/callback";
+
+        // If the client already exists with the correct redirect URI, nothing to do.
+        if (existing != null && existing.getRedirectUris().contains(expectedRedirectUri)) {
+            log.info("Platform OAuth2 client '{}' already registered with correct redirect URI", clientId);
+            return;
+        }
+
+        RegisteredClient platformClient = RegisteredClient.withId(registrationId)
                 .clientId(clientId)
                 .clientName("Kelta Platform UI")
                 .clientAuthenticationMethod(ClientAuthenticationMethod.NONE)
@@ -75,7 +80,7 @@ public class ConnectedAppRegistrar implements ApplicationRunner {
                 .authorizationGrantType(AuthorizationGrantType.REFRESH_TOKEN)
                 // Base redirect URI — the actual tenant-scoped URI is validated by
                 // PlatformRedirectUriValidator which allows any path under this origin
-                .redirectUri(uiBaseUrl + "/auth/callback")
+                .redirectUri(expectedRedirectUri)
                 .scope(OidcScopes.OPENID)
                 .scope(OidcScopes.PROFILE)
                 .scope("email")
@@ -91,7 +96,12 @@ public class ConnectedAppRegistrar implements ApplicationRunner {
                 .build();
 
         clientRepository.save(platformClient);
-        log.info("Registered Platform OAuth2 client '{}' with redirect URIs under '{}'", clientId, uiBaseUrl);
+        if (existing == null) {
+            log.info("Registered Platform OAuth2 client '{}' with redirect URI '{}'", clientId, expectedRedirectUri);
+        } else {
+            log.info("Updated Platform OAuth2 client '{}' redirect URI to '{}' (was '{}')",
+                    clientId, expectedRedirectUri, existing.getRedirectUris());
+        }
     }
 
     private void registerSupersetClient() {

--- a/kelta-worker/src/main/resources/db/migration/V138__migrate_oidc_provider_domain_kelta_io.sql
+++ b/kelta-worker/src/main/resources/db/migration/V138__migrate_oidc_provider_domain_kelta_io.sql
@@ -1,0 +1,20 @@
+-- V138: update internal kelta-auth OIDC provider records from auth.rzware.com to auth.kelta.io
+--
+-- V101 hard-coded the issuer/jwks_uri as https://auth.rzware.com for all tenants
+-- provisioned before the domain migration (PR #943). kelta-auth now identifies as
+-- https://auth.kelta.io, so every existing tenant's internal provider record is stale:
+--
+--   * The UI does OIDC discovery against the stored issuer — wrong domain resolves nothing
+--   * The gateway rejects platform JWTs (iss=auth.kelta.io) that don't match the DB row
+--
+-- TenantProvisioningHook already uses auth.kelta.io for *new* tenants; this migration
+-- catches every tenant that was provisioned before the cutover.
+--
+-- The Authentik provider (authentik.rzware.com) is intentionally left untouched —
+-- Authentik remains on rzware.com infrastructure per the domain migration plan.
+
+UPDATE oidc_provider
+SET issuer     = 'https://auth.kelta.io',
+    jwks_uri   = 'https://auth.kelta.io/oauth2/jwks',
+    updated_at = NOW()
+WHERE issuer = 'https://auth.rzware.com';


### PR DESCRIPTION
## Summary
- Adds Flyway migration V138 to update all existing tenants' internal OIDC provider records from `auth.rzware.com` to `auth.kelta.io` — V101 hard-coded the old domain and no migration was included in #943
- Fixes `ConnectedAppRegistrar` to update the `kelta-platform` registered client's redirect URI on redeploy instead of silently skipping when the client already exists

## Root cause
The domain migration PR (#943) updated code defaults and the `TenantProvisioningHook` for new tenants, but two things were left stale in the DB for existing tenants:
1. `oidc_provider` rows with `issuer/jwks_uri = auth.rzware.com` — causes OIDC discovery failures and JWT issuer mismatches at the gateway
2. `oauth2_registered_client.redirect_uris` still pointing at `app.rzware.com` — causes `PlatformRedirectUriValidator` to reject `app.kelta.io` callbacks with `invalid_redirect_uri`

Note: Authentik app config (allowed redirect URIs) also needs updating in homelab-argo to allow `auth.kelta.io` callbacks — that's the third piece of the Google auth break and lives outside this repo.

## Changes
- `kelta-worker/src/main/resources/db/migration/V138__migrate_oidc_provider_domain_kelta_io.sql` — UPDATE existing rows, Authentik provider intentionally untouched
- `kelta-auth/src/main/java/io/kelta/auth/config/ConnectedAppRegistrar.java` — update existing platform client when redirect URI changes; no-op if already correct

## Testing
- `mvn test -f kelta-auth/pom.xml` passes (all tests green)
- Migration is idempotent — re-running on an already-migrated DB is safe

🤖 Generated with [Claude Code](https://claude.com/claude-code)