### PR TITLE
fix(gateway): guard response header mutations against ReadOnlyHttpHeaders

### DIFF
--- a/kelta-gateway/src/main/java/io/kelta/gateway/auth/JwtAuthenticationFilter.java
+++ b/kelta-gateway/src/main/java/io/kelta/gateway/auth/JwtAuthenticationFilter.java
@@ -1,5 +1,6 @@
 package io.kelta.gateway.auth;
 
+import io.kelta.gateway.error.ResponseHelpers;
 import io.kelta.gateway.filter.TenantResolutionFilter;
 import io.kelta.gateway.metrics.GatewayMetrics;
 import org.slf4j.Logger;
@@ -9,7 +10,6 @@ import org.springframework.cloud.gateway.filter.GlobalFilter;
 import org.springframework.core.Ordered;
 import tools.jackson.core.JacksonException;
 import tools.jackson.databind.ObjectMapper;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.oauth2.jwt.JwtException;
@@ -160,8 +160,9 @@ public class JwtAuthenticationFilter implements GlobalFilter, Ordered {
      * @return a Mono that completes the response
      */
     private Mono<Void> unauthorized(ServerWebExchange exchange, String message) {
-        exchange.getResponse().setStatusCode(HttpStatus.UNAUTHORIZED);
-        exchange.getResponse().getHeaders().add(HttpHeaders.CONTENT_TYPE, "application/json");
+        if (!ResponseHelpers.prepareJsonResponse(exchange.getResponse(), HttpStatus.UNAUTHORIZED)) {
+            return Mono.empty();
+        }
 
         String path = exchange.getRequest().getPath().value();
         String errorJson;

--- a/kelta-gateway/src/main/java/io/kelta/gateway/auth/PatAuthenticationFilter.java
+++ b/kelta-gateway/src/main/java/io/kelta/gateway/auth/PatAuthenticationFilter.java
@@ -2,6 +2,7 @@ package io.kelta.gateway.auth;
 
 import tools.jackson.core.JacksonException;
 import tools.jackson.databind.ObjectMapper;
+import io.kelta.gateway.error.ResponseHelpers;
 import io.kelta.gateway.filter.TenantResolutionFilter;
 import io.kelta.gateway.metrics.GatewayMetrics;
 import org.slf4j.Logger;
@@ -11,7 +12,6 @@ import org.springframework.cloud.gateway.filter.GatewayFilterChain;
 import org.springframework.cloud.gateway.filter.GlobalFilter;
 import org.springframework.core.Ordered;
 import org.springframework.data.redis.core.ReactiveStringRedisTemplate;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -171,8 +171,9 @@ public class PatAuthenticationFilter implements GlobalFilter, Ordered {
     }
 
     private Mono<Void> unauthorized(ServerWebExchange exchange, String message) {
-        exchange.getResponse().setStatusCode(HttpStatus.UNAUTHORIZED);
-        exchange.getResponse().getHeaders().add(HttpHeaders.CONTENT_TYPE, "application/json");
+        if (!ResponseHelpers.prepareJsonResponse(exchange.getResponse(), HttpStatus.UNAUTHORIZED)) {
+            return Mono.empty();
+        }
 
         String path = exchange.getRequest().getPath().value();
         String errorJson;

--- a/kelta-gateway/src/main/java/io/kelta/gateway/authz/RouteAuthorizationFilter.java
+++ b/kelta-gateway/src/main/java/io/kelta/gateway/authz/RouteAuthorizationFilter.java
@@ -4,6 +4,7 @@ import io.kelta.gateway.auth.GatewayPrincipal;
 import io.kelta.gateway.auth.JwtAuthenticationFilter;
 import io.kelta.gateway.auth.PublicPathMatcher;
 import io.kelta.gateway.authz.cerbos.CerbosAuthorizationService;
+import io.kelta.gateway.error.ResponseHelpers;
 import io.kelta.gateway.filter.RequestLoggingFilter;
 import io.kelta.gateway.filter.TenantResolutionFilter;
 import io.kelta.gateway.metrics.GatewayMetrics;
@@ -15,7 +16,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;
 import org.springframework.cloud.gateway.filter.GlobalFilter;
 import org.springframework.core.Ordered;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
@@ -230,8 +230,9 @@ public class RouteAuthorizationFilter implements GlobalFilter, Ordered {
     }
 
     private Mono<Void> forbidden(ServerWebExchange exchange, String message) {
-        exchange.getResponse().setStatusCode(HttpStatus.FORBIDDEN);
-        exchange.getResponse().getHeaders().add(HttpHeaders.CONTENT_TYPE, "application/json");
+        if (!ResponseHelpers.prepareJsonResponse(exchange.getResponse(), HttpStatus.FORBIDDEN)) {
+            return Mono.empty();
+        }
 
         ObjectNode error = objectMapper.createObjectNode();
         error.put("status", "403");

--- a/kelta-gateway/src/main/java/io/kelta/gateway/error/GlobalErrorHandler.java
+++ b/kelta-gateway/src/main/java/io/kelta/gateway/error/GlobalErrorHandler.java
@@ -12,7 +12,6 @@ import org.springframework.boot.webflux.error.ErrorWebExceptionHandler;
 import org.springframework.core.annotation.Order;
 import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.security.oauth2.jwt.JwtException;
 import org.springframework.stereotype.Component;
 import org.springframework.web.server.ResponseStatusException;
@@ -104,9 +103,10 @@ public class GlobalErrorHandler implements ErrorWebExceptionHandler {
                 ex.getMessage() != null ? ex.getMessage() : "Rate limit exceeded"
             );
 
-            // Add Retry-After header
+            // Add Retry-After header (best-effort — response may already be committed)
             long retryAfterSeconds = rateLimitEx.getRetryAfter().getSeconds();
-            exchange.getResponse().getHeaders().add("Retry-After", String.valueOf(retryAfterSeconds));
+            ResponseHelpers.applyHeaderIfWritable(exchange.getResponse(),
+                () -> exchange.getResponse().getHeaders().add("Retry-After", String.valueOf(retryAfterSeconds)));
 
             log.warn("Rate limit exceeded for path: {}, correlationId: {}, retryAfter: {}s",
                 path, correlationId, retryAfterSeconds);
@@ -174,9 +174,13 @@ public class GlobalErrorHandler implements ErrorWebExceptionHandler {
         meta.put("correlationId", correlationId);
         error.setMeta(meta);
 
-        // Set response status and headers
-        exchange.getResponse().setStatusCode(status);
-        exchange.getResponse().getHeaders().setContentType(MediaType.APPLICATION_JSON);
+        // Set response status and headers — abandon if the response was already
+        // committed upstream so we don't surface a 500 in place of the real status.
+        if (!ResponseHelpers.prepareJsonResponse(exchange.getResponse(), status)) {
+            log.warn("Response already committed for path: {}, correlationId: {} — dropping error body",
+                path, correlationId);
+            return Mono.empty();
+        }
 
         // Serialize error response to JSON:API format
         try {

--- a/kelta-gateway/src/main/java/io/kelta/gateway/error/ResponseHelpers.java
+++ b/kelta-gateway/src/main/java/io/kelta/gateway/error/ResponseHelpers.java
@@ -1,0 +1,60 @@
+package io.kelta.gateway.error;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.server.reactive.ServerHttpResponse;
+
+/**
+ * Helpers for safely mutating gateway response status and headers.
+ *
+ * <p>If an upstream filter has already committed the response, the headers
+ * become {@code ReadOnlyHttpHeaders} and any mutation throws
+ * {@link UnsupportedOperationException}. That surfaces as a 500 instead of
+ * the intended 4xx. These helpers short-circuit when the response is already
+ * finalized so the chain completes cleanly.
+ */
+public final class ResponseHelpers {
+
+    private static final Logger log = LoggerFactory.getLogger(ResponseHelpers.class);
+
+    private ResponseHelpers() {}
+
+    /**
+     * Sets status and {@code application/json} content type on the response.
+     * Returns {@code true} if the caller should proceed to write the body,
+     * {@code false} if the response was already finalized upstream and the
+     * caller should abandon the write (return {@code Mono.empty()}).
+     */
+    public static boolean prepareJsonResponse(ServerHttpResponse response, HttpStatus status) {
+        if (response.isCommitted()) {
+            log.debug("Response already committed; skipping JSON error body");
+            return false;
+        }
+        try {
+            response.setStatusCode(status);
+            response.getHeaders().setContentType(MediaType.APPLICATION_JSON);
+            return true;
+        } catch (UnsupportedOperationException e) {
+            log.debug("Response headers read-only; skipping JSON error body: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * Best-effort header mutation: applies the action only if the response is
+     * still writable. Swallows {@link UnsupportedOperationException} so a
+     * read-only headers race does not break the chain.
+     */
+    public static void applyHeaderIfWritable(ServerHttpResponse response, Runnable mutation) {
+        if (response.isCommitted()) {
+            return;
+        }
+        try {
+            mutation.run();
+        } catch (UnsupportedOperationException e) {
+            log.debug("Skipped header mutation — response already finalized: {}", e.getMessage());
+        }
+    }
+}

--- a/kelta-gateway/src/main/java/io/kelta/gateway/filter/IpRateLimitFilter.java
+++ b/kelta-gateway/src/main/java/io/kelta/gateway/filter/IpRateLimitFilter.java
@@ -1,11 +1,11 @@
 package io.kelta.gateway.filter;
 
+import io.kelta.gateway.error.ResponseHelpers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;
 import org.springframework.cloud.gateway.filter.GlobalFilter;
 import org.springframework.core.Ordered;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import org.springframework.web.server.ServerWebExchange;
@@ -157,9 +157,11 @@ public class IpRateLimitFilter implements GlobalFilter, Ordered {
      * Returns a 429 Too Many Requests response.
      */
     private Mono<Void> tooManyRequests(ServerWebExchange exchange, String clientIp) {
-        exchange.getResponse().setStatusCode(HttpStatus.TOO_MANY_REQUESTS);
-        exchange.getResponse().getHeaders().add(HttpHeaders.CONTENT_TYPE, "application/json");
-        exchange.getResponse().getHeaders().add("Retry-After", String.valueOf(WINDOW_MILLIS / 1000));
+        if (!ResponseHelpers.prepareJsonResponse(exchange.getResponse(), HttpStatus.TOO_MANY_REQUESTS)) {
+            return Mono.empty();
+        }
+        ResponseHelpers.applyHeaderIfWritable(exchange.getResponse(),
+                () -> exchange.getResponse().getHeaders().add("Retry-After", String.valueOf(WINDOW_MILLIS / 1000)));
 
         String errorJson = String.format(
                 "{\"error\":{\"status\":429,\"code\":\"TOO_MANY_REQUESTS\",\"message\":\"Rate limit exceeded. Try again later.\",\"path\":\"%s\"}}",

--- a/kelta-gateway/src/main/java/io/kelta/gateway/filter/SystemCollectionResponseCacheFilter.java
+++ b/kelta-gateway/src/main/java/io/kelta/gateway/filter/SystemCollectionResponseCacheFilter.java
@@ -1,6 +1,7 @@
 package io.kelta.gateway.filter;
 
 import io.kelta.gateway.cache.GatewayCacheManager;
+import io.kelta.gateway.error.ResponseHelpers;
 import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -12,7 +13,6 @@ import org.springframework.core.io.buffer.DataBufferFactory;
 import org.springframework.core.io.buffer.DataBufferUtils;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.http.server.reactive.ServerHttpResponse;
 import org.springframework.http.server.reactive.ServerHttpResponseDecorator;
 import org.springframework.stereotype.Component;
@@ -189,9 +189,10 @@ public class SystemCollectionResponseCacheFilter implements GlobalFilter, Ordere
 
     private Mono<Void> writeCachedResponse(ServerWebExchange exchange, byte[] body) {
         ServerHttpResponse response = exchange.getResponse();
-        response.setStatusCode(HttpStatus.OK);
-        response.getHeaders().setContentType(MediaType.APPLICATION_JSON);
-        response.getHeaders().setContentLength(body.length);
+        if (!ResponseHelpers.prepareJsonResponse(response, HttpStatus.OK)) {
+            return Mono.empty();
+        }
+        ResponseHelpers.applyHeaderIfWritable(response, () -> response.getHeaders().setContentLength(body.length));
         DataBuffer buffer = response.bufferFactory().wrap(body);
         return response.writeWith(Mono.just(buffer));
     }

--- a/kelta-gateway/src/main/java/io/kelta/gateway/filter/TenantSlugExtractionFilter.java
+++ b/kelta-gateway/src/main/java/io/kelta/gateway/filter/TenantSlugExtractionFilter.java
@@ -1,6 +1,7 @@
 package io.kelta.gateway.filter;
 
 import io.kelta.gateway.cache.GatewayCacheManager;
+import io.kelta.gateway.error.ResponseHelpers;
 import io.kelta.gateway.metrics.GatewayMetrics;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -8,7 +9,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.Ordered;
 import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.stereotype.Component;
 import org.springframework.web.server.ServerWebExchange;
@@ -208,8 +208,9 @@ public class TenantSlugExtractionFilter implements WebFilter, Ordered {
     }
 
     private Mono<Void> notFound(ServerWebExchange exchange, String detail) {
-        exchange.getResponse().setStatusCode(HttpStatus.NOT_FOUND);
-        exchange.getResponse().getHeaders().setContentType(MediaType.APPLICATION_JSON);
+        if (!ResponseHelpers.prepareJsonResponse(exchange.getResponse(), HttpStatus.NOT_FOUND)) {
+            return Mono.empty();
+        }
 
         String body = String.format(
                 "{\"errors\":[{\"status\":\"404\",\"code\":\"TENANT_NOT_FOUND\",\"title\":\"Tenant Not Found\",\"detail\":\"%s\"}]}",

--- a/kelta-gateway/src/main/java/io/kelta/gateway/ratelimit/RateLimitFilter.java
+++ b/kelta-gateway/src/main/java/io/kelta/gateway/ratelimit/RateLimitFilter.java
@@ -3,6 +3,7 @@ package io.kelta.gateway.ratelimit;
 import io.kelta.gateway.auth.GatewayPrincipal;
 import io.kelta.gateway.auth.JwtAuthenticationFilter;
 import io.kelta.gateway.cache.GatewayCacheManager;
+import io.kelta.gateway.error.ResponseHelpers;
 import io.kelta.gateway.filter.TenantResolutionFilter;
 import io.kelta.gateway.metrics.GatewayMetrics;
 import io.kelta.gateway.route.RateLimitConfig;
@@ -126,17 +127,13 @@ public class RateLimitFilter implements GlobalFilter, Ordered {
      * @param result the rate limit check result
      */
     private void addRateLimitHeaders(ServerWebExchange exchange, RateLimitConfig config, RateLimitResult result) {
-        HttpHeaders headers = exchange.getResponse().getHeaders();
-
-        // X-RateLimit-Limit: Maximum requests per window
-        headers.add("X-RateLimit-Limit", String.valueOf(config.getRequestsPerWindow()));
-
-        // X-RateLimit-Remaining: Remaining requests in current window
-        headers.add("X-RateLimit-Remaining", String.valueOf(result.getRemainingRequests()));
-
-        // X-RateLimit-Reset: Timestamp when window resets (current time + window duration)
-        long resetTimestamp = Instant.now().plus(config.getWindowDuration()).getEpochSecond();
-        headers.add("X-RateLimit-Reset", String.valueOf(resetTimestamp));
+        ResponseHelpers.applyHeaderIfWritable(exchange.getResponse(), () -> {
+            HttpHeaders headers = exchange.getResponse().getHeaders();
+            headers.add("X-RateLimit-Limit", String.valueOf(config.getRequestsPerWindow()));
+            headers.add("X-RateLimit-Remaining", String.valueOf(result.getRemainingRequests()));
+            long resetTimestamp = Instant.now().plus(config.getWindowDuration()).getEpochSecond();
+            headers.add("X-RateLimit-Reset", String.valueOf(resetTimestamp));
+        });
     }
 
     /**
@@ -148,20 +145,20 @@ public class RateLimitFilter implements GlobalFilter, Ordered {
      * @return a Mono that completes the response
      */
     private Mono<Void> tooManyRequests(ServerWebExchange exchange, RateLimitConfig config, RateLimitResult result) {
-        exchange.getResponse().setStatusCode(HttpStatus.TOO_MANY_REQUESTS);
-        exchange.getResponse().getHeaders().add(HttpHeaders.CONTENT_TYPE, "application/json");
-
-        // Add rate limit headers
-        HttpHeaders headers = exchange.getResponse().getHeaders();
-        headers.add("X-RateLimit-Limit", String.valueOf(config.getRequestsPerWindow()));
-        headers.add("X-RateLimit-Remaining", "0");
-
-        long resetTimestamp = Instant.now().plus(config.getWindowDuration()).getEpochSecond();
-        headers.add("X-RateLimit-Reset", String.valueOf(resetTimestamp));
-
-        // Add Retry-After header (in seconds)
         long retryAfterSeconds = result.getRetryAfter().getSeconds();
-        headers.add("Retry-After", String.valueOf(retryAfterSeconds));
+
+        if (!ResponseHelpers.prepareJsonResponse(exchange.getResponse(), HttpStatus.TOO_MANY_REQUESTS)) {
+            return Mono.empty();
+        }
+
+        ResponseHelpers.applyHeaderIfWritable(exchange.getResponse(), () -> {
+            HttpHeaders headers = exchange.getResponse().getHeaders();
+            headers.add("X-RateLimit-Limit", String.valueOf(config.getRequestsPerWindow()));
+            headers.add("X-RateLimit-Remaining", "0");
+            long resetTimestamp = Instant.now().plus(config.getWindowDuration()).getEpochSecond();
+            headers.add("X-RateLimit-Reset", String.valueOf(resetTimestamp));
+            headers.add("Retry-After", String.valueOf(retryAfterSeconds));
+        });
 
         String errorJson = String.format(
             "{\"error\":{\"status\":429,\"code\":\"TOO_MANY_REQUESTS\",\"message\":\"Rate limit exceeded. Retry after %d seconds.\",\"path\":\"%s\"}}",

--- a/kelta-gateway/src/test/java/io/kelta/gateway/auth/PatAuthenticationFilterTest.java
+++ b/kelta-gateway/src/test/java/io/kelta/gateway/auth/PatAuthenticationFilterTest.java
@@ -1,13 +1,53 @@
 package io.kelta.gateway.auth;
 
+import io.kelta.gateway.metrics.GatewayMetrics;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.data.redis.core.ReactiveStringRedisTemplate;
+import org.springframework.data.redis.core.ReactiveValueOperations;
+import org.springframework.http.HttpHeaders;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 @DisplayName("PatAuthenticationFilter Tests")
 class PatAuthenticationFilterTest {
+
+    @Mock
+    private ReactiveStringRedisTemplate redisTemplate;
+
+    @Mock
+    private ReactiveValueOperations<String, String> valueOps;
+
+    @Mock
+    private GatewayMetrics metrics;
+
+    @Mock
+    private GatewayFilterChain filterChain;
+
+    private PatAuthenticationFilter filter;
+
+    @BeforeEach
+    void setUp() {
+        WebClient.Builder builder = WebClient.builder();
+        filter = new PatAuthenticationFilter(redisTemplate, builder, "http://localhost", metrics);
+        lenient().when(filterChain.filter(any(ServerWebExchange.class))).thenReturn(Mono.empty());
+    }
 
     @Test
     void sha256ShouldProduceConsistentHash() {
@@ -24,14 +64,41 @@ class PatAuthenticationFilterTest {
         assertThat(hash1).isNotEqualTo(hash2);
     }
 
+    @Test
+    @DisplayName("unauthorized() short-circuits cleanly when the response is already committed")
+    void unauthorizedShouldNotThrowWhenResponseAlreadyCommitted() {
+        // Drive into unauthorized() via the revoked-PAT branch.
+        String token = "klt_committed_response_test";
+        String hash = PatAuthenticationFilter.sha256(token);
+
+        when(redisTemplate.opsForValue()).thenReturn(valueOps);
+        when(valueOps.get("pat:revoked:" + hash)).thenReturn(Mono.just("revoked"));
+
+        MockServerHttpRequest request = MockServerHttpRequest
+                .get("/api/users")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                .build();
+        MockServerWebExchange exchange = MockServerWebExchange.from(request);
+
+        // Pre-commit the response so headers become ReadOnlyHttpHeaders. Any
+        // mutation attempt would normally throw UnsupportedOperationException
+        // and surface as a 500 instead of the intended 401.
+        exchange.getResponse().setComplete().block();
+        assertThat(exchange.getResponse().isCommitted()).isTrue();
+
+        // Filter must complete cleanly — no exception bubbling out.
+        StepVerifier.create(filter.filter(exchange, filterChain))
+                .verifyComplete();
+    }
+
     @Nested
     @DisplayName("Filter Order")
     class FilterOrder {
         @Test
         void shouldRunAfterJwtFilter() {
-            // PatAuthenticationFilter order is -99, JwtAuthenticationFilter is -100
-            // Lower order runs first, so JWT runs before PAT
-            assertThat(-99).isGreaterThan(-100);
+            // PatAuthenticationFilter order is -99, JwtAuthenticationFilter is -100.
+            // Lower order runs first, so JWT runs before PAT.
+            assertThat(filter.getOrder()).isEqualTo(-99);
         }
     }
 }


### PR DESCRIPTION
## Summary

- When an upstream filter has already committed the response, `exchange.getResponse().getHeaders()` returns Spring's `ReadOnlyHttpHeaders` — any mutation throws `UnsupportedOperationException` and the error propagates as an Internal-error log + 500, masking the intended 4xx/429.
- New `io.kelta.gateway.error.ResponseHelpers` centralizes the safety logic with two helpers:
  - `prepareJsonResponse(response, status)` — sets status + `application/json` content type, returns `false` if the response is already committed or the headers refuse mutation so the caller can return `Mono.empty()` cleanly.
  - `applyHeaderIfWritable(response, runnable)` — best-effort wrapper used for rate-limit (`X-RateLimit-*`) and `Retry-After` headers.
- Applied the guard everywhere a gateway filter mutates response headers and writes a JSON body: PatAuthenticationFilter, JwtAuthenticationFilter, RouteAuthorizationFilter, RateLimitFilter, IpRateLimitFilter, GlobalErrorHandler, TenantSlugExtractionFilter, SystemCollectionResponseCacheFilter.
- `PatAuthenticationFilterTest` now includes a committed-response test that drives the revoked-PAT branch into `unauthorized()` after `setComplete().block()` and asserts the chain completes without exception.

## Test plan

- [x] `mvn test` in kelta-gateway — 439 tests, 0 failures
- [x] New committed-response test (`unauthorizedShouldNotThrowWhenResponseAlreadyCommitted`) passes
- [ ] CI green across full reactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)