### PR TITLE
fix(sdk): correct filter operator names + fix Superset registrar skip-if-exists

### DIFF
--- a/kelta-auth/src/main/java/io/kelta/auth/config/ConnectedAppRegistrar.java
+++ b/kelta-auth/src/main/java/io/kelta/auth/config/ConnectedAppRegistrar.java
@@ -110,12 +110,14 @@ public class ConnectedAppRegistrar implements ApplicationRunner {
         }
 
         RegisteredClient existing = clientRepository.findByClientId(clientId);
-        if (existing != null) {
-            log.info("Superset OAuth2 client '{}' already registered (id={})", clientId, existing.getId());
+        String registrationId = existing != null ? existing.getId() : UUID.randomUUID().toString();
+
+        if (existing != null && existing.getRedirectUris().contains(redirectUri)) {
+            log.info("Superset OAuth2 client '{}' already registered with correct redirect URI", clientId);
             return;
         }
 
-        RegisteredClient supersetClient = RegisteredClient.withId(UUID.randomUUID().toString())
+        RegisteredClient supersetClient = RegisteredClient.withId(registrationId)
                 .clientId(clientId)
                 .clientSecret(passwordEncoder.encode(clientSecret))
                 .clientName("Apache Superset")
@@ -139,6 +141,11 @@ public class ConnectedAppRegistrar implements ApplicationRunner {
                 .build();
 
         clientRepository.save(supersetClient);
-        log.info("Registered Superset OAuth2 client '{}' with redirect URI '{}'", clientId, redirectUri);
+        if (existing == null) {
+            log.info("Registered Superset OAuth2 client '{}' with redirect URI '{}'", clientId, redirectUri);
+        } else {
+            log.info("Updated Superset OAuth2 client '{}' redirect URI to '{}' (was '{}')",
+                    clientId, redirectUri, existing.getRedirectUris());
+        }
     }
 }

--- a/kelta-web/packages/sdk/src/resources/ResourceClient.test.ts
+++ b/kelta-web/packages/sdk/src/resources/ResourceClient.test.ts
@@ -209,6 +209,36 @@ describe('ResourceClient', () => {
       });
     });
 
+    it('should send correct operator strings matching backend FilterOperator enum', async () => {
+      mockAxiosGet.mockResolvedValue({ data: validListResponse });
+
+      await resourceClient.list({
+        filters: [
+          { field: 'name', operator: 'neq', value: 'admin' },
+          { field: 'bio', operator: 'starts', value: 'Hello' },
+          { field: 'email', operator: 'ends', value: '.com' },
+          { field: 'note', operator: 'icontains', value: 'urgent' },
+          { field: 'tag', operator: 'istarts', value: 'vip' },
+          { field: 'code', operator: 'iends', value: 'xyz' },
+          { field: 'type', operator: 'ieq', value: 'admin' },
+          { field: 'deletedAt', operator: 'isnull', value: 'true' },
+        ],
+      });
+
+      expect(mockAxiosGet).toHaveBeenCalledWith('/api/users', {
+        params: {
+          'filter[name][neq]': 'admin',
+          'filter[bio][starts]': 'Hello',
+          'filter[email][ends]': '.com',
+          'filter[note][icontains]': 'urgent',
+          'filter[tag][istarts]': 'vip',
+          'filter[code][iends]': 'xyz',
+          'filter[type][ieq]': 'admin',
+          'filter[deletedAt][isnull]': 'true',
+        },
+      });
+    });
+
     it('should include JSON:API sparse fieldsets with type bracket notation (Requirement 3.5)', async () => {
       mockAxiosGet.mockResolvedValue({ data: validListResponse });
 

--- a/kelta-web/packages/sdk/src/resources/types.ts
+++ b/kelta-web/packages/sdk/src/resources/types.ts
@@ -17,14 +17,19 @@ export interface FilterExpression {
   field: string;
   operator:
     | 'eq'
-    | 'ne'
+    | 'neq'
     | 'gt'
     | 'gte'
     | 'lt'
     | 'lte'
+    | 'isnull'
     | 'contains'
-    | 'startsWith'
-    | 'endsWith'
+    | 'starts'
+    | 'ends'
+    | 'icontains'
+    | 'istarts'
+    | 'iends'
+    | 'ieq'
     | 'in';
   value: unknown;
 }


### PR DESCRIPTION
## Summary
- `FilterExpression` in the SDK had three operator names that didn't match the backend `FilterOperator` enum — they were silently dropped with no error, producing no filtering instead of an exception
- Adds the five operators the backend supports but the SDK never exposed
- `ConnectedAppRegistrar.registerSupersetClient()` had the same skip-if-exists bug fixed for the platform client in #944

## The operator mismatch

`FilterCondition.fromParams()` does `.toUpperCase()` then `FilterOperator.valueOf()` on the URL parameter. Unknown operators are silently ignored (caught `IllegalArgumentException`):

| SDK sent | Backend needed | Effect |
|----------|---------------|--------|
| `ne` | `neq` | filter silently ignored |
| `startsWith` | `starts` | filter silently ignored |
| `endsWith` | `ends` | filter silently ignored |

Missing entirely: `isnull`, `icontains`, `istarts`, `iends`, `ieq`

## Changes
- `kelta-web/packages/sdk/src/resources/types.ts` — fix 3 operator names, add 5 missing ones
- `kelta-web/packages/sdk/src/resources/ResourceClient.test.ts` — add test asserting all corrected/new operators produce the right URL params
- `kelta-auth/src/main/java/io/kelta/auth/config/ConnectedAppRegistrar.java` — update Superset client when redirect URI changes instead of skipping

## Testing
- 853 SDK tests passing
- `mvn test -f kelta-auth/pom.xml` — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)