### PR TITLE
fix(rollback): prevent empty-tree disaster from shallow-clone revert

### DIFF
--- a/.github/workflows/build-and-publish-containers.yml
+++ b/.github/workflows/build-and-publish-containers.yml
@@ -474,6 +474,12 @@ jobs:
           repository: cklinker/homelab-argo
           token: ${{ secrets.ARGOCD_REPO_TOKEN }}
           path: homelab-argo
+          # CRITICAL: fetch full history. `git revert HEAD` needs the parent
+          # commit object to compute the inverse diff. With the default
+          # fetch-depth: 1, the parent is unreachable and revert silently
+          # produces an empty tree — wiping every manifest in homelab-argo
+          # and tearing down every workload via ArgoCD prune.
+          fetch-depth: 0
 
       - name: Roll back image bump
         env:

--- a/scripts/rollback.sh
+++ b/scripts/rollback.sh
@@ -49,6 +49,20 @@ git config user.email "github-actions[bot]@users.noreply.github.com"
 
 REVERT_MSG="revert: roll back image bump (${REASON})"
 git revert --no-edit HEAD
+
+# Safety net: if the resulting tree is the well-known empty tree, the parent
+# commit object was unreachable (shallow clone) and `git revert` silently
+# produced an empty revert. Pushing this would prune every workload via
+# ArgoCD. Abort instead.
+EMPTY_TREE_SHA="4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+REVERT_TREE_SHA="$(git log -1 --pretty=%T HEAD)"
+if [[ "$REVERT_TREE_SHA" == "$EMPTY_TREE_SHA" ]]; then
+  echo "ERROR: revert produced the empty tree — likely a shallow-clone issue." >&2
+  echo "Refusing to push. Check the workflow's actions/checkout fetch-depth." >&2
+  git reset --hard HEAD~ >/dev/null 2>&1 || true
+  exit 5
+fi
+
 # git revert produces a default message; rewrite the subject for searchability.
 git commit --amend -m "$REVERT_MSG" -m "Reverts $(git log -1 --pretty=%H HEAD~ 2>/dev/null || echo unknown)"
 


### PR DESCRIPTION
## Summary

- Auto-rollback workflow checks out homelab-argo with default `fetch-depth: 1`. `git revert HEAD` needs parent commit object to compute inverse diff — without it, git silently produced an **empty tree**, wiping every manifest in homelab-argo. ArgoCD started reconciling toward empty state (would prune every workload).
- Happened in run [26736446050](https://github.com/cklinker/emf/actions/runs/26736446050). Restored homelab-argo from history before ArgoCD finished pruning, but it was a near-miss for the entire homelab.

Two layers of defense:

1. `.github/workflows/build-and-publish-containers.yml`: set `fetch-depth: 0` on homelab-argo checkout so parent commit is reachable.
2. `scripts/rollback.sh`: refuse to push if resulting tree equals well-known empty-tree SHA (`4b825dc642cb6eb9a060e54bf8d69288fbee4904`). Belt + suspenders so future workflow change can't reintroduce same bug silently.

## Test plan

- [ ] Trigger a smoke-test failure on a deploy and verify rollback now produces a real revert commit (non-empty tree).
- [ ] Manually run `bash scripts/rollback.sh` against a shallow-clone homelab-argo and confirm it exits with code 5 + does not push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)