### PR TITLE
fix(worker): normalize jsonb flow definition for scheduled jobs

### DIFF
--- a/kelta-worker/src/main/java/io/kelta/worker/repository/ScheduledJobRepository.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/repository/ScheduledJobRepository.java
@@ -10,6 +10,7 @@ import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -51,13 +52,26 @@ public class ScheduledJobRepository {
 
     /**
      * Loads the flow definition for a scheduled job.
+     *
+     * <p>The {@code definition} and {@code trigger_config} columns are {@code jsonb},
+     * which the JDBC driver returns as {@code PGobject}. Normalize them to their JSON
+     * string form so callers can parse them directly — otherwise
+     * {@code objectMapper.writeValueAsString(pgObject)} would serialize the wrapper
+     * ({@code {"type":"jsonb","value":...}}) and the flow definition's {@code StartAt}
+     * would appear missing. Mirrors {@link FlowRepository#findFlowById}.
      */
     public Optional<Map<String, Object>> findFlowById(String flowId) {
         var results = jdbcTemplate.queryForList(
                 "SELECT id, tenant_id, definition, trigger_config, active FROM flow WHERE id = ?",
                 flowId
         );
-        return results.isEmpty() ? Optional.empty() : Optional.of(results.get(0));
+        if (results.isEmpty()) {
+            return Optional.empty();
+        }
+        Map<String, Object> row = new LinkedHashMap<>(results.get(0));
+        row.computeIfPresent("definition", (k, v) -> v.toString());
+        row.computeIfPresent("trigger_config", (k, v) -> v.toString());
+        return Optional.of(row);
     }
 
     /**

--- a/kelta-worker/src/test/java/io/kelta/worker/repository/ScheduledJobRepositoryTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/repository/ScheduledJobRepositoryTest.java
@@ -1,0 +1,89 @@
+package io.kelta.worker.repository;
+
+import org.junit.jupiter.api.*;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@DisplayName("ScheduledJobRepository")
+class ScheduledJobRepositoryTest {
+
+    private JdbcTemplate jdbcTemplate;
+    private ScheduledJobRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        jdbcTemplate = mock(JdbcTemplate.class);
+        repository = new ScheduledJobRepository(jdbcTemplate);
+    }
+
+    /**
+     * Regression: jsonb columns come back from the driver as a non-String wrapper
+     * (PGobject). If left un-normalized, the scheduled executor calls
+     * {@code objectMapper.writeValueAsString(pgObject)}, which serializes the wrapper
+     * instead of the JSON and the flow definition's {@code StartAt} appears missing,
+     * breaking every scheduled FLOW job. findFlowById must hand back the JSON string.
+     */
+    @Test
+    @DisplayName("findFlowById normalizes jsonb definition + trigger_config to their JSON string")
+    void findFlowByIdNormalizesJsonbToString() {
+        String definitionJson = "{\"StartAt\":\"InitTimestamp\",\"States\":{}}";
+        String triggerConfigJson = "{\"cron\":\"0 0 */4 * * *\",\"timezone\":\"UTC\"}";
+        // Stand-in for the driver's PGobject: a non-String whose toString() is the JSON.
+        Object definitionJsonb = new Object() {
+            @Override public String toString() { return definitionJson; }
+        };
+        Object triggerConfigJsonb = new Object() {
+            @Override public String toString() { return triggerConfigJson; }
+        };
+        Map<String, Object> row = new LinkedHashMap<>();
+        row.put("id", "flow-1");
+        row.put("tenant_id", "t1");
+        row.put("definition", definitionJsonb);
+        row.put("trigger_config", triggerConfigJsonb);
+        row.put("active", true);
+        when(jdbcTemplate.queryForList(contains("FROM flow WHERE id"), eq("flow-1")))
+                .thenReturn(List.of(row));
+
+        var result = repository.findFlowById("flow-1");
+
+        assertThat(result).isPresent();
+        assertThat(result.get().get("definition"))
+                .isInstanceOf(String.class)
+                .isEqualTo(definitionJson);
+        assertThat(result.get().get("trigger_config"))
+                .isInstanceOf(String.class)
+                .isEqualTo(triggerConfigJson);
+    }
+
+    @Test
+    @DisplayName("findFlowById returns empty when the flow does not exist")
+    void findFlowByIdReturnsEmptyWhenNotFound() {
+        when(jdbcTemplate.queryForList(contains("FROM flow WHERE id"), anyString()))
+                .thenReturn(List.of());
+
+        assertThat(repository.findFlowById("missing")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("findFlowById tolerates a null definition without throwing")
+    void findFlowByIdToleratesNullDefinition() {
+        Map<String, Object> row = new LinkedHashMap<>();
+        row.put("id", "flow-1");
+        row.put("tenant_id", "t1");
+        row.put("definition", null);
+        row.put("trigger_config", null);
+        row.put("active", true);
+        when(jdbcTemplate.queryForList(contains("FROM flow WHERE id"), eq("flow-1")))
+                .thenReturn(List.of(row));
+
+        var result = repository.findFlowById("flow-1");
+
+        assertThat(result).isPresent();
+        assertThat(result.get().get("definition")).isNull();
+    }
+}


### PR DESCRIPTION
## Problem

Every cron-triggered (`flowType: SCHEDULED`) flow fails immediately with:

> Required field 'StartAt' is missing or not a string

so **no scheduled flow has ever actually run** in deployments — `scheduled_job` rows fire on cron, but execution dies in the parser.

## Root cause

`ScheduledJobRepository.findFlowById` returns the `jsonb` `definition` and `trigger_config` columns as raw `PGobject`s:

```java
return results.isEmpty() ? Optional.empty() : Optional.of(results.get(0));
```

`ScheduledJobExecutorService.executeFlowJob` then does:

```java
String definitionJson = flow.get("definition") instanceof String s
    ? s : objectMapper.writeValueAsString(flow.get("definition"));
```

Since `definition` is a `PGobject` (not a `String`), Jackson serializes the **wrapper** (`{"type":"jsonb","value":"…"}`) instead of the JSON, so the parsed definition has no top-level `StartAt`. The same bug nulls `trigger_config`, dropping the scheduled flow's static input.

`FlowExecutionController` (the `execute_flow` path) works because it goes through `FlowRepository.findFlowById`, which already normalizes the jsonb columns with `.toString()`.

## Fix

Normalize both jsonb columns to their JSON string form in `ScheduledJobRepository.findFlowById`, mirroring `FlowRepository.findFlowById`.

## Test

`ScheduledJobRepositoryTest` — regression covering the jsonb→String normalization, not-found, and null-definition cases.

## Impact

Restores scheduled flow execution for **all** tenants (e.g. couchpicks' provider-refresh crons and the Tubi 4h ingest, none of which were running).

🤖 Generated with [Claude Code](https://claude.com/claude-code)