### PR TITLE
chore(mcp): fix create_picklist tool to use hyphenated JSON:API paths

### DIFF
--- a/.claude/CHANGELOG.md
+++ b/.claude/CHANGELOG.md
@@ -27,3 +27,7 @@ This file tracks merged autopilot work. Entries are appended by autopilot worker
 ## 2026-06-01
 
 - 2026-06-01 fix(e2e): point E2E workflow + `.env.example` at `app.kelta.io`/`api.kelta.io`/`auth.kelta.io` after the rzware.com cutover; the legacy hostnames no longer serve a valid cert so Playwright was failing every test with `ERR_CERT_AUTHORITY_INVALID` (BUG-2026-06-01-4324)
+
+## 2026-06-03
+
+- 2026-06-03 chore(mcp): fix `create_picklist` admin tool to POST to `/api/global-picklists` and `/api/picklist-values` with `picklistSourceType=GLOBAL`/`picklistSourceId=<uuid>` so it stops 404'ing (CHORE-2026-06-02-0002)

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/CreatePicklistTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/CreatePicklistTool.java
@@ -10,6 +10,8 @@ import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
 import org.springframework.stereotype.Component;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -22,12 +24,16 @@ import java.util.Map;
  *
  * <p>Wraps:
  * <ol>
- *   <li>POST /api/globalPicklists — create the picklist</li>
- *   <li>POST /api/picklistValues (per value) — create each value</li>
+ *   <li>POST /api/global-picklists — create the picklist</li>
+ *   <li>POST /api/picklist-values (per value) — create each value, with
+ *       {@code picklistSourceType=GLOBAL} and {@code picklistSourceId}
+ *       set to the new picklist's UUID.</li>
  * </ol>
  */
 @Component
 public class CreatePicklistTool implements AdminTool {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     private final GatewayHttpClient gateway;
 
@@ -40,7 +46,8 @@ public class CreatePicklistTool implements AdminTool {
         Map<String, Object> valueItem = new LinkedHashMap<>();
         valueItem.put("type", "object");
         valueItem.put("description",
-                "{\"value\":\"...\",\"label\":\"...\",\"sortOrder\":number,\"active\":bool}");
+                "{\"value\":\"...\",\"label\":\"...\",\"sortOrder\":number,"
+                + "\"isActive\":bool,\"isDefault\":bool}");
         valueItem.put("additionalProperties", true);
 
         Map<String, Object> valuesArray = new LinkedHashMap<>();
@@ -56,7 +63,10 @@ public class CreatePicklistTool implements AdminTool {
         Tool tool = Tool.builder()
                 .name("create_picklist")
                 .title("Create Picklist")
-                .description("Create a global picklist with its initial values. The picklist is created first; each value is then POSTed to /api/picklistValues with picklistName backreference.")
+                .description("Create a global picklist with its initial values. "
+                        + "The picklist is created first at /api/global-picklists; each value is "
+                        + "then POSTed to /api/picklist-values with picklistSourceType=GLOBAL and "
+                        + "picklistSourceId set to the new picklist's UUID.")
                 .inputSchema(Schemas.object(properties, List.of("name", "values")))
                 .annotations(ToolHints.write(false, false))
                 .build();
@@ -80,17 +90,18 @@ public class CreatePicklistTool implements AdminTool {
                     if (args.get("description") instanceof String s && !s.isBlank()) attrs.put("description", s);
 
                     Map<String, Object> picklistBody = Map.of("data", Map.of(
-                            "type", "globalPicklists",
+                            "type", "global-picklists",
                             "attributes", attrs));
                     GatewayHttpClient.Response picklistRes;
                     try {
-                        picklistRes = gateway.post("/api/globalPicklists", picklistBody);
+                        picklistRes = gateway.post("/api/global-picklists", picklistBody);
                     } catch (RuntimeException e) {
                         return McpErrorMapper.fromException(e);
                     }
                     if (!picklistRes.isSuccess()) {
                         return McpErrorMapper.toResult(picklistRes);
                     }
+                    String picklistId = extractId(picklistRes.body());
 
                     List<Map<String, Object>> valueResults = new ArrayList<>();
                     for (int i = 0; i < values.size(); i++) {
@@ -103,15 +114,16 @@ public class CreatePicklistTool implements AdminTool {
                         for (Map.Entry<?, ?> e : vAttrs.entrySet()) {
                             vMap.put(String.valueOf(e.getKey()), e.getValue());
                         }
-                        vMap.putIfAbsent("picklistName", n.toString());
+                        vMap.put("picklistSourceType", "GLOBAL");
+                        if (picklistId != null) vMap.put("picklistSourceId", picklistId);
                         if (!vMap.containsKey("sortOrder")) vMap.put("sortOrder", i);
 
                         Map<String, Object> valueBody = Map.of("data", Map.of(
-                                "type", "picklistValues",
+                                "type", "picklist-values",
                                 "attributes", vMap));
                         GatewayHttpClient.Response vr;
                         try {
-                            vr = gateway.post("/api/picklistValues", valueBody);
+                            vr = gateway.post("/api/picklist-values", valueBody);
                         } catch (RuntimeException e) {
                             valueResults.add(Map.of("index", i, "error", e.getClass().getSimpleName()));
                             continue;
@@ -131,6 +143,17 @@ public class CreatePicklistTool implements AdminTool {
                             .build();
                 })
                 .build();
+    }
+
+    private static String extractId(String body) {
+        if (body == null) return null;
+        try {
+            JsonNode n = OBJECT_MAPPER.readTree(body);
+            JsonNode id = n.path("data").path("id");
+            return id.isMissingNode() || id.isNull() ? null : id.asString();
+        } catch (RuntimeException e) {
+            return null;
+        }
     }
 
     private static CallToolResult error(String message) {

--- a/kelta-mcp/src/test/java/io/kelta/mcp/tool/admin/CreatePicklistToolTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/tool/admin/CreatePicklistToolTest.java
@@ -54,10 +54,10 @@ class CreatePicklistToolTest {
     }
 
     @Test
-    void createsPicklistThenEachValueWithSortOrder() {
-        wm.stubFor(post(urlEqualTo("/api/globalPicklists"))
+    void createsPicklistThenEachValueWithSourceIdAndSortOrder() {
+        wm.stubFor(post(urlEqualTo("/api/global-picklists"))
                 .willReturn(aResponse().withStatus(201).withBody("{\"data\":{\"id\":\"p1\"}}")));
-        wm.stubFor(post(urlEqualTo("/api/picklistValues"))
+        wm.stubFor(post(urlEqualTo("/api/picklist-values"))
                 .willReturn(aResponse().withStatus(201).withBody("{\"data\":{\"id\":\"pv\"}}")));
 
         CallToolResult result = tool.toSpecification().callHandler().apply(
@@ -68,11 +68,17 @@ class CreatePicklistToolTest {
                                 Map.of("value", "CLOSED", "label", "Closed"))), null));
 
         assertThat(result.isError()).isNotEqualTo(Boolean.TRUE);
-        wm.verify(2, WireMock.postRequestedFor(urlEqualTo("/api/picklistValues")));
-        wm.verify(WireMock.postRequestedFor(urlEqualTo("/api/picklistValues"))
+        wm.verify(WireMock.postRequestedFor(urlEqualTo("/api/global-picklists"))
                 .withHeader("Authorization", equalTo("Bearer klt_picklist_test"))
+                .withRequestBody(matchingJsonPath("$.data.type", equalTo("global-picklists")))
+                .withRequestBody(matchingJsonPath("$.data.attributes.name", equalTo("stages"))));
+        wm.verify(2, WireMock.postRequestedFor(urlEqualTo("/api/picklist-values")));
+        wm.verify(WireMock.postRequestedFor(urlEqualTo("/api/picklist-values"))
+                .withHeader("Authorization", equalTo("Bearer klt_picklist_test"))
+                .withRequestBody(matchingJsonPath("$.data.type", equalTo("picklist-values")))
                 .withRequestBody(matchingJsonPath("$.data.attributes.value", equalTo("OPEN")))
-                .withRequestBody(matchingJsonPath("$.data.attributes.picklistName", equalTo("stages")))
+                .withRequestBody(matchingJsonPath("$.data.attributes.picklistSourceType", equalTo("GLOBAL")))
+                .withRequestBody(matchingJsonPath("$.data.attributes.picklistSourceId", equalTo("p1")))
                 .withRequestBody(matchingJsonPath("$.data.attributes.sortOrder", equalTo("0"))));
     }
 }


### PR DESCRIPTION
The MCP admin tool was POSTing to /api/globalPicklists and
/api/picklistValues, which returned 404 — the gateway routes are
/api/global-picklists and /api/picklist-values. Switch the URLs, the
JSON:API resource types, and the value backreference: instead of
picklistName, set picklistSourceType=GLOBAL and picklistSourceId to
the new picklist's UUID (extracted from the create response). Also
update the value-attribute schema description to use isActive (the
actual field name).

(CHORE-2026-06-02-0002)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
