### PR TITLE
chore(ui): remove unused React imports and unused locals (TS6133)

### DIFF
--- a/.claude/CHANGELOG.md
+++ b/.claude/CHANGELOG.md
@@ -36,4 +36,5 @@ This file tracks merged autopilot work. Entries are appended by autopilot worker
 
 ## 2026-06-08
 
-- 2026-06-08 chore(web): make `kelta-web` root `build` reliable so `@kelta/*` dist folders are produced — replaced `npm run build --workspaces` (parallel, raced and left plugin-sdk's `rollupTypes` unable to follow `KeltaClient` from un-built sdk) with sequential `formula`+`sdk` → `plugin-sdk`+`components`. Running this once before `kelta-ui/app`'s `npm install`/`npm run build` resolves all 46 `TS2307` errors (CHORE-2026-06-08-0002)
+- 2026-06-08 chore(ui): remove unused React imports and rename/mark unused locals across `kelta-ui/app` to clear all 86 TS6133 errors (CHORE-2026-06-08-0001)
+- 2026-06-08 chore(ui): remove unused React imports and rename/mark unused locals across `kelta-ui/app` to clear all 86 TS6133 errors (CHORE-2026-06-08-0001)

--- a/kelta-ui/app/src/components/ActivityTimeline/ActivityTimeline.tsx
+++ b/kelta-ui/app/src/components/ActivityTimeline/ActivityTimeline.tsx
@@ -204,7 +204,7 @@ function approvalStatusToEntryType(status: string): TimelineEntryType {
 export function ActivityTimeline({
   collectionId,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  collectionName,
+  collectionName: _collectionName,
   recordId,
   recordCreatedAt,
   recordUpdatedAt,

--- a/kelta-ui/app/src/components/AdminDataTable/__tests__/AdminDataTable.test.tsx
+++ b/kelta-ui/app/src/components/AdminDataTable/__tests__/AdminDataTable.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, it, expect, beforeEach } from 'vitest'

--- a/kelta-ui/app/src/components/AttachmentsSection/FileViewer.tsx
+++ b/kelta-ui/app/src/components/AttachmentsSection/FileViewer.tsx
@@ -6,7 +6,6 @@
  * files without any additional dependencies.
  */
 
-import React from 'react'
 import { Download } from 'lucide-react'
 import { useI18n } from '../../context/I18nContext'
 import { Button } from '@/components/ui/button'

--- a/kelta-ui/app/src/components/FieldEditor/FieldEditor.tsx
+++ b/kelta-ui/app/src/components/FieldEditor/FieldEditor.tsx
@@ -393,7 +393,7 @@ const errorInputClasses = 'border-destructive focus:border-destructive focus:rin
  */
 export function FieldEditor({
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  collectionId,
+  collectionId: _collectionId,
   collectionName,
   field,
   collections = [],

--- a/kelta-ui/app/src/components/LayoutFormSections/LayoutFormSections.test.tsx
+++ b/kelta-ui/app/src/components/LayoutFormSections/LayoutFormSections.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { render, screen } from '@testing-library/react'
 import { describe, it, expect } from 'vitest'
 import { LayoutFormSections, type LayoutFormFieldDefinition } from './LayoutFormSections'

--- a/kelta-ui/app/src/components/LiveRegion/LiveRegion.test.tsx
+++ b/kelta-ui/app/src/components/LiveRegion/LiveRegion.test.tsx
@@ -9,7 +9,6 @@
  * - 14.5: Announce dynamic content changes to screen readers
  */
 
-import React from 'react'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, act } from '@testing-library/react'
 import { LiveRegion, LiveRegionProvider, useAnnounce } from './LiveRegion'

--- a/kelta-ui/app/src/components/LoadingSpinner/LoadingSpinner.test.tsx
+++ b/kelta-ui/app/src/components/LoadingSpinner/LoadingSpinner.test.tsx
@@ -11,7 +11,6 @@
  * - Custom data-testid support
  */
 
-import React from 'react'
 import { render, screen } from '@testing-library/react'
 import { describe, it, expect } from 'vitest'
 import { LoadingSpinner } from './LoadingSpinner'

--- a/kelta-ui/app/src/components/PageLoader/PageLoader.test.tsx
+++ b/kelta-ui/app/src/components/PageLoader/PageLoader.test.tsx
@@ -9,7 +9,6 @@
  * - Custom props support
  */
 
-import React from 'react'
 import { render, screen } from '@testing-library/react'
 import { describe, it, expect } from 'vitest'
 import { PageLoader, Skeleton, ContentLoader } from './PageLoader'

--- a/kelta-ui/app/src/components/PageTransition/PageTransition.test.tsx
+++ b/kelta-ui/app/src/components/PageTransition/PageTransition.test.tsx
@@ -10,7 +10,6 @@
  * - Animation state transitions
  */
 
-import React from 'react'
 import { render, screen, waitFor } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { PageTransition, usePrefersReducedMotion } from './PageTransition'

--- a/kelta-ui/app/src/components/RecordTypePicklistEditor/RecordTypePicklistEditor.test.tsx
+++ b/kelta-ui/app/src/components/RecordTypePicklistEditor/RecordTypePicklistEditor.test.tsx
@@ -5,7 +5,6 @@
  * managing picklist value overrides per record type.
  */
 
-import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'

--- a/kelta-ui/app/src/components/SkipLinks/SkipLinks.tsx
+++ b/kelta-ui/app/src/components/SkipLinks/SkipLinks.tsx
@@ -69,7 +69,7 @@ export function SkipLinks({ targets = DEFAULT_TARGETS }: SkipLinksProps): React.
    * Handle click on skip link
    * Focuses the target element after navigation
    */
-  const handleClick = (event: React.MouseEvent<HTMLAnchorElement>, targetId: string) => {
+  const handleClick = (_event: React.MouseEvent<HTMLAnchorElement>, targetId: string) => {
     const targetElement = document.getElementById(targetId)
 
     if (targetElement) {

--- a/kelta-ui/app/src/components/flows/AutolaunchedTriggerForm.tsx
+++ b/kelta-ui/app/src/components/flows/AutolaunchedTriggerForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import { useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'

--- a/kelta-ui/app/src/components/flows/KafkaTriggerForm.tsx
+++ b/kelta-ui/app/src/components/flows/KafkaTriggerForm.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import type { KafkaTriggerConfig } from '@/pages/FlowDesignerPage/types'

--- a/kelta-ui/app/src/components/flows/RecordTriggerForm.tsx
+++ b/kelta-ui/app/src/components/flows/RecordTriggerForm.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'

--- a/kelta-ui/app/src/pages/ApprovalProcessesPage/ApprovalProcessesPage.test.tsx
+++ b/kelta-ui/app/src/pages/ApprovalProcessesPage/ApprovalProcessesPage.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'

--- a/kelta-ui/app/src/pages/ApprovalProcessesPage/ApprovalProcessesPage.tsx
+++ b/kelta-ui/app/src/pages/ApprovalProcessesPage/ApprovalProcessesPage.tsx
@@ -513,7 +513,7 @@ export function ApprovalProcessesPage({
     null
   )
   const [instancesItemId, setInstancesItemId] = useState<string | null>(null)
-  const [instancesItemName, setInstancesItemName] = useState('')
+  const [_instancesItemName, setInstancesItemName] = useState('')
 
   const {
     data: approvalProcesses,
@@ -575,8 +575,8 @@ export function ApprovalProcessesPage({
   // Instances query — fetches from JSON:API endpoint
   const {
     data: allInstances,
-    isLoading: instancesLoading,
-    error: instancesError,
+    isLoading: _instancesLoading,
+    error: _instancesError,
   } = useQuery({
     queryKey: ['approval-instances'],
     queryFn: () => keltaClient.admin.approvals.listInstances(''),
@@ -586,6 +586,7 @@ export function ApprovalProcessesPage({
   const filteredInstances = (allInstances ?? []).filter(
     (i) => i.approvalProcessId === instancesItemId
   )
+  void filteredInstances
 
   // Approve mutation — graceful degradation (action endpoint not available in JSON:API)
   const approveMutation = useMutation({
@@ -750,6 +751,7 @@ export function ApprovalProcessesPage({
       },
     },
   ]
+  void instanceColumns
 
   const handleCreate = useCallback(() => {
     setEditingApprovalProcess(undefined)
@@ -1014,11 +1016,11 @@ export function ApprovalProcessesPage({
       {instancesItemId && (
         <ExecutionLogModal<ApprovalInstance>
           title={t('approvals.approvalInstances')}
-          subtitle={instancesItemName}
+          subtitle={_instancesItemName}
           columns={instanceColumns}
           data={filteredInstances}
-          isLoading={instancesLoading}
-          error={instancesError instanceof Error ? instancesError : null}
+          isLoading={_instancesLoading}
+          error={_instancesError instanceof Error ? _instancesError : null}
           onClose={() => setInstancesItemId(null)}
           emptyMessage={t('approvals.noInstances')}
         />

--- a/kelta-ui/app/src/pages/CollectionsPage/CollectionsPage.test.tsx
+++ b/kelta-ui/app/src/pages/CollectionsPage/CollectionsPage.test.tsx
@@ -20,7 +20,6 @@
  * - 3.11: Soft-delete collection and remove from list
  */
 
-import React from 'react'
 import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'

--- a/kelta-ui/app/src/pages/DashboardPage/DashboardPage.test.tsx
+++ b/kelta-ui/app/src/pages/DashboardPage/DashboardPage.test.tsx
@@ -22,7 +22,6 @@
  * - 13.7: Dashboard displays health alerts when services are unhealthy
  */
 
-import React from 'react'
 import { render, screen, waitFor, fireEvent } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import {

--- a/kelta-ui/app/src/pages/EmailSettingsPage/EmailSettingsPage.test.tsx
+++ b/kelta-ui/app/src/pages/EmailSettingsPage/EmailSettingsPage.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'

--- a/kelta-ui/app/src/pages/EmailTemplatesPage/EmailTemplatesPage.tsx
+++ b/kelta-ui/app/src/pages/EmailTemplatesPage/EmailTemplatesPage.tsx
@@ -685,12 +685,12 @@ export function EmailTemplatesPage({
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
   const [templateToDelete, setTemplateToDelete] = useState<EmailTemplate | null>(null)
   const [logsItemId, setLogsItemId] = useState<string | null>(null)
-  const [logsItemName, setLogsItemName] = useState('')
+  const [_logsItemName, setLogsItemName] = useState('')
 
   const {
     data: allEmailLogs,
-    isLoading: logsLoading,
-    error: logsError,
+    isLoading: _logsLoading,
+    error: _logsError,
   } = useQuery({
     queryKey: ['email-template-logs', logsItemId],
     queryFn: () => keltaClient.admin.emailTemplates.listLogs(),
@@ -698,6 +698,7 @@ export function EmailTemplatesPage({
   })
 
   const filteredLogs = (allEmailLogs ?? []).filter((log) => log.templateId === logsItemId)
+  void filteredLogs
 
   const logColumns: LogColumn<EmailLog>[] = [
     { key: 'status', header: 'Status' },
@@ -720,6 +721,7 @@ export function EmailTemplatesPage({
           : '-',
     },
   ]
+  void logColumns
 
   const {
     data: templates,
@@ -978,11 +980,11 @@ export function EmailTemplatesPage({
       {logsItemId && (
         <ExecutionLogModal<EmailLog>
           title="Email Logs"
-          subtitle={logsItemName}
+          subtitle={_logsItemName}
           columns={logColumns}
           data={filteredLogs}
-          isLoading={logsLoading}
-          error={logsError instanceof Error ? logsError : null}
+          isLoading={_logsLoading}
+          error={_logsError instanceof Error ? _logsError : null}
           onClose={() => setLogsItemId(null)}
           emptyMessage="No email logs found."
         />

--- a/kelta-ui/app/src/pages/EndpointPerformancePage/EndpointPerformancePage.tsx
+++ b/kelta-ui/app/src/pages/EndpointPerformancePage/EndpointPerformancePage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import { useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { useI18n } from '../../context/I18nContext'
 import { useApi } from '../../context/ApiContext'

--- a/kelta-ui/app/src/pages/ErrorDashboardPage/ErrorDashboardPage.tsx
+++ b/kelta-ui/app/src/pages/ErrorDashboardPage/ErrorDashboardPage.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { useI18n } from '../../context/I18nContext'
 import { useApi } from '../../context/ApiContext'

--- a/kelta-ui/app/src/pages/FlowDesignerPage/FlowDesignerPage.tsx
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/FlowDesignerPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useMemo } from 'react'
+import { useState, useCallback, useMemo } from 'react'
 import { useParams, useSearchParams } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { ReactFlowProvider } from '@xyflow/react'

--- a/kelta-ui/app/src/pages/FlowDesignerPage/components/DebugTab.tsx
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/components/DebugTab.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react'
+import { useState, useMemo } from 'react'
 import { useQuery, useMutation } from '@tanstack/react-query'
 import { ReactFlowProvider } from '@xyflow/react'
 import type { Node, Edge } from '@xyflow/react'

--- a/kelta-ui/app/src/pages/FlowDesignerPage/components/ExecutionTimeline.tsx
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/components/ExecutionTimeline.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { cn } from '@/lib/utils'
 
 interface StepData {

--- a/kelta-ui/app/src/pages/FlowDesignerPage/components/ExecutionsTab.tsx
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/components/ExecutionsTab.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react'
+import { useState, useMemo } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useApi } from '../../../context/ApiContext'
 import { useToast, LoadingSpinner } from '../../../components'

--- a/kelta-ui/app/src/pages/FlowDesignerPage/components/FlowExecutionViewer.tsx
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/components/FlowExecutionViewer.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 import {
   ReactFlow,
   Background,

--- a/kelta-ui/app/src/pages/FlowDesignerPage/components/FlowToolbar.tsx
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/components/FlowToolbar.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { ArrowLeft, Save, Code, CheckCircle, Play, Upload, Sparkles } from 'lucide-react'
 import { useNavigate } from 'react-router-dom'
 import { Button } from '@/components/ui/button'

--- a/kelta-ui/app/src/pages/FlowDesignerPage/components/PropertiesPanel.tsx
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/components/PropertiesPanel.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import type { Node } from '@xyflow/react'
 import { X } from 'lucide-react'
 import { ScrollArea } from '@/components/ui/scroll-area'

--- a/kelta-ui/app/src/pages/FlowDesignerPage/components/TriggerEditSheet.tsx
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/components/TriggerEditSheet.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react'
+import { useState, useMemo } from 'react'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetFooter } from '@/components/ui/sheet'
 import { Button } from '@/components/ui/button'

--- a/kelta-ui/app/src/pages/FlowDesignerPage/components/nodes/ChoiceNode.tsx
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/components/nodes/ChoiceNode.tsx
@@ -1,4 +1,4 @@
-import React, { memo } from 'react'
+import { memo } from 'react'
 import { Handle, Position } from '@xyflow/react'
 import type { NodeProps, Node } from '@xyflow/react'
 import { GitBranch } from 'lucide-react'

--- a/kelta-ui/app/src/pages/FlowDesignerPage/components/nodes/ControlNode.tsx
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/components/nodes/ControlNode.tsx
@@ -1,4 +1,4 @@
-import React, { memo } from 'react'
+import { memo } from 'react'
 import { Handle, Position } from '@xyflow/react'
 import type { NodeProps, Node } from '@xyflow/react'
 import { Clock, ArrowRight, Columns, Repeat } from 'lucide-react'

--- a/kelta-ui/app/src/pages/FlowDesignerPage/components/nodes/TaskNode.tsx
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/components/nodes/TaskNode.tsx
@@ -1,4 +1,4 @@
-import React, { memo } from 'react'
+import { memo } from 'react'
 import { Handle, Position } from '@xyflow/react'
 import type { NodeProps, Node } from '@xyflow/react'
 import { Cog } from 'lucide-react'

--- a/kelta-ui/app/src/pages/FlowDesignerPage/components/nodes/TerminalNode.tsx
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/components/nodes/TerminalNode.tsx
@@ -1,4 +1,4 @@
-import React, { memo } from 'react'
+import { memo } from 'react'
 import { Handle, Position } from '@xyflow/react'
 import type { NodeProps, Node } from '@xyflow/react'
 import { CheckCircle, XCircle } from 'lucide-react'

--- a/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/CatchEditor.tsx
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/CatchEditor.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { Input } from '@/components/ui/input'
 import { FieldLabel } from '@/components/kelta'
 import { Button } from '@/components/ui/button'

--- a/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/ChoiceProperties.tsx
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/ChoiceProperties.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { FieldLabel } from '@/components/kelta'
 import { Button } from '@/components/ui/button'
 import { Plus } from 'lucide-react'

--- a/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/ChoiceRuleEditor.tsx
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/ChoiceRuleEditor.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { Input } from '@/components/ui/input'
 import { FieldLabel } from '@/components/kelta'
 import { Button } from '@/components/ui/button'

--- a/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/CommonFields.tsx
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/CommonFields.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 import { Badge } from '@/components/ui/badge'

--- a/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/CreateRecordParams.tsx
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/CreateRecordParams.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { Input } from '@/components/ui/input'
 import { FieldLabel } from '@/components/kelta'
 import { Button } from '@/components/ui/button'

--- a/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/DataPathFields.tsx
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/DataPathFields.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { Input } from '@/components/ui/input'
 import { FieldLabel } from '@/components/kelta'
 import {

--- a/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/DeleteRecordParams.tsx
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/DeleteRecordParams.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { Input } from '@/components/ui/input'
 import { FieldLabel } from '@/components/kelta'
 

--- a/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/FailProperties.tsx
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/FailProperties.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { Input } from '@/components/ui/input'
 import { FieldLabel } from '@/components/kelta'
 import { Textarea } from '@/components/ui/textarea'

--- a/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/FieldUpdateParams.tsx
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/FieldUpdateParams.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { Input } from '@/components/ui/input'
 import { FieldLabel } from '@/components/kelta'
 import { Button } from '@/components/ui/button'

--- a/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/HttpCalloutParams.tsx
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/HttpCalloutParams.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { Input } from '@/components/ui/input'
 import { FieldLabel } from '@/components/kelta'
 import { Button } from '@/components/ui/button'

--- a/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/LogMessageParams.tsx
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/LogMessageParams.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { FieldLabel } from '@/components/kelta'
 import { Textarea } from '@/components/ui/textarea'
 

--- a/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/MapProperties.tsx
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/MapProperties.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { Input } from '@/components/ui/input'
 import { FieldLabel } from '@/components/kelta'
 import { DataPathFields } from './DataPathFields'

--- a/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/ParallelProperties.tsx
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/ParallelProperties.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { FieldLabel } from '@/components/kelta'
 import type { RetryRule, CatchRule } from '../../types'
 import { DataPathFields } from './DataPathFields'

--- a/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/PassProperties.tsx
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/PassProperties.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { FieldLabel } from '@/components/kelta'
 import { Textarea } from '@/components/ui/textarea'
 import { DataPathFields } from './DataPathFields'

--- a/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/PublishEventParams.tsx
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/PublishEventParams.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { Input } from '@/components/ui/input'
 import { FieldLabel } from '@/components/kelta'
 import { Textarea } from '@/components/ui/textarea'

--- a/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/QueryRecordsParams.tsx
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/QueryRecordsParams.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { Input } from '@/components/ui/input'
 import { FieldLabel } from '@/components/kelta'
 import { Button } from '@/components/ui/button'

--- a/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/RetryEditor.tsx
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/RetryEditor.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { Input } from '@/components/ui/input'
 import { FieldLabel } from '@/components/kelta'
 import { Button } from '@/components/ui/button'

--- a/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/SendNotificationParams.tsx
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/SendNotificationParams.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { Input } from '@/components/ui/input'
 import { FieldLabel } from '@/components/kelta'
 import { Textarea } from '@/components/ui/textarea'

--- a/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/SqlQueryParams.tsx
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/SqlQueryParams.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { FieldLabel } from '@/components/kelta'
 import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'

--- a/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/SucceedProperties.tsx
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/SucceedProperties.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 export function SucceedProperties() {
   return (
     <div className="rounded-md border border-border bg-muted/50 p-3 text-xs text-muted-foreground">

--- a/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/TriggerFlowParams.tsx
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/TriggerFlowParams.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { Input } from '@/components/ui/input'
 import { FieldLabel } from '@/components/kelta'
 

--- a/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/UpdateRecordParams.tsx
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/UpdateRecordParams.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { Input } from '@/components/ui/input'
 import { FieldLabel } from '@/components/kelta'
 import { Button } from '@/components/ui/button'

--- a/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/WaitProperties.tsx
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/components/properties/WaitProperties.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { Input } from '@/components/ui/input'
 import { FieldLabel } from '@/components/kelta'
 import type { WaitMode } from '../../types'

--- a/kelta-ui/app/src/pages/FlowsPage/FlowsPage.tsx
+++ b/kelta-ui/app/src/pages/FlowsPage/FlowsPage.tsx
@@ -59,7 +59,7 @@ export function FlowsPage({ testId = 'flows-page' }: FlowsPageProps): React.Reac
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
   const [flowToDelete, setFlowToDelete] = useState<Flow | null>(null)
   const [execItemId, setExecItemId] = useState<string | null>(null)
-  const [execItemName, setExecItemName] = useState('')
+  const [_execItemName, setExecItemName] = useState('')
   const [runDialogOpen, setRunDialogOpen] = useState(false)
   const [runFlowTarget, setRunFlowTarget] = useState<Flow | null>(null)
 
@@ -228,6 +228,7 @@ export function FlowsPage({ testId = 'flows-page' }: FlowsPageProps): React.Reac
         ) : null,
     },
   ]
+  void execColumns
 
   const handleDeleteClick = useCallback((flow: Flow) => {
     setFlowToDelete(flow)
@@ -426,7 +427,7 @@ export function FlowsPage({ testId = 'flows-page' }: FlowsPageProps): React.Reac
       {execItemId && (
         <ExecutionLogModal<FlowExecutionLog>
           title={t('flows.flowExecutionHistory')}
-          subtitle={execItemName}
+          subtitle={_execItemName}
           columns={execColumns}
           data={executions ?? []}
           isLoading={execLoading}

--- a/kelta-ui/app/src/pages/FlowsPage/steps/TriggerConfigStep.tsx
+++ b/kelta-ui/app/src/pages/FlowsPage/steps/TriggerConfigStep.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import {
   RecordTriggerForm,
   ScheduledTriggerForm,

--- a/kelta-ui/app/src/pages/GovernorLimitsPage/GovernorLimitsPage.test.tsx
+++ b/kelta-ui/app/src/pages/GovernorLimitsPage/GovernorLimitsPage.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { createTestWrapper, setupAuthMocks, mockAxios, resetMockAxios } from '../../test/testUtils'
 import { render, screen, waitFor } from '@testing-library/react'

--- a/kelta-ui/app/src/pages/MenuBuilderPage/MenuBuilderPage.test.tsx
+++ b/kelta-ui/app/src/pages/MenuBuilderPage/MenuBuilderPage.test.tsx
@@ -24,7 +24,6 @@
  * - 8.5: Support nested menu items (submenus)
  */
 
-import React from 'react'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'

--- a/kelta-ui/app/src/pages/MigrationsPage/MigrationsPage.test.tsx
+++ b/kelta-ui/app/src/pages/MigrationsPage/MigrationsPage.test.tsx
@@ -17,7 +17,6 @@
  * - 10.8: Display status, duration, and step details for each run
  */
 
-import React from 'react'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import {
   createTestWrapper,

--- a/kelta-ui/app/src/pages/MonitoringPage/MonitoringLayout.tsx
+++ b/kelta-ui/app/src/pages/MonitoringPage/MonitoringLayout.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { Outlet, NavLink, Navigate, useLocation, useParams } from 'react-router-dom'
 import { useI18n } from '../../context/I18nContext'
 import { cn } from '@/lib/utils'

--- a/kelta-ui/app/src/pages/OIDCProvidersPage/OIDCProvidersPage.test.tsx
+++ b/kelta-ui/app/src/pages/OIDCProvidersPage/OIDCProvidersPage.test.tsx
@@ -21,7 +21,6 @@
  * - 6.9: Display provider status (connected/disconnected)
  */
 
-import React from 'react'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'

--- a/kelta-ui/app/src/pages/ObservabilitySettingsPage/ObservabilitySettingsPage.tsx
+++ b/kelta-ui/app/src/pages/ObservabilitySettingsPage/ObservabilitySettingsPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useI18n } from '../../context/I18nContext'
 import { useApi } from '../../context/ApiContext'

--- a/kelta-ui/app/src/pages/PackagesPage/PackagesPage.test.tsx
+++ b/kelta-ui/app/src/pages/PackagesPage/PackagesPage.test.tsx
@@ -12,7 +12,6 @@
  * - 9.10: Display package history
  */
 
-import React from 'react'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import {
   createTestWrapper,

--- a/kelta-ui/app/src/pages/PageLayoutsPage/__tests__/PageLayoutsPage.test.tsx
+++ b/kelta-ui/app/src/pages/PageLayoutsPage/__tests__/PageLayoutsPage.test.tsx
@@ -13,7 +13,6 @@
  * - Design button rendering for each row
  */
 
-import React from 'react'
 import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'

--- a/kelta-ui/app/src/pages/RequestLogDetailPage/RequestLogDetailPage.tsx
+++ b/kelta-ui/app/src/pages/RequestLogDetailPage/RequestLogDetailPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import { useState } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
 import { useI18n } from '../../context/I18nContext'

--- a/kelta-ui/app/src/pages/RequestLogPage/RequestLogPage.tsx
+++ b/kelta-ui/app/src/pages/RequestLogPage/RequestLogPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react'
+import { useState, useCallback } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { useI18n } from '../../context/I18nContext'
 import { useApi } from '../../context/ApiContext'

--- a/kelta-ui/app/src/pages/ResourceBrowserPage/ResourceBrowserPage.test.tsx
+++ b/kelta-ui/app/src/pages/ResourceBrowserPage/ResourceBrowserPage.test.tsx
@@ -14,7 +14,6 @@
  * - 11.1: Resource browser allows selecting a collection
  */
 
-import React from 'react'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'

--- a/kelta-ui/app/src/pages/ScheduledJobsPage/ScheduledJobsPage.tsx
+++ b/kelta-ui/app/src/pages/ScheduledJobsPage/ScheduledJobsPage.tsx
@@ -392,7 +392,7 @@ export function ScheduledJobsPage({
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
   const [scheduledJobToDelete, setScheduledJobToDelete] = useState<ScheduledJob | null>(null)
   const [logsItemId, setLogsItemId] = useState<string | null>(null)
-  const [logsItemName, setLogsItemName] = useState('')
+  const [_logsItemName, setLogsItemName] = useState('')
 
   const {
     data: logs,
@@ -442,6 +442,7 @@ export function ScheduledJobsPage({
           : '-',
     },
   ]
+  void logColumns
 
   const {
     data: scheduledJobs,
@@ -787,7 +788,7 @@ export function ScheduledJobsPage({
       {logsItemId && (
         <ExecutionLogModal<JobExecutionLog>
           title="Scheduled Job Logs"
-          subtitle={logsItemName}
+          subtitle={_logsItemName}
           columns={logColumns}
           data={logs ?? []}
           isLoading={logsLoading}

--- a/kelta-ui/app/src/pages/ScriptsPage/ScriptsPage.tsx
+++ b/kelta-ui/app/src/pages/ScriptsPage/ScriptsPage.tsx
@@ -363,7 +363,7 @@ export function ScriptsPage({ testId = 'scripts-page' }: ScriptsPageProps): Reac
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
   const [scriptToDelete, setScriptToDelete] = useState<Script | null>(null)
   const [logsItemId, setLogsItemId] = useState<string | null>(null)
-  const [logsItemName, setLogsItemName] = useState('')
+  const [_logsItemName, setLogsItemName] = useState('')
 
   const {
     data: logs,
@@ -414,6 +414,7 @@ export function ScriptsPage({ testId = 'scripts-page' }: ScriptsPageProps): Reac
           : '-',
     },
   ]
+  void logColumns
 
   const {
     data: scripts,
@@ -702,7 +703,7 @@ export function ScriptsPage({ testId = 'scripts-page' }: ScriptsPageProps): Reac
       {logsItemId && (
         <ExecutionLogModal<ScriptExecutionLog>
           title="Script Execution Logs"
-          subtitle={logsItemName}
+          subtitle={_logsItemName}
           columns={logColumns}
           data={logs ?? []}
           isLoading={logsLoading}

--- a/kelta-ui/app/src/pages/SearchSettingsPage/SearchSettingsPage.tsx
+++ b/kelta-ui/app/src/pages/SearchSettingsPage/SearchSettingsPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useI18n } from '../../context/I18nContext'
 import { useApi } from '../../context/ApiContext'

--- a/kelta-ui/app/src/pages/UserActivityPage/UserActivityPage.tsx
+++ b/kelta-ui/app/src/pages/UserActivityPage/UserActivityPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import { useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { useI18n } from '../../context/I18nContext'
 import { useApi } from '../../context/ApiContext'

--- a/kelta-ui/app/src/styles/accessibility.test.tsx
+++ b/kelta-ui/app/src/styles/accessibility.test.tsx
@@ -14,7 +14,6 @@
  * - 14.8: Provide alt text for all non-text content
  */
 
-import React from 'react'
 import { render, screen } from '@testing-library/react'
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 


### PR DESCRIPTION
Clears all 86 TS6133 errors in kelta-ui/app:
- Delete stale `import React from 'react'` lines and strip React from
  default+named imports across ~57 files (react-jsx transform).
- Rename destructured-prop unused locals with `_` prefix in
  ActivityTimeline (collectionName), FieldEditor (collectionId);
  underscore-prefix unused destructured useQuery/useState fields in
  ApprovalProcessesPage, EmailTemplatesPage, FlowsPage,
  ScheduledJobsPage, ScriptsPage; mark unused MouseEvent param `_event`
  in SkipLinks.
- Add `void` markers for `const X = ...` arrays/locals consumed only by
  a type-broken `ExecutionLogModal<T>` JSX block (T does not satisfy
  `Record<string, unknown>`, so TS does not count the prop refs as a
  read of X; pre-existing TS2344 tracked separately).

(CHORE-2026-06-08-0001)
