### PR TITLE
fix(ci): namespace e2e runner container to avoid collisions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -389,7 +389,9 @@ jobs:
         id: playwright
         run: |
           NETWORK="${COMPOSE_PROJECT_NAME}_kelta-network"
-          docker run --name kelta-e2e-run \
+          CONTAINER="${COMPOSE_PROJECT_NAME}_kelta-e2e-run"
+          docker rm -f "$CONTAINER" 2>/dev/null || true
+          docker run --name "$CONTAINER" \
             --network "$NETWORK" \
             -e CI=true \
             -e E2E_BASE_URL=http://kelta-ui:8080 \
@@ -405,10 +407,11 @@ jobs:
       - name: Copy Playwright reports out of container
         if: always() && steps.playwright.outcome != 'skipped'
         run: |
+          CONTAINER="${COMPOSE_PROJECT_NAME}_kelta-e2e-run"
           mkdir -p e2e-tests/playwright-report e2e-tests/test-results
-          docker cp kelta-e2e-run:/work/playwright-report/. e2e-tests/playwright-report/ 2>/dev/null || true
-          docker cp kelta-e2e-run:/work/test-results/. e2e-tests/test-results/ 2>/dev/null || true
-          docker rm -f kelta-e2e-run || true
+          docker cp "$CONTAINER":/work/playwright-report/. e2e-tests/playwright-report/ 2>/dev/null || true
+          docker cp "$CONTAINER":/work/test-results/. e2e-tests/test-results/ 2>/dev/null || true
+          docker rm -f "$CONTAINER" || true
 
       - name: Dump compose logs on failure
         if: failure()


### PR DESCRIPTION
## Summary
- E2E job used hardcoded \`kelta-e2e-run\` container name on a shared remote Docker daemon
- When a prior run died mid-job (e.g., disk-pressure eviction on \`fc16\` runner node), the orphan container blocked the next run with \`Conflict. The container name "/kelta-e2e-run" is already in use\` and exit code 125
- Namespace the container with \`COMPOSE_PROJECT_NAME\` (same scheme already used for the compose network) and pre-clean any orphan before \`docker run\`

Seen in run [26863693911](https://github.com/cklinker/emf/actions/runs/26863693911/job/79222691093).

## Test plan
- [ ] CI on this PR completes E2E job without 125 collision
- [ ] Concurrent PR runs on the same Docker daemon no longer fight over the container name
- [ ] Report/test-results copy step picks up the namespaced container

🤖 Generated with [Claude Code](https://claude.com/claude-code)