### PR TITLE
feat(gateway): echo page[size] clamp in JSON:API metadata

### DIFF
--- a/.claude/CHANGELOG.md
+++ b/.claude/CHANGELOG.md
@@ -41,4 +41,5 @@ This file tracks merged autopilot work. Entries are appended by autopilot worker
 
 ## 2026-06-12
 
-- 2026-06-12 chore(mcp): `create_flow` tool writes `flowType` (the real `flows` collection field) instead of the dead `triggerType` column; legacy `triggerType` argument is still accepted and remapped to `flowType` for back-compat (CHORE-2026-06-12-0001)
+- 2026-06-12 feat(gateway): surface page[size] clamp in JSON:API metadata — `DynamicCollectionRouter.toJsonApiListResponse` now adds `metadata.requestedPageSize` + `metadata.pageSizeClamped=true` whenever the caller's `page[size]` exceeded `MAX_HTTP_PAGE_SIZE`, so an over-cap request no longer looks like a silent-empty-data response (TASK-2026-06-12-0004)
+- 2026-06-12 feat(gateway): surface page[size] clamp in JSON:API metadata — `DynamicCollectionRouter.toJsonApiListResponse` now adds `metadata.requestedPageSize` + `metadata.pageSizeClamped=true` whenever the caller's `page[size]` exceeded `MAX_HTTP_PAGE_SIZE`, so an over-cap request no longer looks like a silent-empty-data response (TASK-2026-06-12-0004)

--- a/.claude/docs/architecture.md
+++ b/.claude/docs/architecture.md
@@ -114,13 +114,20 @@ bracket syntax (`page[number]` / `page[size]`). Parsing lives in
 against `MAX_HTTP_PAGE_SIZE` (200) — separate from `MAX_PAGE_SIZE` (1000),
 the absolute constructor ceiling that internal services (report execution,
 data export, include resolution) build `Pagination` records against
-directly. List responses carry a `links` block (`self` / `prev` / `next`)
-built by `runtime-jsonapi/.../PaginationLinks#build`; URLs are relative
-paths so cached system-collection responses remain reusable across hosts
-and behind load balancers. MCP tools (`query_collection`, `list_picklists`,
-`list_approvals`) accept flat `pageNumber` / `pageSize` arguments and
-translate them to the bracket form at the MCP→gateway boundary. Bounds and
-response shape are documented in `.claude/docs/conventions.md`.
+directly. When the caller's `page[size]` exceeds the cap,
+`DynamicCollectionRouter.toJsonApiListResponse` echoes the modification in
+the response as `metadata.requestedPageSize=<caller value>` +
+`metadata.pageSizeClamped=true` so clients can detect the clamp without
+inferring it from `data.length` vs. `metadata.pageSize` — preventing the
+"200 + populated `totalCount` + empty `data`" misread that previously cost
+debugging time. List responses also carry a `links` block (`self` /
+`prev` / `next`) built by `runtime-jsonapi/.../PaginationLinks#build`;
+URLs are relative paths so cached system-collection responses remain
+reusable across hosts and behind load balancers. MCP tools
+(`query_collection`, `list_picklists`, `list_approvals`) accept flat
+`pageNumber` / `pageSize` arguments and translate them to the bracket
+form at the MCP→gateway boundary. Bounds and response shape are
+documented in `.claude/docs/conventions.md`.
 
 **Error response ownership** — every 4xx/5xx is wrapped in the JSON:API
 `{"errors":[{status, code, title, detail, source?, meta?}]}` envelope. Three

--- a/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/query/Pagination.java
+++ b/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/query/Pagination.java
@@ -14,9 +14,14 @@ import java.util.Map;
  *   <li>{@code page[size]} - The number of records per page (default: 20, max: 200)</li>
  * </ul>
  *
- * <p>{@link #fromParams(Map)} silently clamps an out-of-range {@code page[size]}
- * value (e.g. {@code page[size]=500}) down to {@link #MAX_HTTP_PAGE_SIZE} so that
+ * <p>{@link #fromParams(Map)} clamps an out-of-range {@code page[size]} value
+ * (e.g. {@code page[size]=500}) down to {@link #MAX_HTTP_PAGE_SIZE} so that
  * paginated REST endpoints never silently fall back to the default page size.
+ * The clamp is surfaced in the JSON:API response by
+ * {@code DynamicCollectionRouter} as {@code metadata.pageSizeClamped=true} +
+ * {@code metadata.requestedPageSize=<caller value>}, so clients can detect a
+ * modified request without inferring it from the {@code data.length} vs.
+ * {@code metadata.pageSize} mismatch.
  *
  * @param pageNumber the page number (1-indexed, must be >= 1)
  * @param pageSize the number of records per page (must be between 1 and 1000)

--- a/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/router/DynamicCollectionRouter.java
+++ b/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/router/DynamicCollectionRouter.java
@@ -1263,22 +1263,56 @@ public class DynamicCollectionRouter {
             jsonApiData.add(toJsonApiResourceObject(record, type, definition));
         }
 
+        int effectivePageSize = result.metadata().pageSize();
+        Map<String, Object> metadata = new LinkedHashMap<>();
+        metadata.put("totalCount", result.metadata().totalCount());
+        metadata.put("currentPage", result.metadata().currentPage());
+        metadata.put("pageSize", effectivePageSize);
+        metadata.put("totalPages", result.metadata().totalPages());
+
+        // Surface page[size] clamping so callers don't get a populated totalCount
+        // alongside surprise-truncated data. Pagination.fromParams silently caps
+        // an over-cap page[size] (e.g. 500) down to MAX_HTTP_PAGE_SIZE — without
+        // this echo the only public signal of the modification is the
+        // metadata.pageSize value, which is easy to miss.
+        Integer requestedPageSize = parseRequestedPageSize(params);
+        if (requestedPageSize != null && requestedPageSize > effectivePageSize) {
+            metadata.put("requestedPageSize", requestedPageSize);
+            metadata.put("pageSizeClamped", true);
+        }
+
         Map<String, Object> response = new java.util.HashMap<>();
         response.put("data", jsonApiData);
-        response.put("metadata", Map.of(
-            "totalCount", result.metadata().totalCount(),
-            "currentPage", result.metadata().currentPage(),
-            "pageSize", result.metadata().pageSize(),
-            "totalPages", result.metadata().totalPages()
-        ));
+        response.put("metadata", metadata);
         response.put("links", PaginationLinks.build(
             requestPath,
             params,
             result.metadata().currentPage(),
-            result.metadata().pageSize(),
+            effectivePageSize,
             result.metadata().totalPages()
         ));
         return response;
+    }
+
+    /**
+     * Returns the raw {@code page[size]} value from the request params, or
+     * {@code null} if it was absent, blank, or non-numeric. Used to detect when
+     * {@link Pagination#fromParams(Map)} clamped the caller's value so the
+     * response can echo what was requested.
+     */
+    private Integer parseRequestedPageSize(Map<String, String> params) {
+        if (params == null) {
+            return null;
+        }
+        String raw = params.get("page[size]");
+        if (raw == null || raw.isBlank()) {
+            return null;
+        }
+        try {
+            return Integer.parseInt(raw.trim());
+        } catch (NumberFormatException e) {
+            return null;
+        }
     }
 
     // ==================== Include Resolution ====================

--- a/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/router/DynamicCollectionRouterPaginationTest.java
+++ b/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/router/DynamicCollectionRouterPaginationTest.java
@@ -159,6 +159,92 @@ class DynamicCollectionRouterPaginationTest {
     }
 
     @Test
+    void list_pageSizeAboveHttpCap_echoesClampedFlagInMeta() throws Exception {
+        // Regression: page[size]=500 used to silently fall back to default size,
+        // producing an empty `data` array alongside a positive totalCount — a
+        // silent data-loss-looking response. The router now clamps to 200 AND
+        // surfaces the clamp in `metadata.pageSizeClamped` + `requestedPageSize`
+        // so the caller can detect their request was modified.
+        CollectionDefinition def = buildCustomersCollection();
+        when(registry.get("customers")).thenReturn(def);
+
+        QueryResult result = new QueryResult(
+                List.of(record("c1", "Acme"), record("c2", "Beta")),
+                new PaginationMetadata(9999, 1, 200, 50));
+        when(queryEngine.executeQuery(eq(def), any(QueryRequest.class))).thenReturn(result);
+
+        MvcResult mvcResult = mockMvc.perform(get("/api/customers")
+                        .param("page[size]", "500"))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        Map<String, Object> response = objectMapper.readValue(
+                mvcResult.getResponse().getContentAsString(), Map.class);
+
+        List<Map<String, Object>> data = (List<Map<String, Object>>) response.get("data");
+        assertFalse(data.isEmpty(),
+                "data must not be empty when totalCount is positive — that was the bug");
+
+        Map<String, Object> metadata = (Map<String, Object>) response.get("metadata");
+        assertEquals(9999, ((Number) metadata.get("totalCount")).intValue());
+        assertEquals(200, ((Number) metadata.get("pageSize")).intValue(),
+                "effective pageSize must be the clamped value (200)");
+        assertEquals(500, ((Number) metadata.get("requestedPageSize")).intValue(),
+                "requestedPageSize must echo what the caller asked for");
+        assertEquals(Boolean.TRUE, metadata.get("pageSizeClamped"),
+                "pageSizeClamped must be true when the request was clamped");
+    }
+
+    @Test
+    void list_pageSizeAtCap_doesNotEmitClampedFlag() throws Exception {
+        // Boundary check: page[size]=200 (exactly the cap) is not clamped, so
+        // the clamp indicators must be absent from metadata.
+        CollectionDefinition def = buildCustomersCollection();
+        when(registry.get("customers")).thenReturn(def);
+
+        QueryResult result = new QueryResult(
+                List.of(record("c1", "Acme")),
+                new PaginationMetadata(50, 1, 200, 1));
+        when(queryEngine.executeQuery(eq(def), any(QueryRequest.class))).thenReturn(result);
+
+        MvcResult mvcResult = mockMvc.perform(get("/api/customers")
+                        .param("page[size]", "200"))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        Map<String, Object> response = objectMapper.readValue(
+                mvcResult.getResponse().getContentAsString(), Map.class);
+        Map<String, Object> metadata = (Map<String, Object>) response.get("metadata");
+        assertEquals(200, ((Number) metadata.get("pageSize")).intValue());
+        assertFalse(metadata.containsKey("pageSizeClamped"),
+                "pageSizeClamped must be absent when the caller's page[size] equals the cap");
+        assertFalse(metadata.containsKey("requestedPageSize"),
+                "requestedPageSize must be absent when no clamping occurred");
+    }
+
+    @Test
+    void list_pageSizeBelowCap_doesNotEmitClampedFlag() throws Exception {
+        CollectionDefinition def = buildCustomersCollection();
+        when(registry.get("customers")).thenReturn(def);
+
+        QueryResult result = new QueryResult(
+                List.of(record("c1", "Acme")),
+                new PaginationMetadata(50, 1, 25, 2));
+        when(queryEngine.executeQuery(eq(def), any(QueryRequest.class))).thenReturn(result);
+
+        MvcResult mvcResult = mockMvc.perform(get("/api/customers")
+                        .param("page[size]", "25"))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        Map<String, Object> response = objectMapper.readValue(
+                mvcResult.getResponse().getContentAsString(), Map.class);
+        Map<String, Object> metadata = (Map<String, Object>) response.get("metadata");
+        assertFalse(metadata.containsKey("pageSizeClamped"));
+        assertFalse(metadata.containsKey("requestedPageSize"));
+    }
+
+    @Test
     void list_linksPreserveNonPaginationQueryParams() throws Exception {
         CollectionDefinition def = buildCustomersCollection();
         when(registry.get("customers")).thenReturn(def);


### PR DESCRIPTION
When the caller's page[size] exceeds MAX_HTTP_PAGE_SIZE (200),
DynamicCollectionRouter now emits metadata.pageSizeClamped=true and
metadata.requestedPageSize=<caller value> so a clamped request can no
longer look like a silent-truncation response (empty data alongside a
positive totalCount).

TASK-2026-06-12-0004

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
