### PR TITLE
feat(flow): validate flow definition on save

### DIFF
--- a/.claude/CHANGELOG.md
+++ b/.claude/CHANGELOG.md
@@ -42,3 +42,4 @@ This file tracks merged autopilot work. Entries are appended by autopilot worker
 ## 2026-06-12
 
 - 2026-06-12 chore(mcp): `create_flow` tool writes `flowType` (the real `flows` collection field) instead of the dead `triggerType` column; legacy `triggerType` argument is still accepted and remapped to `flowType` for back-compat (CHORE-2026-06-12-0001)
+- 2026-06-12 feat(flow): validate flow definitions on save — new `FlowDefinitionValidator` runs the parser plus a graph check (dangling `Next`/`Default`/Choice rule/`Catch.Next` targets, `StartAt` resolution, Map states missing `Iterator`), wired through `FlowDefinitionValidationHook` on the `flows` collection so authors get a 400 listing every problem at write time instead of a runtime crash (TASK-2026-06-12-0002)

--- a/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/flow/FlowDefinitionValidator.java
+++ b/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/flow/FlowDefinitionValidator.java
@@ -1,0 +1,167 @@
+package io.kelta.runtime.flow;
+
+import tools.jackson.databind.ObjectMapper;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Validates a flow definition JSON string by parsing it and walking the
+ * resulting state graph to find dangling transitions.
+ *
+ * <p>The validator returns the list of structural problems instead of
+ * throwing, so save-time callers can report every issue at once. An empty
+ * list means the definition is structurally valid and safe to execute.
+ *
+ * <p>Reported errors include:
+ * <ul>
+ *   <li>Parse-level failures (missing {@code StartAt}, missing
+ *       {@code Resource}, malformed JSON, unknown state types, &c.)</li>
+ *   <li>{@code StartAt} pointing at a state that is not defined</li>
+ *   <li>{@code Next}, Choice {@code Default}, Choice-rule {@code Next}, or
+ *       {@code Catch.Next} pointing at a state that is not defined</li>
+ *   <li>{@code Map} states without an {@code Iterator}</li>
+ * </ul>
+ *
+ * <p>Branches of {@code Parallel} states and {@code Map} iterators are
+ * validated as independent sub-graphs, since their transitions resolve
+ * within their own state map.
+ *
+ * @since 1.0.0
+ */
+public class FlowDefinitionValidator {
+
+    private final FlowDefinitionParser parser;
+
+    public FlowDefinitionValidator(ObjectMapper objectMapper) {
+        this(new FlowDefinitionParser(objectMapper));
+    }
+
+    public FlowDefinitionValidator(FlowDefinitionParser parser) {
+        this.parser = parser;
+    }
+
+    /**
+     * Validates the given flow definition JSON.
+     *
+     * @param json the flow definition JSON
+     * @return ordered list of error messages — empty if the definition is valid
+     */
+    public List<String> validate(String json) {
+        List<String> errors = new ArrayList<>();
+        if (json == null || json.isBlank()) {
+            errors.add("Flow definition is empty");
+            return errors;
+        }
+
+        FlowDefinition definition;
+        try {
+            definition = parser.parse(json);
+        } catch (FlowDefinitionException e) {
+            errors.add(e.getMessage());
+            return errors;
+        }
+        validateGraph(definition, errors, "");
+        return errors;
+    }
+
+    private void validateGraph(FlowDefinition definition, List<String> errors, String path) {
+        if (definition.startAt() == null || definition.startAt().isBlank()) {
+            errors.add(path + "StartAt is missing");
+        } else if (!definition.hasState(definition.startAt())) {
+            errors.add(path + "StartAt '" + definition.startAt()
+                    + "' does not match any defined state");
+        }
+
+        if (definition.states() == null || definition.states().isEmpty()) {
+            return;
+        }
+
+        for (var entry : definition.states().entrySet()) {
+            String stateId = entry.getKey();
+            StateDefinition state = entry.getValue();
+            String statePath = path + "State '" + stateId + "': ";
+
+            switch (state) {
+                case StateDefinition.TaskState task -> {
+                    checkTarget(task.next(), "Next", definition, errors, statePath);
+                    checkCatchTargets(task.catchPolicies(), definition, errors, statePath);
+                }
+                case StateDefinition.ChoiceState choice -> {
+                    if (choice.defaultState() != null
+                            && !definition.hasState(choice.defaultState())) {
+                        errors.add(statePath + "Default '" + choice.defaultState()
+                                + "' does not match any defined state");
+                    }
+                    for (ChoiceRule rule : choice.choices()) {
+                        validateChoiceRule(rule, definition, errors, statePath);
+                    }
+                }
+                case StateDefinition.ParallelState parallel -> {
+                    checkTarget(parallel.next(), "Next", definition, errors, statePath);
+                    checkCatchTargets(parallel.catchPolicies(), definition, errors, statePath);
+                    int i = 0;
+                    for (FlowDefinition branch : parallel.branches()) {
+                        validateGraph(branch, errors, statePath + "branch[" + i + "] ");
+                        i++;
+                    }
+                }
+                case StateDefinition.MapState map -> {
+                    checkTarget(map.next(), "Next", definition, errors, statePath);
+                    if (map.iterator() == null) {
+                        errors.add(statePath + "Map state must contain an 'Iterator'");
+                    } else {
+                        validateGraph(map.iterator(), errors, statePath + "iterator ");
+                    }
+                }
+                case StateDefinition.WaitState wait ->
+                        checkTarget(wait.next(), "Next", definition, errors, statePath);
+                case StateDefinition.PassState pass ->
+                        checkTarget(pass.next(), "Next", definition, errors, statePath);
+                case StateDefinition.SucceedState ignored -> { }
+                case StateDefinition.FailState ignored -> { }
+            }
+        }
+    }
+
+    private void checkTarget(String next, String fieldName, FlowDefinition definition,
+                             List<String> errors, String statePath) {
+        if (next != null && !definition.hasState(next)) {
+            errors.add(statePath + fieldName + " '" + next
+                    + "' does not match any defined state");
+        }
+    }
+
+    private void checkCatchTargets(List<CatchPolicy> policies, FlowDefinition definition,
+                                   List<String> errors, String statePath) {
+        if (policies == null) return;
+        for (CatchPolicy c : policies) {
+            if (c.next() != null && !definition.hasState(c.next())) {
+                errors.add(statePath + "Catch target '" + c.next()
+                        + "' does not match any defined state");
+            }
+        }
+    }
+
+    private void validateChoiceRule(ChoiceRule rule, FlowDefinition definition,
+                                    List<String> errors, String statePath) {
+        if (rule.next() != null && !definition.hasState(rule.next())) {
+            errors.add(statePath + "Choice rule target '" + rule.next()
+                    + "' does not match any defined state");
+        }
+        switch (rule) {
+            case ChoiceRule.And and -> {
+                for (ChoiceRule inner : and.rules()) {
+                    validateChoiceRule(inner, definition, errors, statePath);
+                }
+            }
+            case ChoiceRule.Or or -> {
+                for (ChoiceRule inner : or.rules()) {
+                    validateChoiceRule(inner, definition, errors, statePath);
+                }
+            }
+            case ChoiceRule.Not not -> validateChoiceRule(not.rule(), definition, errors, statePath);
+            default -> { }
+        }
+    }
+}

--- a/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/flow/FlowDefinitionValidatorTest.java
+++ b/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/flow/FlowDefinitionValidatorTest.java
@@ -1,0 +1,254 @@
+package io.kelta.runtime.flow;
+
+import tools.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("FlowDefinitionValidator")
+class FlowDefinitionValidatorTest {
+
+    private FlowDefinitionValidator validator;
+
+    @BeforeEach
+    void setUp() {
+        validator = new FlowDefinitionValidator(new ObjectMapper());
+    }
+
+    @Test
+    @DisplayName("returns no errors for a valid single-state flow")
+    void validMinimalFlow() {
+        List<String> errors = validator.validate("""
+                { "StartAt": "Done", "States": { "Done": { "Type": "Succeed" } } }
+                """);
+
+        assertThat(errors).isEmpty();
+    }
+
+    @Test
+    @DisplayName("returns no errors for a valid chained flow")
+    void validChainedFlow() {
+        List<String> errors = validator.validate("""
+                {
+                    "StartAt": "A",
+                    "States": {
+                        "A": { "Type": "Task", "Resource": "LOG_MESSAGE", "Next": "B" },
+                        "B": { "Type": "Succeed" }
+                    }
+                }
+                """);
+
+        assertThat(errors).isEmpty();
+    }
+
+    @Test
+    @DisplayName("reports missing StartAt as a parse error")
+    void missingStartAt() {
+        List<String> errors = validator.validate("""
+                { "States": { "Done": { "Type": "Succeed" } } }
+                """);
+
+        assertThat(errors).hasSize(1);
+        assertThat(errors.get(0)).contains("StartAt");
+    }
+
+    @Test
+    @DisplayName("reports StartAt pointing at an undefined state")
+    void startAtUnknownState() {
+        List<String> errors = validator.validate("""
+                { "StartAt": "Missing", "States": { "Done": { "Type": "Succeed" } } }
+                """);
+
+        assertThat(errors).containsExactly(
+                "StartAt 'Missing' does not match any defined state");
+    }
+
+    @Test
+    @DisplayName("reports dangling Task Next")
+    void danglingTaskNext() {
+        List<String> errors = validator.validate("""
+                {
+                    "StartAt": "A",
+                    "States": {
+                        "A": { "Type": "Task", "Resource": "LOG_MESSAGE", "Next": "Ghost" }
+                    }
+                }
+                """);
+
+        assertThat(errors).containsExactly(
+                "State 'A': Next 'Ghost' does not match any defined state");
+    }
+
+    @Test
+    @DisplayName("reports dangling Choice Default")
+    void danglingChoiceDefault() {
+        List<String> errors = validator.validate("""
+                {
+                    "StartAt": "Decide",
+                    "States": {
+                        "Decide": {
+                            "Type": "Choice",
+                            "Choices": [
+                                { "Variable": "$.x", "StringEquals": "y", "Next": "Yes" }
+                            ],
+                            "Default": "Ghost"
+                        },
+                        "Yes": { "Type": "Succeed" }
+                    }
+                }
+                """);
+
+        assertThat(errors).containsExactly(
+                "State 'Decide': Default 'Ghost' does not match any defined state");
+    }
+
+    @Test
+    @DisplayName("reports dangling Choice rule Next")
+    void danglingChoiceRuleNext() {
+        List<String> errors = validator.validate("""
+                {
+                    "StartAt": "Decide",
+                    "States": {
+                        "Decide": {
+                            "Type": "Choice",
+                            "Choices": [
+                                { "Variable": "$.x", "StringEquals": "y", "Next": "Ghost" }
+                            ],
+                            "Default": "Fallback"
+                        },
+                        "Fallback": { "Type": "Succeed" }
+                    }
+                }
+                """);
+
+        assertThat(errors).containsExactly(
+                "State 'Decide': Choice rule target 'Ghost' does not match any defined state");
+    }
+
+    @Test
+    @DisplayName("reports dangling Catch.Next")
+    void danglingCatchNext() {
+        List<String> errors = validator.validate("""
+                {
+                    "StartAt": "Risky",
+                    "States": {
+                        "Risky": {
+                            "Type": "Task",
+                            "Resource": "HTTP_CALLOUT",
+                            "End": true,
+                            "Catch": [
+                                { "ErrorEquals": ["States.ALL"], "Next": "Ghost" }
+                            ]
+                        }
+                    }
+                }
+                """);
+
+        assertThat(errors).containsExactly(
+                "State 'Risky': Catch target 'Ghost' does not match any defined state");
+    }
+
+    @Test
+    @DisplayName("reports a Map state without an Iterator")
+    void mapWithoutIterator() {
+        List<String> errors = validator.validate("""
+                {
+                    "StartAt": "Loop",
+                    "States": {
+                        "Loop": { "Type": "Map", "ItemsPath": "$.items", "End": true }
+                    }
+                }
+                """);
+
+        assertThat(errors).containsExactly(
+                "State 'Loop': Map state must contain an 'Iterator'");
+    }
+
+    @Test
+    @DisplayName("reports a Map iterator missing StartAt as a parse error")
+    void mapIteratorMissingStartAt() {
+        List<String> errors = validator.validate("""
+                {
+                    "StartAt": "Loop",
+                    "States": {
+                        "Loop": {
+                            "Type": "Map",
+                            "ItemsPath": "$.items",
+                            "Iterator": {
+                                "States": { "Inner": { "Type": "Succeed" } }
+                            },
+                            "End": true
+                        }
+                    }
+                }
+                """);
+
+        // Parser throws on the inner missing StartAt; validator returns the message.
+        assertThat(errors).hasSize(1);
+        assertThat(errors.get(0)).contains("StartAt");
+    }
+
+    @Test
+    @DisplayName("validates Parallel branches as independent sub-graphs")
+    void parallelBranchValidation() {
+        List<String> errors = validator.validate("""
+                {
+                    "StartAt": "Fan",
+                    "States": {
+                        "Fan": {
+                            "Type": "Parallel",
+                            "End": true,
+                            "Branches": [
+                                {
+                                    "StartAt": "A",
+                                    "States": {
+                                        "A": { "Type": "Task", "Resource": "LOG_MESSAGE", "Next": "Ghost" }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+                """);
+
+        assertThat(errors).anyMatch(e -> e.contains("branch[0]"))
+                .anyMatch(e -> e.contains("'Ghost'"));
+    }
+
+    @Test
+    @DisplayName("collects multiple errors in one pass")
+    void collectsMultipleErrors() {
+        List<String> errors = validator.validate("""
+                {
+                    "StartAt": "Ghost",
+                    "States": {
+                        "A": { "Type": "Task", "Resource": "LOG_MESSAGE", "Next": "AlsoMissing" },
+                        "B": {
+                            "Type": "Choice",
+                            "Choices": [
+                                { "Variable": "$.x", "StringEquals": "y", "Next": "Nowhere" }
+                            ],
+                            "Default": "Nope"
+                        }
+                    }
+                }
+                """);
+
+        assertThat(errors).hasSize(4)
+                .anyMatch(e -> e.startsWith("StartAt 'Ghost'"))
+                .anyMatch(e -> e.contains("'AlsoMissing'"))
+                .anyMatch(e -> e.contains("'Nowhere'"))
+                .anyMatch(e -> e.contains("'Nope'"));
+    }
+
+    @Test
+    @DisplayName("rejects empty JSON input")
+    void emptyInput() {
+        assertThat(validator.validate("")).containsExactly("Flow definition is empty");
+        assertThat(validator.validate(null)).containsExactly("Flow definition is empty");
+    }
+}

--- a/kelta-worker/src/main/java/io/kelta/worker/config/FlowConfig.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/config/FlowConfig.java
@@ -317,6 +317,17 @@ public class FlowConfig {
     }
 
     @Bean
+    public io.kelta.worker.listener.FlowDefinitionValidationHook flowDefinitionValidationHook(
+            BeforeSaveHookRegistry hookRegistry,
+            ObjectMapper objectMapper) {
+        FlowDefinitionValidator validator = new FlowDefinitionValidator(objectMapper);
+        io.kelta.worker.listener.FlowDefinitionValidationHook hook =
+                new io.kelta.worker.listener.FlowDefinitionValidationHook(validator, objectMapper);
+        hookRegistry.register(hook);
+        return hook;
+    }
+
+    @Bean
     public FlowScheduleSyncHook flowScheduleSyncHook(
             BeforeSaveHookRegistry hookRegistry,
             io.kelta.worker.repository.ScheduledJobRepository scheduledJobRepository,

--- a/kelta-worker/src/main/java/io/kelta/worker/listener/FlowDefinitionValidationHook.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/listener/FlowDefinitionValidationHook.java
@@ -1,0 +1,98 @@
+package io.kelta.worker.listener;
+
+import io.kelta.runtime.flow.FlowDefinitionValidator;
+import io.kelta.runtime.workflow.BeforeSaveHook;
+import io.kelta.runtime.workflow.BeforeSaveResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import tools.jackson.databind.ObjectMapper;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Rejects flow create/update requests whose {@code definition} cannot be
+ * parsed or whose state graph has dangling transitions, so authors see
+ * structural errors at save time instead of at execution time.
+ *
+ * <p>The hook delegates to {@link FlowDefinitionValidator}: a parse-level
+ * failure (missing {@code StartAt}, unknown state type, etc.) collapses
+ * to a single error, and graph-level problems (dangling {@code Next},
+ * Choice {@code Default}, {@code Catch.Next}, &amp;c.) are each reported
+ * separately. All collected messages are returned as field-level errors
+ * on {@code definition}, which the runtime translates into an HTTP 400.
+ *
+ * <p>On update, the hook is only run when the {@code definition} field is
+ * part of the PATCH payload — partial updates that don't touch the
+ * definition stay fast.
+ *
+ * @since 1.0.0
+ */
+public class FlowDefinitionValidationHook implements BeforeSaveHook {
+
+    private static final Logger log = LoggerFactory.getLogger(FlowDefinitionValidationHook.class);
+    private static final String FIELD = "definition";
+
+    private final FlowDefinitionValidator validator;
+    private final ObjectMapper objectMapper;
+
+    public FlowDefinitionValidationHook(FlowDefinitionValidator validator, ObjectMapper objectMapper) {
+        this.validator = validator;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override public String getCollectionName() { return "flows"; }
+
+    @Override
+    public int getOrder() {
+        // Run before the event publisher (100) and schedule sync (150) so a
+        // malformed definition is rejected before any side effects fire.
+        return -100;
+    }
+
+    @Override
+    public BeforeSaveResult beforeCreate(Map<String, Object> record, String tenantId) {
+        return validateIfPresent(record);
+    }
+
+    @Override
+    public BeforeSaveResult beforeUpdate(String id, Map<String, Object> record,
+                                         Map<String, Object> previous, String tenantId) {
+        if (!record.containsKey(FIELD) && !record.containsKey("flow_definition")) {
+            return BeforeSaveResult.ok();
+        }
+        return validateIfPresent(record);
+    }
+
+    private BeforeSaveResult validateIfPresent(Map<String, Object> record) {
+        String json = extractDefinitionJson(record);
+        if (json == null) {
+            return BeforeSaveResult.ok();
+        }
+
+        List<String> errors = validator.validate(json);
+        if (errors.isEmpty()) {
+            return BeforeSaveResult.ok();
+        }
+
+        List<BeforeSaveResult.ValidationError> validationErrors = new ArrayList<>(errors.size());
+        for (String msg : errors) {
+            validationErrors.add(new BeforeSaveResult.ValidationError(FIELD, msg));
+        }
+        return BeforeSaveResult.errors(validationErrors);
+    }
+
+    private String extractDefinitionJson(Map<String, Object> record) {
+        Object raw = record.get(FIELD);
+        if (raw == null) raw = record.get("flow_definition");
+        if (raw == null) return null;
+        if (raw instanceof String s) return s.isBlank() ? null : s;
+        try {
+            return objectMapper.writeValueAsString(raw);
+        } catch (Exception e) {
+            log.warn("Failed to serialize flow definition for validation: {}", e.getMessage());
+            return null;
+        }
+    }
+}

--- a/kelta-worker/src/test/java/io/kelta/worker/listener/FlowDefinitionValidationHookTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/listener/FlowDefinitionValidationHookTest.java
@@ -1,0 +1,180 @@
+package io.kelta.worker.listener;
+
+import io.kelta.runtime.flow.FlowDefinitionValidator;
+import io.kelta.runtime.workflow.BeforeSaveResult;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("FlowDefinitionValidationHook")
+class FlowDefinitionValidationHookTest {
+
+    private FlowDefinitionValidationHook hook;
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+        hook = new FlowDefinitionValidationHook(new FlowDefinitionValidator(objectMapper), objectMapper);
+    }
+
+    @Test
+    @DisplayName("targets the 'flows' system collection")
+    void targetsFlowsCollection() {
+        assertThat(hook.getCollectionName()).isEqualTo("flows");
+    }
+
+    @Test
+    @DisplayName("runs before event publisher and schedule sync hooks")
+    void orderRunsFirst() {
+        assertThat(hook.getOrder()).isLessThan(100);
+    }
+
+    @Test
+    @DisplayName("accepts a valid definition supplied as a Map")
+    void acceptsValidMapDefinition() {
+        Map<String, Object> record = newRecord(validDefinitionMap());
+
+        BeforeSaveResult result = hook.beforeCreate(record, "tenant-1");
+
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(result.hasErrors()).isFalse();
+    }
+
+    @Test
+    @DisplayName("accepts a valid definition supplied as a JSON string")
+    void acceptsValidStringDefinition() throws Exception {
+        Map<String, Object> record = newRecord(
+                objectMapper.writeValueAsString(validDefinitionMap()));
+
+        BeforeSaveResult result = hook.beforeCreate(record, "tenant-1");
+
+        assertThat(result.isSuccess()).isTrue();
+    }
+
+    @Test
+    @DisplayName("rejects definition missing StartAt with a field-level error")
+    void rejectsMissingStartAt() {
+        Map<String, Object> definition = new LinkedHashMap<>();
+        definition.put("States", Map.of("Done", Map.of("Type", "Succeed")));
+        Map<String, Object> record = newRecord(definition);
+
+        BeforeSaveResult result = hook.beforeCreate(record, "tenant-1");
+
+        assertThat(result.isSuccess()).isFalse();
+        assertThat(result.getErrors()).hasSize(1);
+        assertThat(result.getErrors().get(0).field()).isEqualTo("definition");
+        assertThat(result.getErrors().get(0).message()).contains("StartAt");
+    }
+
+    @Test
+    @DisplayName("rejects definition with a dangling Next target")
+    void rejectsDanglingNext() {
+        Map<String, Object> definition = new LinkedHashMap<>();
+        definition.put("StartAt", "A");
+        definition.put("States", Map.of(
+                "A", Map.of("Type", "Task", "Resource", "LOG_MESSAGE", "Next", "Ghost")));
+        Map<String, Object> record = newRecord(definition);
+
+        BeforeSaveResult result = hook.beforeCreate(record, "tenant-1");
+
+        assertThat(result.isSuccess()).isFalse();
+        assertThat(result.getErrors())
+                .singleElement()
+                .satisfies(e -> {
+                    assertThat(e.field()).isEqualTo("definition");
+                    assertThat(e.message()).contains("Ghost");
+                });
+    }
+
+    @Test
+    @DisplayName("rejects Map state without an Iterator")
+    void rejectsMapWithoutIterator() {
+        Map<String, Object> definition = new LinkedHashMap<>();
+        definition.put("StartAt", "Loop");
+        definition.put("States", Map.of(
+                "Loop", Map.of("Type", "Map", "ItemsPath", "$.items", "End", true)));
+        Map<String, Object> record = newRecord(definition);
+
+        BeforeSaveResult result = hook.beforeCreate(record, "tenant-1");
+
+        assertThat(result.isSuccess()).isFalse();
+        assertThat(result.getErrors().get(0).message()).contains("Iterator");
+    }
+
+    @Test
+    @DisplayName("collects multiple errors in a single response")
+    void collectsMultipleErrors() {
+        Map<String, Object> definition = new LinkedHashMap<>();
+        definition.put("StartAt", "Ghost");
+        definition.put("States", Map.of(
+                "A", Map.of("Type", "Task", "Resource", "LOG_MESSAGE", "Next", "Nowhere")));
+        Map<String, Object> record = newRecord(definition);
+
+        BeforeSaveResult result = hook.beforeCreate(record, "tenant-1");
+
+        assertThat(result.isSuccess()).isFalse();
+        assertThat(result.getErrors()).hasSizeGreaterThanOrEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("update with no definition in payload skips validation")
+    void updateSkipsWhenDefinitionAbsent() {
+        Map<String, Object> record = new HashMap<>(Map.of(
+                "name", "Renamed Flow",
+                "active", true));
+
+        BeforeSaveResult result = hook.beforeUpdate("flow-1", record, Map.of(), "tenant-1");
+
+        assertThat(result.isSuccess()).isTrue();
+    }
+
+    @Test
+    @DisplayName("update with malformed definition is rejected")
+    void updateRejectsMalformedDefinition() {
+        Map<String, Object> definition = new LinkedHashMap<>();
+        definition.put("States", Map.of("Done", Map.of("Type", "Succeed")));
+        Map<String, Object> record = new HashMap<>();
+        record.put("definition", definition);
+
+        BeforeSaveResult result = hook.beforeUpdate("flow-1", record, Map.of(), "tenant-1");
+
+        assertThat(result.isSuccess()).isFalse();
+        assertThat(result.getErrors().get(0).field()).isEqualTo("definition");
+    }
+
+    @Test
+    @DisplayName("missing definition field on create is allowed (required check handles it)")
+    void missingDefinitionFieldOnCreate() {
+        Map<String, Object> record = new HashMap<>(Map.of(
+                "name", "Flow w/o def", "flowType", "RECORD_TRIGGERED"));
+
+        BeforeSaveResult result = hook.beforeCreate(record, "tenant-1");
+
+        assertThat(result.isSuccess()).isTrue();
+    }
+
+    private Map<String, Object> validDefinitionMap() {
+        Map<String, Object> def = new LinkedHashMap<>();
+        def.put("StartAt", "Done");
+        def.put("States", Map.of("Done", Map.of("Type", "Succeed")));
+        return def;
+    }
+
+    private Map<String, Object> newRecord(Object definition) {
+        Map<String, Object> record = new HashMap<>();
+        record.put("id", "flow-1");
+        record.put("name", "Sample Flow");
+        record.put("flowType", "RECORD_TRIGGERED");
+        record.put("active", true);
+        record.put("definition", definition);
+        return record;
+    }
+}


### PR DESCRIPTION
Reject malformed flow definitions at write time instead of letting them
blow up at execution. A new FlowDefinitionValidator runs the existing
parser and walks the resulting state graph for dangling references —
StartAt, Next, Choice Default, Choice rule Next, and Catch.Next all
have to resolve to a defined state, and Map states have to declare an
Iterator. Parse errors collapse to a single message; graph problems are
collected so authors see every issue in one shot.

The new FlowDefinitionValidationHook wires the validator into the
"flows" system collection as a BeforeSaveHook (order -100, ahead of the
event publisher and schedule sync), returning field-level errors on
`definition` so DefaultQueryEngine turns them into a 400. Update
payloads without a `definition` field skip validation so partial PATCH
calls stay fast.

TASK-2026-06-12-0002

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
