### PR TITLE
fix(gateway): default worker-service-url to emf-worker

### DIFF
--- a/kelta-gateway/README.md
+++ b/kelta-gateway/README.md
@@ -44,7 +44,7 @@ spring.security.oauth2.resourceserver.jwt:
   issuer-uri: ${OIDC_ISSUER_URI:http://localhost:9000/realms/kelta}
 
 kelta.gateway:
-  worker-service-url: ${WORKER_SERVICE_URL:http://kelta-worker:80}
+  worker-service-url: ${WORKER_SERVICE_URL:http://emf-worker:80}
   tenant-slug:
     enabled: ${TENANT_SLUG_ENABLED:true}
     cache-refresh-ms: 60000

--- a/kelta-gateway/src/main/java/io/kelta/gateway/auth/UserIdentityResolutionFilter.java
+++ b/kelta-gateway/src/main/java/io/kelta/gateway/auth/UserIdentityResolutionFilter.java
@@ -42,7 +42,7 @@ public class UserIdentityResolutionFilter implements GlobalFilter, Ordered {
             ReactiveRedisTemplate<String, String> redisTemplate,
             ObjectMapper objectMapper,
             PublicPathMatcher publicPathMatcher,
-            @Value("${kelta.gateway.worker-service-url:http://kelta-worker:80}") String workerServiceUrl,
+            @Value("${kelta.gateway.worker-service-url:http://emf-worker:80}") String workerServiceUrl,
             @Value("${kelta.gateway.security.identity-cache-ttl-minutes:5}") int cacheTtlMinutes) {
         this.webClient = webClientBuilder.baseUrl(workerServiceUrl).build();
         this.redisTemplate = redisTemplate;

--- a/kelta-gateway/src/main/java/io/kelta/gateway/cache/GatewayCacheManager.java
+++ b/kelta-gateway/src/main/java/io/kelta/gateway/cache/GatewayCacheManager.java
@@ -66,7 +66,7 @@ public class GatewayCacheManager {
 
     public GatewayCacheManager(
             WebClient.Builder webClientBuilder,
-            @Value("${kelta.gateway.worker-service-url:http://kelta-worker:80}") String workerServiceUrl) {
+            @Value("${kelta.gateway.worker-service-url:http://emf-worker:80}") String workerServiceUrl) {
 
         this.webClient = webClientBuilder.baseUrl(workerServiceUrl).build();
 

--- a/kelta-gateway/src/main/java/io/kelta/gateway/health/WorkerHealthIndicator.java
+++ b/kelta-gateway/src/main/java/io/kelta/gateway/health/WorkerHealthIndicator.java
@@ -30,7 +30,7 @@ public class WorkerHealthIndicator implements HealthIndicator {
 
     public WorkerHealthIndicator(
             WebClient.Builder webClientBuilder,
-            @Value("${kelta.gateway.worker-service-url:http://kelta-worker:80}") String workerServiceUrl) {
+            @Value("${kelta.gateway.worker-service-url:http://emf-worker:80}") String workerServiceUrl) {
         this.webClient = webClientBuilder.baseUrl(workerServiceUrl).build();
         this.workerServiceUrl = workerServiceUrl;
     }

--- a/kelta-gateway/src/main/java/io/kelta/gateway/listener/ConfigEventListener.java
+++ b/kelta-gateway/src/main/java/io/kelta/gateway/listener/ConfigEventListener.java
@@ -40,7 +40,7 @@ public class ConfigEventListener {
     public ConfigEventListener(RouteRegistry routeRegistry,
                               ObjectMapper objectMapper,
                               ApplicationEventPublisher applicationEventPublisher,
-                              @org.springframework.beans.factory.annotation.Value("${kelta.gateway.worker-service-url:http://kelta-worker:80}") String workerServiceUrl) {
+                              @org.springframework.beans.factory.annotation.Value("${kelta.gateway.worker-service-url:http://emf-worker:80}") String workerServiceUrl) {
         this.routeRegistry = routeRegistry;
         this.objectMapper = objectMapper;
         this.applicationEventPublisher = applicationEventPublisher;

--- a/kelta-gateway/src/main/java/io/kelta/gateway/service/RouteConfigService.java
+++ b/kelta-gateway/src/main/java/io/kelta/gateway/service/RouteConfigService.java
@@ -45,13 +45,13 @@ public class RouteConfigService {
             WebClient.Builder webClientBuilder,
             RouteRegistry routeRegistry,
             GatewayCacheManager cacheManager,
-            @Value("${kelta.gateway.worker-service-url:http://kelta-worker:80}") String workerServiceUrl) {
+            @Value("${kelta.gateway.worker-service-url:http://emf-worker:80}") String workerServiceUrl) {
         this.webClient = webClientBuilder.baseUrl(workerServiceUrl).build();
         this.routeRegistry = routeRegistry;
         this.cacheManager = cacheManager;
         this.workerServiceUrl = workerServiceUrl;
 
-        logger.info("RouteConfigService initialized with worker URL: {}", workerServiceUrl);
+        logger.info("Gateway → worker URL resolved to: {}", workerServiceUrl);
     }
 
     /**
@@ -138,7 +138,7 @@ public class RouteConfigService {
             // Always use the configured worker service URL (K8s Service DNS) instead
             // of the pod-specific IP from the bootstrap response. Pod IPs are ephemeral
             // and become stale when pods restart, causing routing failures. The K8s
-            // Service URL (e.g., http://kelta-worker:80) is stable and load-balances
+            // Service URL (e.g., http://emf-worker:80) is stable and load-balances
             // across all worker pods.
             RouteDefinition route = new RouteDefinition(
                 collectionId,

--- a/kelta-gateway/src/main/resources/application.yml
+++ b/kelta-gateway/src/main/resources/application.yml
@@ -70,7 +70,7 @@ kelta:
       cache-refresh-ms: 60000
 
     # Worker service URL (used for routing AND internal API calls)
-    worker-service-url: ${WORKER_SERVICE_URL:http://kelta-worker:80}
+    worker-service-url: ${WORKER_SERVICE_URL:http://emf-worker:80}
 
     # AI service URL (used for routing /api/ai/** requests)
     ai-service-url: ${AI_SERVICE_URL:http://emf-ai:80}

--- a/kelta-gateway/src/test/java/io/kelta/gateway/health/WorkerHealthIndicatorTest.java
+++ b/kelta-gateway/src/test/java/io/kelta/gateway/health/WorkerHealthIndicatorTest.java
@@ -41,7 +41,7 @@ class WorkerHealthIndicatorTest {
 
     private WorkerHealthIndicator healthIndicator;
 
-    private static final String WORKER_URL = "http://kelta-worker:80";
+    private static final String WORKER_URL = "http://emf-worker:80";
     private static final String HEALTH_PATH = "/actuator/health";
 
     @BeforeEach

--- a/kelta-gateway/src/test/java/io/kelta/gateway/listener/ConfigEventListenerTest.java
+++ b/kelta-gateway/src/test/java/io/kelta/gateway/listener/ConfigEventListenerTest.java
@@ -40,7 +40,7 @@ class ConfigEventListenerTest {
     private ObjectMapper objectMapper;
     private ConfigEventListener listener;
 
-    private static final String WORKER_SERVICE_URL = "http://kelta-worker:80";
+    private static final String WORKER_SERVICE_URL = "http://emf-worker:80";
 
     @BeforeEach
     void setUp() {

--- a/kelta-gateway/src/test/resources/application-test.yml
+++ b/kelta-gateway/src/test/resources/application-test.yml
@@ -31,7 +31,7 @@ spring:
 # Kelta Gateway test configuration
 kelta:
   gateway:
-    worker-service-url: http://kelta-worker:80
+    worker-service-url: http://emf-worker:80
     kafka:
       topics:
         collection-changed: kelta.collection.changed


### PR DESCRIPTION
## Summary
- Switched in-code default for `kelta.gateway.worker-service-url` from `http://kelta-worker:80` to `http://emf-worker:80` to match the deployed K8s Service name. Closes the silent-failure gap when `WORKER_SERVICE_URL` env override is missing (fresh chart install, local dev, new test env).
- Renamed startup log to `Gateway → worker URL resolved to: {url}` (INFO) in `RouteConfigService` so operators can verify worker routing without grepping `@Value` internals.
- Updated 10 files: `application.yml`, 5 `@Value` bindings (`UserIdentityResolutionFilter`, `GatewayCacheManager`, `WorkerHealthIndicator`, `ConfigEventListener`, `RouteConfigService`), 2 test fixtures (`WorkerHealthIndicatorTest`, `ConfigEventListenerTest`), `application-test.yml`, and `README.md`.

## Deferred
- **`PatAuthenticationFilter.java` intentionally not in this PR** — another in-flight branch has uncommitted refactor work on that file (introduces `ResponseHelpers`); the `kelta-worker:80` default there will be fixed in a follow-up once that branch lands.
- Long-term: rename K8s Service `emf-worker` → `kelta-worker` in `homelab-argo` as part of `kelta-*` branding migration, then drop the `WORKER_SERVICE_URL` env override entirely.

## Test plan
- [x] `mvn install -DskipTests` for runtime modules — green
- [x] `mvn verify -f kelta-gateway/pom.xml -B` — 438 tests, 0 failures
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)