### PR TITLE
fix(ci): route remaining Dockerfile FROM lines through Harbor proxy

### DIFF
--- a/docker/bootstrap/Dockerfile
+++ b/docker/bootstrap/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.19
+FROM harbor.rzware.com/dockerhub-cache/library/alpine:3.19
 RUN apk add --no-cache bash curl jq
 WORKDIR /scripts
 COPY seed.sh .

--- a/kelta-ai/Dockerfile
+++ b/kelta-ai/Dockerfile
@@ -3,7 +3,7 @@
 # =============================================================================
 # Stage 1: Build runtime-platform dependencies
 # =============================================================================
-FROM maven:3.9-eclipse-temurin-25 AS runtime-builder
+FROM harbor.rzware.com/dockerhub-cache/library/maven:3.9-eclipse-temurin-25 AS runtime-builder
 
 # Survive transient Maven Central 429 / 503 / connection resets — both the
 # legacy wagon HTTP transport and the newer Aether connector retry up to 10
@@ -47,7 +47,7 @@ RUN mvn clean install -DskipTests -B \
 # =============================================================================
 # Stage 2: Build the application
 # =============================================================================
-FROM maven:3.9-eclipse-temurin-25 AS builder
+FROM harbor.rzware.com/dockerhub-cache/library/maven:3.9-eclipse-temurin-25 AS builder
 
 ENV MAVEN_OPTS="-Dmaven.wagon.http.retryHandler.count=10 -Dmaven.wagon.http.retryHandler.requestSentEnabled=true -Daether.connector.http.retryHandler.count=10"
 
@@ -73,7 +73,7 @@ RUN mvn clean package -DskipTests -B && \
 # =============================================================================
 # Stage 3: Runtime image
 # =============================================================================
-FROM eclipse-temurin:25-jre
+FROM harbor.rzware.com/dockerhub-cache/library/eclipse-temurin:25-jre
 
 WORKDIR /app
 

--- a/kelta-auth/Dockerfile
+++ b/kelta-auth/Dockerfile
@@ -86,7 +86,7 @@ RUN mvn -Pnative native:compile -DskipTests -B
 # =============================================================================
 # Stage 3: Minimal runtime (no JRE — binary is self-contained)
 # =============================================================================
-FROM debian:12-slim
+FROM harbor.rzware.com/dockerhub-cache/library/debian:12-slim
 
 WORKDIR /app
 

--- a/kelta-gateway/Dockerfile
+++ b/kelta-gateway/Dockerfile
@@ -86,7 +86,7 @@ RUN mvn -Pnative native:compile -DskipTests -B
 # =============================================================================
 # Stage 3: Minimal runtime (no JRE — binary is self-contained)
 # =============================================================================
-FROM debian:12-slim
+FROM harbor.rzware.com/dockerhub-cache/library/debian:12-slim
 
 WORKDIR /app
 

--- a/kelta-marketing/Dockerfile
+++ b/kelta-marketing/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM node:22-alpine AS build
+FROM harbor.rzware.com/dockerhub-cache/library/node:22-alpine AS build
 WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci
@@ -7,7 +7,7 @@ COPY . .
 RUN npm run build
 
 # Production stage — serve static files with nginx
-FROM nginx:1.27-alpine
+FROM harbor.rzware.com/dockerhub-cache/library/nginx:1.27-alpine
 COPY --from=build /app/dist /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 EXPOSE 80

--- a/kelta-mcp/Dockerfile
+++ b/kelta-mcp/Dockerfile
@@ -8,7 +8,7 @@
 # AtomicResult), so all three must be built. We mirror kelta-ai's module
 # list for cache-key compatibility — Maven's -am handles the dep graph.
 # =============================================================================
-FROM maven:3.9-eclipse-temurin-25 AS runtime-builder
+FROM harbor.rzware.com/dockerhub-cache/library/maven:3.9-eclipse-temurin-25 AS runtime-builder
 
 # Survive transient Maven Central 429 / 503 / connection resets — both the
 # legacy wagon HTTP transport and the newer Aether connector retry up to 10
@@ -48,7 +48,7 @@ RUN mvn clean install -DskipTests -B \
 # =============================================================================
 # Stage 2: Build the application
 # =============================================================================
-FROM maven:3.9-eclipse-temurin-25 AS builder
+FROM harbor.rzware.com/dockerhub-cache/library/maven:3.9-eclipse-temurin-25 AS builder
 
 ENV MAVEN_OPTS="-Dmaven.wagon.http.retryHandler.count=10 -Dmaven.wagon.http.retryHandler.requestSentEnabled=true -Daether.connector.http.retryHandler.count=10"
 
@@ -74,7 +74,7 @@ RUN mvn clean package -DskipTests -B && \
 # =============================================================================
 # Stage 3: Runtime image
 # =============================================================================
-FROM eclipse-temurin:25-jre
+FROM harbor.rzware.com/dockerhub-cache/library/eclipse-temurin:25-jre
 
 WORKDIR /app
 

--- a/kelta-web/Dockerfile
+++ b/kelta-web/Dockerfile
@@ -4,7 +4,7 @@
 # =============================================================================
 # Stage 1: Install dependencies and build
 # =============================================================================
-FROM node:18-alpine AS builder
+FROM harbor.rzware.com/dockerhub-cache/library/node:18-alpine AS builder
 
 WORKDIR /app
 
@@ -26,7 +26,7 @@ RUN npm run build
 # =============================================================================
 # Stage 2: Runtime with Nginx
 # =============================================================================
-FROM nginx:1.25-alpine AS runtime
+FROM harbor.rzware.com/dockerhub-cache/library/nginx:1.25-alpine AS runtime
 
 LABEL org.opencontainers.image.title="Kelta Web UI"
 LABEL org.opencontainers.image.description="Admin UI for Kelta Platform"

--- a/kelta-worker/Dockerfile
+++ b/kelta-worker/Dockerfile
@@ -90,7 +90,7 @@ RUN mvn -Pnative native:compile -DskipTests -B \
 # =============================================================================
 # Stage 3: Minimal runtime (no JRE — binary is self-contained)
 # =============================================================================
-FROM debian:12-slim
+FROM harbor.rzware.com/dockerhub-cache/library/debian:12-slim
 
 WORKDIR /app
 

--- a/kelta-worker/Dockerfile.migrate
+++ b/kelta-worker/Dockerfile.migrate
@@ -76,7 +76,7 @@ RUN mvn package -DskipTests -B
 # =============================================================================
 # Stage 3: JRE runtime
 # =============================================================================
-FROM eclipse-temurin:25-jre
+FROM harbor.rzware.com/dockerhub-cache/library/eclipse-temurin:25-jre
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- PR #982 routed JVM CI Dockerfiles + \`docker-compose.yml\` images through \`harbor.rzware.com/dockerhub-cache\` but missed several Dockerfiles
- E2E still hit \`toomanyrequests\` on \`alpine:3.19\` via \`docker/bootstrap/Dockerfile\` (the E2E seed step)
- This PR routes every remaining \`FROM\` to Harbor

## Files
- \`docker/bootstrap/Dockerfile\`: alpine
- \`kelta-{auth,worker,gateway}/Dockerfile\` (native prod build runtime stage): debian
- \`kelta-{ai,mcp}/Dockerfile\`: maven + eclipse-temurin
- \`kelta-marketing/Dockerfile\`: node + nginx
- \`kelta-web/Dockerfile\`: node + nginx
- \`kelta-worker/Dockerfile.migrate\`: eclipse-temurin

## Test plan
- [ ] E2E build no longer pulls anything from \`docker.io\`
- [ ] Native prod builds (non-CI) still pull base images via Harbor
- [ ] Harbor \`dockerhub-cache\` shows all base repos cached

🤖 Generated with [Claude Code](https://claude.com/claude-code)