### PR TITLE
fix(ui): unwrap /api/modules envelope in TaskProperties

### DIFF
--- a/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/TaskProperties.tsx
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/TaskProperties.tsx
@@ -50,13 +50,22 @@ export function TaskProperties({ nodeId, data, allNodeIds, onUpdate }: TaskPrope
   const resource = (data.resource as string) || ''
   const { apiClient } = useApi()
 
-  const { data: modules } = useQuery({
+  const { data: modulesResponse } = useQuery({
     queryKey: ['modules'],
-    queryFn: () => apiClient.get<TenantModule[]>('/api/modules'),
+    queryFn: () => apiClient.get<unknown>('/api/modules'),
     staleTime: 30_000,
   })
 
-  const activeModules = (modules ?? []).filter(
+  const modules: TenantModule[] = React.useMemo(() => {
+    if (Array.isArray(modulesResponse)) return modulesResponse as TenantModule[]
+    if (modulesResponse && typeof modulesResponse === 'object') {
+      const envelope = modulesResponse as { data?: unknown }
+      if (Array.isArray(envelope.data)) return envelope.data as TenantModule[]
+    }
+    return []
+  }, [modulesResponse])
+
+  const activeModules = modules.filter(
     (m) => m.status === 'ACTIVE' && m.actions.length > 0
   )
 


### PR DESCRIPTION
## Summary
- `TaskProperties.tsx` crashed every Task properties panel with `(a ?? []).filter is not a function`.
- `apiClient.get<TenantModule[]>('/api/modules')` returns the JSON:API envelope `{ data: [...], metadata: {...} }`, not `TenantModule[]`. The TS cast lied; `(modules ?? []).filter` treated the truthy envelope as the array.
- Crash fired for every Resource type (QUERY_RECORDS, CALL_API, INVOKE_SCRIPT, …) because `useQuery` runs on every Task render.
- Defensive unwrap: accept bare array, fall back to `envelope.data`, default to `[]`. Memoized.

## Test plan
- [ ] Open any flow → click each Task node type (QUERY_RECORDS, CREATE_RECORD, UPDATE_RECORD, CALL_API, INVOKE_SCRIPT, PUBLISH_EVENT, TRIGGER_FLOW) → properties panel renders without ErrorBoundary fallback
- [ ] Module-action Task still resolves its `selectedModuleAction` for installed tenant modules
- [ ] No console errors on click
- [ ] Hot reload + cold load both clean

## Repro
1. Create scheduled flow with one Task state (any Resource)
2. Open `/flows/<id>/design`
3. Click the Task node → properties panel crashes

Bug surfaced while building `ingest_provider_tubi` for the couchpicks tenant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)