### PR TITLE
fix(ci): stop publishing Kelta images to Docker Hub

### DIFF
--- a/.github/workflows/build-and-publish-containers.yml
+++ b/.github/workflows/build-and-publish-containers.yml
@@ -38,7 +38,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  DOCKERHUB_USERNAME: cklinker
   JAVA_VERSION: '25'
   NODE_VERSION: '18'
   MAVEN_VERSION: '3.9.9'
@@ -263,13 +262,6 @@ jobs:
         if: matrix.changed == 'true' || needs.changes.outputs.workflows == 'true'
         uses: docker/setup-buildx-action@v3
 
-      - name: Log in to DockerHub
-        if: (matrix.changed == 'true' || needs.changes.outputs.workflows == 'true') && (github.event_name != 'workflow_dispatch' || inputs.push_images)
-        uses: docker/login-action@v3
-        with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
       - name: Log in to Harbor
         if: (matrix.changed == 'true' || needs.changes.outputs.workflows == 'true') && (github.event_name != 'workflow_dispatch' || inputs.push_images)
         uses: docker/login-action@v3
@@ -296,10 +288,6 @@ jobs:
           file: ${{ matrix.dockerfile }}
           push: ${{ github.event_name != 'workflow_dispatch' || inputs.push_images }}
           tags: |
-            ${{ env.DOCKERHUB_USERNAME }}/${{ matrix.image }}:latest
-            ${{ env.DOCKERHUB_USERNAME }}/${{ matrix.image }}:main-${{ steps.sha.outputs.short }}
-            ${{ env.DOCKERHUB_USERNAME }}/${{ steps.legacy.outputs.image }}:latest
-            ${{ env.DOCKERHUB_USERNAME }}/${{ steps.legacy.outputs.image }}:main-${{ steps.sha.outputs.short }}
             harbor.rzware.com/emf/${{ steps.legacy.outputs.image }}:latest
             harbor.rzware.com/emf/${{ steps.legacy.outputs.image }}:main-${{ steps.sha.outputs.short }}
           cache-from: type=gha,scope=${{ matrix.service }}


### PR DESCRIPTION
## Summary
- \`build-and-publish-containers.yml\` was pushing every Kelta image to BOTH Docker Hub (\`cklinker/*\` + \`cklinker/emf-*\`) AND Harbor (\`harbor.rzware.com/emf/*\`)
- Harbor is the source of truth (homelab-argo deploys from there). Docker Hub push is wasted bandwidth + second registry to keep private
- Saw it after spotting recent pushes in https://hub.docker.com/repositories/cklinker (emf-worker, kelta-worker, emf-worker-migrate, etc all updated minutes ago)

## Changes
- Remove \`Log in to DockerHub\` step
- Drop 4 Docker Hub tag lines from build-push-action (keep 2 Harbor tags)
- Remove \`DOCKERHUB_USERNAME\` env

## Follow-ups
- Delete \`DOCKERHUB_TOKEN\` from repo secrets
- Optional: delete \`cklinker/*\` and \`cklinker/emf-*\` repos from Docker Hub after confirming nothing pulls them

## Test plan
- [ ] Next push to main triggers build-and-publish workflow
- [ ] Workflow succeeds without Docker Hub login
- [ ] Harbor receives the tag (`harbor.rzware.com/emf/emf-<service>:latest` + sha tag)
- [ ] Docker Hub repos no longer get new tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)