### PR TITLE
fix(ci): route Maven Central through Google GCS mirror in native builds

### DIFF
--- a/ci/maven-settings.xml
+++ b/ci/maven-settings.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Maven settings used by native-image Docker builds in CI.
+
+  Maven Central rate-limits aggressive parallel fetches (HTTP 429), which
+  breaks builds when worker/worker-migrate/gateway/ai/mcp native images
+  all download the same Spring Boot artifacts simultaneously. Route
+  fetches through Google's free GCS mirror of central — same content,
+  no rate limit, lower latency from most regions.
+
+  This is a stopgap until the homelab Nexus proxy comes online (see
+  homelab-argo#117). At that point, swap the mirror URL to
+  https://nexus.rzware.com/repository/maven-public/ and drop the GCS
+  dependency entirely.
+-->
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                              https://maven.apache.org/xsd/settings-1.0.0.xsd">
+    <mirrors>
+        <mirror>
+            <id>google-maven-central</id>
+            <name>Google Cloud Storage mirror of Maven Central</name>
+            <url>https://maven-central.storage-download.googleapis.com/maven2/</url>
+            <mirrorOf>central</mirrorOf>
+        </mirror>
+    </mirrors>
+</settings>

--- a/kelta-ai/Dockerfile
+++ b/kelta-ai/Dockerfile
@@ -7,6 +7,9 @@ FROM maven:3.9-eclipse-temurin-25 AS runtime-builder
 
 WORKDIR /kelta-platform
 
+# Route Maven Central through Google's GCS mirror to dodge 429 rate limits.
+COPY ci/maven-settings.xml /root/.m2/settings.xml
+
 # Copy only POMs first for dependency layer caching
 COPY kelta-platform/pom.xml ./
 COPY kelta-platform/runtime/pom.xml ./runtime/
@@ -42,6 +45,9 @@ RUN mvn clean install -DskipTests -B \
 FROM maven:3.9-eclipse-temurin-25 AS builder
 
 WORKDIR /build
+
+# Route Maven Central through Google's GCS mirror to dodge 429 rate limits.
+COPY ci/maven-settings.xml /root/.m2/settings.xml
 
 # Copy runtime artifacts from previous stage
 COPY --from=runtime-builder /root/.m2/repository/io/kelta /root/.m2/repository/io/kelta

--- a/kelta-ai/Dockerfile.jvm
+++ b/kelta-ai/Dockerfile.jvm
@@ -8,6 +8,9 @@ FROM maven:3.9-eclipse-temurin-25 AS runtime-builder
 
 WORKDIR /kelta-platform
 
+# Route Maven Central through Google's GCS mirror to dodge 429 rate limits.
+COPY ci/maven-settings.xml /root/.m2/settings.xml
+
 COPY kelta-platform/pom.xml ./
 COPY kelta-platform/runtime/pom.xml ./runtime/
 COPY kelta-platform/runtime/runtime-core/pom.xml ./runtime/runtime-core/
@@ -40,6 +43,9 @@ RUN mvn clean install -DskipTests -B \
 FROM maven:3.9-eclipse-temurin-25 AS builder
 
 WORKDIR /build
+
+# Route Maven Central through Google's GCS mirror to dodge 429 rate limits.
+COPY ci/maven-settings.xml /root/.m2/settings.xml
 
 COPY --from=runtime-builder /root/.m2/repository/io/kelta /root/.m2/repository/io/kelta
 

--- a/kelta-auth/Dockerfile
+++ b/kelta-auth/Dockerfile
@@ -18,6 +18,9 @@ RUN microdnf install -y findutils && \
     tar xzf - -C /opt && \
     ln -sf /opt/apache-maven-${MAVEN_VERSION}/bin/mvn /usr/local/bin/mvn
 
+# Route Maven Central through Google's GCS mirror to dodge 429 rate limits.
+COPY ci/maven-settings.xml /root/.m2/settings.xml
+
 # Copy only POMs first for dependency layer caching
 COPY kelta-platform/pom.xml ./
 COPY kelta-platform/runtime/pom.xml ./runtime/
@@ -58,6 +61,9 @@ RUN microdnf install -y findutils && \
     curl -fsSL "https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz" | \
     tar xzf - -C /opt && \
     ln -sf /opt/apache-maven-${MAVEN_VERSION}/bin/mvn /usr/local/bin/mvn
+
+# Route Maven Central through Google's GCS mirror to dodge 429 rate limits.
+COPY ci/maven-settings.xml /root/.m2/settings.xml
 
 COPY --from=runtime-builder /root/.m2/repository /root/.m2/repository
 

--- a/kelta-auth/Dockerfile.jvm
+++ b/kelta-auth/Dockerfile.jvm
@@ -8,6 +8,9 @@ FROM maven:3.9-eclipse-temurin-25 AS runtime-builder
 
 WORKDIR /kelta-platform
 
+# Route Maven Central through Google's GCS mirror to dodge 429 rate limits.
+COPY ci/maven-settings.xml /root/.m2/settings.xml
+
 COPY kelta-platform/pom.xml ./
 COPY kelta-platform/runtime/pom.xml ./runtime/
 COPY kelta-platform/runtime/runtime-core/pom.xml ./runtime/runtime-core/
@@ -40,6 +43,9 @@ RUN mvn clean install -DskipTests -B \
 FROM maven:3.9-eclipse-temurin-25 AS builder
 
 WORKDIR /build
+
+# Route Maven Central through Google's GCS mirror to dodge 429 rate limits.
+COPY ci/maven-settings.xml /root/.m2/settings.xml
 
 COPY --from=runtime-builder /root/.m2/repository/io/kelta /root/.m2/repository/io/kelta
 

--- a/kelta-gateway/Dockerfile
+++ b/kelta-gateway/Dockerfile
@@ -18,6 +18,9 @@ RUN microdnf install -y findutils && \
     tar xzf - -C /opt && \
     ln -sf /opt/apache-maven-${MAVEN_VERSION}/bin/mvn /usr/local/bin/mvn
 
+# Route Maven Central through Google's GCS mirror to dodge 429 rate limits.
+COPY ci/maven-settings.xml /root/.m2/settings.xml
+
 # Copy only POMs first for dependency layer caching
 COPY kelta-platform/pom.xml ./
 COPY kelta-platform/runtime/pom.xml ./runtime/
@@ -58,6 +61,9 @@ RUN microdnf install -y findutils && \
     curl -fsSL "https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz" | \
     tar xzf - -C /opt && \
     ln -sf /opt/apache-maven-${MAVEN_VERSION}/bin/mvn /usr/local/bin/mvn
+
+# Route Maven Central through Google's GCS mirror to dodge 429 rate limits.
+COPY ci/maven-settings.xml /root/.m2/settings.xml
 
 COPY --from=runtime-builder /root/.m2/repository /root/.m2/repository
 

--- a/kelta-gateway/Dockerfile.jvm
+++ b/kelta-gateway/Dockerfile.jvm
@@ -8,6 +8,9 @@ FROM maven:3.9-eclipse-temurin-25 AS runtime-builder
 
 WORKDIR /kelta-platform
 
+# Route Maven Central through Google's GCS mirror to dodge 429 rate limits.
+COPY ci/maven-settings.xml /root/.m2/settings.xml
+
 COPY kelta-platform/pom.xml ./
 COPY kelta-platform/runtime/pom.xml ./runtime/
 COPY kelta-platform/runtime/runtime-core/pom.xml ./runtime/runtime-core/
@@ -40,6 +43,9 @@ RUN mvn clean install -DskipTests -B \
 FROM maven:3.9-eclipse-temurin-25 AS builder
 
 WORKDIR /build
+
+# Route Maven Central through Google's GCS mirror to dodge 429 rate limits.
+COPY ci/maven-settings.xml /root/.m2/settings.xml
 
 COPY --from=runtime-builder /root/.m2/repository/io/kelta /root/.m2/repository/io/kelta
 

--- a/kelta-mcp/Dockerfile
+++ b/kelta-mcp/Dockerfile
@@ -12,6 +12,9 @@ FROM maven:3.9-eclipse-temurin-25 AS runtime-builder
 
 WORKDIR /kelta-platform
 
+# Route Maven Central through Google's GCS mirror to dodge 429 rate limits.
+COPY ci/maven-settings.xml /root/.m2/settings.xml
+
 # Copy only POMs first for dependency layer caching
 COPY kelta-platform/pom.xml ./
 COPY kelta-platform/runtime/pom.xml ./runtime/
@@ -43,6 +46,9 @@ RUN mvn clean install -DskipTests -B \
 FROM maven:3.9-eclipse-temurin-25 AS builder
 
 WORKDIR /build
+
+# Route Maven Central through Google's GCS mirror to dodge 429 rate limits.
+COPY ci/maven-settings.xml /root/.m2/settings.xml
 
 # Copy runtime artifacts from previous stage
 COPY --from=runtime-builder /root/.m2/repository/io/kelta /root/.m2/repository/io/kelta

--- a/kelta-worker/Dockerfile
+++ b/kelta-worker/Dockerfile
@@ -18,6 +18,9 @@ RUN microdnf install -y findutils && \
     tar xzf - -C /opt && \
     ln -sf /opt/apache-maven-${MAVEN_VERSION}/bin/mvn /usr/local/bin/mvn
 
+# Route Maven Central through Google's GCS mirror to dodge 429 rate limits.
+COPY ci/maven-settings.xml /root/.m2/settings.xml
+
 # Copy only POMs first for dependency layer caching
 COPY kelta-platform/pom.xml ./
 COPY kelta-platform/runtime/pom.xml ./runtime/
@@ -58,6 +61,9 @@ RUN microdnf install -y findutils && \
     curl -fsSL "https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz" | \
     tar xzf - -C /opt && \
     ln -sf /opt/apache-maven-${MAVEN_VERSION}/bin/mvn /usr/local/bin/mvn
+
+# Route Maven Central through Google's GCS mirror to dodge 429 rate limits.
+COPY ci/maven-settings.xml /root/.m2/settings.xml
 
 COPY --from=runtime-builder /root/.m2/repository /root/.m2/repository
 

--- a/kelta-worker/Dockerfile.jvm
+++ b/kelta-worker/Dockerfile.jvm
@@ -8,6 +8,9 @@ FROM maven:3.9-eclipse-temurin-25 AS runtime-builder
 
 WORKDIR /kelta-platform
 
+# Route Maven Central through Google's GCS mirror to dodge 429 rate limits.
+COPY ci/maven-settings.xml /root/.m2/settings.xml
+
 COPY kelta-platform/pom.xml ./
 COPY kelta-platform/runtime/pom.xml ./runtime/
 COPY kelta-platform/runtime/runtime-core/pom.xml ./runtime/runtime-core/
@@ -40,6 +43,9 @@ RUN mvn clean install -DskipTests -B \
 FROM maven:3.9-eclipse-temurin-25 AS builder
 
 WORKDIR /build
+
+# Route Maven Central through Google's GCS mirror to dodge 429 rate limits.
+COPY ci/maven-settings.xml /root/.m2/settings.xml
 
 COPY --from=runtime-builder /root/.m2/repository/io/kelta /root/.m2/repository/io/kelta
 

--- a/kelta-worker/Dockerfile.migrate
+++ b/kelta-worker/Dockerfile.migrate
@@ -16,6 +16,9 @@ RUN curl -fsSL "https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/b
     tar xzf - -C /opt && \
     ln -sf /opt/apache-maven-${MAVEN_VERSION}/bin/mvn /usr/local/bin/mvn
 
+# Route Maven Central through Google's GCS mirror to dodge 429 rate limits.
+COPY ci/maven-settings.xml /root/.m2/settings.xml
+
 COPY kelta-platform/pom.xml ./
 COPY kelta-platform/runtime/pom.xml ./runtime/
 COPY kelta-platform/runtime/runtime-core/pom.xml ./runtime/runtime-core/
@@ -56,6 +59,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf 
 RUN curl -fsSL "https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz" | \
     tar xzf - -C /opt && \
     ln -sf /opt/apache-maven-${MAVEN_VERSION}/bin/mvn /usr/local/bin/mvn
+
+# Route Maven Central through Google's GCS mirror to dodge 429 rate limits.
+COPY ci/maven-settings.xml /root/.m2/settings.xml
 
 COPY --from=runtime-builder /root/.m2/repository /root/.m2/repository
 


### PR DESCRIPTION
## Summary

- Parallel native-image builds (worker, worker-migrate, gateway, ai, mcp) all fetch `spring-boot-starter-parent` + transitives fresh from Maven Central. Under load it returns HTTP 429 and builds fail. Deploy pipeline keeps failing on post-merge builds of `main`.
- Add `ci/maven-settings.xml` that mirrors `central` to Google's free GCS mirror — same artifacts, no rate limit, lower latency. Wire it into every native Dockerfile at `/root/.m2/settings.xml` so mvn picks it up automatically.

Stopgap. Once homelab Nexus proxy (homelab-argo#117) lands and the `maven-public` group repo is configured, swap the mirror URL to `https://nexus.rzware.com/repository/maven-public/` and drop the GCS dependency.

Files:
- `ci/maven-settings.xml` (new)
- `kelta-{worker,auth,gateway,ai,mcp}/Dockerfile` (+ `kelta-worker/Dockerfile.migrate`) — COPY settings.xml in each stage that runs mvn

## Test plan

- [ ] Build job for each of worker, worker-migrate, gateway, ai, mcp completes without 429
- [ ] After homelab-argo#117 is live, follow-up PR swaps mirror URL to Nexus

🤖 Generated with [Claude Code](https://claude.com/claude-code)