### PR TITLE
feat(worker): validate cron on flow save; accept 5-field crons or reject loudly

### DIFF
--- a/.claude/CHANGELOG.md
+++ b/.claude/CHANGELOG.md
@@ -38,3 +38,7 @@ This file tracks merged autopilot work. Entries are appended by autopilot worker
 
 - 2026-06-08 chore(ui): remove unused React imports and rename/mark unused locals across `kelta-ui/app` to clear all 86 TS6133 errors (CHORE-2026-06-08-0001)
 - 2026-06-08 chore(ui): remove unused React imports and rename/mark unused locals across `kelta-ui/app` to clear all 86 TS6133 errors (CHORE-2026-06-08-0001)
+
+## 2026-06-12
+
+- 2026-06-12 feat(worker): accept 5-field crons on SCHEDULED flow save by normalizing to Spring's 6-field form, and reject unparseable crons with a 400 from `FlowScheduleSyncHook#beforeCreate`/`beforeUpdate` instead of silently dropping them in the after-hook (TASK-2026-06-12-0001)

--- a/kelta-worker/src/main/java/io/kelta/worker/listener/FlowScheduleSyncHook.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/listener/FlowScheduleSyncHook.java
@@ -1,6 +1,7 @@
 package io.kelta.worker.listener;
 
 import io.kelta.runtime.workflow.BeforeSaveHook;
+import io.kelta.runtime.workflow.BeforeSaveResult;
 import io.kelta.worker.repository.ScheduledJobRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,6 +49,24 @@ public class FlowScheduleSyncHook implements BeforeSaveHook {
         return 150;
     }
 
+    /**
+     * Reject SCHEDULED-flow saves with an unparseable cron BEFORE the row hits the
+     * database, so the user sees a clear 400 instead of the previous silent skip
+     * in {@link #syncScheduledJob}. The 5-field/6-field divergence is the most
+     * common cause — {@link ScheduledJobRepository#normalizeCron} handles that,
+     * and anything still invalid here is genuinely wrong.
+     */
+    @Override
+    public BeforeSaveResult beforeCreate(Map<String, Object> record, String tenantId) {
+        return validateCron(record);
+    }
+
+    @Override
+    public BeforeSaveResult beforeUpdate(String id, Map<String, Object> record,
+                                          Map<String, Object> previous, String tenantId) {
+        return validateCron(record);
+    }
+
     @Override
     public void afterCreate(Map<String, Object> record, String tenantId) {
         if (!"SCHEDULED".equals(record.get("flowType"))) return;
@@ -72,6 +91,28 @@ public class FlowScheduleSyncHook implements BeforeSaveHook {
         scheduledJobRepository.deleteForFlow(id, tenantId);
     }
 
+    private BeforeSaveResult validateCron(Map<String, Object> record) {
+        if (!"SCHEDULED".equals(asString(record.get("flowType")))) {
+            return BeforeSaveResult.ok();
+        }
+        Map<String, Object> triggerConfig = extractTriggerConfig(record);
+        if (triggerConfig == null || triggerConfig.isEmpty()) {
+            return BeforeSaveResult.ok();
+        }
+        String cron = asString(triggerConfig.get("cron"));
+        if (cron == null || cron.isBlank()) {
+            return BeforeSaveResult.ok();
+        }
+        try {
+            CronExpression.parse(ScheduledJobRepository.normalizeCron(cron));
+        } catch (IllegalArgumentException e) {
+            return BeforeSaveResult.error("triggerConfig.cron",
+                    "cron must be a 5- or 6-field Spring expression (with seconds); got '"
+                            + cron + "'");
+        }
+        return BeforeSaveResult.ok();
+    }
+
     private void syncScheduledJob(Map<String, Object> record, String tenantId) {
         String flowId = asString(record.get("id"));
         String flowName = asString(record.get("name"));
@@ -84,22 +125,27 @@ public class FlowScheduleSyncHook implements BeforeSaveHook {
             return;
         }
 
-        String cron = asString(triggerConfig.get("cron"));
+        String rawCron = asString(triggerConfig.get("cron"));
         String timezone = asString(triggerConfig.get("timezone"));
 
-        if (cron == null || cron.isBlank()) {
+        if (rawCron == null || rawCron.isBlank()) {
             log.debug("SCHEDULED flow {} triggerConfig has no cron — skipping job sync", flowId);
             return;
         }
 
+        // beforeCreate/beforeUpdate already rejected invalid crons with a 400, so a
+        // parse failure here means the row reached us by another path (legacy data,
+        // direct DB write). Log and skip rather than throw — the after-hook can't
+        // surface a user-visible error.
+        String normalizedCron = ScheduledJobRepository.normalizeCron(rawCron);
         try {
-            CronExpression.parse(cron);
+            CronExpression.parse(normalizedCron);
         } catch (IllegalArgumentException e) {
-            log.warn("SCHEDULED flow {} has invalid cron '{}' — skipping job sync: {}", flowId, cron, e.getMessage());
+            log.warn("SCHEDULED flow {} has invalid cron '{}' — skipping job sync: {}", flowId, rawCron, e.getMessage());
             return;
         }
 
-        Instant nextRunAt = active ? ScheduledJobRepository.calculateNextRunAt(cron, timezone) : null;
+        Instant nextRunAt = active ? ScheduledJobRepository.calculateNextRunAt(normalizedCron, timezone) : null;
 
         Optional<Map<String, Object>> existing = scheduledJobRepository.findByFlowId(flowId, tenantId);
         if (existing.isEmpty()) {
@@ -108,10 +154,10 @@ public class FlowScheduleSyncHook implements BeforeSaveHook {
                 log.warn("Cannot create scheduled_job for flow {} — could not resolve createdBy", flowId);
                 return;
             }
-            scheduledJobRepository.insertForFlow(flowId, tenantId, flowName, cron, timezone, active, nextRunAt, createdBy);
+            scheduledJobRepository.insertForFlow(flowId, tenantId, flowName, normalizedCron, timezone, active, nextRunAt, createdBy);
         } else {
             String jobId = asString(existing.get().get("id"));
-            scheduledJobRepository.updateForFlow(jobId, flowName, cron, timezone, active, nextRunAt);
+            scheduledJobRepository.updateForFlow(jobId, flowName, normalizedCron, timezone, active, nextRunAt);
         }
     }
 

--- a/kelta-worker/src/main/java/io/kelta/worker/repository/ScheduledJobRepository.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/repository/ScheduledJobRepository.java
@@ -106,12 +106,35 @@ public class ScheduledJobRepository {
     /**
      * Calculates the next run time from NOW for a given cron expression and timezone.
      * Always calculates from NOW to prevent burst-fire after downtime.
+     *
+     * <p>Accepts both standard 5-field crons ({@code min hour dom month dow}) and
+     * Spring's 6-field form (with a leading seconds field) — see
+     * {@link #normalizeCron(String)}.
      */
     public static Instant calculateNextRunAt(String cronExpression, String timezone) {
-        CronExpression cron = CronExpression.parse(cronExpression);
+        CronExpression cron = CronExpression.parse(normalizeCron(cronExpression));
         ZoneId zone = (timezone != null && !timezone.isBlank()) ? ZoneId.of(timezone) : ZoneId.of("UTC");
         ZonedDateTime next = cron.next(ZonedDateTime.now(zone));
         return next != null ? next.toInstant() : null;
+    }
+
+    /**
+     * Normalizes a cron expression to the 6-field form Spring's {@link CronExpression}
+     * requires. Standard Unix 5-field crons (minute hour dom month dow) get a leading
+     * {@code "0 "} prepended for the seconds field; Spring macros ({@code "@hourly"},
+     * etc.) and already-6-field expressions pass through unchanged.
+     *
+     * <p>Returns null/blank input unchanged so callers can decide how to handle
+     * missing crons. Throws nothing — invalid syntax is still surfaced by the
+     * subsequent {@link CronExpression#parse(String)} call.
+     */
+    public static String normalizeCron(String cronExpression) {
+        if (cronExpression == null) return null;
+        String trimmed = cronExpression.trim();
+        if (trimmed.isEmpty() || trimmed.startsWith("@")) return trimmed;
+        // Whitespace-delimited fields; CronExpression itself splits on any whitespace.
+        int fieldCount = trimmed.split("\\s+").length;
+        return fieldCount == 5 ? "0 " + trimmed : trimmed;
     }
 
     /**

--- a/kelta-worker/src/test/java/io/kelta/worker/listener/FlowScheduleSyncHookTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/listener/FlowScheduleSyncHookTest.java
@@ -1,0 +1,220 @@
+package io.kelta.worker.listener;
+
+import io.kelta.runtime.workflow.BeforeSaveResult;
+import io.kelta.worker.repository.ScheduledJobRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@DisplayName("FlowScheduleSyncHook")
+class FlowScheduleSyncHookTest {
+
+    private ScheduledJobRepository scheduledJobRepository;
+    private FlowScheduleSyncHook hook;
+
+    @BeforeEach
+    void setUp() {
+        scheduledJobRepository = mock(ScheduledJobRepository.class);
+        hook = new FlowScheduleSyncHook(scheduledJobRepository, new ObjectMapper());
+    }
+
+    @Test
+    @DisplayName("targets the flows system collection")
+    void targetsFlows() {
+        assertThat(hook.getCollectionName()).isEqualTo("flows");
+    }
+
+    @Nested
+    @DisplayName("validateCron (beforeCreate / beforeUpdate)")
+    class ValidateCron {
+
+        @Test
+        @DisplayName("accepts a standard 5-field Unix cron — normalization handles seconds")
+        void acceptsFiveFieldCron() {
+            Map<String, Object> record = scheduledFlow("0 */4 * * *");
+
+            BeforeSaveResult result = hook.beforeCreate(record, "tenant-1");
+
+            assertThat(result.isSuccess()).isTrue();
+        }
+
+        @Test
+        @DisplayName("accepts a 6-field Spring cron")
+        void acceptsSixFieldCron() {
+            Map<String, Object> record = scheduledFlow("0 0 */4 * * *");
+
+            BeforeSaveResult result = hook.beforeCreate(record, "tenant-1");
+
+            assertThat(result.isSuccess()).isTrue();
+        }
+
+        @Test
+        @DisplayName("rejects garbage cron loudly with an actionable message")
+        void rejectsGarbageCronLoudly() {
+            Map<String, Object> record = scheduledFlow("not a cron at all");
+
+            BeforeSaveResult result = hook.beforeCreate(record, "tenant-1");
+
+            assertThat(result.isSuccess()).isFalse();
+            assertThat(result.getErrors()).hasSize(1);
+            BeforeSaveResult.ValidationError error = result.getErrors().get(0);
+            assertThat(error.field()).isEqualTo("triggerConfig.cron");
+            // Message must echo the offending value and name the expected format,
+            // so users can fix it without grepping logs.
+            assertThat(error.message())
+                    .contains("not a cron at all")
+                    .contains("Spring expression");
+        }
+
+        @Test
+        @DisplayName("rejects on update too — not just create")
+        void rejectsOnUpdate() {
+            Map<String, Object> record = scheduledFlow("totally bogus");
+
+            BeforeSaveResult result = hook.beforeUpdate("flow-1", record, new HashMap<>(record), "tenant-1");
+
+            assertThat(result.isSuccess()).isFalse();
+        }
+
+        @Test
+        @DisplayName("ignores non-SCHEDULED flows — cron field, if any, is unused")
+        void ignoresNonScheduledFlows() {
+            Map<String, Object> record = new HashMap<>();
+            record.put("id", "flow-1");
+            record.put("flowType", "RECORD_TRIGGERED");
+            record.put("triggerConfig", Map.of("cron", "garbage"));
+
+            BeforeSaveResult result = hook.beforeCreate(record, "tenant-1");
+
+            assertThat(result.isSuccess()).isTrue();
+        }
+
+        @Test
+        @DisplayName("allows SCHEDULED flows without a cron — handled downstream as a no-op sync")
+        void allowsMissingCron() {
+            Map<String, Object> record = new HashMap<>();
+            record.put("id", "flow-1");
+            record.put("flowType", "SCHEDULED");
+            record.put("triggerConfig", Map.of());
+
+            BeforeSaveResult result = hook.beforeCreate(record, "tenant-1");
+
+            assertThat(result.isSuccess()).isTrue();
+        }
+
+        @Test
+        @DisplayName("validates a triggerConfig that arrived as a JSON string (e.g. jsonb passthrough)")
+        void validatesJsonStringTriggerConfig() {
+            Map<String, Object> record = new HashMap<>();
+            record.put("id", "flow-1");
+            record.put("flowType", "SCHEDULED");
+            record.put("triggerConfig", "{\"cron\":\"definitely bad\"}");
+
+            BeforeSaveResult result = hook.beforeCreate(record, "tenant-1");
+
+            assertThat(result.isSuccess()).isFalse();
+            assertThat(result.getErrors().get(0).message()).contains("definitely bad");
+        }
+    }
+
+    @Nested
+    @DisplayName("afterCreate / afterUpdate — scheduled_job sync")
+    class ScheduledJobSync {
+
+        @Test
+        @DisplayName("inserts scheduled_job with the normalized 6-field cron for a 5-field input")
+        void insertsWithNormalizedCron() {
+            Map<String, Object> record = scheduledFlow("0 */4 * * *");
+            record.put("id", "flow-1");
+            record.put("name", "Tubi 4h ingest");
+            record.put("createdBy", "user-1");
+
+            when(scheduledJobRepository.findByFlowId("flow-1", "tenant-1")).thenReturn(Optional.empty());
+
+            hook.afterCreate(record, "tenant-1");
+
+            // The row written to scheduled_job MUST be the 6-field form, otherwise the
+            // executor's own CronExpression.parse would later throw and the job would
+            // never fire — that's exactly the bug this task fixes.
+            verify(scheduledJobRepository).insertForFlow(
+                    eq("flow-1"),
+                    eq("tenant-1"),
+                    eq("Tubi 4h ingest"),
+                    eq("0 0 */4 * * *"),
+                    any(),
+                    eq(true),
+                    any(Instant.class),
+                    eq("user-1")
+            );
+        }
+
+        @Test
+        @DisplayName("updates an existing scheduled_job using the normalized cron")
+        void updatesWithNormalizedCron() {
+            Map<String, Object> record = scheduledFlow("0 */4 * * *");
+            record.put("id", "flow-1");
+            record.put("name", "Tubi 4h ingest");
+
+            Map<String, Object> existingJob = new LinkedHashMap<>();
+            existingJob.put("id", "job-1");
+            when(scheduledJobRepository.findByFlowId("flow-1", "tenant-1"))
+                    .thenReturn(Optional.of(existingJob));
+
+            hook.afterCreate(record, "tenant-1");
+
+            verify(scheduledJobRepository).updateForFlow(
+                    eq("job-1"),
+                    eq("Tubi 4h ingest"),
+                    eq("0 0 */4 * * *"),
+                    any(),
+                    eq(true),
+                    any(Instant.class)
+            );
+        }
+
+        @Test
+        @DisplayName("does not silently skip when sync encounters an unparseable cron — logs and skips, but beforeCreate is the guard")
+        void skipsRatherThanThrowsOnLegacyInvalidCron() {
+            // Simulate legacy/direct-DB-write data: beforeCreate never ran but afterCreate
+            // is invoked. The old behavior was silent skip; new behavior is still skip
+            // (we can't surface a 400 in an after-hook), but the user-facing path is
+            // protected by beforeCreate's validation.
+            Map<String, Object> record = scheduledFlow("totally broken");
+            record.put("id", "flow-1");
+
+            hook.afterCreate(record, "tenant-1");
+
+            verify(scheduledJobRepository, never())
+                    .insertForFlow(anyString(), anyString(), anyString(), anyString(),
+                            anyString(), anyBoolean(), any(), anyString());
+        }
+    }
+
+    private static Map<String, Object> scheduledFlow(String cron) {
+        Map<String, Object> record = new HashMap<>();
+        record.put("flowType", "SCHEDULED");
+        Map<String, Object> triggerConfig = new HashMap<>();
+        triggerConfig.put("cron", cron);
+        triggerConfig.put("timezone", "UTC");
+        record.put("triggerConfig", triggerConfig);
+        return record;
+    }
+}

--- a/kelta-worker/src/test/java/io/kelta/worker/repository/ScheduledJobRepositoryTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/repository/ScheduledJobRepositoryTest.java
@@ -86,4 +86,50 @@ class ScheduledJobRepositoryTest {
         assertThat(result).isPresent();
         assertThat(result.get().get("definition")).isNull();
     }
+
+    @Nested
+    @DisplayName("normalizeCron")
+    class NormalizeCron {
+
+        @Test
+        @DisplayName("prepends seconds for a 5-field Unix cron so Spring CronExpression accepts it")
+        void normalizesFiveFieldUnixCron() {
+            assertThat(ScheduledJobRepository.normalizeCron("0 */4 * * *"))
+                    .isEqualTo("0 0 */4 * * *");
+        }
+
+        @Test
+        @DisplayName("passes a 6-field Spring cron through unchanged")
+        void passesSixFieldCronThrough() {
+            assertThat(ScheduledJobRepository.normalizeCron("30 0 */4 * * *"))
+                    .isEqualTo("30 0 */4 * * *");
+        }
+
+        @Test
+        @DisplayName("trims surrounding whitespace before counting fields")
+        void trimsWhitespace() {
+            assertThat(ScheduledJobRepository.normalizeCron("  0 */4 * * *  "))
+                    .isEqualTo("0 0 */4 * * *");
+        }
+
+        @Test
+        @DisplayName("passes Spring macros through unchanged")
+        void passesMacrosThrough() {
+            assertThat(ScheduledJobRepository.normalizeCron("@hourly")).isEqualTo("@hourly");
+            assertThat(ScheduledJobRepository.normalizeCron("@daily")).isEqualTo("@daily");
+        }
+
+        @Test
+        @DisplayName("returns null for null input")
+        void returnsNullForNull() {
+            assertThat(ScheduledJobRepository.normalizeCron(null)).isNull();
+        }
+
+        @Test
+        @DisplayName("leaves obviously-invalid (wrong field count) input alone for the caller to reject")
+        void leavesUnknownLengthForCallerToReject() {
+            assertThat(ScheduledJobRepository.normalizeCron("not a cron"))
+                    .isEqualTo("not a cron");
+        }
+    }
 }


### PR DESCRIPTION
A SCHEDULED flow saved with a standard 5-field cron (e.g. `0 */4 * * *`) was
silently dropped: Spring's CronExpression.parse requires 6 fields (with a
leading seconds field), so FlowScheduleSyncHook caught the IllegalArgumentException,
logged at WARN, and never created a scheduled_job row. The flow appeared to
save but never ran — and no error surfaced to the user.

This change does two things:

1. **Normalize** in `ScheduledJobRepository.normalizeCron`: a 5-field Unix cron
   gets a leading "0 " prepended for the seconds field; 6-field forms and
   Spring macros (@hourly, @daily, etc.) pass through. Called from both
   `calculateNextRunAt` and the sync hook so the row written to scheduled_job
   is always in Spring's 6-field form (which the executor's own parse can read).

2. **Reject loudly** in `FlowScheduleSyncHook.beforeCreate`/`beforeUpdate`:
   for SCHEDULED flows with a non-empty `triggerConfig.cron` that is still
   unparseable after normalization, return a `BeforeSaveResult.error` keyed at
   `triggerConfig.cron`. `DefaultQueryEngine` lifts that into a
   `ValidationException`, which `GlobalExceptionHandler` maps to a 400 with
   a message that echoes the offending value — no more silent drops.

Tests cover the matrix from the brief: 5-field normalized, 6-field passthrough,
macros passthrough, garbage rejected loudly. Hook tests verify both create and
update paths reject invalid crons and that the inserted `scheduled_job.cron_expression`
is the normalized form for legacy 5-field inputs.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
