### PR TITLE
chore(mcp): translate add_field aliases to native FieldType + payload shapes

### DIFF
--- a/.claude/CHANGELOG.md
+++ b/.claude/CHANGELOG.md
@@ -27,3 +27,7 @@ This file tracks merged autopilot work. Entries are appended by autopilot worker
 ## 2026-06-01
 
 - 2026-06-01 fix(e2e): point E2E workflow + `.env.example` at `app.kelta.io`/`api.kelta.io`/`auth.kelta.io` after the rzware.com cutover; the legacy hostnames no longer serve a valid cert so Playwright was failing every test with `ERR_CERT_AUTHORITY_INVALID` (BUG-2026-06-01-4324)
+
+## 2026-06-03
+
+- 2026-06-03 chore(mcp): map `add_field` friendly type aliases (text, number, picklist, …) to the native uppercase `FieldType` enum, translate `fieldName`/`collectionName`/`unique` to `name`/`collectionId`/`uniqueConstraint`, assemble picklist `fieldTypeConfig` and lookup `relationships.referenceCollectionId`, and expose `displayName`/`indexed`/`searchable` — fixes the 400-for-every-field-type regression on `POST /api/fields` (CHORE-2026-06-02-0003)

--- a/.claude/docs/conventions.md
+++ b/.claude/docs/conventions.md
@@ -71,3 +71,12 @@
 - Do not add a new shared list/table/filter/form component in `kelta-ui/app/src/components/` if one already exists for the same purpose in either `kelta-ui/app/` or `kelta-web/packages/components/`. Reuse or extend the existing one.
 - The unification target for these families (DataTable, FilterBuilder, FieldRenderer, ResourceForm, RelatedList) is the library variant under `@kelta/components`. App-side variants are being collapsed into thin re-exports — see `.claude/docs/ui-consolidation-plan.md` for the current state and migration order.
 - `@kelta/components` is a public plugin surface. Breaking changes to its exported props need a deprecation window (additive props, `legacy*` flags) — never a hard cutover.
+
+## MCP tools (kelta-mcp)
+
+### Friendly args → native JSON:API body
+MCP admin tools expose camelCase, lowercase-friendly argument names to LLM callers and translate them to the native worker payload before hitting the gateway. The worker is strict — uppercase enums, `name` (not `fieldName`), `collectionId` (not `collectionName`), `uniqueConstraint` (not `unique`) — so do the translation at the tool boundary, not in the prompt.
+
+- **Field types**: accept friendly aliases (`text`, `number`, `picklist`, `lookup`, …) and map to the uppercase `FieldType` enum the worker expects. Centralise the mapping in `FieldBodyBuilder.resolveNativeType` so `add_field` and `create_collection`'s nested field array stay in sync.
+- **Per-type payload**: picklist fields need `attributes.fieldTypeConfig = {picklistSourceType, picklistSourceId}`; reference/lookup fields need `relationships.referenceCollectionId.data.id` + `attributes.relationshipName` (and optional `relationshipType`). Build these in the same helper so the on-the-wire shape can be unit-tested with WireMock JSON path matchers.
+- **ID resolution**: accept either a UUID (`collectionId`, `referenceCollectionId`, `picklistSourceId`) or a friendly name (`collectionName`, `referenceCollection`) and resolve names via `GET /api/collections?filter[name][eq]=…`. UUIDs match `FieldBodyBuilder.UUID_PATTERN`; anything else triggers the lookup.

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/AddFieldTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/AddFieldTool.java
@@ -19,32 +19,54 @@ import java.util.Map;
 public class AddFieldTool implements AdminTool {
 
     private final GatewayHttpClient gateway;
+    private final FieldBodyBuilder bodyBuilder;
 
     public AddFieldTool(GatewayHttpClient gateway) {
         this.gateway = gateway;
+        this.bodyBuilder = new FieldBodyBuilder(gateway);
     }
 
     @Override
     public SyncToolSpecification toSpecification() {
         Map<String, Object> properties = new LinkedHashMap<>();
-        properties.put("collectionName", Schemas.string("Collection the field belongs to."));
+        properties.put("collectionName", Schemas.string(
+                "Collection the field belongs to. Resolved to collectionId via lookup unless collectionId is provided."));
+        properties.put("collectionId", Schemas.string(
+                "Optional UUID of the collection — bypasses the name lookup."));
         properties.put("fieldName", Schemas.string("Field name (camelCase recommended)."));
+        properties.put("displayName", Schemas.string("Optional human-readable label shown in the admin UI."));
         properties.put("type", Schemas.string(
-                "Field type: text, longText, number, integer, decimal, boolean, date, datetime, reference, picklist, multiPicklist, json, file, image."));
+                "Field type alias. Mapped to the native uppercase enum: "
+                + "text|string→STRING, longText→STRING, number|integer→INTEGER, decimal|double→DOUBLE, "
+                + "long→LONG, boolean→BOOLEAN, date→DATE, datetime→DATETIME, "
+                + "picklist→PICKLIST, multiPicklist→MULTI_PICKLIST, "
+                + "reference|lookup→LOOKUP, json→JSON. Uppercase enum values are also accepted."));
         properties.put("required", Schemas.bool("Whether the field is required (default false).", false));
-        properties.put("unique", Schemas.bool("Whether values must be unique (default false).", false));
+        properties.put("unique", Schemas.bool("Whether values must be unique (default false). Sent as uniqueConstraint.", false));
+        properties.put("indexed", Schemas.bool("Whether the column has a database index (default false).", false));
+        properties.put("searchable", Schemas.bool("Whether the field is indexed for full-text search (default false).", false));
         properties.put("description", Schemas.string("Optional description shown in the admin UI."));
         properties.put("defaultValue", Schemas.string("Optional default value as a string. Numeric/boolean values are still passed as strings here."));
         properties.put("validation", Schemas.freeObject(
                 "Optional validation config (regex, min/max, etc.) — shape depends on the field type."));
+        properties.put("referenceCollectionId", Schemas.string(
+                "UUID of the target collection for reference/lookup fields."));
         properties.put("referenceCollection", Schemas.string(
-                "For type=reference, the target collection name."));
+                "(Legacy) Target collection name for reference/lookup fields. Resolved via name lookup."));
+        properties.put("relationshipName", Schemas.string(
+                "Human-readable relationship name for reference/lookup fields."));
+        properties.put("relationshipType", Schemas.string(
+                "Relationship semantics for reference/lookup fields: \"LOOKUP\" (default) or \"MASTER_DETAIL\"."));
+        properties.put("picklistSourceId", Schemas.string(
+                "UUID of the source picklist for picklist/multiPicklist fields."));
+        properties.put("picklistSourceType", Schemas.string(
+                "Source of picklist values: \"GLOBAL\" (default) or \"FIELD\"."));
 
         Tool tool = Tool.builder()
                 .name("add_field")
                 .title("Add Field")
-                .description("Add a field to an existing collection. Wraps POST /api/fields with a JSON:API body.")
-                .inputSchema(Schemas.object(properties, List.of("collectionName", "fieldName", "type")))
+                .description("Add a field to an existing collection. Wraps POST /api/fields with a JSON:API body, translating friendly type aliases (text, number, picklist, …) into the native uppercase enum and assembling per-type payload (fieldTypeConfig for picklists, referenceCollectionId relationship + relationshipName for lookups).")
+                .inputSchema(Schemas.object(properties, List.of("fieldName", "type")))
                 .annotations(ToolHints.write(false, false))
                 .build();
 
@@ -53,31 +75,13 @@ public class AddFieldTool implements AdminTool {
                 .callHandler((context, request) -> {
                     Map<String, Object> args = request.arguments();
                     if (args == null) args = Map.of();
-                    Object cn = args.get("collectionName");
-                    Object fn = args.get("fieldName");
-                    Object t = args.get("type");
-                    if (cn == null || cn.toString().isBlank()
-                            || fn == null || fn.toString().isBlank()
-                            || t == null || t.toString().isBlank()) {
-                        return error("Arguments \"collectionName\", \"fieldName\", and \"type\" are required.");
+
+                    FieldBodyBuilder.Result result = bodyBuilder.build(args);
+                    if (result.isError()) {
+                        return error(result.errorMessage());
                     }
-
-                    Map<String, Object> attrs = new LinkedHashMap<>();
-                    attrs.put("collectionName", cn.toString());
-                    attrs.put("fieldName", fn.toString());
-                    attrs.put("type", t.toString());
-                    if (args.get("required") instanceof Boolean b) attrs.put("required", b);
-                    if (args.get("unique") instanceof Boolean b) attrs.put("unique", b);
-                    if (args.get("description") instanceof String s && !s.isBlank()) attrs.put("description", s);
-                    if (args.get("defaultValue") instanceof String s) attrs.put("defaultValue", s);
-                    if (args.get("validation") instanceof Map<?, ?> v) attrs.put("validation", v);
-                    if (args.get("referenceCollection") instanceof String s && !s.isBlank()) attrs.put("referenceCollection", s);
-
-                    Map<String, Object> body = Map.of("data", Map.of(
-                            "type", "fields",
-                            "attributes", attrs));
                     try {
-                        return McpErrorMapper.toResult(gateway.post("/api/fields", body));
+                        return McpErrorMapper.toResult(gateway.post("/api/fields", result.body()));
                     } catch (RuntimeException e) {
                         return McpErrorMapper.fromException(e);
                     }

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/CreateCollectionTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/CreateCollectionTool.java
@@ -35,9 +35,11 @@ import java.util.Map;
 public class CreateCollectionTool implements AdminTool {
 
     private final GatewayHttpClient gateway;
+    private final FieldBodyBuilder bodyBuilder;
 
     public CreateCollectionTool(GatewayHttpClient gateway) {
         this.gateway = gateway;
+        this.bodyBuilder = new FieldBodyBuilder(gateway);
     }
 
     @Override
@@ -108,6 +110,8 @@ public class CreateCollectionTool implements AdminTool {
                                 .build();
                     }
 
+                    String newCollectionId = FieldBodyBuilder.extractFirstId(collectionRes.body());
+
                     List<Map<String, Object>> fieldResults = new ArrayList<>();
                     for (int i = 0; i < fields.size(); i++) {
                         Object item = fields.get(i);
@@ -119,14 +123,24 @@ public class CreateCollectionTool implements AdminTool {
                         for (Map.Entry<?, ?> e : fieldAttrs.entrySet()) {
                             fAttrs.put(String.valueOf(e.getKey()), e.getValue());
                         }
-                        fAttrs.putIfAbsent("collectionName", n.toString());
+                        if (newCollectionId != null) {
+                            fAttrs.putIfAbsent("collectionId", newCollectionId);
+                        } else {
+                            fAttrs.putIfAbsent("collectionName", n.toString());
+                        }
 
-                        Map<String, Object> fieldBody = Map.of("data", Map.of(
-                                "type", "fields",
-                                "attributes", fAttrs));
+                        FieldBodyBuilder.Result built = bodyBuilder.build(fAttrs);
+                        if (built.isError()) {
+                            fieldResults.add(Map.of(
+                                    "index", i,
+                                    "fieldName", fAttrs.getOrDefault("fieldName", "?"),
+                                    "error", built.errorMessage()));
+                            continue;
+                        }
+
                         GatewayHttpClient.Response fr;
                         try {
-                            fr = gateway.post("/api/fields", fieldBody);
+                            fr = gateway.post("/api/fields", built.body());
                         } catch (RuntimeException e) {
                             fieldResults.add(Map.of("index", i, "error", e.getClass().getSimpleName()));
                             continue;

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/FieldBodyBuilder.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/FieldBodyBuilder.java
@@ -1,0 +1,215 @@
+package io.kelta.mcp.tool.admin;
+
+import io.kelta.mcp.client.GatewayHttpClient;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+/**
+ * Translates MCP-friendly field-creation arguments into the JSON:API body the
+ * worker's {@code POST /api/fields} endpoint expects. Shared by {@link AddFieldTool}
+ * and {@code CreateCollectionTool} so both go through the same alias mapping
+ * and per-type payload assembly.
+ */
+final class FieldBodyBuilder {
+
+    static final Pattern UUID_PATTERN = Pattern.compile(
+            "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$");
+
+    private final GatewayHttpClient gateway;
+
+    FieldBodyBuilder(GatewayHttpClient gateway) {
+        this.gateway = gateway;
+    }
+
+    /** Builds the body, or returns a {@link Result} carrying a user-readable error. */
+    Result build(Map<String, Object> args) {
+        Object fn = args.get("fieldName");
+        Object t = args.get("type");
+        if (fn == null || fn.toString().isBlank()
+                || t == null || t.toString().isBlank()) {
+            return Result.error("Arguments \"fieldName\" and \"type\" are required.");
+        }
+
+        String collectionId = resolveCollectionId(args);
+        if (collectionId == null) {
+            return Result.error("Provide either \"collectionId\" or \"collectionName\".");
+        }
+
+        String nativeType = resolveNativeType(t.toString());
+        if (nativeType == null) {
+            return Result.error("Unknown field type \"" + t + "\". See the tool description for accepted aliases.");
+        }
+
+        Map<String, Object> attrs = new LinkedHashMap<>();
+        attrs.put("collectionId", collectionId);
+        attrs.put("name", fn.toString());
+        attrs.put("type", nativeType);
+        if (args.get("displayName") instanceof String s && !s.isBlank()) attrs.put("displayName", s);
+        if (args.get("required") instanceof Boolean b) attrs.put("required", b);
+        if (args.get("unique") instanceof Boolean b) attrs.put("uniqueConstraint", b);
+        if (args.get("indexed") instanceof Boolean b) attrs.put("indexed", b);
+        if (args.get("searchable") instanceof Boolean b) attrs.put("searchable", b);
+        if (args.get("description") instanceof String s && !s.isBlank()) attrs.put("description", s);
+        if (args.get("defaultValue") instanceof String s) attrs.put("defaultValue", s);
+        if (args.get("validation") instanceof Map<?, ?> v) attrs.put("constraints", v);
+
+        Map<String, Object> relationships = new LinkedHashMap<>();
+
+        if ("PICKLIST".equals(nativeType) || "MULTI_PICKLIST".equals(nativeType)) {
+            String err = applyPicklistConfig(args, attrs);
+            if (err != null) return Result.error(err);
+        } else if (isLookupType(nativeType)) {
+            String err = applyReferenceRelationship(args, attrs, relationships);
+            if (err != null) return Result.error(err);
+        }
+
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("type", "fields");
+        data.put("attributes", attrs);
+        if (!relationships.isEmpty()) {
+            data.put("relationships", relationships);
+        }
+        return Result.ok(Map.of("data", data));
+    }
+
+    /**
+     * Resolves the collection id from either an explicit collectionId arg or by
+     * name-looking-up collectionName. Returns null if neither is usable.
+     */
+    String resolveCollectionId(Map<String, Object> args) {
+        if (args.get("collectionId") instanceof String cid && !cid.isBlank()) {
+            return cid;
+        }
+        if (args.get("collectionName") instanceof String cn && !cn.isBlank()) {
+            if (UUID_PATTERN.matcher(cn).matches()) {
+                return cn;
+            }
+            return lookupCollectionIdByName(cn);
+        }
+        return null;
+    }
+
+    String lookupCollectionIdByName(String collectionName) {
+        String path = "/api/collections?filter[name][eq]="
+                + URLEncoder.encode(collectionName, StandardCharsets.UTF_8);
+        GatewayHttpClient.Response res = gateway.get(path);
+        if (!res.isSuccess() || res.body() == null) {
+            return null;
+        }
+        return extractFirstId(res.body());
+    }
+
+    /**
+     * Lightweight extraction of an {@code id} from the first record in a JSON:API
+     * response — handles either a {@code "data": [...]} list or a {@code "data": {...}}
+     * object. Avoids pulling Jackson into this helper.
+     */
+    static String extractFirstId(String json) {
+        if (json == null) return null;
+        int dataIdx = json.indexOf("\"data\"");
+        if (dataIdx < 0) return null;
+        int idIdx = json.indexOf("\"id\"", dataIdx);
+        if (idIdx < 0) return null;
+        int openQuote = json.indexOf('"', idIdx + 4);
+        if (openQuote < 0) return null;
+        int closeQuote = json.indexOf('"', openQuote + 1);
+        if (closeQuote < 0) return null;
+        String value = json.substring(openQuote + 1, closeQuote);
+        return value.isBlank() ? null : value;
+    }
+
+    private String applyPicklistConfig(Map<String, Object> args, Map<String, Object> attrs) {
+        Object pid = args.get("picklistSourceId");
+        if (!(pid instanceof String picklistSourceId) || picklistSourceId.isBlank()) {
+            return "picklist fields require \"picklistSourceId\" (UUID of the source picklist).";
+        }
+        String sourceType = "GLOBAL";
+        if (args.get("picklistSourceType") instanceof String st && !st.isBlank()) {
+            sourceType = st.toUpperCase(Locale.ROOT);
+        }
+        Map<String, Object> config = new LinkedHashMap<>();
+        config.put("picklistSourceType", sourceType);
+        config.put("picklistSourceId", picklistSourceId);
+        attrs.put("fieldTypeConfig", config);
+        return null;
+    }
+
+    private String applyReferenceRelationship(Map<String, Object> args,
+                                               Map<String, Object> attrs,
+                                               Map<String, Object> relationships) {
+        String targetId = null;
+        if (args.get("referenceCollectionId") instanceof String s && !s.isBlank()) {
+            targetId = s;
+        } else if (args.get("referenceCollection") instanceof String s && !s.isBlank()) {
+            targetId = UUID_PATTERN.matcher(s).matches() ? s : lookupCollectionIdByName(s);
+        }
+        if (targetId == null) {
+            return "reference/lookup fields require \"referenceCollectionId\" (UUID of the target collection) or a resolvable \"referenceCollection\" name.";
+        }
+
+        if (args.get("relationshipName") instanceof String rn && !rn.isBlank()) {
+            attrs.put("relationshipName", rn);
+        }
+        if (args.get("relationshipType") instanceof String rt && !rt.isBlank()) {
+            attrs.put("relationshipType", rt.toUpperCase(Locale.ROOT));
+        }
+
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("type", "collections");
+        data.put("id", targetId);
+        relationships.put("referenceCollectionId", Map.of("data", data));
+        return null;
+    }
+
+    private static boolean isLookupType(String nativeType) {
+        return "LOOKUP".equals(nativeType)
+                || "REFERENCE".equals(nativeType)
+                || "MASTER_DETAIL".equals(nativeType);
+    }
+
+    /**
+     * Maps an MCP-friendly type alias to the native uppercase {@code FieldType}
+     * enum value the worker accepts. Returns null for unknown aliases.
+     */
+    static String resolveNativeType(String alias) {
+        if (alias == null) return null;
+        String trimmed = alias.trim();
+        if (trimmed.isEmpty()) return null;
+        return switch (trimmed) {
+            case "text", "string", "String", "STRING" -> "STRING";
+            case "longText", "longtext", "long_text" -> "STRING";
+            case "number", "integer", "Integer", "INTEGER" -> "INTEGER";
+            case "decimal", "double", "Double", "DOUBLE" -> "DOUBLE";
+            case "long", "Long", "LONG" -> "LONG";
+            case "boolean", "bool", "Boolean", "BOOLEAN" -> "BOOLEAN";
+            case "date", "Date", "DATE" -> "DATE";
+            case "datetime", "dateTime", "DateTime", "DATETIME" -> "DATETIME";
+            case "picklist", "Picklist", "PICKLIST" -> "PICKLIST";
+            case "multiPicklist", "multipicklist", "MULTI_PICKLIST" -> "MULTI_PICKLIST";
+            case "reference", "Reference", "REFERENCE",
+                 "lookup", "Lookup", "LOOKUP" -> "LOOKUP";
+            case "masterDetail", "master_detail", "MASTER_DETAIL" -> "MASTER_DETAIL";
+            case "json", "Json", "JSON" -> "JSON";
+            default -> null;
+        };
+    }
+
+    record Result(Map<String, Object> body, String errorMessage) {
+        static Result ok(Map<String, Object> body) {
+            return new Result(body, null);
+        }
+
+        static Result error(String message) {
+            return new Result(null, message);
+        }
+
+        boolean isError() {
+            return errorMessage != null;
+        }
+    }
+}

--- a/kelta-mcp/src/test/java/io/kelta/mcp/tool/admin/AddFieldToolTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/tool/admin/AddFieldToolTest.java
@@ -16,12 +16,17 @@ import java.util.Map;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class AddFieldToolTest {
+
+    private static final String COLLECTION_ID = "11111111-1111-1111-1111-111111111111";
+    private static final String LOOKUP_FILTER = "/api/collections?filter[name][eq]=projects";
 
     private WireMockServer wm;
     private AddFieldTool tool;
@@ -51,40 +56,217 @@ class AddFieldToolTest {
     }
 
     @Test
-    void postsJsonApiBodyWithRequiredAttributes() {
+    void mapsFriendlyAliasToNativeUppercaseType() {
+        stubCollectionLookup();
         wm.stubFor(post(urlEqualTo("/api/fields"))
                 .willReturn(aResponse().withStatus(201).withBody("{\"data\":{\"id\":\"f1\"}}")));
 
         CallToolResult result = tool.toSpecification().callHandler().apply(
                 null, new CallToolRequest("add_field", Map.of(
                         "collectionName", "projects",
-                        "fieldName", "deadline",
-                        "type", "datetime",
+                        "fieldName", "summary",
+                        "type", "text",
                         "required", true), null));
 
         assertThat(result.isError()).isNotEqualTo(Boolean.TRUE);
         wm.verify(WireMock.postRequestedFor(urlEqualTo("/api/fields"))
                 .withHeader("Authorization", equalTo("Bearer klt_addfield"))
                 .withRequestBody(matchingJsonPath("$.data.type", equalTo("fields")))
-                .withRequestBody(matchingJsonPath("$.data.attributes.collectionName", equalTo("projects")))
-                .withRequestBody(matchingJsonPath("$.data.attributes.fieldName", equalTo("deadline")))
-                .withRequestBody(matchingJsonPath("$.data.attributes.type", equalTo("datetime")))
+                .withRequestBody(matchingJsonPath("$.data.attributes.collectionId", equalTo(COLLECTION_ID)))
+                .withRequestBody(matchingJsonPath("$.data.attributes.name", equalTo("summary")))
+                .withRequestBody(matchingJsonPath("$.data.attributes.type", equalTo("STRING")))
                 .withRequestBody(matchingJsonPath("$.data.attributes.required", equalTo("true"))));
     }
 
     @Test
-    void includesReferenceCollectionForReferenceType() {
+    void mapsNumberAliasToInteger() {
+        stubCollectionLookup();
         wm.stubFor(post(urlEqualTo("/api/fields"))
                 .willReturn(aResponse().withStatus(201).withBody("{}")));
 
         tool.toSpecification().callHandler().apply(
                 null, new CallToolRequest("add_field", Map.of(
                         "collectionName", "projects",
-                        "fieldName", "owner",
-                        "type", "reference",
-                        "referenceCollection", "users"), null));
+                        "fieldName", "count",
+                        "type", "number"), null));
 
         wm.verify(WireMock.postRequestedFor(urlEqualTo("/api/fields"))
-                .withRequestBody(matchingJsonPath("$.data.attributes.referenceCollection", equalTo("users"))));
+                .withRequestBody(matchingJsonPath("$.data.attributes.type", equalTo("INTEGER"))));
+    }
+
+    @Test
+    void translatesUniqueToUniqueConstraint() {
+        stubCollectionLookup();
+        wm.stubFor(post(urlEqualTo("/api/fields"))
+                .willReturn(aResponse().withStatus(201).withBody("{}")));
+
+        tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("add_field", Map.of(
+                        "collectionName", "projects",
+                        "fieldName", "code",
+                        "type", "text",
+                        "unique", true), null));
+
+        wm.verify(WireMock.postRequestedFor(urlEqualTo("/api/fields"))
+                .withRequestBody(matchingJsonPath("$.data.attributes.uniqueConstraint", equalTo("true"))));
+    }
+
+    @Test
+    void exposesDisplayNameIndexedSearchable() {
+        stubCollectionLookup();
+        wm.stubFor(post(urlEqualTo("/api/fields"))
+                .willReturn(aResponse().withStatus(201).withBody("{}")));
+
+        tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("add_field", Map.of(
+                        "collectionName", "projects",
+                        "fieldName", "name",
+                        "type", "text",
+                        "displayName", "Project Name",
+                        "indexed", true,
+                        "searchable", true), null));
+
+        wm.verify(WireMock.postRequestedFor(urlEqualTo("/api/fields"))
+                .withRequestBody(matchingJsonPath("$.data.attributes.displayName", equalTo("Project Name")))
+                .withRequestBody(matchingJsonPath("$.data.attributes.indexed", equalTo("true")))
+                .withRequestBody(matchingJsonPath("$.data.attributes.searchable", equalTo("true"))));
+    }
+
+    @Test
+    void usesCollectionIdDirectlyWhenProvided() {
+        wm.stubFor(post(urlEqualTo("/api/fields"))
+                .willReturn(aResponse().withStatus(201).withBody("{}")));
+
+        tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("add_field", Map.of(
+                        "collectionId", COLLECTION_ID,
+                        "fieldName", "deadline",
+                        "type", "datetime"), null));
+
+        wm.verify(0, WireMock.getRequestedFor(urlPathEqualTo("/api/collections")));
+        wm.verify(WireMock.postRequestedFor(urlEqualTo("/api/fields"))
+                .withRequestBody(matchingJsonPath("$.data.attributes.collectionId", equalTo(COLLECTION_ID)))
+                .withRequestBody(matchingJsonPath("$.data.attributes.type", equalTo("DATETIME"))));
+    }
+
+    @Test
+    void picklistAttachesFieldTypeConfig() {
+        stubCollectionLookup();
+        wm.stubFor(post(urlEqualTo("/api/fields"))
+                .willReturn(aResponse().withStatus(201).withBody("{}")));
+
+        String picklistId = "22222222-2222-2222-2222-222222222222";
+
+        tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("add_field", Map.of(
+                        "collectionName", "projects",
+                        "fieldName", "status",
+                        "type", "picklist",
+                        "picklistSourceId", picklistId), null));
+
+        wm.verify(WireMock.postRequestedFor(urlEqualTo("/api/fields"))
+                .withRequestBody(matchingJsonPath("$.data.attributes.type", equalTo("PICKLIST")))
+                .withRequestBody(matchingJsonPath("$.data.attributes.fieldTypeConfig.picklistSourceType", equalTo("GLOBAL")))
+                .withRequestBody(matchingJsonPath("$.data.attributes.fieldTypeConfig.picklistSourceId", equalTo(picklistId))));
+    }
+
+    @Test
+    void picklistRequiresSourceId() {
+        stubCollectionLookup();
+
+        CallToolResult result = tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("add_field", Map.of(
+                        "collectionName", "projects",
+                        "fieldName", "status",
+                        "type", "picklist"), null));
+
+        assertThat(result.isError()).isEqualTo(Boolean.TRUE);
+    }
+
+    @Test
+    void referenceBuildsRelationshipAndRelationshipName() {
+        stubCollectionLookup();
+        wm.stubFor(post(urlEqualTo("/api/fields"))
+                .willReturn(aResponse().withStatus(201).withBody("{}")));
+
+        String targetId = "33333333-3333-3333-3333-333333333333";
+
+        tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("add_field", Map.of(
+                        "collectionName", "projects",
+                        "fieldName", "owner",
+                        "type", "reference",
+                        "referenceCollectionId", targetId,
+                        "relationshipName", "Owner"), null));
+
+        wm.verify(WireMock.postRequestedFor(urlEqualTo("/api/fields"))
+                .withRequestBody(matchingJsonPath("$.data.attributes.type", equalTo("LOOKUP")))
+                .withRequestBody(matchingJsonPath("$.data.attributes.relationshipName", equalTo("Owner")))
+                .withRequestBody(matchingJsonPath("$.data.relationships.referenceCollectionId.data.id", equalTo(targetId)))
+                .withRequestBody(matchingJsonPath("$.data.relationships.referenceCollectionId.data.type", equalTo("collections"))));
+    }
+
+    @Test
+    void referenceAcceptsOptionalRelationshipType() {
+        stubCollectionLookup();
+        wm.stubFor(post(urlEqualTo("/api/fields"))
+                .willReturn(aResponse().withStatus(201).withBody("{}")));
+
+        String targetId = "33333333-3333-3333-3333-333333333333";
+
+        tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("add_field", Map.of(
+                        "collectionName", "projects",
+                        "fieldName", "account",
+                        "type", "reference",
+                        "referenceCollectionId", targetId,
+                        "relationshipName", "Account",
+                        "relationshipType", "master_detail"), null));
+
+        wm.verify(WireMock.postRequestedFor(urlEqualTo("/api/fields"))
+                .withRequestBody(matchingJsonPath("$.data.attributes.relationshipType", equalTo("MASTER_DETAIL"))));
+    }
+
+    @Test
+    void referenceRequiresTargetCollection() {
+        stubCollectionLookup();
+
+        CallToolResult result = tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("add_field", Map.of(
+                        "collectionName", "projects",
+                        "fieldName", "owner",
+                        "type", "reference"), null));
+
+        assertThat(result.isError()).isEqualTo(Boolean.TRUE);
+    }
+
+    @Test
+    void rejectsUnknownTypeAlias() {
+        stubCollectionLookup();
+
+        CallToolResult result = tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("add_field", Map.of(
+                        "collectionName", "projects",
+                        "fieldName", "x",
+                        "type", "blob"), null));
+
+        assertThat(result.isError()).isEqualTo(Boolean.TRUE);
+    }
+
+    @Test
+    void extractFirstIdReadsJsonApiListResponse() {
+        String body = "{\"data\":[{\"type\":\"collections\",\"id\":\"abc-123\",\"attributes\":{}}]}";
+        assertThat(FieldBodyBuilder.extractFirstId(body)).isEqualTo("abc-123");
+    }
+
+    @Test
+    void extractFirstIdReturnsNullForEmptyList() {
+        assertThat(FieldBodyBuilder.extractFirstId("{\"data\":[]}")).isNull();
+    }
+
+    private void stubCollectionLookup() {
+        wm.stubFor(get(urlEqualTo(LOOKUP_FILTER))
+                .willReturn(aResponse().withStatus(200)
+                        .withBody("{\"data\":[{\"type\":\"collections\",\"id\":\"" + COLLECTION_ID + "\"}]}")));
     }
 }

--- a/kelta-mcp/src/test/java/io/kelta/mcp/tool/admin/CreateCollectionToolTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/tool/admin/CreateCollectionToolTest.java
@@ -74,11 +74,16 @@ class CreateCollectionToolTest {
 
     @Test
     void createsCollectionThenEachField() {
+        String newCollectionId = "44444444-4444-4444-4444-444444444444";
+        String usersId = "55555555-5555-5555-5555-555555555555";
         wm.stubFor(post(urlEqualTo("/api/collections"))
                 .willReturn(aResponse().withStatus(201)
-                        .withBody("{\"data\":{\"id\":\"c1\"}}")));
+                        .withBody("{\"data\":{\"id\":\"" + newCollectionId + "\"}}")));
         wm.stubFor(post(urlEqualTo("/api/fields"))
                 .willReturn(aResponse().withStatus(201).withBody("{\"data\":{\"id\":\"f\"}}")));
+        wm.stubFor(WireMock.get(WireMock.urlPathEqualTo("/api/collections"))
+                .willReturn(aResponse().withStatus(200)
+                        .withBody("{\"data\":[{\"type\":\"collections\",\"id\":\"" + usersId + "\"}]}")));
 
         CallToolResult result = tool.toSpecification().callHandler().apply(
                 null, new CallToolRequest("create_collection", Map.of(
@@ -86,15 +91,20 @@ class CreateCollectionToolTest {
                         "fields", List.of(
                                 Map.of("fieldName", "name", "type", "text", "required", true),
                                 Map.of("fieldName", "owner", "type", "reference",
-                                        "referenceCollection", "users"))), null));
+                                        "referenceCollection", "users",
+                                        "relationshipName", "Owner"))), null));
 
         assertThat(result.isError()).isNotEqualTo(Boolean.TRUE);
         String text = ((TextContent) result.content().get(0)).text();
         assertThat(text).contains("collection", "fields");
         wm.verify(2, WireMock.postRequestedFor(urlEqualTo("/api/fields")));
         wm.verify(WireMock.postRequestedFor(urlEqualTo("/api/fields"))
-                .withRequestBody(matchingJsonPath("$.data.attributes.fieldName", equalTo("name")))
-                .withRequestBody(matchingJsonPath("$.data.attributes.collectionName", equalTo("projects"))));
+                .withRequestBody(matchingJsonPath("$.data.attributes.name", equalTo("name")))
+                .withRequestBody(matchingJsonPath("$.data.attributes.type", equalTo("STRING")))
+                .withRequestBody(matchingJsonPath("$.data.attributes.collectionId", equalTo(newCollectionId))));
+        wm.verify(WireMock.postRequestedFor(urlEqualTo("/api/fields"))
+                .withRequestBody(matchingJsonPath("$.data.attributes.type", equalTo("LOOKUP")))
+                .withRequestBody(matchingJsonPath("$.data.relationships.referenceCollectionId.data.id", equalTo(usersId))));
     }
 
     @Test


### PR DESCRIPTION
Map MCP-friendly type aliases (text, number, picklist, lookup, …) to the
uppercase FieldType enum the worker expects, translate fieldName / unique
to the native name / uniqueConstraint attributes, and resolve collectionName
to collectionId via /api/collections lookup (or accept collectionId
directly). Build per-type payload — fieldTypeConfig for picklist /
multiPicklist, relationships.referenceCollectionId + relationshipName for
lookup / reference. Expose displayName, indexed, searchable.

Extract FieldBodyBuilder so create_collection's nested field array goes
through the same translation as add_field. Fixes the HTTP-400-for-every-
field-type regression on POST /api/fields.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
