### PR TITLE
fix(runtime): emit ANY()/ALL() SQL for MULTI_PICKLIST filter operators

### DIFF
--- a/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/storage/PhysicalTableStorageAdapter.java
+++ b/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/storage/PhysicalTableStorageAdapter.java
@@ -918,14 +918,26 @@ public class PhysicalTableStorageAdapter implements StorageAdapter {
             value = TypeCoercionService.coerceValue(value, fieldDef.type());
         }
 
+        // Detect array-backed columns (Postgres TEXT[]) so we emit ANY(...) /
+        // <> ALL(...) / unnest+ILIKE instead of scalar operators that 500 the
+        // gateway on JSONB-coerced arrays. Currently only MULTI_PICKLIST maps
+        // to TEXT[]; the legacy FieldType.ARRAY value lands in JSONB so it is
+        // intentionally NOT included here.
+        boolean isArrayColumn = fieldDef != null
+            && fieldDef.type() == FieldType.MULTI_PICKLIST;
+
         return switch (operator) {
             case EQ -> {
                 params.add(value);
-                yield fieldName + " = ?";
+                yield isArrayColumn
+                    ? "? = ANY(" + fieldName + ")"
+                    : fieldName + " = ?";
             }
             case NEQ -> {
                 params.add(value);
-                yield fieldName + " != ?";
+                yield isArrayColumn
+                    ? "? <> ALL(" + fieldName + ")"
+                    : fieldName + " != ?";
             }
             case GT -> {
                 params.add(value);
@@ -949,6 +961,13 @@ public class PhysicalTableStorageAdapter implements StorageAdapter {
                 yield isNull ? fieldName + " IS NULL" : fieldName + " IS NOT NULL";
             }
             case CONTAINS -> {
+                if (isArrayColumn) {
+                    // Array-contains: exact element match. Use ANY() so the
+                    // index on the array column can be considered. For
+                    // substring search across elements, use ICONTAINS.
+                    params.add(value);
+                    yield "? = ANY(" + fieldName + ")";
+                }
                 params.add("%" + value + "%");
                 yield fieldName + " LIKE ?";
             }
@@ -961,6 +980,12 @@ public class PhysicalTableStorageAdapter implements StorageAdapter {
                 yield fieldName + " LIKE ?";
             }
             case ICONTAINS -> {
+                if (isArrayColumn) {
+                    // Case-insensitive element match across the array.
+                    params.add(value.toString().toLowerCase());
+                    yield "EXISTS (SELECT 1 FROM unnest(" + fieldName
+                        + ") AS elt WHERE LOWER(elt) = ?)";
+                }
                 params.add("%" + value.toString().toLowerCase() + "%");
                 yield "LOWER(" + fieldName + ") LIKE ?";
             }


### PR DESCRIPTION
## Summary
- Detect `FieldType.MULTI_PICKLIST` (TEXT[]) columns in `PhysicalTableStorageAdapter.buildFilterCondition`
- Emit `? = ANY(field)` for `EQ`/`CONTAINS`, `? <> ALL(field)` for `NEQ`, and `EXISTS (SELECT 1 FROM unnest(field) elt WHERE LOWER(elt) = ?)` for `ICONTAINS`
- Scalar columns continue to use the previous `=`/`!=`/`LIKE`/`LOWER() LIKE` SQL

## Why
Filtering JSON:API requests on TEXT[] columns previously generated scalar SQL (`field = ?`, `field LIKE ?`), which Postgres rejects against array columns with HTTP 500 `{"errors":[{}]}`. The gateway accepted the request but the query plan failed at execute time. This unblocks `couchpicks/discover?genre=Drama` and any future filter on a multi-value picklist column (e.g. tags, audiences).

## Test plan
- [ ] `mvn -pl runtime/runtime-core -am compile` passes locally on Java 25
- [ ] Existing unit tests for `PhysicalTableStorageAdapter` still pass
- [ ] After deploy: `curl 'https://api.kelta.io/couchpicks/titles?filter[genres][CONTAINS]=Drama&filter[status][EQ]=published&page[size]=5'` returns 200 with matching titles
- [ ] `curl 'https://api.kelta.io/couchpicks/titles?filter[genres][ICONTAINS]=action&page[size]=5'` returns 200 with matching titles (case-insensitive)
- [ ] Pre-existing scalar EQ/CONTAINS queries (e.g. `filter[status][EQ]=published`) continue to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)