### PR TITLE
fix(auth): OTel instrumentation for OidcDiscoveryHook + TTL cache for OIDC registrations

### DIFF
--- a/kelta-auth/src/main/java/io/kelta/auth/federation/DynamicClientRegistrationRepository.java
+++ b/kelta-auth/src/main/java/io/kelta/auth/federation/DynamicClientRegistrationRepository.java
@@ -12,6 +12,8 @@ import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
 import org.springframework.security.oauth2.core.oidc.IdTokenClaimNames;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -29,10 +31,14 @@ public class DynamicClientRegistrationRepository implements ClientRegistrationRe
 
     private static final Logger log = LoggerFactory.getLogger(DynamicClientRegistrationRepository.class);
 
+    private static final Duration CACHE_TTL = Duration.ofMinutes(5);
+
+    private record CachedRegistration(ClientRegistration registration, Instant cachedAt) {}
+
     private final WorkerClient workerClient;
     private final OidcDiscoveryService discoveryService;
     private final EncryptionService encryptionService;
-    private final Map<String, ClientRegistration> registrationCache = new ConcurrentHashMap<>();
+    private final Map<String, CachedRegistration> registrationCache = new ConcurrentHashMap<>();
 
     public DynamicClientRegistrationRepository(
             WorkerClient workerClient,
@@ -45,10 +51,11 @@ public class DynamicClientRegistrationRepository implements ClientRegistrationRe
 
     @Override
     public ClientRegistration findByRegistrationId(String registrationId) {
-        // Check cache first
-        ClientRegistration cached = registrationCache.get(registrationId);
-        if (cached != null) {
-            return cached;
+        // Check cache first — entries expire after CACHE_TTL so secret rotations
+        // and provider config changes take effect without a pod restart.
+        CachedRegistration cached = registrationCache.get(registrationId);
+        if (cached != null && cached.cachedAt().plus(CACHE_TTL).isAfter(Instant.now())) {
+            return cached.registration();
         }
 
         // The registrationId format is: {tenantId}:{providerId}
@@ -67,7 +74,7 @@ public class DynamicClientRegistrationRepository implements ClientRegistrationRe
             if (providerId.equals(provider.id())) {
                 ClientRegistration registration = buildClientRegistration(registrationId, provider);
                 if (registration != null) {
-                    registrationCache.put(registrationId, registration);
+                    registrationCache.put(registrationId, new CachedRegistration(registration, Instant.now()));
                 }
                 return registration;
             }
@@ -91,7 +98,7 @@ public class DynamicClientRegistrationRepository implements ClientRegistrationRe
                     String registrationId = tenantId + ":" + p.id();
                     ClientRegistration reg = buildClientRegistration(registrationId, p);
                     if (reg != null) {
-                        registrationCache.put(registrationId, reg);
+                        registrationCache.put(registrationId, new CachedRegistration(reg, Instant.now()));
                     }
                     return reg;
                 })

--- a/kelta-worker/pom.xml
+++ b/kelta-worker/pom.xml
@@ -114,6 +114,10 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-restclient</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
         <dependency>

--- a/kelta-worker/src/main/java/io/kelta/worker/listener/OidcDiscoveryHook.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/listener/OidcDiscoveryHook.java
@@ -30,8 +30,8 @@ public class OidcDiscoveryHook implements BeforeSaveHook {
     private final RestClient restClient;
     private final ObjectMapper objectMapper;
 
-    public OidcDiscoveryHook(ObjectMapper objectMapper) {
-        this.restClient = RestClient.builder()
+    public OidcDiscoveryHook(ObjectMapper objectMapper, RestClient.Builder restClientBuilder) {
+        this.restClient = restClientBuilder
                 .defaultHeader("Accept", "application/json")
                 .build();
         this.objectMapper = objectMapper;


### PR DESCRIPTION
## Summary
- `OidcDiscoveryHook` was using the static `RestClient.builder()` factory — outbound OIDC discovery calls had no `traceparent` header and no CLIENT span, breaking traces at the auth→external-IdP boundary in Tempo. Same fix applied to `WorkerClient` in #932.
- `DynamicClientRegistrationRepository` cached OIDC client registrations indefinitely. A tenant rotating their Google OAuth client secret would continue hitting the old credentials until pod restart. Replaced with a 5-minute TTL using `Instant` — no new dependencies.

## Changes
- `kelta-worker/.../listener/OidcDiscoveryHook.java` — inject `RestClient.Builder` instead of static factory
- `kelta-auth/.../federation/DynamicClientRegistrationRepository.java` — `ConcurrentHashMap<String, ClientRegistration>` → `ConcurrentHashMap<String, CachedRegistration>` with 5-min TTL

## Testing
- `mvn test -f kelta-auth/pom.xml` — all green
- `mvn test -f kelta-worker/pom.xml` — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)