### PR TITLE
feat(worker): publish record-level webhook events to Svix

### DIFF
--- a/kelta-worker/src/main/java/io/kelta/worker/config/NatsSubscriptionConfig.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/config/NatsSubscriptionConfig.java
@@ -10,6 +10,7 @@ import io.kelta.worker.listener.FlowEventListener;
 import io.kelta.worker.listener.LayoutCacheInvalidationListener;
 import io.kelta.worker.listener.SearchIndexListener;
 import io.kelta.worker.listener.SupersetCollectionSyncListener;
+import io.kelta.worker.listener.RecordWebhookPublisher;
 import io.kelta.worker.listener.SvixWebhookPublisher;
 import io.kelta.worker.listener.SystemFeatureCacheInvalidationListener;
 import io.kelta.worker.listener.TenantEmailCacheInvalidationListener;
@@ -54,6 +55,9 @@ public class NatsSubscriptionConfig {
 
     @Autowired(required = false)
     private SvixWebhookPublisher svixWebhookPublisher;
+
+    @Autowired(required = false)
+    private RecordWebhookPublisher recordWebhookPublisher;
 
     @Autowired(required = false)
     private TenantEmailCacheInvalidationListener tenantEmailCacheInvalidationListener;
@@ -152,6 +156,13 @@ public class NatsSubscriptionConfig {
             log.info("Registered NATS subscription for Svix webhook publisher");
         }
 
+        if (recordWebhookPublisher != null) {
+            subscriptionManager.register(EventSubscription.queueGroup(
+                    "worker-svix-records", "kelta.record.changed.>", "worker-svix-records",
+                    recordWebhookPublisher::onRecordChanged));
+            log.info("Registered NATS subscription for Svix record webhook publisher");
+        }
+
         // Tenant email config invalidation — every pod evicts its
         // SmtpEmailProvider sender cache when tenant email columns change,
         // and broadly when any credential rotates (small cache, cheap to refill).
@@ -169,6 +180,7 @@ public class NatsSubscriptionConfig {
                 + (credentialCacheInvalidationListener != null ? 1 : 0)
                 + (supersetCollectionSyncListener != null ? 1 : 0)
                 + (svixWebhookPublisher != null ? 1 : 0)
+                + (recordWebhookPublisher != null ? 1 : 0)
                 + (tenantEmailCacheInvalidationListener != null ? 2 : 0));
     }
 }

--- a/kelta-worker/src/main/java/io/kelta/worker/config/SvixConfig.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/config/SvixConfig.java
@@ -2,6 +2,7 @@ package io.kelta.worker.config;
 
 import tools.jackson.databind.ObjectMapper;
 import io.kelta.runtime.workflow.BeforeSaveHookRegistry;
+import io.kelta.worker.listener.RecordWebhookPublisher;
 import io.kelta.worker.listener.SvixTenantLifecycleHook;
 import io.kelta.worker.listener.SvixWebhookPublisher;
 import io.kelta.worker.service.SvixTenantService;
@@ -42,7 +43,10 @@ public class SvixConfig {
 
     private static final List<String> EVENT_TYPES = List.of(
             "collection.created",
-            "collection.updated"
+            "collection.updated",
+            "record.created",
+            "record.updated",
+            "record.deleted"
     );
 
     @Value("${kelta.svix.server-url:http://localhost:8071}")
@@ -80,6 +84,11 @@ public class SvixConfig {
     @Bean
     public SvixWebhookPublisher svixWebhookPublisher(RestClient svixRestClient, ObjectMapper objectMapper) {
         return new SvixWebhookPublisher(svixRestClient, objectMapper);
+    }
+
+    @Bean
+    public RecordWebhookPublisher recordWebhookPublisher(RestClient svixRestClient, ObjectMapper objectMapper) {
+        return new RecordWebhookPublisher(svixRestClient, objectMapper);
     }
 
     /**

--- a/kelta-worker/src/main/java/io/kelta/worker/listener/RecordWebhookPublisher.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/listener/RecordWebhookPublisher.java
@@ -1,0 +1,106 @@
+package io.kelta.worker.listener;
+
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
+import io.kelta.runtime.event.ChangeType;
+import io.kelta.runtime.event.PlatformEvent;
+import io.kelta.runtime.event.RecordChangedPayload;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.MediaType;
+import org.springframework.web.client.RestClient;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Bridges record-change platform events to Svix for outbound webhook delivery,
+ * scoped to the appropriate tenant.
+ *
+ * <p>Subscribes to {@code kelta.record.changed.>} as a queue group so only one
+ * worker pod delivers each event. Talks to the Svix REST API directly via
+ * {@link RestClient} — the Svix Java SDK 1.68.0 ships Jackson-2 model annotations
+ * and doesn't deserialize cleanly under Spring Boot 4 / Jackson 3.
+ *
+ * @since 1.0.0
+ */
+public class RecordWebhookPublisher {
+
+    private static final Logger log = LoggerFactory.getLogger(RecordWebhookPublisher.class);
+
+    private static final Map<ChangeType, String> EVENT_TYPE_MAP = Map.of(
+            ChangeType.CREATED, "record.created",
+            ChangeType.UPDATED, "record.updated",
+            ChangeType.DELETED, "record.deleted"
+    );
+
+    private final RestClient svixRestClient;
+    private final ObjectMapper objectMapper;
+
+    public RecordWebhookPublisher(RestClient svixRestClient, ObjectMapper objectMapper) {
+        this.svixRestClient = svixRestClient;
+        this.objectMapper = objectMapper;
+    }
+
+    public void onRecordChanged(String message) {
+        try {
+            PlatformEvent<RecordChangedPayload> event = objectMapper.readValue(
+                    message,
+                    new TypeReference<>() {}
+            );
+
+            String tenantId = event.getTenantId();
+            if (tenantId == null || tenantId.isBlank()) {
+                log.debug("Skipping Svix publish — no tenant ID in record change event (id={})",
+                        event.getEventId());
+                return;
+            }
+
+            RecordChangedPayload payload = event.getPayload();
+            if (payload == null || payload.getChangeType() == null) {
+                return;
+            }
+
+            String eventType = EVENT_TYPE_MAP.get(payload.getChangeType());
+            if (eventType == null) {
+                log.debug("Skipping Svix publish — unhandled change type: {}", payload.getChangeType());
+                return;
+            }
+
+            Map<String, Object> webhookPayload = new HashMap<>();
+            webhookPayload.put("recordId", payload.getRecordId());
+            webhookPayload.put("collectionName", payload.getCollectionName());
+            webhookPayload.put("changeType", payload.getChangeType().name());
+            webhookPayload.put("data", payload.getData());
+            webhookPayload.put("timestamp", event.getTimestamp() != null ? event.getTimestamp().toString() : null);
+
+            if (payload.getChangeType() == ChangeType.UPDATED) {
+                webhookPayload.put("previousData", payload.getPreviousData());
+                webhookPayload.put("changedFields", payload.getChangedFields());
+            }
+
+            Map<String, Object> body = new LinkedHashMap<>();
+            body.put("eventType", eventType);
+            body.put("payload", webhookPayload);
+            body.put("eventId", event.getEventId());
+            if (payload.getCollectionName() != null && !payload.getCollectionName().isBlank()) {
+                body.put("channels", Set.of(payload.getCollectionName()));
+            }
+
+            svixRestClient.post()
+                    .uri("/api/v1/app/{appId}/msg/", tenantId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(body)
+                    .retrieve()
+                    .toBodilessEntity();
+
+            log.info("Published Svix webhook: type={}, tenant={}, collection={}, record={}",
+                    eventType, tenantId, payload.getCollectionName(), payload.getRecordId());
+
+        } catch (Exception e) {
+            log.error("Failed to publish record change event to Svix: {}", e.getMessage());
+        }
+    }
+}

--- a/kelta-worker/src/test/java/io/kelta/worker/listener/RecordWebhookPublisherTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/listener/RecordWebhookPublisherTest.java
@@ -1,0 +1,146 @@
+package io.kelta.worker.listener;
+
+import tools.jackson.databind.ObjectMapper;
+import io.kelta.runtime.event.ChangeType;
+import io.kelta.runtime.event.PlatformEvent;
+import io.kelta.runtime.event.RecordChangedPayload;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.*;
+
+@DisplayName("RecordWebhookPublisher")
+class RecordWebhookPublisherTest {
+
+    private MockRestServiceServer server;
+    private ObjectMapper objectMapper;
+    private RecordWebhookPublisher publisher;
+
+    @BeforeEach
+    void setUp() {
+        var builder = RestClient.builder()
+                .baseUrl("http://svix.test")
+                .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer test-token");
+        server = MockRestServiceServer.bindTo(builder).build();
+        objectMapper = new ObjectMapper();
+        publisher = new RecordWebhookPublisher(builder.build(), objectMapper);
+    }
+
+    private String buildEventJson(String tenantId, String collectionName, String recordId, ChangeType changeType) {
+        RecordChangedPayload payload = switch (changeType) {
+            case CREATED -> RecordChangedPayload.created(collectionName, recordId, Map.of("name", "Acme"));
+            case UPDATED -> RecordChangedPayload.updated(collectionName, recordId,
+                    Map.of("name", "Acme Updated"), Map.of("name", "Acme"), List.of("name"));
+            case DELETED -> RecordChangedPayload.deleted(collectionName, recordId, Map.of("name", "Acme"));
+        };
+
+        var event = new PlatformEvent<RecordChangedPayload>();
+        event.setEventId(UUID.randomUUID().toString());
+        event.setTenantId(tenantId);
+        event.setTimestamp(Instant.now());
+        event.setPayload(payload);
+
+        return objectMapper.writeValueAsString(event);
+    }
+
+    @Test
+    @DisplayName("publishes record.created event with collection as channel")
+    void publishesCreatedEvent() {
+        String json = buildEventJson("tenant-1", "orders", "rec-123", ChangeType.CREATED);
+
+        server.expect(requestTo("http://svix.test/api/v1/app/tenant-1/msg/"))
+                .andExpect(method(HttpMethod.POST))
+                .andExpect(header(HttpHeaders.AUTHORIZATION, "Bearer test-token"))
+                .andExpect(jsonPath("$.eventType").value("record.created"))
+                .andExpect(jsonPath("$.channels[0]").value("orders"))
+                .andExpect(jsonPath("$.payload.recordId").value("rec-123"))
+                .andExpect(jsonPath("$.payload.collectionName").value("orders"))
+                .andExpect(jsonPath("$.payload.changeType").value("CREATED"))
+                .andRespond(withSuccess());
+
+        publisher.onRecordChanged(json);
+
+        server.verify();
+    }
+
+    @Test
+    @DisplayName("publishes record.updated event with previousData and changedFields")
+    void publishesUpdatedEventWithDiff() {
+        String json = buildEventJson("tenant-1", "orders", "rec-123", ChangeType.UPDATED);
+
+        server.expect(requestTo("http://svix.test/api/v1/app/tenant-1/msg/"))
+                .andExpect(jsonPath("$.eventType").value("record.updated"))
+                .andExpect(jsonPath("$.payload.previousData.name").value("Acme"))
+                .andExpect(jsonPath("$.payload.changedFields[0]").value("name"))
+                .andRespond(withSuccess());
+
+        publisher.onRecordChanged(json);
+
+        server.verify();
+    }
+
+    @Test
+    @DisplayName("publishes record.deleted event")
+    void publishesDeletedEvent() {
+        String json = buildEventJson("tenant-2", "contacts", "rec-456", ChangeType.DELETED);
+
+        server.expect(requestTo("http://svix.test/api/v1/app/tenant-2/msg/"))
+                .andExpect(jsonPath("$.eventType").value("record.deleted"))
+                .andExpect(jsonPath("$.payload.recordId").value("rec-456"))
+                .andRespond(withSuccess());
+
+        publisher.onRecordChanged(json);
+
+        server.verify();
+    }
+
+    @Test
+    @DisplayName("does not publish when tenant ID is missing")
+    void skipsMissingTenantId() {
+        String json = buildEventJson(null, "orders", "rec-123", ChangeType.CREATED);
+
+        publisher.onRecordChanged(json);
+
+        server.verify();
+    }
+
+    @Test
+    @DisplayName("payload contains record data")
+    void payloadContainsRecordData() {
+        String json = buildEventJson("tenant-1", "orders", "rec-789", ChangeType.CREATED);
+
+        server.expect(requestTo("http://svix.test/api/v1/app/tenant-1/msg/"))
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.payload.data.name").value("Acme"))
+                .andRespond(withSuccess());
+
+        publisher.onRecordChanged(json);
+
+        server.verify();
+    }
+
+    @Test
+    @DisplayName("swallows Svix errors and does not throw")
+    void swallowsErrors() {
+        String json = buildEventJson("tenant-1", "orders", "rec-123", ChangeType.CREATED);
+
+        server.expect(requestTo("http://svix.test/api/v1/app/tenant-1/msg/"))
+                .andRespond(withServerError());
+
+        publisher.onRecordChanged(json);
+
+        server.verify();
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `RecordWebhookPublisher` which subscribes to `kelta.record.changed.>` as a queue group and delivers `record.created`, `record.updated`, and `record.deleted` events to Svix per tenant
- Updated events include `previousData` and `changedFields` in the payload so subscribers can see exactly what changed
- Registers the three new event types with Svix on startup via `SvixConfig`
- Wires the new publisher in `NatsSubscriptionConfig` alongside the existing collection webhook publisher

## How it fits the architecture

NATS JetStream already emits `kelta.record.changed.>` for every record mutation — the flow engine and search indexer already consume it. This PR adds a queue-group consumer on the same subject that forwards events to Svix, which handles delivery, retries, and signature verification to tenant-registered endpoints. The existing `GET /api/svix/portal` endpoint already gives tenants a UI to manage their subscriptions, so no frontend changes are needed.

## Test plan

- [ ] `RecordWebhookPublisherTest` — 6 unit tests covering created/updated/deleted, missing tenant ID, error swallowing, and payload shape
- [ ] Existing `SvixWebhookPublisherTest` and `NatsSubscriptionConfigTest` still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)