### PR TITLE
fix(runtime): CREATE_RECORD action actually persists via QueryEngine

### DIFF
--- a/kelta-platform/runtime/runtime-module-core/src/main/java/io/kelta/runtime/module/core/CoreActionsModule.java
+++ b/kelta-platform/runtime/runtime-module-core/src/main/java/io/kelta/runtime/module/core/CoreActionsModule.java
@@ -62,7 +62,7 @@ public class CoreActionsModule implements KeltaModule {
         handlers.add(new TriggerFlowActionHandler(objectMapper));
 
         // Handlers needing CollectionRegistry
-        handlers.add(new CreateRecordActionHandler(objectMapper, collectionRegistry));
+        handlers.add(new CreateRecordActionHandler(objectMapper, collectionRegistry, queryEngine));
         handlers.add(new UpdateRecordActionHandler(objectMapper, collectionRegistry, queryEngine));
         handlers.add(new DeleteRecordActionHandler(objectMapper, collectionRegistry));
 

--- a/kelta-platform/runtime/runtime-module-core/src/main/java/io/kelta/runtime/module/core/handlers/CreateRecordActionHandler.java
+++ b/kelta-platform/runtime/runtime-module-core/src/main/java/io/kelta/runtime/module/core/handlers/CreateRecordActionHandler.java
@@ -1,6 +1,7 @@
 package io.kelta.runtime.module.core.handlers;
 
 import io.kelta.runtime.model.CollectionDefinition;
+import io.kelta.runtime.query.QueryEngine;
 import io.kelta.runtime.registry.CollectionRegistry;
 import io.kelta.runtime.workflow.ActionContext;
 import io.kelta.runtime.workflow.ActionHandler;
@@ -39,10 +40,14 @@ public class CreateRecordActionHandler implements ActionHandler {
 
     private final ObjectMapper objectMapper;
     private final CollectionRegistry collectionRegistry;
+    private final QueryEngine queryEngine;
 
-    public CreateRecordActionHandler(ObjectMapper objectMapper, CollectionRegistry collectionRegistry) {
+    public CreateRecordActionHandler(ObjectMapper objectMapper,
+                                     CollectionRegistry collectionRegistry,
+                                     QueryEngine queryEngine) {
         this.objectMapper = objectMapper;
         this.collectionRegistry = collectionRegistry;
+        this.queryEngine = queryEngine;
     }
 
     @Override
@@ -92,10 +97,16 @@ public class CreateRecordActionHandler implements ActionHandler {
             log.info("Create record action: targetCollection={}, fields={}",
                 targetCollectionName, recordData.keySet());
 
-            return ActionResult.success(Map.of(
-                "targetCollectionName", targetCollectionName,
-                "recordData", recordData
-            ));
+            Map<String, Object> created = queryEngine.create(targetCollection, recordData);
+            Object createdId = created != null ? created.get("id") : null;
+
+            Map<String, Object> output = new HashMap<>();
+            output.put("targetCollectionName", targetCollectionName);
+            output.put("recordData", recordData);
+            output.put("record", created);
+            output.put("id", createdId);
+            output.put("recordId", createdId);
+            return ActionResult.success(output);
         } catch (Exception e) {
             log.error("Failed to execute create record action: {}", e.getMessage(), e);
             return ActionResult.failure(e);

--- a/kelta-platform/runtime/runtime-module-core/src/test/java/io/kelta/runtime/module/core/handlers/CreateRecordActionHandlerTest.java
+++ b/kelta-platform/runtime/runtime-module-core/src/test/java/io/kelta/runtime/module/core/handlers/CreateRecordActionHandlerTest.java
@@ -1,6 +1,7 @@
 package io.kelta.runtime.module.core.handlers;
 
 import io.kelta.runtime.model.CollectionDefinition;
+import io.kelta.runtime.query.QueryEngine;
 import io.kelta.runtime.registry.CollectionRegistry;
 import io.kelta.runtime.workflow.ActionContext;
 import io.kelta.runtime.workflow.ActionResult;
@@ -8,9 +9,11 @@ import tools.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 @DisplayName("CreateRecordActionHandler")
@@ -18,7 +21,17 @@ class CreateRecordActionHandlerTest {
 
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final CollectionRegistry registry = mock(CollectionRegistry.class);
-    private final CreateRecordActionHandler handler = new CreateRecordActionHandler(objectMapper, registry);
+    private final QueryEngine queryEngine = mock(QueryEngine.class);
+    private final CreateRecordActionHandler handler =
+        new CreateRecordActionHandler(objectMapper, registry, queryEngine);
+
+    {
+        when(queryEngine.create(any(), any())).thenAnswer(inv -> {
+            Map<String, Object> created = new HashMap<>((Map<String, Object>) inv.getArgument(1));
+            created.put("id", "test-id-001");
+            return created;
+        });
+    }
 
     @Test
     @DisplayName("Should have correct action type key")


### PR DESCRIPTION
## Summary
- `CreateRecordActionHandler` resolved the target collection and assembled `recordData` but **never wrote to the database**. The handler returned the prepared map and called it a day.
- Downstream flow states that referenced `${$.snapshot.id}` (or any other field of the supposed created record) resolved to null and failed with `Could not resolve target record ID`.
- Inject `QueryEngine` (same dep `UpdateRecordActionHandler` already uses) and call `queryEngine.create(...)`. Surface `id`, `recordId`, and full `record` so downstream states can reference either alias.
- Wire the new constructor arg in `CoreActionsModule` and update the unit test.

## Test plan
- [ ] `./gradlew :runtime-module-core:test` — `CreateRecordActionHandler` test green with mocked QueryEngine returning `{id: "test-id-001", ...}`
- [ ] Author a flow with `CREATE_RECORD` followed by an `UPDATE_RECORD` referencing `${$.<resultPath>.id}` — UPDATE finds the row
- [ ] Existing flows that ignore the create's output keep working (output is a superset — `targetCollectionName` and `recordData` still present)

## Repro
1. Build a SCHEDULED flow with a CREATE_RECORD task whose `ResultPath` is `$.snapshot`, followed by an UPDATE_RECORD task with `recordId: \"\${\$.snapshot.id}\"`.
2. Trigger via `POST /api/flows/{id}/execute` with `{state:{input:{}},test:true}`.
3. Execution fails at the UPDATE_RECORD step with `Could not resolve target record ID`. After this patch it succeeds.

Surfaced while running the couchpicks `ingest_provider_tubi` flow that creates a `provider-snapshots` row and later updates it with diff counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)