### PR TITLE
fix(mcp): create_flow writes flowType, not triggerType

### DIFF
--- a/.claude/CHANGELOG.md
+++ b/.claude/CHANGELOG.md
@@ -38,3 +38,7 @@ This file tracks merged autopilot work. Entries are appended by autopilot worker
 
 - 2026-06-08 chore(ui): remove unused React imports and rename/mark unused locals across `kelta-ui/app` to clear all 86 TS6133 errors (CHORE-2026-06-08-0001)
 - 2026-06-08 chore(ui): remove unused React imports and rename/mark unused locals across `kelta-ui/app` to clear all 86 TS6133 errors (CHORE-2026-06-08-0001)
+
+## 2026-06-12
+
+- 2026-06-12 chore(mcp): `create_flow` tool writes `flowType` (the real `flows` collection field) instead of the dead `triggerType` column; legacy `triggerType` argument is still accepted and remapped to `flowType` for back-compat (CHORE-2026-06-12-0001)

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/CreateFlowTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/CreateFlowTool.java
@@ -29,10 +29,12 @@ public class CreateFlowTool implements AdminTool {
         Map<String, Object> properties = new LinkedHashMap<>();
         properties.put("name", Schemas.string("Flow name (unique within tenant)."));
         properties.put("description", Schemas.string("Optional description."));
-        properties.put("triggerType", Schemas.string(
-                "Trigger type: manual, recordCreated, recordUpdated, scheduled, webhook, etc."));
+        properties.put("flowType", Schemas.string(
+                "Flow type: RECORD_TRIGGERED, SCHEDULED, AUTOLAUNCHED, or SCREEN. "
+                        + "Legacy alias \"triggerType\" is also accepted."));
         properties.put("triggerConfig", Schemas.freeObject(
-                "Trigger-specific config (e.g. {\"collectionName\":\"orders\"} for recordCreated)."));
+                "Trigger-specific config (e.g. {\"collectionName\":\"orders\"} for RECORD_TRIGGERED, "
+                        + "{\"cron\":\"0 * * * *\"} for SCHEDULED)."));
         properties.put("definition", Schemas.freeObject(
                 "Flow JSON definition: nodes, edges, conditions, actions. Shape is flow-engine specific."));
         properties.put("active", Schemas.bool("Whether the flow is active on creation (default false).", false));
@@ -41,7 +43,7 @@ public class CreateFlowTool implements AdminTool {
                 .name("create_flow")
                 .title("Create Flow")
                 .description("Create a new automation flow. Wraps POST /api/flows. The definition payload is opaque to this tool — pass the flow-engine JSON directly.")
-                .inputSchema(Schemas.object(properties, List.of("name", "triggerType", "definition")))
+                .inputSchema(Schemas.object(properties, List.of("name", "flowType", "definition")))
                 .annotations(ToolHints.write(false, false))
                 .build();
 
@@ -51,21 +53,24 @@ public class CreateFlowTool implements AdminTool {
                     Map<String, Object> args = request.arguments();
                     if (args == null) args = Map.of();
                     Object name = args.get("name");
-                    Object trigger = args.get("triggerType");
+                    Object flowType = args.get("flowType");
+                    if (flowType == null || flowType.toString().isBlank()) {
+                        flowType = args.get("triggerType");
+                    }
                     Object def = args.get("definition");
                     if (name == null || name.toString().isBlank()
-                            || trigger == null || trigger.toString().isBlank()
+                            || flowType == null || flowType.toString().isBlank()
                             || !(def instanceof Map<?, ?> definition) || definition.isEmpty()) {
                         return CallToolResult.builder()
                                 .isError(true)
                                 .content(List.of(new TextContent(
-                                        "Arguments \"name\", \"triggerType\", and a non-empty \"definition\" are required.")))
+                                        "Arguments \"name\", \"flowType\", and a non-empty \"definition\" are required.")))
                                 .build();
                     }
 
                     Map<String, Object> attrs = new LinkedHashMap<>();
                     attrs.put("name", name.toString());
-                    attrs.put("triggerType", trigger.toString());
+                    attrs.put("flowType", flowType.toString());
                     attrs.put("definition", definition);
                     if (args.get("description") instanceof String s && !s.isBlank()) attrs.put("description", s);
                     if (args.get("triggerConfig") instanceof Map<?, ?> tc) attrs.put("triggerConfig", tc);

--- a/kelta-mcp/src/test/java/io/kelta/mcp/tool/admin/CreateFlowToolTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/tool/admin/CreateFlowToolTest.java
@@ -17,6 +17,7 @@ import java.util.Map;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
+import static com.github.tomakehurst.wiremock.client.WireMock.notMatching;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -48,20 +49,29 @@ class CreateFlowToolTest {
         CallToolResult result = tool.toSpecification().callHandler().apply(
                 null, new CallToolRequest("create_flow", Map.of(
                         "name", "f",
-                        "triggerType", "manual"), null));
+                        "flowType", "SCHEDULED"), null));
         assertThat(result.isError()).isEqualTo(Boolean.TRUE);
     }
 
     @Test
-    void postsFlowWithDefinitionPassedThrough() {
+    void rejectsWithoutFlowType() {
+        CallToolResult result = tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("create_flow", Map.of(
+                        "name", "f",
+                        "definition", Map.of("nodes", java.util.List.of(Map.of("type", "start")))), null));
+        assertThat(result.isError()).isEqualTo(Boolean.TRUE);
+    }
+
+    @Test
+    void postsFlowWithFlowType() {
         wm.stubFor(post(urlEqualTo("/api/flows"))
                 .willReturn(aResponse().withStatus(201).withBody("{\"data\":{\"id\":\"f1\"}}")));
 
         CallToolResult result = tool.toSpecification().callHandler().apply(
                 null, new CallToolRequest("create_flow", Map.of(
-                        "name", "OnboardCustomer",
-                        "triggerType", "recordCreated",
-                        "triggerConfig", Map.of("collectionName", "customers"),
+                        "name", "NightlyIngest",
+                        "flowType", "SCHEDULED",
+                        "triggerConfig", Map.of("cron", "0 2 * * *"),
                         "definition", Map.of(
                                 "nodes", java.util.List.of(Map.of("type", "start"))),
                         "active", true), null));
@@ -69,10 +79,30 @@ class CreateFlowToolTest {
         assertThat(result.isError()).isNotEqualTo(Boolean.TRUE);
         wm.verify(WireMock.postRequestedFor(urlEqualTo("/api/flows"))
                 .withHeader("Authorization", equalTo("Bearer klt_flow_create"))
-                .withRequestBody(matchingJsonPath("$.data.attributes.name", equalTo("OnboardCustomer")))
-                .withRequestBody(matchingJsonPath("$.data.attributes.triggerType", equalTo("recordCreated")))
-                .withRequestBody(matchingJsonPath("$.data.attributes.triggerConfig.collectionName", equalTo("customers")))
+                .withRequestBody(matchingJsonPath("$.data.type", equalTo("flows")))
+                .withRequestBody(matchingJsonPath("$.data.attributes.name", equalTo("NightlyIngest")))
+                .withRequestBody(matchingJsonPath("$.data.attributes.flowType", equalTo("SCHEDULED")))
+                .withRequestBody(matchingJsonPath("$.data.attributes.triggerConfig.cron", equalTo("0 2 * * *")))
                 .withRequestBody(matchingJsonPath("$.data.attributes.definition.nodes[0].type", equalTo("start")))
                 .withRequestBody(matchingJsonPath("$.data.attributes.active", equalTo("true"))));
+    }
+
+    @Test
+    void mapsLegacyTriggerTypeArgumentToFlowType() {
+        wm.stubFor(post(urlEqualTo("/api/flows"))
+                .willReturn(aResponse().withStatus(201).withBody("{\"data\":{\"id\":\"f2\"}}")));
+
+        CallToolResult result = tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("create_flow", Map.of(
+                        "name", "OnboardCustomer",
+                        "triggerType", "RECORD_TRIGGERED",
+                        "triggerConfig", Map.of("collectionName", "customers"),
+                        "definition", Map.of(
+                                "nodes", java.util.List.of(Map.of("type", "start")))), null));
+
+        assertThat(result.isError()).isNotEqualTo(Boolean.TRUE);
+        wm.verify(WireMock.postRequestedFor(urlEqualTo("/api/flows"))
+                .withRequestBody(matchingJsonPath("$.data.attributes.flowType", equalTo("RECORD_TRIGGERED")))
+                .withRequestBody(notMatching("(?s).*\"triggerType\".*")));
     }
 }


### PR DESCRIPTION
The flows collection field is `flowType` (RECORD_TRIGGERED, SCHEDULED,
AUTOLAUNCHED, SCREEN); writing `triggerType` silently produced a flow
with a null type that never scheduled or triggered. Rename the schema
property and the outbound JSON:API attribute to `flowType`, keep the
legacy `triggerType` argument as a back-compat alias mapped to
`flowType`, and update CreateFlowToolTest to assert the renamed payload
plus that the deprecated key never appears in the body (CHORE-2026-06-12-0001).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
