### PR TITLE
fix(runtime): sub-flows reuse parent executionId so step rows fit FK

### DIFF
--- a/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/flow/FlowEngine.java
+++ b/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/flow/FlowEngine.java
@@ -201,8 +201,14 @@ public class FlowEngine {
     public Map<String, Object> executeSubFlow(FlowDefinition subFlow,
                                                Map<String, Object> input,
                                                FlowExecutionContext parent) {
+        // Sub-flows reuse the parent's executionId so their step rows fit the
+        // flow_step_log.execution_id VARCHAR(36) FK to flow_execution(id). The
+        // parent execution row already exists; sub-step rows simply attach to
+        // it (their state_id and own row id disambiguate). Synthesizing a
+        // longer id ("<parent>-sub-<uuid>") used to overflow the column and
+        // would also FK-violate because no matching flow_execution row exists.
         FlowExecutionContext subContext = new FlowExecutionContext(
-            parent.executionId() + "-sub-" + UUID.randomUUID().toString().substring(0, 8),
+            parent.executionId(),
             parent.tenantId(), parent.flowId(), parent.userId(),
             subFlow, input);
 


### PR DESCRIPTION
## Summary
- \`FlowEngine.executeSubFlow\` synthesized a child \`executionId\` as \`\"<parent>-sub-<8-char-uuid>\"\` — 44+ chars.
- \`flow_step_log.execution_id\` is \`VARCHAR(36) NOT NULL REFERENCES flow_execution(id)\`. The INSERT failed with \`value too long for type character varying(36)\` before the FK was even checked.
- Even widened, the synthetic id has no matching \`flow_execution\` row, so the FK would reject it next.

## Fix
Reuse the parent's \`executionId\` for the sub-context. Sub-flow step rows attach to the parent execution; their \`state_id\` and own primary key still disambiguate iterations. Map-state iteration loses no information.

## Repro
1. Run a flow with a Map state whose Iterator contains any Task that writes to \`flow_step_log\` (which is all of them).
2. Execution fails on Map.Item 0 with the VARCHAR(36) overflow.

## Test plan
- [ ] \`./gradlew :runtime-core:test\` green
- [ ] Trigger a flow with a Map iterator running QUERY_RECORDS + CREATE_RECORD per item — sub-step rows persist under parent execution_id, no overflow
- [ ] Existing top-level flows unaffected (FlowExecutionContext for top-level still constructed via \`flowStore.createExecution\` path)

Surfaced while running \`ingest_provider_tubi\` (UpsertTitlesMap iterator failed at item 0 immediately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)