### PR TITLE
fix(ci): use FQDN for kelta-ci-db host in JDBC URL

### DIFF
--- a/scripts/ci/checkout-db.sh
+++ b/scripts/ci/checkout-db.sh
@@ -46,7 +46,12 @@ else
   ord=$(( RANDOM % CI_DB_POOL_SIZE ))
 fi
 
-host="${CI_DB_SVC}-${ord}.${CI_DB_SVC}.${CI_DB_NAMESPACE}.svc"
+# Use the fully qualified .svc.cluster.local form. The bare ".svc" works
+# inside k8s pods (DNS search domains + ndots:5) but the JDBC URL below is
+# also consumed by service containers spawned via the host docker daemon,
+# whose embedded resolver uses ndots:0 → no search-domain expansion. Without
+# the .cluster.local suffix those containers fail with UnknownHostException.
+host="${CI_DB_SVC}-${ord}.${CI_DB_SVC}.${CI_DB_NAMESPACE}.svc.cluster.local"
 port=5432
 
 # Unique schema per run. GITHUB_RUN_ID + GITHUB_RUN_ATTEMPT is unique within


### PR DESCRIPTION
## Summary
- `scripts/ci/checkout-db.sh` constructed a kelta-ci-db pod hostname using the bare `.svc` form. That resolves inside k8s pods (ndots:5 + search domains) but the same string ends up in `CI_DB_JDBC_URL` consumed by testcontainers-spawned service containers on the host docker daemon. Docker's embedded DNS uses `ndots:0` → no search-domain expansion → Flyway fails with `UnknownHostException: kelta-ci-db-N.kelta-ci-db.kelta-ci-db.svc`.
- Append `.cluster.local` to the host so the JDBC URL works in both the runner pod and inside docker-spawned containers.

## Repro
- [run 27318597863](https://github.com/cklinker/emf/actions/runs/27318597863) → Integration Tests → `Run cross-service harness` → `kelta-worker` container exits with the UnknownHostException above.

## Test plan
- [ ] Re-trigger Integration Tests on this PR — `Run cross-service harness` reaches the actual scenarios (not the worker-startup wait timeout).