### PR TITLE
chore(mcp): add delete_collection admin tool

### DIFF
--- a/.claude/CHANGELOG.md
+++ b/.claude/CHANGELOG.md
@@ -27,3 +27,7 @@ This file tracks merged autopilot work. Entries are appended by autopilot worker
 ## 2026-06-01
 
 - 2026-06-01 fix(e2e): point E2E workflow + `.env.example` at `app.kelta.io`/`api.kelta.io`/`auth.kelta.io` after the rzware.com cutover; the legacy hostnames no longer serve a valid cert so Playwright was failing every test with `ERR_CERT_AUTHORITY_INVALID` (BUG-2026-06-01-4324)
+
+## 2026-06-03
+
+- 2026-06-03 chore(mcp): add `delete_collection` admin tool that wraps `DELETE /api/collections/{id}` and resolves a name argument via `filter[name][EQ]` so stale collections can be removed without falling back to direct REST (CHORE-2026-06-02-0009)

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/DeleteCollectionTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/DeleteCollectionTool.java
@@ -1,0 +1,115 @@
+package io.kelta.mcp.tool.admin;
+
+import io.kelta.mcp.client.GatewayHttpClient;
+import io.kelta.mcp.error.McpErrorMapper;
+import io.kelta.mcp.tool.AdminTool;
+import io.kelta.mcp.tool.Schemas;
+import io.kelta.mcp.tool.ToolHints;
+import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import io.modelcontextprotocol.spec.McpSchema.Tool;
+import org.springframework.stereotype.Component;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+@Component
+public class DeleteCollectionTool implements AdminTool {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final Pattern UUID_PATTERN = Pattern.compile(
+            "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$");
+
+    private final GatewayHttpClient gateway;
+
+    public DeleteCollectionTool(GatewayHttpClient gateway) {
+        this.gateway = gateway;
+    }
+
+    @Override
+    public SyncToolSpecification toSpecification() {
+        Map<String, Object> properties = new LinkedHashMap<>();
+        properties.put("collection", Schemas.string(
+                "Collection name (e.g. \"projects\") or id (UUID). Names are resolved to ids via "
+                        + "GET /api/collections?filter[name][EQ]=... before the delete is issued."));
+
+        Tool tool = Tool.builder()
+                .name("delete_collection")
+                .title("Delete Collection")
+                .description("Delete a collection definition and all of its records. Wraps DELETE /api/collections/{id}. Irreversible — every record in the collection is dropped along with the schema. Accepts either the collection name or a UUID; names are looked up first.")
+                .inputSchema(Schemas.object(properties, List.of("collection")))
+                .annotations(ToolHints.write(true, true))
+                .build();
+
+        return SyncToolSpecification.builder()
+                .tool(tool)
+                .callHandler((context, request) -> {
+                    Map<String, Object> args = request.arguments();
+                    Object cv = args == null ? null : args.get("collection");
+                    if (cv == null || cv.toString().isBlank()) {
+                        return CallToolResult.builder()
+                                .isError(true)
+                                .content(List.of(new TextContent("Argument \"collection\" is required.")))
+                                .build();
+                    }
+                    String input = cv.toString();
+
+                    try {
+                        String id;
+                        if (UUID_PATTERN.matcher(input).matches()) {
+                            id = input;
+                        } else {
+                            GatewayHttpClient.Response lookup = gateway.get(
+                                    "/api/collections?filter[name][EQ]="
+                                            + URLEncoder.encode(input, StandardCharsets.UTF_8)
+                                            + "&page[size]=1");
+                            if (!lookup.isSuccess()) {
+                                return McpErrorMapper.toResult(lookup);
+                            }
+                            id = extractFirstId(lookup.body());
+                            if (id == null) {
+                                return CallToolResult.builder()
+                                        .isError(true)
+                                        .content(List.of(new TextContent(
+                                                "No collection found with name \"" + input + "\".")))
+                                        .build();
+                            }
+                        }
+
+                        GatewayHttpClient.Response response = gateway.delete(
+                                "/api/collections/" + URLEncoder.encode(id, StandardCharsets.UTF_8));
+                        if (response.isSuccess()) {
+                            return CallToolResult.builder()
+                                    .content(List.of(new TextContent(
+                                            "Deleted collection " + input + " (id=" + id
+                                                    + ", HTTP " + response.status().value() + ")")))
+                                    .build();
+                        }
+                        return McpErrorMapper.toResult(response);
+                    } catch (RuntimeException e) {
+                        return McpErrorMapper.fromException(e);
+                    }
+                })
+                .build();
+    }
+
+    static String extractFirstId(String body) {
+        if (body == null || body.isBlank()) return null;
+        try {
+            JsonNode root = OBJECT_MAPPER.readTree(body);
+            JsonNode data = root.path("data");
+            JsonNode first = data.isArray() && !data.isEmpty() ? data.get(0) : data;
+            JsonNode id = first.path("id");
+            return id.isMissingNode() || id.isNull() ? null : id.asString();
+        } catch (RuntimeException e) {
+            return null;
+        }
+    }
+}

--- a/kelta-mcp/src/test/java/io/kelta/mcp/tool/admin/DeleteCollectionToolTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/tool/admin/DeleteCollectionToolTest.java
@@ -1,0 +1,124 @@
+package io.kelta.mcp.tool.admin;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import io.kelta.mcp.auth.RequestPatHolder;
+import io.kelta.mcp.client.GatewayHttpClient;
+import io.kelta.mcp.config.McpProperties;
+import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestClient;
+
+import java.util.Map;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.delete;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DeleteCollectionToolTest {
+
+    private static final String COLLECTION_UUID = "11111111-2222-3333-4444-555555555555";
+
+    private WireMockServer wm;
+    private DeleteCollectionTool tool;
+
+    @BeforeEach
+    void setUp() {
+        wm = new WireMockServer(0);
+        wm.start();
+        GatewayHttpClient client = new GatewayHttpClient(
+                RestClient.builder(),
+                new McpProperties("http://localhost:" + wm.port(), 30, 60_000, null));
+        tool = new DeleteCollectionTool(client);
+        RequestPatHolder.set("klt_delete_coll");
+    }
+
+    @AfterEach
+    void tearDown() {
+        RequestPatHolder.clear();
+        wm.stop();
+    }
+
+    @Test
+    void rejectsWithoutCollection() {
+        CallToolResult result = tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("delete_collection", Map.of(), null));
+        assertThat(result.isError()).isEqualTo(Boolean.TRUE);
+    }
+
+    @Test
+    void deletesDirectlyWhenInputLooksLikeUuid() {
+        wm.stubFor(delete(urlEqualTo("/api/collections/" + COLLECTION_UUID))
+                .willReturn(aResponse().withStatus(204)));
+
+        CallToolResult result = tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("delete_collection",
+                        Map.of("collection", COLLECTION_UUID), null));
+
+        assertThat(result.isError()).isNotEqualTo(Boolean.TRUE);
+        assertThat(((TextContent) result.content().get(0)).text())
+                .contains("Deleted collection", COLLECTION_UUID, "204");
+        wm.verify(WireMock.deleteRequestedFor(
+                urlEqualTo("/api/collections/" + COLLECTION_UUID)));
+        wm.verify(0, WireMock.getRequestedFor(urlPathEqualTo("/api/collections")));
+    }
+
+    @Test
+    void resolvesNameToIdBeforeDeleting() {
+        wm.stubFor(get(urlEqualTo(
+                "/api/collections?filter[name][EQ]=e2e_wizard_1780349727631&page[size]=1"))
+                .willReturn(aResponse().withStatus(200).withBody(
+                        "{\"data\":[{\"type\":\"collections\",\"id\":\"" + COLLECTION_UUID
+                                + "\",\"attributes\":{\"name\":\"e2e_wizard_1780349727631\"}}]}")));
+        wm.stubFor(delete(urlEqualTo("/api/collections/" + COLLECTION_UUID))
+                .willReturn(aResponse().withStatus(204)));
+
+        CallToolResult result = tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("delete_collection",
+                        Map.of("collection", "e2e_wizard_1780349727631"), null));
+
+        assertThat(result.isError()).isNotEqualTo(Boolean.TRUE);
+        assertThat(((TextContent) result.content().get(0)).text())
+                .contains("e2e_wizard_1780349727631", COLLECTION_UUID, "204");
+        wm.verify(WireMock.deleteRequestedFor(
+                urlEqualTo("/api/collections/" + COLLECTION_UUID)));
+    }
+
+    @Test
+    void reportsErrorWhenNameLookupReturnsEmpty() {
+        wm.stubFor(get(urlEqualTo(
+                "/api/collections?filter[name][EQ]=missing&page[size]=1"))
+                .willReturn(aResponse().withStatus(200)
+                        .withBody("{\"data\":[]}")));
+
+        CallToolResult result = tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("delete_collection",
+                        Map.of("collection", "missing"), null));
+
+        assertThat(result.isError()).isEqualTo(Boolean.TRUE);
+        assertThat(((TextContent) result.content().get(0)).text())
+                .contains("No collection found", "missing");
+        wm.verify(0, WireMock.deleteRequestedFor(WireMock.urlMatching("/api/collections/.*")));
+    }
+
+    @Test
+    void surfacesGatewayErrorOnDeleteFailure() {
+        wm.stubFor(delete(urlEqualTo("/api/collections/" + COLLECTION_UUID))
+                .willReturn(aResponse().withStatus(404).withBody(
+                        "{\"errors\":[{\"detail\":\"not found\"}]}")));
+
+        CallToolResult result = tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("delete_collection",
+                        Map.of("collection", COLLECTION_UUID), null));
+
+        assertThat(result.isError()).isEqualTo(Boolean.TRUE);
+        assertThat(((TextContent) result.content().get(0)).text()).contains("404");
+    }
+}


### PR DESCRIPTION
Wraps DELETE /api/collections/{id}. Accepts a name or UUID; names are
resolved via filter[name][EQ] before the delete is issued. Removes the
need to drop stale collections (e.g. e2e_wizard_*) via direct REST.

Refs CHORE-2026-06-02-0009

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
