### PR TITLE
test(mcp): add create_unique_constraint to admin endpoint surface assertion

### DIFF
--- a/kelta-mcp/src/test/java/io/kelta/mcp/McpApplicationTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/McpApplicationTest.java
@@ -127,6 +127,7 @@ class McpApplicationTest {
                 "update_field",
                 "remove_field",
                 "create_validation_rule",
+                "create_unique_constraint",
                 "create_picklist",
                 "list_picklists",
                 "get_picklist",


### PR DESCRIPTION
## Summary
- \`CreateUniqueConstraintTool\` shipped via #984 but \`McpApplicationTest.adminEndpointSurfaceCoversPhase6Through8\` fixture wasn't updated
- Every open PR that touches kelta-mcp fails Test mcp with \"unexpected element: create_unique_constraint\"
- Add the tool to the Phase 6 schema-admin group

🤖 Generated with [Claude Code](https://claude.com/claude-code)