### PR TITLE
fix(ci): route base images through Harbor dockerhub-cache proxy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
   # ═══════════════════════════════════════════════════════════════════════════
 
   postgres:
-    image: postgres:15-alpine
+    image: harbor.rzware.com/dockerhub-cache/library/postgres:15-alpine
     container_name: kelta-postgres
     restart: unless-stopped
     environment:
@@ -46,7 +46,7 @@ services:
       - kelta-network
 
   redis:
-    image: redis:7-alpine
+    image: harbor.rzware.com/dockerhub-cache/library/redis:7-alpine
     container_name: kelta-redis
     restart: unless-stopped
     command: redis-server --appendonly yes
@@ -63,7 +63,7 @@ services:
       - kelta-network
 
   nats:
-    image: nats:2.10-alpine
+    image: harbor.rzware.com/dockerhub-cache/library/nats:2.10-alpine
     container_name: kelta-nats
     restart: unless-stopped
     command: ["--jetstream", "--store_dir", "/data/nats-server/jetstream", "-m", "8222"]
@@ -336,7 +336,7 @@ services:
   # ═══════════════════════════════════════════════════════════════════════════
 
   pgadmin:
-    image: dpage/pgadmin4:latest
+    image: harbor.rzware.com/dockerhub-cache/dpage/pgadmin4:latest
     container_name: kelta-pgadmin
     restart: unless-stopped
     environment:
@@ -356,7 +356,7 @@ services:
       - tools
 
   redis-commander:
-    image: rediscommander/redis-commander:latest
+    image: harbor.rzware.com/dockerhub-cache/rediscommander/redis-commander:latest
     container_name: kelta-redis-commander
     restart: unless-stopped
     environment:
@@ -372,7 +372,7 @@ services:
       - tools
 
   mailpit:
-    image: axllent/mailpit:latest
+    image: harbor.rzware.com/dockerhub-cache/axllent/mailpit:latest
     container_name: kelta-mailpit
     restart: unless-stopped
     ports:
@@ -388,7 +388,7 @@ services:
   # ═══════════════════════════════════════════════════════════════════════════
 
   opensearch:
-    image: opensearchproject/opensearch:2.17.1
+    image: harbor.rzware.com/dockerhub-cache/opensearchproject/opensearch:2.17.1
     container_name: kelta-opensearch
     environment:
       discovery.type: single-node
@@ -411,7 +411,7 @@ services:
       - observability
 
   jaeger:
-    image: jaegertracing/jaeger:2
+    image: harbor.rzware.com/dockerhub-cache/jaegertracing/jaeger:2
     container_name: kelta-jaeger
     command: ["--config", "/etc/jaeger/config.yaml"]
     volumes:

--- a/kelta-ai/Dockerfile.jvm
+++ b/kelta-ai/Dockerfile.jvm
@@ -4,7 +4,7 @@
 # =============================================================================
 # Stage 1: Build runtime-platform dependencies
 # =============================================================================
-FROM maven:3.9-eclipse-temurin-25 AS runtime-builder
+FROM harbor.rzware.com/dockerhub-cache/library/maven:3.9-eclipse-temurin-25 AS runtime-builder
 
 WORKDIR /kelta-platform
 
@@ -40,7 +40,7 @@ RUN mvn clean install -DskipTests -B \
 # =============================================================================
 # Stage 2: Build the service jar
 # =============================================================================
-FROM maven:3.9-eclipse-temurin-25 AS builder
+FROM harbor.rzware.com/dockerhub-cache/library/maven:3.9-eclipse-temurin-25 AS builder
 
 WORKDIR /build
 
@@ -59,7 +59,7 @@ RUN mvn clean package -DskipTests -B && \
 # =============================================================================
 # Stage 3: Runtime
 # =============================================================================
-FROM eclipse-temurin:25-jre-alpine
+FROM harbor.rzware.com/dockerhub-cache/library/eclipse-temurin:25-jre-alpine
 
 WORKDIR /app
 

--- a/kelta-auth/Dockerfile.jvm
+++ b/kelta-auth/Dockerfile.jvm
@@ -4,7 +4,7 @@
 # =============================================================================
 # Stage 1: Build runtime-platform dependencies
 # =============================================================================
-FROM maven:3.9-eclipse-temurin-25 AS runtime-builder
+FROM harbor.rzware.com/dockerhub-cache/library/maven:3.9-eclipse-temurin-25 AS runtime-builder
 
 WORKDIR /kelta-platform
 
@@ -40,7 +40,7 @@ RUN mvn clean install -DskipTests -B \
 # =============================================================================
 # Stage 2: Build the service jar
 # =============================================================================
-FROM maven:3.9-eclipse-temurin-25 AS builder
+FROM harbor.rzware.com/dockerhub-cache/library/maven:3.9-eclipse-temurin-25 AS builder
 
 WORKDIR /build
 
@@ -59,7 +59,7 @@ RUN mvn clean package -DskipTests -B && \
 # =============================================================================
 # Stage 3: Runtime
 # =============================================================================
-FROM eclipse-temurin:25-jre-alpine
+FROM harbor.rzware.com/dockerhub-cache/library/eclipse-temurin:25-jre-alpine
 
 WORKDIR /app
 

--- a/kelta-gateway/Dockerfile.jvm
+++ b/kelta-gateway/Dockerfile.jvm
@@ -4,7 +4,7 @@
 # =============================================================================
 # Stage 1: Build runtime-platform dependencies
 # =============================================================================
-FROM maven:3.9-eclipse-temurin-25 AS runtime-builder
+FROM harbor.rzware.com/dockerhub-cache/library/maven:3.9-eclipse-temurin-25 AS runtime-builder
 
 WORKDIR /kelta-platform
 
@@ -40,7 +40,7 @@ RUN mvn clean install -DskipTests -B \
 # =============================================================================
 # Stage 2: Build the service jar
 # =============================================================================
-FROM maven:3.9-eclipse-temurin-25 AS builder
+FROM harbor.rzware.com/dockerhub-cache/library/maven:3.9-eclipse-temurin-25 AS builder
 
 WORKDIR /build
 
@@ -59,7 +59,7 @@ RUN mvn clean package -DskipTests -B && \
 # =============================================================================
 # Stage 3: Runtime
 # =============================================================================
-FROM eclipse-temurin:25-jre-alpine
+FROM harbor.rzware.com/dockerhub-cache/library/eclipse-temurin:25-jre-alpine
 
 WORKDIR /app
 

--- a/kelta-ui/Dockerfile
+++ b/kelta-ui/Dockerfile
@@ -4,7 +4,7 @@
 # =============================================================================
 # Stage 1: Install dependencies and build
 # =============================================================================
-FROM node:18-alpine AS builder
+FROM harbor.rzware.com/dockerhub-cache/library/node:18-alpine AS builder
 
 WORKDIR /app
 
@@ -52,7 +52,7 @@ RUN npx vite build
 # =============================================================================
 # Stage 2: Runtime with Nginx
 # =============================================================================
-FROM nginx:1.25-alpine
+FROM harbor.rzware.com/dockerhub-cache/library/nginx:1.25-alpine
 
 LABEL org.opencontainers.image.title="Kelta Admin UI"
 LABEL org.opencontainers.image.description="Admin/Builder UI for Kelta Platform"

--- a/kelta-worker/Dockerfile.jvm
+++ b/kelta-worker/Dockerfile.jvm
@@ -4,7 +4,7 @@
 # =============================================================================
 # Stage 1: Build runtime-platform dependencies
 # =============================================================================
-FROM maven:3.9-eclipse-temurin-25 AS runtime-builder
+FROM harbor.rzware.com/dockerhub-cache/library/maven:3.9-eclipse-temurin-25 AS runtime-builder
 
 WORKDIR /kelta-platform
 
@@ -40,7 +40,7 @@ RUN mvn clean install -DskipTests -B \
 # =============================================================================
 # Stage 2: Build the service jar
 # =============================================================================
-FROM maven:3.9-eclipse-temurin-25 AS builder
+FROM harbor.rzware.com/dockerhub-cache/library/maven:3.9-eclipse-temurin-25 AS builder
 
 WORKDIR /build
 
@@ -59,7 +59,7 @@ RUN mvn clean package -DskipTests -B && \
 # =============================================================================
 # Stage 3: Runtime
 # =============================================================================
-FROM eclipse-temurin:25-jre-alpine
+FROM harbor.rzware.com/dockerhub-cache/library/eclipse-temurin:25-jre-alpine
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- Anonymous Docker Hub pulls cap at 100 per 6h per source IP
- E2E builds pull \`node\`, \`maven\`, \`eclipse-temurin\`, \`nginx\`, \`postgres\`, \`redis\`, \`nats\` every run and blow past it with \`429 Too Many Requests\` — seen in [run 26865529733](https://github.com/cklinker/emf/actions/runs/26865529733/job/79228269245)
- Route every docker.io image through \`harbor.rzware.com/dockerhub-cache\` (Harbor proxy-cache project). Harbor caches each image after the first pull and serves subsequent builds from the homelab
- \`ghcr.io/cerbos\` untouched — different registry, not throttled

## Files
- \`kelta-{auth,worker,gateway,ai}/Dockerfile.jvm\`: \`maven\` + \`eclipse-temurin\`
- \`kelta-ui/Dockerfile\`: \`node\` + \`nginx\`
- \`docker-compose.yml\`: postgres, redis, nats, pgadmin, redis-commander, mailpit, opensearch, jaeger

## Test plan
- [ ] CI E2E build no longer hits Docker Hub directly
- [ ] No \`429 Too Many Requests\` in build logs
- [ ] Harbor \`dockerhub-cache\` project shows new cached repositories after first run
- [ ] Local dev with \`docker compose up\` still works (homelab dev machines reach harbor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)