### PR TITLE
fix(ci): verify Harbor tag exists before bumping ArgoCD manifests

### DIFF
--- a/.github/workflows/build-and-publish-containers.yml
+++ b/.github/workflows/build-and-publish-containers.yml
@@ -337,18 +337,44 @@ jobs:
           MCP_CHANGED: ${{ needs.changes.outputs.mcp }}
           UI_CHANGED: ${{ needs.changes.outputs.ui }}
           WORKFLOWS_CHANGED: ${{ needs.changes.outputs.workflows }}
+          HARBOR_USERNAME: ${{ secrets.HARBOR_USERNAME }}
+          HARBOR_PASSWORD: ${{ secrets.HARBOR_PASSWORD }}
         run: |
           IMAGE_TAG="main-${{ steps.sha.outputs.short }}"
+
+          # Confirm the image:tag actually exists on Harbor before we write
+          # it into kustomization.yaml. Without this guard, a skipped or
+          # silently-failed Build & Push job would still bump the manifest,
+          # leaving ArgoCD trying to pull a tag that was never pushed
+          # (ImagePullBackOff, stuck PreSync Job hooks, etc.).
+          verify_image_exists() {
+            local img="$1"            # harbor.rzware.com/emf/emf-worker
+            local tag="$2"            # main-1234567
+            local repo="${img#harbor.rzware.com/}"
+            local code
+            code=$(curl -sk -o /dev/null -w "%{http_code}" \
+              -u "${HARBOR_USERNAME}:${HARBOR_PASSWORD}" \
+              -H "Accept: application/vnd.docker.distribution.manifest.v2+json" \
+              -H "Accept: application/vnd.docker.distribution.manifest.list.v2+json" \
+              -H "Accept: application/vnd.oci.image.manifest.v1+json" \
+              -H "Accept: application/vnd.oci.image.index.v1+json" \
+              "https://harbor.rzware.com/v2/${repo}/manifests/${tag}")
+            [[ "$code" == "200" ]]
+          }
 
           bump() {
             local img="$1"
             local changed_flag="$2"
-            if [[ "$changed_flag" == "true" || "$WORKFLOWS_CHANGED" == "true" ]]; then
-              echo "Bumping ${img} → ${IMAGE_TAG}"
-              kustomize edit set image "${img}:${IMAGE_TAG}"
-            else
+            if [[ "$changed_flag" != "true" && "$WORKFLOWS_CHANGED" != "true" ]]; then
               echo "Skipping ${img} (no changes)"
+              return
             fi
+            if ! verify_image_exists "$img" "$IMAGE_TAG"; then
+              echo "::error::Refusing to bump ${img} → ${IMAGE_TAG}: tag not found on Harbor (build skipped or failed)."
+              return 1
+            fi
+            echo "Bumping ${img} → ${IMAGE_TAG}"
+            kustomize edit set image "${img}:${IMAGE_TAG}"
           }
 
           if [ -d emf ]; then


### PR DESCRIPTION
## Summary
- When build-and-push matrix is skipped (path-filter said service unchanged) or silently misses pushing for a service, deploy job still wrote the new SHA tag into homelab-argo
- ArgoCD then tried to pull \`harbor.rzware.com/emf/emf-worker-migrate:main-5ff1621\` (never pushed) → ImagePullBackOff → PreSync Job hook hung 11h, blocking entire app sync
- Seen on PR #975 (SHA \`5ff1621\`) where \`Build & Push\` matrix was skipped but \`Update ArgoCD Manifests\` ran anyway

## Fix
- Add \`verify_image_exists\` curl probe against Harbor in the bump function
- If \`/v2/<repo>/manifests/<tag>\` doesn't return 200, log a GH Actions error annotation and \`return 1\` from bump → step fails loud instead of producing a broken manifest

## Test plan
- [ ] Trigger build-and-publish on a docs-only main commit — no bumps attempted, step passes
- [ ] Trigger a normal main commit — all 7 services verify + bump as expected
- [ ] Trigger a commit where one service's push fails — verify step errors instead of bumping

🤖 Generated with [Claude Code](https://claude.com/claude-code)