### PR TITLE
chore(mcp): fix create_picklist paths and value payload shape

### DIFF
--- a/.claude/CHANGELOG.md
+++ b/.claude/CHANGELOG.md
@@ -27,3 +27,7 @@ This file tracks merged autopilot work. Entries are appended by autopilot worker
 ## 2026-06-01
 
 - 2026-06-01 fix(e2e): point E2E workflow + `.env.example` at `app.kelta.io`/`api.kelta.io`/`auth.kelta.io` after the rzware.com cutover; the legacy hostnames no longer serve a valid cert so Playwright was failing every test with `ERR_CERT_AUTHORITY_INVALID` (BUG-2026-06-01-4324)
+
+## 2026-06-03
+
+- 2026-06-03 chore(mcp): point `create_picklist` admin tool at `/api/global-picklists` and `/api/picklist-values` with kebab-case JSON:API types; values now carry `picklistSourceType=GLOBAL` + `picklistSourceId=<uuid>` flat attributes and `isActive` (not `active`) (CHORE-2026-06-02-0002)

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/CreatePicklistTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/CreatePicklistTool.java
@@ -10,6 +10,8 @@ import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
 import org.springframework.stereotype.Component;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -22,12 +24,17 @@ import java.util.Map;
  *
  * <p>Wraps:
  * <ol>
- *   <li>POST /api/globalPicklists — create the picklist</li>
- *   <li>POST /api/picklistValues (per value) — create each value</li>
+ *   <li>POST /api/global-picklists — create the picklist</li>
+ *   <li>POST /api/picklist-values (per value) — create each value, linked
+ *       to the parent picklist via {@code picklistSourceType=GLOBAL} +
+ *       {@code picklistSourceId=<uuid>} flat attributes (not a JSON:API
+ *       relationship).</li>
  * </ol>
  */
 @Component
 public class CreatePicklistTool implements AdminTool {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     private final GatewayHttpClient gateway;
 
@@ -40,7 +47,7 @@ public class CreatePicklistTool implements AdminTool {
         Map<String, Object> valueItem = new LinkedHashMap<>();
         valueItem.put("type", "object");
         valueItem.put("description",
-                "{\"value\":\"...\",\"label\":\"...\",\"sortOrder\":number,\"active\":bool}");
+                "{\"value\":\"...\",\"label\":\"...\",\"sortOrder\":number,\"isActive\":bool,\"isDefault\":bool}");
         valueItem.put("additionalProperties", true);
 
         Map<String, Object> valuesArray = new LinkedHashMap<>();
@@ -56,7 +63,7 @@ public class CreatePicklistTool implements AdminTool {
         Tool tool = Tool.builder()
                 .name("create_picklist")
                 .title("Create Picklist")
-                .description("Create a global picklist with its initial values. The picklist is created first; each value is then POSTed to /api/picklistValues with picklistName backreference.")
+                .description("Create a global picklist with its initial values. The picklist is created first; each value is then POSTed to /api/picklist-values with picklistSourceType=GLOBAL and picklistSourceId set to the new picklist's UUID.")
                 .inputSchema(Schemas.object(properties, List.of("name", "values")))
                 .annotations(ToolHints.write(false, false))
                 .build();
@@ -80,17 +87,18 @@ public class CreatePicklistTool implements AdminTool {
                     if (args.get("description") instanceof String s && !s.isBlank()) attrs.put("description", s);
 
                     Map<String, Object> picklistBody = Map.of("data", Map.of(
-                            "type", "globalPicklists",
+                            "type", "global-picklists",
                             "attributes", attrs));
                     GatewayHttpClient.Response picklistRes;
                     try {
-                        picklistRes = gateway.post("/api/globalPicklists", picklistBody);
+                        picklistRes = gateway.post("/api/global-picklists", picklistBody);
                     } catch (RuntimeException e) {
                         return McpErrorMapper.fromException(e);
                     }
                     if (!picklistRes.isSuccess()) {
                         return McpErrorMapper.toResult(picklistRes);
                     }
+                    String picklistId = extractId(picklistRes.body());
 
                     List<Map<String, Object>> valueResults = new ArrayList<>();
                     for (int i = 0; i < values.size(); i++) {
@@ -101,17 +109,22 @@ public class CreatePicklistTool implements AdminTool {
                         }
                         Map<String, Object> vMap = new LinkedHashMap<>();
                         for (Map.Entry<?, ?> e : vAttrs.entrySet()) {
-                            vMap.put(String.valueOf(e.getKey()), e.getValue());
+                            String key = String.valueOf(e.getKey());
+                            if ("active".equals(key)) key = "isActive";
+                            vMap.put(key, e.getValue());
                         }
-                        vMap.putIfAbsent("picklistName", n.toString());
-                        if (!vMap.containsKey("sortOrder")) vMap.put("sortOrder", i);
+                        vMap.put("picklistSourceType", "GLOBAL");
+                        if (picklistId != null) vMap.put("picklistSourceId", picklistId);
+                        vMap.putIfAbsent("sortOrder", i);
+                        vMap.putIfAbsent("isActive", true);
+                        vMap.putIfAbsent("isDefault", false);
 
                         Map<String, Object> valueBody = Map.of("data", Map.of(
-                                "type", "picklistValues",
+                                "type", "picklist-values",
                                 "attributes", vMap));
                         GatewayHttpClient.Response vr;
                         try {
-                            vr = gateway.post("/api/picklistValues", valueBody);
+                            vr = gateway.post("/api/picklist-values", valueBody);
                         } catch (RuntimeException e) {
                             valueResults.add(Map.of("index", i, "error", e.getClass().getSimpleName()));
                             continue;
@@ -131,6 +144,17 @@ public class CreatePicklistTool implements AdminTool {
                             .build();
                 })
                 .build();
+    }
+
+    private static String extractId(String body) {
+        if (body == null) return null;
+        try {
+            JsonNode n = OBJECT_MAPPER.readTree(body);
+            JsonNode id = n.path("data").path("id");
+            return id.isMissingNode() || id.isNull() ? null : id.asString();
+        } catch (RuntimeException e) {
+            return null;
+        }
     }
 
     private static CallToolResult error(String message) {

--- a/kelta-mcp/src/test/java/io/kelta/mcp/tool/admin/CreatePicklistToolTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/tool/admin/CreatePicklistToolTest.java
@@ -54,10 +54,11 @@ class CreatePicklistToolTest {
     }
 
     @Test
-    void createsPicklistThenEachValueWithSortOrder() {
-        wm.stubFor(post(urlEqualTo("/api/globalPicklists"))
-                .willReturn(aResponse().withStatus(201).withBody("{\"data\":{\"id\":\"p1\"}}")));
-        wm.stubFor(post(urlEqualTo("/api/picklistValues"))
+    void createsPicklistThenEachValueWithSourceIdAndDefaults() {
+        wm.stubFor(post(urlEqualTo("/api/global-picklists"))
+                .willReturn(aResponse().withStatus(201)
+                        .withBody("{\"data\":{\"id\":\"pl-123\",\"type\":\"global-picklists\"}}")));
+        wm.stubFor(post(urlEqualTo("/api/picklist-values"))
                 .willReturn(aResponse().withStatus(201).withBody("{\"data\":{\"id\":\"pv\"}}")));
 
         CallToolResult result = tool.toSpecification().callHandler().apply(
@@ -68,11 +69,38 @@ class CreatePicklistToolTest {
                                 Map.of("value", "CLOSED", "label", "Closed"))), null));
 
         assertThat(result.isError()).isNotEqualTo(Boolean.TRUE);
-        wm.verify(2, WireMock.postRequestedFor(urlEqualTo("/api/picklistValues")));
-        wm.verify(WireMock.postRequestedFor(urlEqualTo("/api/picklistValues"))
+        wm.verify(WireMock.postRequestedFor(urlEqualTo("/api/global-picklists"))
                 .withHeader("Authorization", equalTo("Bearer klt_picklist_test"))
+                .withRequestBody(matchingJsonPath("$.data.type", equalTo("global-picklists")))
+                .withRequestBody(matchingJsonPath("$.data.attributes.name", equalTo("stages"))));
+        wm.verify(2, WireMock.postRequestedFor(urlEqualTo("/api/picklist-values")));
+        wm.verify(WireMock.postRequestedFor(urlEqualTo("/api/picklist-values"))
+                .withHeader("Authorization", equalTo("Bearer klt_picklist_test"))
+                .withRequestBody(matchingJsonPath("$.data.type", equalTo("picklist-values")))
                 .withRequestBody(matchingJsonPath("$.data.attributes.value", equalTo("OPEN")))
-                .withRequestBody(matchingJsonPath("$.data.attributes.picklistName", equalTo("stages")))
-                .withRequestBody(matchingJsonPath("$.data.attributes.sortOrder", equalTo("0"))));
+                .withRequestBody(matchingJsonPath("$.data.attributes.picklistSourceType", equalTo("GLOBAL")))
+                .withRequestBody(matchingJsonPath("$.data.attributes.picklistSourceId", equalTo("pl-123")))
+                .withRequestBody(matchingJsonPath("$.data.attributes.sortOrder", equalTo("0")))
+                .withRequestBody(matchingJsonPath("$.data.attributes.isActive", equalTo("true")))
+                .withRequestBody(matchingJsonPath("$.data.attributes.isDefault", equalTo("false"))));
+    }
+
+    @Test
+    void rewritesLegacyActiveFieldToIsActive() {
+        wm.stubFor(post(urlEqualTo("/api/global-picklists"))
+                .willReturn(aResponse().withStatus(201)
+                        .withBody("{\"data\":{\"id\":\"pl-9\"}}")));
+        wm.stubFor(post(urlEqualTo("/api/picklist-values"))
+                .willReturn(aResponse().withStatus(201).withBody("{\"data\":{\"id\":\"pv\"}}")));
+
+        CallToolResult result = tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("create_picklist", Map.of(
+                        "name", "stages",
+                        "values", List.of(
+                                Map.of("value", "OPEN", "label", "Open", "active", false))), null));
+
+        assertThat(result.isError()).isNotEqualTo(Boolean.TRUE);
+        wm.verify(WireMock.postRequestedFor(urlEqualTo("/api/picklist-values"))
+                .withRequestBody(matchingJsonPath("$.data.attributes.isActive", equalTo("false"))));
     }
 }


### PR DESCRIPTION
POST /api/globalPicklists → /api/global-picklists (404 before).
POST /api/picklistValues → /api/picklist-values. JSON:API types
switch to kebab-case to match the gateway's registered routes.

Values now carry picklistSourceType=GLOBAL + picklistSourceId=<uuid>
flat attributes (extracted from the picklist-create response) instead
of the old picklistName backreference; the relationship is flat, not
a JSON:API relationship. isActive replaces active; isDefault defaults
to false. Legacy active=… input is rewritten to isActive for
backward compatibility.

Task: CHORE-2026-06-02-0002

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
