### PR TITLE
fix(auth): use DelegatingPasswordEncoder for connected-app client secrets

### DIFF
--- a/kelta-auth/src/main/java/io/kelta/auth/config/AuthorizationServerConfig.java
+++ b/kelta-auth/src/main/java/io/kelta/auth/config/AuthorizationServerConfig.java
@@ -16,6 +16,8 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.DelegatingPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.JwtEncoder;
@@ -358,7 +360,16 @@ public class AuthorizationServerConfig {
 
     @Bean
     public PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
+        // DelegatingPasswordEncoder understands the {bcrypt} prefix used by
+        // connected-app client secrets (ConnectedAppClientSynchronizer stores
+        // "{bcrypt}" + bcryptHash). encode() now emits a {bcrypt}-prefixed value.
+        DelegatingPasswordEncoder encoder =
+                (DelegatingPasswordEncoder) PasswordEncoderFactories.createDelegatingPasswordEncoder();
+        // Back-compat: existing internal/Superset secrets were stored as BARE
+        // bcrypt hashes (no {id} prefix). By default the delegating encoder
+        // throws on prefix-less hashes; treat them as bcrypt so they still match.
+        encoder.setDefaultPasswordEncoderForMatches(new BCryptPasswordEncoder());
+        return encoder;
     }
 
     @Bean

--- a/kelta-auth/src/test/java/io/kelta/auth/service/ConnectedAppClientSynchronizerTest.java
+++ b/kelta-auth/src/test/java/io/kelta/auth/service/ConnectedAppClientSynchronizerTest.java
@@ -8,10 +8,14 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
 import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
 import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository;
+
+import io.kelta.auth.config.AuthorizationServerConfig;
 
 import java.util.List;
 import java.util.Map;
@@ -142,5 +146,58 @@ class ConnectedAppClientSynchronizerTest {
         synchronizer.synchronizeClients();
 
         verify(clientRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("stored connected-app secret authenticates with the production password encoder (no invalid_client)")
+    void connectedAppSecretMatchesProductionEncoder() {
+        // The connected_app table stores a pre-computed bcrypt hash of the secret.
+        String plaintextSecret = "s3cr3t-client-secret";
+        String bcryptHash = new BCryptPasswordEncoder().encode(plaintextSecret);
+
+        Map<String, Object> app = Map.of(
+                "id", "app-1",
+                "client_id", "couchpicks-web",
+                "client_secret_hash", bcryptHash,
+                "name", "CouchPicks Web",
+                "redirect_uris", "[\"https://couchpicks.example.com/callback\"]",
+                "scopes", "[\"api\"]",
+                "grant_types", "[\"authorization_code\"]",
+                "require_pkce", false,
+                "consent_required", false
+        );
+
+        when(jdbcTemplate.queryForList(anyString())).thenReturn(List.of(app));
+        when(clientRepository.findByClientId("couchpicks-web")).thenReturn(null);
+
+        synchronizer.synchronizeClients();
+
+        ArgumentCaptor<RegisteredClient> captor = ArgumentCaptor.forClass(RegisteredClient.class);
+        verify(clientRepository).save(captor.capture());
+        RegisteredClient registered = captor.getValue();
+
+        // Synchronizer stores the secret with a {bcrypt} prefix for the delegating encoder.
+        assertThat(registered.getClientSecret()).startsWith("{bcrypt}");
+
+        // The production password encoder must accept the plaintext secret against the
+        // stored value; otherwise CLIENT_SECRET_BASIC/POST auth fails with invalid_client.
+        PasswordEncoder encoder = new AuthorizationServerConfig().passwordEncoder();
+        assertThat(encoder.matches(plaintextSecret, registered.getClientSecret())).isTrue();
+        assertThat(encoder.matches("wrong-secret", registered.getClientSecret())).isFalse();
+    }
+
+    @Test
+    @DisplayName("production password encoder still matches legacy bare-bcrypt secrets (Superset/internal back-compat)")
+    void productionEncoderMatchesBareBcryptSecret() {
+        // ConnectedAppRegistrar stores Superset/internal secrets via passwordEncoder.encode(),
+        // which historically produced a BARE bcrypt hash (no {bcrypt} prefix). Those rows must
+        // keep authenticating after switching to the delegating encoder.
+        String plaintextSecret = "superset-secret";
+        String bareBcrypt = new BCryptPasswordEncoder().encode(plaintextSecret);
+        assertThat(bareBcrypt).doesNotStartWith("{");
+
+        PasswordEncoder encoder = new AuthorizationServerConfig().passwordEncoder();
+        assertThat(encoder.matches(plaintextSecret, bareBcrypt)).isTrue();
+        assertThat(encoder.matches("wrong-secret", bareBcrypt)).isFalse();
     }
 }


### PR DESCRIPTION
## Problem

Connected-app OAuth clients (grant_types incl. `authorization_code`, `require_pkce=false`, with a `client_secret`) failed the token endpoint with HTTP 401 `invalid_client`. Confirmed live with `couchpicks-web`.

**Root cause:** `ConnectedAppClientSynchronizer.registerConnectedAppClient()` stores the secret as `"{bcrypt}" + clientSecretHash` (assuming a `DelegatingPasswordEncoder`), but `AuthorizationServerConfig.passwordEncoder()` was a plain `BCryptPasswordEncoder`. A plain bcrypt encoder cannot parse the `{bcrypt}` prefix → `matches()` always returns `false` → client rejected.

The Superset client works because `ConnectedAppRegistrar` registers via `passwordEncoder.encode(secret)`, producing a **bare** bcrypt hash (no prefix).

## Fix

Switch the bean to `PasswordEncoderFactories.createDelegatingPasswordEncoder()`:
- Understands the `{bcrypt}` prefix used by connected-app secrets.
- `encode()` now emits a `{bcrypt}`-prefixed hash.

**Back-compat caveat:** the delegating encoder *throws* on prefix-less hashes by default — it does NOT silently treat bare hashes as bcrypt. Existing internal/Superset secrets are stored bare, so we set `setDefaultPasswordEncoderForMatches(new BCryptPasswordEncoder())`. Result:
- `{bcrypt}$2y$…` (connected apps) → bcrypt id → match
- bare `$2a$…` (Superset/internal) → bcrypt fallback → match
- new `encode()` → `{bcrypt}…`

## Migration — none

- Existing `{bcrypt}`-prefixed rows match automatically.
- The hot-patched `couchpicks-web` row (prefix stripped as interim workaround → bare) matches via the bcrypt fallback. The synchronizer skips existing clients, so it stays bare and keeps working.

## Tests

Two regression tests added to `ConnectedAppClientSynchronizerTest`:
- `connectedAppSecretMatchesProductionEncoder` — synchronizer stores secret; assert the production `passwordEncoder()` bean matches plaintext vs the stored `{bcrypt}…` value (fails under the old plain encoder).
- `productionEncoderMatchesBareBcryptSecret` — legacy bare-bcrypt (Superset/internal) still matches.

Full `kelta-auth` suite green: **191 run, 0 fail, 1 skipped** (the `@Disabled` infra-dependent `@SpringBootTest`). A full token-exchange test isn't viable in CI since the only `@SpringBootTest` requires PostgreSQL + Redis; the unit-level encoder-match assertion catches the exact `invalid_client` regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)