### PR TITLE
fix(worker): sync Cerbos policies on tenant provisioning

### DIFF
--- a/kelta-worker/src/main/java/io/kelta/worker/config/TenantProvisioningConfig.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/config/TenantProvisioningConfig.java
@@ -2,6 +2,7 @@ package io.kelta.worker.config;
 
 import io.kelta.runtime.workflow.BeforeSaveHookRegistry;
 import io.kelta.worker.listener.TenantProvisioningHook;
+import io.kelta.worker.service.CerbosPolicySyncService;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -22,8 +23,10 @@ public class TenantProvisioningConfig {
     public TenantProvisioningHook tenantProvisioningHook(
             BeforeSaveHookRegistry hookRegistry,
             JdbcTemplate jdbcTemplate,
+            CerbosPolicySyncService cerbosPolicySyncService,
             @Value("${kelta.auth.issuer-uri:https://auth.kelta.io}") String authIssuerUri) {
-        TenantProvisioningHook hook = new TenantProvisioningHook(jdbcTemplate, authIssuerUri);
+        TenantProvisioningHook hook = new TenantProvisioningHook(
+                jdbcTemplate, authIssuerUri, cerbosPolicySyncService);
         hookRegistry.register(hook);
         return hook;
     }

--- a/kelta-worker/src/main/java/io/kelta/worker/listener/TenantProvisioningHook.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/listener/TenantProvisioningHook.java
@@ -2,6 +2,7 @@ package io.kelta.worker.listener;
 
 import io.kelta.runtime.context.TenantContext;
 import io.kelta.runtime.workflow.BeforeSaveHook;
+import io.kelta.worker.service.CerbosPolicySyncService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -42,10 +43,14 @@ public class TenantProvisioningHook implements BeforeSaveHook {
 
     private final JdbcTemplate jdbcTemplate;
     private final String authIssuerUri;
+    private final CerbosPolicySyncService cerbosPolicySyncService;
 
-    public TenantProvisioningHook(JdbcTemplate jdbcTemplate, String authIssuerUri) {
+    public TenantProvisioningHook(JdbcTemplate jdbcTemplate,
+                                   String authIssuerUri,
+                                   CerbosPolicySyncService cerbosPolicySyncService) {
         this.jdbcTemplate = jdbcTemplate;
         this.authIssuerUri = authIssuerUri;
+        this.cerbosPolicySyncService = cerbosPolicySyncService;
     }
 
     @Override
@@ -73,6 +78,7 @@ public class TenantProvisioningHook implements BeforeSaveHook {
             seedDefaultProfiles(id);
             seedOidcProvider(id);
             seedAdminUser(id, slug);
+            syncCerbosPolicies(id);
             activateTenant(id);
             log.info("Tenant provisioning complete for tenant '{}' (slug={})", id, slug);
         } catch (Exception e) {
@@ -81,6 +87,20 @@ public class TenantProvisioningHook implements BeforeSaveHook {
         } finally {
             TenantContext.clear();
         }
+    }
+
+    /**
+     * Pushes Cerbos policies for the newly seeded profiles. Required because
+     * seedDefaultProfiles writes directly via JDBC and bypasses the profiles
+     * collection BeforeSaveHook that normally triggers sync. Without this,
+     * gateway API_ACCESS checks fail-closed for the new tenant.
+     */
+    void syncCerbosPolicies(String tenantId) {
+        if (cerbosPolicySyncService == null) {
+            log.debug("CerbosPolicySyncService not configured, skipping policy sync for tenant {}", tenantId);
+            return;
+        }
+        cerbosPolicySyncService.syncTenant(tenantId);
     }
 
     /**

--- a/kelta-worker/src/test/java/io/kelta/worker/listener/TenantProvisioningHookTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/listener/TenantProvisioningHookTest.java
@@ -1,5 +1,6 @@
 package io.kelta.worker.listener;
 
+import io.kelta.worker.service.CerbosPolicySyncService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -18,6 +19,7 @@ import static org.mockito.Mockito.*;
 class TenantProvisioningHookTest {
 
     private JdbcTemplate jdbcTemplate;
+    private CerbosPolicySyncService cerbosPolicySyncService;
     private TenantProvisioningHook hook;
 
     private static final String AUTH_ISSUER = "https://auth.example.com";
@@ -27,7 +29,8 @@ class TenantProvisioningHookTest {
     @BeforeEach
     void setUp() {
         jdbcTemplate = mock(JdbcTemplate.class);
-        hook = new TenantProvisioningHook(jdbcTemplate, AUTH_ISSUER);
+        cerbosPolicySyncService = mock(CerbosPolicySyncService.class);
+        hook = new TenantProvisioningHook(jdbcTemplate, AUTH_ISSUER, cerbosPolicySyncService);
     }
 
     @Test
@@ -245,6 +248,44 @@ class TenantProvisioningHookTest {
             verify(jdbcTemplate).update(
                     contains("UPDATE tenant SET status = 'ACTIVE'"),
                     eq(TENANT_ID));
+        }
+    }
+
+    @Nested
+    @DisplayName("syncCerbosPolicies")
+    class SyncCerbosPolicies {
+
+        @Test
+        @DisplayName("Should delegate to CerbosPolicySyncService")
+        void shouldDelegateToSyncService() {
+            hook.syncCerbosPolicies(TENANT_ID);
+
+            verify(cerbosPolicySyncService).syncTenant(TENANT_ID);
+        }
+
+        @Test
+        @DisplayName("Should no-op when sync service is null")
+        void shouldNoOpWhenServiceNull() {
+            TenantProvisioningHook hookNoSync =
+                    new TenantProvisioningHook(jdbcTemplate, AUTH_ISSUER, null);
+
+            assertDoesNotThrow(() -> hookNoSync.syncCerbosPolicies(TENANT_ID));
+            verifyNoInteractions(cerbosPolicySyncService);
+        }
+
+        @Test
+        @DisplayName("Should be invoked from afterCreate after seeding")
+        void shouldBeInvokedFromAfterCreate() {
+            Map<String, Object> record = new HashMap<>(Map.of("id", TENANT_ID, "slug", TENANT_SLUG));
+
+            when(jdbcTemplate.queryForObject(anyString(), eq(Integer.class), any()))
+                    .thenReturn(0);
+            when(jdbcTemplate.queryForList(anyString(), eq(String.class), any()))
+                    .thenReturn(List.of("profile-sys-admin"));
+
+            hook.afterCreate(record, TENANT_ID);
+
+            verify(cerbosPolicySyncService).syncTenant(TENANT_ID);
         }
     }
 }


### PR DESCRIPTION
## Summary
- New tenants were locked out: gateway `API_ACCESS` Cerbos check returned 403 because policies were never pushed for the new tenant scope.
- `TenantProvisioningHook` seeded `profile` + `profile_system_permission` via raw JDBC, bypassing the `profiles` collection `BeforeSaveHook` that normally triggers `CerbosPolicySyncService.syncTenant`.
- Inject `CerbosPolicySyncService` and call `syncTenant` after `seedAdminUser`, before `activateTenant`.

## Repro
1. Create tenant via UI.
2. Log in as `<slug>-admin@kelta.local`.
3. `GET /<slug>/api/me/permissions` returns 403 `API access not permitted`.

After fix: policies pushed at provisioning time; admin pages reachable immediately.

## Workaround for tenants already stuck
Restart any worker pod — `CerbosPolicySeeder` runs `syncAllTenants()` on `ApplicationReadyEvent`.

## Test plan
- [x] `TenantProvisioningHookTest` — new `syncCerbosPolicies` cases (delegates, null-safe, invoked from `afterCreate`)
- [x] Worker module tests: 1167/1167
- [x] Gateway module tests: 432/432
- [x] kelta-web lint/typecheck/format/tests
- [ ] Manual: create new tenant in staging, log in as `<slug>-admin@kelta.local`, hit `/api/me/permissions` — expect 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)