### PR TITLE
fix(ci): point runner-level mvn at homelab Nexus mirror

### DIFF
--- a/.github/workflows/build-and-publish-containers.yml
+++ b/.github/workflows/build-and-publish-containers.yml
@@ -143,6 +143,10 @@ jobs:
             curl -fsSL https://archive.apache.org/dist/maven/maven-3/${{ env.MAVEN_VERSION }}/binaries/apache-maven-${{ env.MAVEN_VERSION }}-bin.tar.gz | tar xz -C /opt
             echo "/opt/apache-maven-${{ env.MAVEN_VERSION }}/bin" >> $GITHUB_PATH
           fi
+          # Route all Maven traffic through the homelab Nexus proxy so direct
+          # mvn calls on the runner share the same mirror as the Docker builds.
+          mkdir -p ~/.m2
+          cp ci/maven-settings.xml ~/.m2/settings.xml
 
       - name: Cache Maven dependencies
         if: matrix.changed == 'true' || needs.changes.outputs.workflows == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,11 @@ jobs:
             curl -fsSL https://archive.apache.org/dist/maven/maven-3/${{ env.MAVEN_VERSION }}/binaries/apache-maven-${{ env.MAVEN_VERSION }}-bin.tar.gz | tar xz -C /opt
             echo "/opt/apache-maven-${{ env.MAVEN_VERSION }}/bin" >> $GITHUB_PATH
           fi
+          # Route all Maven traffic through the homelab Nexus proxy so direct
+          # mvn calls on the runner share the same mirror as the Docker builds
+          # (otherwise harness builds hit Maven Central directly and 429 us).
+          mkdir -p ~/.m2
+          cp ci/maven-settings.xml ~/.m2/settings.xml
 
       - name: Cache Maven dependencies
         if: matrix.changed == 'true' || needs.changes.outputs.workflows == 'true'
@@ -219,6 +224,11 @@ jobs:
             curl -fsSL https://archive.apache.org/dist/maven/maven-3/${{ env.MAVEN_VERSION }}/binaries/apache-maven-${{ env.MAVEN_VERSION }}-bin.tar.gz | tar xz -C /opt
             echo "/opt/apache-maven-${{ env.MAVEN_VERSION }}/bin" >> $GITHUB_PATH
           fi
+          # Route all Maven traffic through the homelab Nexus proxy so direct
+          # mvn calls on the runner share the same mirror as the Docker builds
+          # (otherwise harness builds hit Maven Central directly and 429 us).
+          mkdir -p ~/.m2
+          cp ci/maven-settings.xml ~/.m2/settings.xml
 
       - name: Cache Maven dependencies
         uses: actions/cache@v4


### PR DESCRIPTION
## Summary

`ci/maven-settings.xml` only gets copied into Docker build contexts today. Workflow steps that call `mvn` directly on the runner (Build runtime modules, Build service JARs, integration verify) hit Maven Central directly and 429 us under load. PR #950's Integration Tests hit this.

Fix: copy `ci/maven-settings.xml` to `~/.m2/settings.xml` on the runner inside the `Install Maven` step so every subsequent mvn picks up the Nexus mirror automatically.

## Test plan

- [ ] CI on this PR — runner-level mvn no longer logs `Downloading from central: https://repo.maven.apache.org/...`; pulls go through `https://nexus.rzware.com/repository/maven-public/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)