### PR TITLE
fix(ci): unbreak main — native build curl retries + e2e auth URL

### DIFF
--- a/.github/workflows/build-and-publish-containers.yml
+++ b/.github/workflows/build-and-publish-containers.yml
@@ -540,6 +540,9 @@ jobs:
           # serves /auth/direct-login (returns HTML, breaking JSON.parse).
           E2E_AUTH_BASE_URL: https://auth.kelta.io
           E2E_AUTH_DIRECT_LOGIN_URL: https://auth.kelta.io
+          # Pre-issued PAT for DataFactory API calls. When set, fixtures
+          # short-circuit the direct-login / Authentik dance entirely.
+          E2E_API_TOKEN: ${{ secrets.E2E_API_TOKEN }}
           E2E_AUTHENTIK_URL: ${{ secrets.E2E_AUTHENTIK_URL }}
           E2E_CLIENT_ID: ${{ secrets.E2E_CLIENT_ID }}
           E2E_OIDC_PROVIDER_ID: ${{ secrets.E2E_OIDC_PROVIDER_ID }}

--- a/.github/workflows/build-and-publish-containers.yml
+++ b/.github/workflows/build-and-publish-containers.yml
@@ -535,7 +535,11 @@ jobs:
           E2E_BASE_URL: https://app.kelta.io
           E2E_API_BASE_URL: https://api.kelta.io
           E2E_TENANT_SLUG: default
-          E2E_AUTH_BASE_URL: ${{ secrets.E2E_AUTH_BASE_URL }}
+          # Hardcoded post-kelta.io cutover — the secret was set before #943
+          # and pointed at the legacy *.rzware.com host that no longer
+          # serves /auth/direct-login (returns HTML, breaking JSON.parse).
+          E2E_AUTH_BASE_URL: https://auth.kelta.io
+          E2E_AUTH_DIRECT_LOGIN_URL: https://auth.kelta.io
           E2E_AUTHENTIK_URL: ${{ secrets.E2E_AUTHENTIK_URL }}
           E2E_CLIENT_ID: ${{ secrets.E2E_CLIENT_ID }}
           E2E_OIDC_PROVIDER_ID: ${{ secrets.E2E_OIDC_PROVIDER_ID }}

--- a/e2e-tests/fixtures/auth-tokens.ts
+++ b/e2e-tests/fixtures/auth-tokens.ts
@@ -19,10 +19,20 @@ export function clearTokenCache(): void {
 /**
  * Get an API bearer token for test data operations.
  *
- * Strategy 1: Use kelta-auth direct-login endpoint (preferred).
- * Strategy 2: Fall back to Authentik client_credentials grant.
+ * Strategy 0: Use a pre-issued PAT from E2E_API_TOKEN (highest priority).
+ *             PATs are long-lived and tenant-scoped, so they sidestep both
+ *             the direct-login dependency and the dead Authentik fallback.
+ * Strategy 1: Use kelta-auth direct-login endpoint.
+ * Strategy 2: Fall back to Authentik client_credentials grant (legacy).
  */
 export async function getApiToken(): Promise<string> {
+  // Strategy 0: pre-issued PAT. Long-lived, no caching/refresh needed —
+  // the gateway accepts `Authorization: Bearer klt_*` directly.
+  const staticToken = process.env.E2E_API_TOKEN;
+  if (staticToken) {
+    return staticToken;
+  }
+
   // Return cached token if still valid (with 60s buffer)
   if (cachedToken && Date.now() < tokenExpiry - 60_000) {
     return cachedToken;

--- a/e2e-tests/fixtures/auth-tokens.ts
+++ b/e2e-tests/fixtures/auth-tokens.ts
@@ -80,11 +80,25 @@ async function getAuthentikToken(): Promise<string> {
     scope: "openid profile email",
   });
 
-  const response = await fetch(tokenUrl, {
-    method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    body: params.toString(),
-  });
+  let response: Response;
+  try {
+    response = await fetch(tokenUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: params.toString(),
+    });
+  } catch (err) {
+    // Authentik was decommissioned during the rzware.com → kelta.io migration;
+    // from inside the cluster the legacy hostname now serves a self-signed cert
+    // that node's fetch rejects. Don't let the network error bubble up as a
+    // test failure — direct-login is the supported path; this branch only
+    // exists for legacy local-dev setups.
+    console.warn(
+      `Authentik token endpoint unreachable: ${err}. ` +
+        "DataFactory API calls will fail — use direct-login (E2E_AUTH_BASE_URL) instead.",
+    );
+    return "";
+  }
 
   if (!response.ok) {
     const errorBody = await response.text().catch(() => "");

--- a/kelta-auth/Dockerfile
+++ b/kelta-auth/Dockerfile
@@ -14,7 +14,8 @@ ARG MAVEN_VERSION
 WORKDIR /kelta-platform
 
 RUN microdnf install -y findutils && \
-    curl -fsSL "https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz" | \
+    curl -fsSL --retry 8 --retry-delay 5 --retry-connrefused --retry-all-errors \
+      "https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz" | \
     tar xzf - -C /opt && \
     ln -sf /opt/apache-maven-${MAVEN_VERSION}/bin/mvn /usr/local/bin/mvn
 
@@ -62,7 +63,8 @@ ARG MAVEN_VERSION
 WORKDIR /build
 
 RUN microdnf install -y findutils && \
-    curl -fsSL "https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz" | \
+    curl -fsSL --retry 8 --retry-delay 5 --retry-connrefused --retry-all-errors \
+      "https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz" | \
     tar xzf - -C /opt && \
     ln -sf /opt/apache-maven-${MAVEN_VERSION}/bin/mvn /usr/local/bin/mvn
 

--- a/kelta-auth/Dockerfile
+++ b/kelta-auth/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /kelta-platform
 
 RUN microdnf install -y findutils && \
     curl -fsSL --retry 8 --retry-delay 5 --retry-connrefused --retry-all-errors \
-      "https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz" | \
+      "https://nexus.rzware.com/repository/maven-public/org/apache/maven/apache-maven/${MAVEN_VERSION}/apache-maven-${MAVEN_VERSION}-bin.tar.gz" | \
     tar xzf - -C /opt && \
     ln -sf /opt/apache-maven-${MAVEN_VERSION}/bin/mvn /usr/local/bin/mvn
 
@@ -64,7 +64,7 @@ WORKDIR /build
 
 RUN microdnf install -y findutils && \
     curl -fsSL --retry 8 --retry-delay 5 --retry-connrefused --retry-all-errors \
-      "https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz" | \
+      "https://nexus.rzware.com/repository/maven-public/org/apache/maven/apache-maven/${MAVEN_VERSION}/apache-maven-${MAVEN_VERSION}-bin.tar.gz" | \
     tar xzf - -C /opt && \
     ln -sf /opt/apache-maven-${MAVEN_VERSION}/bin/mvn /usr/local/bin/mvn
 

--- a/kelta-gateway/Dockerfile
+++ b/kelta-gateway/Dockerfile
@@ -14,7 +14,8 @@ ARG MAVEN_VERSION
 WORKDIR /kelta-platform
 
 RUN microdnf install -y findutils && \
-    curl -fsSL "https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz" | \
+    curl -fsSL --retry 8 --retry-delay 5 --retry-connrefused --retry-all-errors \
+      "https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz" | \
     tar xzf - -C /opt && \
     ln -sf /opt/apache-maven-${MAVEN_VERSION}/bin/mvn /usr/local/bin/mvn
 
@@ -62,7 +63,8 @@ ARG MAVEN_VERSION
 WORKDIR /build
 
 RUN microdnf install -y findutils && \
-    curl -fsSL "https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz" | \
+    curl -fsSL --retry 8 --retry-delay 5 --retry-connrefused --retry-all-errors \
+      "https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz" | \
     tar xzf - -C /opt && \
     ln -sf /opt/apache-maven-${MAVEN_VERSION}/bin/mvn /usr/local/bin/mvn
 

--- a/kelta-gateway/Dockerfile
+++ b/kelta-gateway/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /kelta-platform
 
 RUN microdnf install -y findutils && \
     curl -fsSL --retry 8 --retry-delay 5 --retry-connrefused --retry-all-errors \
-      "https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz" | \
+      "https://nexus.rzware.com/repository/maven-public/org/apache/maven/apache-maven/${MAVEN_VERSION}/apache-maven-${MAVEN_VERSION}-bin.tar.gz" | \
     tar xzf - -C /opt && \
     ln -sf /opt/apache-maven-${MAVEN_VERSION}/bin/mvn /usr/local/bin/mvn
 
@@ -64,7 +64,7 @@ WORKDIR /build
 
 RUN microdnf install -y findutils && \
     curl -fsSL --retry 8 --retry-delay 5 --retry-connrefused --retry-all-errors \
-      "https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz" | \
+      "https://nexus.rzware.com/repository/maven-public/org/apache/maven/apache-maven/${MAVEN_VERSION}/apache-maven-${MAVEN_VERSION}-bin.tar.gz" | \
     tar xzf - -C /opt && \
     ln -sf /opt/apache-maven-${MAVEN_VERSION}/bin/mvn /usr/local/bin/mvn
 

--- a/kelta-worker/Dockerfile
+++ b/kelta-worker/Dockerfile
@@ -14,7 +14,8 @@ ARG MAVEN_VERSION
 WORKDIR /kelta-platform
 
 RUN microdnf install -y findutils && \
-    curl -fsSL "https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz" | \
+    curl -fsSL --retry 8 --retry-delay 5 --retry-connrefused --retry-all-errors \
+      "https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz" | \
     tar xzf - -C /opt && \
     ln -sf /opt/apache-maven-${MAVEN_VERSION}/bin/mvn /usr/local/bin/mvn
 
@@ -62,7 +63,8 @@ ARG MAVEN_VERSION
 WORKDIR /build
 
 RUN microdnf install -y findutils && \
-    curl -fsSL "https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz" | \
+    curl -fsSL --retry 8 --retry-delay 5 --retry-connrefused --retry-all-errors \
+      "https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz" | \
     tar xzf - -C /opt && \
     ln -sf /opt/apache-maven-${MAVEN_VERSION}/bin/mvn /usr/local/bin/mvn
 

--- a/kelta-worker/Dockerfile
+++ b/kelta-worker/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /kelta-platform
 
 RUN microdnf install -y findutils && \
     curl -fsSL --retry 8 --retry-delay 5 --retry-connrefused --retry-all-errors \
-      "https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz" | \
+      "https://nexus.rzware.com/repository/maven-public/org/apache/maven/apache-maven/${MAVEN_VERSION}/apache-maven-${MAVEN_VERSION}-bin.tar.gz" | \
     tar xzf - -C /opt && \
     ln -sf /opt/apache-maven-${MAVEN_VERSION}/bin/mvn /usr/local/bin/mvn
 
@@ -64,7 +64,7 @@ WORKDIR /build
 
 RUN microdnf install -y findutils && \
     curl -fsSL --retry 8 --retry-delay 5 --retry-connrefused --retry-all-errors \
-      "https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz" | \
+      "https://nexus.rzware.com/repository/maven-public/org/apache/maven/apache-maven/${MAVEN_VERSION}/apache-maven-${MAVEN_VERSION}-bin.tar.gz" | \
     tar xzf - -C /opt && \
     ln -sf /opt/apache-maven-${MAVEN_VERSION}/bin/mvn /usr/local/bin/mvn
 

--- a/kelta-worker/Dockerfile.migrate
+++ b/kelta-worker/Dockerfile.migrate
@@ -12,7 +12,8 @@ WORKDIR /kelta-platform
 
 RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
 
-RUN curl -fsSL "https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz" | \
+RUN curl -fsSL --retry 8 --retry-delay 5 --retry-connrefused --retry-all-errors \
+      "https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz" | \
     tar xzf - -C /opt && \
     ln -sf /opt/apache-maven-${MAVEN_VERSION}/bin/mvn /usr/local/bin/mvn
 
@@ -56,7 +57,8 @@ WORKDIR /build
 
 RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
 
-RUN curl -fsSL "https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz" | \
+RUN curl -fsSL --retry 8 --retry-delay 5 --retry-connrefused --retry-all-errors \
+      "https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz" | \
     tar xzf - -C /opt && \
     ln -sf /opt/apache-maven-${MAVEN_VERSION}/bin/mvn /usr/local/bin/mvn
 

--- a/kelta-worker/Dockerfile.migrate
+++ b/kelta-worker/Dockerfile.migrate
@@ -13,7 +13,7 @@ WORKDIR /kelta-platform
 RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
 
 RUN curl -fsSL --retry 8 --retry-delay 5 --retry-connrefused --retry-all-errors \
-      "https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz" | \
+      "https://nexus.rzware.com/repository/maven-public/org/apache/maven/apache-maven/${MAVEN_VERSION}/apache-maven-${MAVEN_VERSION}-bin.tar.gz" | \
     tar xzf - -C /opt && \
     ln -sf /opt/apache-maven-${MAVEN_VERSION}/bin/mvn /usr/local/bin/mvn
 
@@ -58,7 +58,7 @@ WORKDIR /build
 RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
 
 RUN curl -fsSL --retry 8 --retry-delay 5 --retry-connrefused --retry-all-errors \
-      "https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz" | \
+      "https://nexus.rzware.com/repository/maven-public/org/apache/maven/apache-maven/${MAVEN_VERSION}/apache-maven-${MAVEN_VERSION}-bin.tar.gz" | \
     tar xzf - -C /opt && \
     ln -sf /opt/apache-maven-${MAVEN_VERSION}/bin/mvn /usr/local/bin/mvn
 


### PR DESCRIPTION
## Summary

Main has been red on every push since the rzware.com → kelta.io cutover (#943). Two unrelated regressions, plus a follow-up that swaps the workaround for the right long-term fix.

### 1. Native builds (auth + worker) — Maven tarball download

`curl: (7) Couldn't connect to server` pulling `apache-maven-3.9.9-bin.tar.gz` from `archive.apache.org`. Four parallel native builder stages race the same throttled host; bare `curl -fsSL` gives up on the first failure.

**Fix:** pull the Maven 3.9.9 tarball from the homelab Nexus 3 group repo (`maven-public`) instead of `archive.apache.org`. Nexus already proxies Maven Central via the GCS mirror (#952), and `org/apache/maven/apache-maven/...` is just a regular Maven artifact, so the group repo already serves the tarball at LAN speed with no rate limit. Verified live:
```
curl -I https://nexus.rzware.com/repository/maven-public/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.tar.gz
-> 200 application/x-gzip, 9.1 MB
```
`--retry 8 --retry-delay 5 --retry-connrefused --retry-all-errors` stays in place as belt-and-braces against Nexus pod restarts mid-build.

Applied to `kelta-{auth,gateway,worker}/Dockerfile` + `kelta-worker/Dockerfile.migrate`.

### 2. E2E auth flow (44 tests red)

`E2E_AUTH_BASE_URL` came from a secret last touched 2026-04-13 — still pointing at the legacy `*.rzware.com` host. `helpers/direct-login.ts` POSTs there, gets HTML back (SPA 405 page), `JSON.parse` throws, fixtures fall through to the Authentik fallback. `getAuthentikToken()` then hits Authentik (decommissioned), which from inside the cluster serves a self-signed cert. Node fetch throws `[cause]: Error: self-signed certificate` straight out of `await fetch(...)` — no try/catch — surfacing as `TypeError: fetch failed` on every dataFactory call.

**Fixes:**
- Hardcode `E2E_AUTH_BASE_URL=https://auth.kelta.io` + `E2E_AUTH_DIRECT_LOGIN_URL=https://auth.kelta.io` in the workflow so the secret can't drift again. Probed live: direct-login → 401 JSON ✓, OIDC discovery → 200 ✓.
- Wrap the Authentik fallback fetch in try/catch so a TLS/network error returns `""` (existing missing-creds path) instead of crashing.
- **New: `E2E_API_TOKEN` PAT bypass.** `fixtures/auth-tokens.ts` checks `process.env.E2E_API_TOKEN` first; when set, returns it directly and skips both the direct-login fetch and the Authentik fallback. Backed by a long-lived PAT (`klt_*`), this sidesteps the whole token-issuance dance for CI runs. Workflow already wires `E2E_API_TOKEN: ${{ secrets.E2E_API_TOKEN }}` through.

## Required before merge

- [ ] Add `E2E_API_TOKEN` repo secret (long-lived PAT `klt_*` for the e2e admin user)

## Test plan

- [ ] Native build jobs for `auth`, `worker`, `worker-migrate`, `gateway` all green (Nexus tarball pull is reliable; curl retries cover Nexus hiccups)
- [ ] E2E job green (DataFactory calls authenticate via the PAT, no dependency on `auth.kelta.io` / Authentik for token issuance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)