### PR TITLE
feat(worker+ui): CSV import for collection records

### DIFF
--- a/kelta-ui/app/src/components/CsvImportDialog/CsvImportDialog.tsx
+++ b/kelta-ui/app/src/components/CsvImportDialog/CsvImportDialog.tsx
@@ -1,0 +1,195 @@
+import React, { useState, useCallback } from 'react'
+import { CheckCircle2, XCircle, AlertCircle, Loader2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { ScrollArea } from '@/components/ui/scroll-area'
+import { FileDropzone } from '@/components/FileDropzone/FileDropzone'
+import { useApi } from '@/context/ApiContext'
+
+interface RowError {
+  row: number
+  message: string
+}
+
+interface ImportResult {
+  rowsProcessed: number
+  rowsImported: number
+  errorCount: number
+  errors: RowError[]
+}
+
+export interface CsvImportDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  collectionName: string
+  onImported: () => void
+}
+
+type Phase = 'idle' | 'uploading' | 'done'
+
+export function CsvImportDialog({
+  open,
+  onOpenChange,
+  collectionName,
+  onImported,
+}: CsvImportDialogProps): React.ReactElement {
+  const { apiClient } = useApi()
+  const [file, setFile] = useState<File | null>(null)
+  const [fileError, setFileError] = useState<string | null>(null)
+  const [phase, setPhase] = useState<Phase>('idle')
+  const [result, setResult] = useState<ImportResult | null>(null)
+  const [uploadError, setUploadError] = useState<string | null>(null)
+
+  const reset = useCallback(() => {
+    setFile(null)
+    setFileError(null)
+    setPhase('idle')
+    setResult(null)
+    setUploadError(null)
+  }, [])
+
+  const handleOpenChange = useCallback(
+    (next: boolean) => {
+      if (!next) reset()
+      onOpenChange(next)
+    },
+    [onOpenChange, reset]
+  )
+
+  const handleFile = useCallback((f: File) => {
+    setFile(f)
+    setFileError(null)
+    setUploadError(null)
+    setResult(null)
+  }, [])
+
+  const handleImport = useCallback(async () => {
+    if (!file) return
+    setPhase('uploading')
+    setUploadError(null)
+
+    const formData = new FormData()
+    formData.append('file', file)
+
+    try {
+      const data = await apiClient.postFormData<ImportResult>(
+        `/api/collections/${collectionName}/import/csv`,
+        formData
+      )
+      setResult(data)
+      setPhase('done')
+      if (data.rowsImported > 0) {
+        onImported()
+      }
+    } catch (err: unknown) {
+      const msg =
+        err && typeof err === 'object' && 'message' in err
+          ? String((err as { message: unknown }).message)
+          : 'Import failed'
+      setUploadError(msg)
+      setPhase('idle')
+    }
+  }, [apiClient, collectionName, file, onImported])
+
+  const isSuccess = result && result.errorCount === 0
+  const isPartial = result && result.rowsImported > 0 && result.errorCount > 0
+  const isAllFailed = result && result.rowsImported === 0 && result.errorCount > 0
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Import CSV</DialogTitle>
+          <DialogDescription>
+            Upload a CSV file to bulk-create records. The header row must match your field names
+            exactly. System fields (id, createdAt, etc.) are ignored.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          {phase !== 'done' && (
+            <FileDropzone
+              accept=".csv"
+              maxBytes={10 * 1024 * 1024}
+              onFile={handleFile}
+              onError={setFileError}
+              hint={
+                file ? (
+                  <span className="text-sm font-medium text-foreground">{file.name}</span>
+                ) : (
+                  <span className="text-sm text-muted-foreground">
+                    Drop a .csv file here or click to browse
+                  </span>
+                )
+              }
+            />
+          )}
+
+          {fileError && (
+            <p className="flex items-center gap-1.5 text-sm text-destructive">
+              <AlertCircle className="h-4 w-4 shrink-0" />
+              {fileError}
+            </p>
+          )}
+
+          {uploadError && (
+            <p className="flex items-center gap-1.5 text-sm text-destructive">
+              <XCircle className="h-4 w-4 shrink-0" />
+              {uploadError}
+            </p>
+          )}
+
+          {result && (
+            <div className="space-y-3 rounded-md border p-4">
+              <div className="flex items-center gap-2">
+                {isSuccess && <CheckCircle2 className="h-5 w-5 text-green-600" />}
+                {isPartial && <AlertCircle className="h-5 w-5 text-yellow-600" />}
+                {isAllFailed && <XCircle className="h-5 w-5 text-destructive" />}
+                <span className="text-sm font-medium">
+                  {result.rowsImported} of {result.rowsProcessed} row
+                  {result.rowsProcessed !== 1 ? 's' : ''} imported
+                </span>
+              </div>
+
+              {result.errors.length > 0 && (
+                <ScrollArea className="h-40">
+                  <ul className="space-y-1">
+                    {result.errors.map((e, idx) => (
+                      <li key={idx} className="text-xs text-muted-foreground">
+                        <span className="font-medium text-destructive">Row {e.row}:</span>{' '}
+                        {e.message}
+                      </li>
+                    ))}
+                  </ul>
+                </ScrollArea>
+              )}
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          {phase === 'done' ? (
+            <Button onClick={() => handleOpenChange(false)}>Done</Button>
+          ) : (
+            <>
+              <Button variant="outline" onClick={() => handleOpenChange(false)}>
+                Cancel
+              </Button>
+              <Button onClick={handleImport} disabled={!file || phase === 'uploading'}>
+                {phase === 'uploading' && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                Import
+              </Button>
+            </>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/kelta-ui/app/src/components/ListViewToolbar/ListViewToolbar.tsx
+++ b/kelta-ui/app/src/components/ListViewToolbar/ListViewToolbar.tsx
@@ -9,7 +9,7 @@
  */
 
 import React from 'react'
-import { Plus, Download, Trash2, ChevronDown } from 'lucide-react'
+import { Plus, Download, Upload, Trash2, ChevronDown } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import {
   DropdownMenu,
@@ -34,6 +34,8 @@ export interface ListViewToolbarProps {
   onExportCsv?: () => void
   /** Callback for JSON export */
   onExportJson?: () => void
+  /** Callback for CSV import */
+  onImportCsv?: () => void
   /** Callback to clear selection */
   onClearSelection?: () => void
   /** Whether the user can create records (controls New button visibility) */
@@ -52,6 +54,7 @@ export function ListViewToolbar({
   onBulkDelete,
   onExportCsv,
   onExportJson,
+  onImportCsv,
   onClearSelection,
   canCreate = true,
   canDelete = true,
@@ -95,7 +98,15 @@ export function ListViewToolbar({
                   Export as JSON
                 </DropdownMenuItem>
               )}
-              {(onExportCsv || onExportJson) && onBulkDelete && <DropdownMenuSeparator />}
+              {onImportCsv && (
+                <DropdownMenuItem onClick={onImportCsv}>
+                  <Upload className="mr-2 h-4 w-4" />
+                  Import CSV
+                </DropdownMenuItem>
+              )}
+              {(onExportCsv || onExportJson || onImportCsv) && onBulkDelete && (
+                <DropdownMenuSeparator />
+              )}
               {canDelete && onBulkDelete && selectedCount > 0 && (
                 <DropdownMenuItem
                   className="text-destructive focus:text-destructive"

--- a/kelta-ui/app/src/pages/app/ObjectListPage/ObjectListPage.tsx
+++ b/kelta-ui/app/src/pages/app/ObjectListPage/ObjectListPage.tsx
@@ -49,6 +49,7 @@ import type { SortState, FilterCondition, CollectionRecord } from '@/hooks/useCo
 import { ObjectDataTable } from '@/components/ObjectDataTable/ObjectDataTable'
 import { DataTablePagination } from '@/components/ObjectDataTable/DataTablePagination'
 import { ListViewToolbar } from '@/components/ListViewToolbar'
+import { CsvImportDialog } from '@/components/CsvImportDialog/CsvImportDialog'
 import { FilterBar } from '@/components/FilterBar'
 import { InsufficientPrivileges } from '@/components/InsufficientPrivileges'
 import { QuickActionsMenu } from '@/components/QuickActions'
@@ -168,6 +169,9 @@ export function ObjectListPage(): React.ReactElement {
   // Delete confirmation state
   const [deleteTarget, setDeleteTarget] = useState<CollectionRecord | null>(null)
   const [showBulkDeleteDialog, setShowBulkDeleteDialog] = useState(false)
+
+  // Import dialog state
+  const [showImportDialog, setShowImportDialog] = useState(false)
 
   // Fetch collection schema
   const {
@@ -491,6 +495,7 @@ export function ObjectListPage(): React.ReactElement {
         onBulkDelete={handleBulkDeleteClick}
         onExportCsv={handleExportCsv}
         onExportJson={handleExportJson}
+        onImportCsv={permissions.canCreate ? () => setShowImportDialog(true) : undefined}
         onClearSelection={handleClearSelection}
         canCreate={permissions.canCreate}
         canDelete={permissions.canDelete}
@@ -545,6 +550,14 @@ export function ObjectListPage(): React.ReactElement {
           onPageSizeChange={handlePageSizeChange}
         />
       )}
+
+      {/* CSV import dialog */}
+      <CsvImportDialog
+        open={showImportDialog}
+        onOpenChange={setShowImportDialog}
+        collectionName={collectionName || ''}
+        onImported={refetch}
+      />
 
       {/* Single delete confirmation */}
       <AlertDialog

--- a/kelta-worker/src/main/java/io/kelta/worker/controller/CsvImportController.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/controller/CsvImportController.java
@@ -1,0 +1,95 @@
+package io.kelta.worker.controller;
+
+import io.kelta.jsonapi.JsonApiResponseBuilder;
+import io.kelta.worker.service.CsvImportService;
+import io.kelta.worker.service.CsvImportService.ImportResult;
+import io.kelta.worker.service.CsvImportService.RowError;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Accepts a CSV file upload and bulk-creates records in the named collection.
+ *
+ * <p>The CSV must have a header row with column names matching field names.
+ * System fields (id, createdAt, updatedAt, createdBy, updatedBy) are ignored.
+ * Rows that fail validation are reported per-row; successful rows are committed.
+ */
+@RestController
+@RequestMapping("/api/collections/{collectionName}/import")
+public class CsvImportController {
+
+    private static final Logger log = LoggerFactory.getLogger(CsvImportController.class);
+    private static final Logger securityLog = LoggerFactory.getLogger("security.audit");
+
+    private static final long MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
+
+    private final CsvImportService csvImportService;
+
+    public CsvImportController(CsvImportService csvImportService) {
+        this.csvImportService = csvImportService;
+    }
+
+    @PostMapping(value = "/csv", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<Map<String, Object>> importCsv(
+            @PathVariable String collectionName,
+            @RequestHeader("X-Tenant-ID") String tenantId,
+            @RequestHeader("X-User-Email") String userEmail,
+            @RequestParam("file") MultipartFile file) {
+
+        if (file.isEmpty()) {
+            return ResponseEntity.badRequest().body(
+                    JsonApiResponseBuilder.error("400", "Empty file", "No file content received"));
+        }
+
+        if (file.getSize() > MAX_FILE_SIZE) {
+            return ResponseEntity.badRequest().body(
+                    JsonApiResponseBuilder.error("400", "File too large",
+                            "Maximum file size is 10 MB"));
+        }
+
+        String originalFilename = file.getOriginalFilename();
+        if (originalFilename != null && !originalFilename.toLowerCase().endsWith(".csv")) {
+            return ResponseEntity.badRequest().body(
+                    JsonApiResponseBuilder.error("400", "Invalid file type",
+                            "Only CSV files are supported"));
+        }
+
+        ImportResult result;
+        try {
+            result = csvImportService.importCsv(collectionName, file.getInputStream());
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(
+                    JsonApiResponseBuilder.error("400", "Import failed", e.getMessage()));
+        } catch (Exception e) {
+            log.error("CSV import error: collection={}, tenant={}, error={}",
+                    collectionName, tenantId, e.getMessage(), e);
+            return ResponseEntity.internalServerError().body(
+                    JsonApiResponseBuilder.error("500", "Import failed", e.getMessage()));
+        }
+
+        securityLog.info("security_event=CSV_IMPORT user={} tenant={} collection={} rows={} imported={}",
+                userEmail, tenantId, collectionName, result.rowsProcessed(), result.rowsImported());
+
+        log.info("CSV import completed: collection={}, tenant={}, rows={}, imported={}, errors={}",
+                collectionName, tenantId, result.rowsProcessed(), result.rowsImported(),
+                result.errors().size());
+
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("rowsProcessed", result.rowsProcessed());
+        body.put("rowsImported", result.rowsImported());
+        body.put("errorCount", result.errors().size());
+        body.put("errors", result.errors().stream()
+                .map(e -> Map.of("row", e.row(), "message", e.message()))
+                .toList());
+
+        return ResponseEntity.ok(body);
+    }
+}

--- a/kelta-worker/src/main/java/io/kelta/worker/service/CsvImportService.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/service/CsvImportService.java
@@ -1,0 +1,260 @@
+package io.kelta.worker.service;
+
+import io.kelta.runtime.model.CollectionDefinition;
+import io.kelta.runtime.model.FieldDefinition;
+import io.kelta.runtime.model.FieldType;
+import io.kelta.runtime.query.QueryEngine;
+import io.kelta.runtime.registry.CollectionRegistry;
+import io.kelta.runtime.storage.UniqueConstraintViolationException;
+import io.kelta.runtime.validation.ValidationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import tools.jackson.databind.ObjectMapper;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+
+@Service
+public class CsvImportService {
+
+    private static final Logger log = LoggerFactory.getLogger(CsvImportService.class);
+
+    private static final Set<String> SYSTEM_FIELDS = Set.of(
+            "id", "createdAt", "updatedAt", "createdBy", "updatedBy");
+
+    private static final int MAX_ROWS = 10_000;
+
+    private final QueryEngine queryEngine;
+    private final CollectionRegistry collectionRegistry;
+    private final ObjectMapper objectMapper;
+
+    public CsvImportService(QueryEngine queryEngine,
+                            CollectionRegistry collectionRegistry,
+                            ObjectMapper objectMapper) {
+        this.queryEngine = queryEngine;
+        this.collectionRegistry = collectionRegistry;
+        this.objectMapper = objectMapper;
+    }
+
+    public record RowError(int row, String message) {}
+
+    public record ImportResult(int rowsProcessed, int rowsImported, List<RowError> errors) {}
+
+    public ImportResult importCsv(String collectionName, InputStream csvStream) throws IOException {
+        CollectionDefinition definition = collectionRegistry.get(collectionName);
+        if (definition == null) {
+            throw new IllegalArgumentException("Collection not found: " + collectionName);
+        }
+
+        Map<String, FieldDefinition> fieldsByName = new LinkedHashMap<>();
+        if (definition.fields() != null) {
+            for (FieldDefinition f : definition.fields()) {
+                fieldsByName.put(f.name(), f);
+            }
+        }
+
+        List<String[]> rows = parseCsv(csvStream);
+        if (rows.isEmpty()) {
+            return new ImportResult(0, 0, List.of());
+        }
+
+        String[] headers = rows.get(0);
+        List<String> columnNames = Arrays.asList(headers);
+
+        // Identify which columns map to writable fields
+        List<String> importableColumns = columnNames.stream()
+                .map(String::trim)
+                .filter(name -> !name.isBlank() && !SYSTEM_FIELDS.contains(name) && fieldsByName.containsKey(name))
+                .toList();
+
+        if (importableColumns.isEmpty()) {
+            return new ImportResult(0, 0,
+                    List.of(new RowError(1, "No matching fields found in CSV header. " +
+                            "Expected columns matching field names of collection '" + collectionName + "'")));
+        }
+
+        int dataRowCount = rows.size() - 1;
+        if (dataRowCount > MAX_ROWS) {
+            return new ImportResult(0, 0,
+                    List.of(new RowError(0, "CSV exceeds maximum of " + MAX_ROWS + " rows. " +
+                            "Split the file and import in batches.")));
+        }
+
+        List<RowError> errors = new ArrayList<>();
+        int imported = 0;
+
+        for (int i = 1; i < rows.size(); i++) {
+            String[] cells = rows.get(i);
+            int rowNumber = i + 1; // 1-based, row 1 is header
+
+            // Skip completely blank rows
+            if (isBlankRow(cells)) continue;
+
+            Map<String, Object> record = new LinkedHashMap<>();
+            boolean rowHasParseError = false;
+
+            for (String colName : importableColumns) {
+                int colIdx = columnNames.indexOf(colName);
+                String rawValue = colIdx < cells.length ? cells[colIdx].trim() : "";
+                FieldDefinition field = fieldsByName.get(colName);
+
+                try {
+                    Object coerced = coerceValue(rawValue, field);
+                    if (coerced != null) {
+                        record.put(colName, coerced);
+                    }
+                } catch (Exception e) {
+                    errors.add(new RowError(rowNumber,
+                            "Column '" + colName + "': " + e.getMessage()));
+                    rowHasParseError = true;
+                    break;
+                }
+            }
+
+            if (rowHasParseError) continue;
+
+            try {
+                queryEngine.create(definition, record);
+                imported++;
+            } catch (ValidationException e) {
+                String msg = e.getValidationResult().errors().stream()
+                        .map(fe -> fe.fieldName() + ": " + fe.message())
+                        .reduce((a, b) -> a + "; " + b)
+                        .orElse(e.getMessage());
+                errors.add(new RowError(rowNumber, msg));
+            } catch (UniqueConstraintViolationException e) {
+                errors.add(new RowError(rowNumber, "Duplicate value: " + e.getMessage()));
+            } catch (Exception e) {
+                log.warn("Row {} import failed: {}", rowNumber, e.getMessage());
+                errors.add(new RowError(rowNumber, e.getMessage()));
+            }
+        }
+
+        return new ImportResult(dataRowCount, imported, errors);
+    }
+
+    // =========================================================================
+    // CSV parsing (RFC 4180)
+    // =========================================================================
+
+    private List<String[]> parseCsv(InputStream stream) throws IOException {
+        List<String[]> rows = new ArrayList<>();
+        try (BufferedReader reader = new BufferedReader(
+                new InputStreamReader(stream, StandardCharsets.UTF_8))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                if (line.startsWith("#")) continue; // skip section headers from multi-collection export
+                rows.add(parseCsvRow(line));
+            }
+        }
+        return rows;
+    }
+
+    private String[] parseCsvRow(String line) {
+        List<String> fields = new ArrayList<>();
+        boolean inQuotes = false;
+        StringBuilder current = new StringBuilder();
+
+        for (int i = 0; i < line.length(); i++) {
+            char c = line.charAt(i);
+            if (inQuotes) {
+                if (c == '"') {
+                    if (i + 1 < line.length() && line.charAt(i + 1) == '"') {
+                        current.append('"');
+                        i++;
+                    } else {
+                        inQuotes = false;
+                    }
+                } else {
+                    current.append(c);
+                }
+            } else {
+                if (c == '"') {
+                    inQuotes = true;
+                } else if (c == ',') {
+                    fields.add(current.toString());
+                    current.setLength(0);
+                } else {
+                    current.append(c);
+                }
+            }
+        }
+        fields.add(current.toString());
+        return fields.toArray(String[]::new);
+    }
+
+    private boolean isBlankRow(String[] cells) {
+        for (String cell : cells) {
+            if (cell != null && !cell.trim().isEmpty()) return false;
+        }
+        return true;
+    }
+
+    // =========================================================================
+    // Type coercion
+    // =========================================================================
+
+    @SuppressWarnings("unchecked")
+    private Object coerceValue(String raw, FieldDefinition field) {
+        if (raw == null || raw.isEmpty()) {
+            return null; // let the engine apply the default or null
+        }
+
+        FieldType type = field.type();
+        return switch (type) {
+            case STRING, TEXT, RICH_TEXT, PICKLIST, PHONE, EMAIL, URL, ENCRYPTED, EXTERNAL_ID -> raw;
+            case INTEGER -> {
+                try {
+                    yield Long.parseLong(raw);
+                } catch (NumberFormatException e) {
+                    throw new IllegalArgumentException("expected integer, got '" + raw + "'");
+                }
+            }
+            case LONG -> {
+                try {
+                    yield Long.parseLong(raw);
+                } catch (NumberFormatException e) {
+                    throw new IllegalArgumentException("expected integer, got '" + raw + "'");
+                }
+            }
+            case DOUBLE, CURRENCY, PERCENT -> {
+                try {
+                    yield Double.parseDouble(raw);
+                } catch (NumberFormatException e) {
+                    throw new IllegalArgumentException("expected number, got '" + raw + "'");
+                }
+            }
+            case BOOLEAN -> {
+                if ("true".equalsIgnoreCase(raw) || "1".equals(raw) || "yes".equalsIgnoreCase(raw)) {
+                    yield Boolean.TRUE;
+                } else if ("false".equalsIgnoreCase(raw) || "0".equals(raw) || "no".equalsIgnoreCase(raw)) {
+                    yield Boolean.FALSE;
+                } else {
+                    throw new IllegalArgumentException("expected boolean (true/false/1/0), got '" + raw + "'");
+                }
+            }
+            case DATE, DATETIME -> raw; // pass as string; storage layer parses ISO dates
+            case MULTI_PICKLIST -> {
+                // Exported as JSON array; also accept comma-separated plain list
+                if (raw.startsWith("[")) {
+                    try {
+                        yield objectMapper.readValue(raw, List.class);
+                    } catch (Exception e) {
+                        throw new IllegalArgumentException("expected JSON array for multi-picklist, got '" + raw + "'");
+                    }
+                } else {
+                    yield Arrays.stream(raw.split(","))
+                            .map(String::trim)
+                            .filter(s -> !s.isEmpty())
+                            .toList();
+                }
+            }
+            default -> raw; // URL, PHONE, EMAIL, GEOLOCATION etc — pass as string
+        };
+    }
+}


### PR DESCRIPTION
## Summary

- `POST /api/collections/{name}/import/csv` endpoint in kelta-worker accepts a multipart CSV upload and bulk-creates records, returning per-row errors for any failures
- `CsvImportDialog` in kelta-ui: drag-and-drop file picker, upload progress, result summary with scrollable error list
- **Import CSV** item added to the Actions dropdown in the list view toolbar (only shown when user has `canCreate` permission)
- Symmetric with the existing CSV/JSON export — same column format (header row matches field names)

## How it works

1. CSV header row is matched against the collection's field names; system fields (`id`, `createdAt`, etc.) are skipped
2. Values are coerced to the correct type per field (`INTEGER`, `DOUBLE`, `BOOLEAN`, `MULTI_PICKLIST` JSON arrays, etc.)
3. Each row is created via `QueryEngine.create()` — validation rules, unique constraints, and lifecycle events all fire normally
4. Failed rows are reported back with row number + error message; successful rows are committed regardless

## Test plan

- [ ] Upload a CSV exported from the same collection — all rows import cleanly
- [ ] Upload a CSV with a bad row (wrong type, missing required field) — bad rows reported with row number, good rows still created
- [ ] Upload a file > 10 MB — rejected with a clear error
- [ ] Upload a non-.csv file — rejected
- [ ] Import button hidden when user lacks create permission

🤖 Generated with [Claude Code](https://claude.com/claude-code)