### PR TITLE
feat(query): add IN/ANY filter operator with multi-value parsing

### DIFF
--- a/kelta-gateway/src/test/java/io/kelta/gateway/integration/RelatedCollectionsIntegrationTest.java
+++ b/kelta-gateway/src/test/java/io/kelta/gateway/integration/RelatedCollectionsIntegrationTest.java
@@ -509,7 +509,87 @@ public class RelatedCollectionsIntegrationTest extends IntegrationTestBase {
         List<String> returnedIds = data.stream()
             .map(item -> (String) item.get("id"))
             .toList();
-        
+
         assertThat(returnedIds).contains(task1Id, task2Id);
+    }
+
+    /**
+     * Multi-id lookup via the {@code in} operator: a single GET returns every
+     * matching task, replacing what used to be N sequential get-by-id calls.
+     *
+     * <p>Validates: {@code filter[id][in]=u1,u2,u3} parameterizes the value
+     * list and {@code metadata.totalCount} reflects the matched rows.
+     */
+    @Test
+    void testQueryByIdInOperator() {
+        String projectId = testDataHelper.createProject(
+            "IN Op Project", "Project for IN operator testing", "ACTIVE");
+        createdProjectIds.add(projectId);
+
+        String task1Id = testDataHelper.createTask("IN Task 1", "first", projectId);
+        String task2Id = testDataHelper.createTask("IN Task 2", "second", projectId);
+        String task3Id = testDataHelper.createTask("IN Task 3", "third", projectId);
+        createdTaskIds.add(task1Id);
+        createdTaskIds.add(task2Id);
+        createdTaskIds.add(task3Id);
+
+        // Untargeted task to confirm the IN filter is exclusive
+        String untargeted = testDataHelper.createTask("Untargeted", "skipped", projectId);
+        createdTaskIds.add(untargeted);
+
+        String token = authHelper.getAdminToken();
+        HttpEntity<Void> request = new HttpEntity<>(authHelper.createAuthHeaders(token));
+
+        String url = GATEWAY_URL + "/api/tasks?filter[id][in]="
+                + task1Id + "," + task2Id + "," + task3Id;
+        ResponseEntity<Map> response = restTemplate.exchange(
+            url, HttpMethod.GET, request, Map.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+
+        List<Map<String, Object>> data =
+                (List<Map<String, Object>>) response.getBody().get("data");
+        assertThat(data).hasSize(3);
+
+        List<String> returnedIds = data.stream()
+                .map(item -> (String) item.get("id"))
+                .toList();
+        assertThat(returnedIds).containsExactlyInAnyOrder(task1Id, task2Id, task3Id);
+
+        Map<String, Object> meta = (Map<String, Object>) response.getBody().get("metadata");
+        assertThat(meta).isNotNull();
+        assertThat(((Number) meta.get("totalCount")).intValue()).isEqualTo(3);
+    }
+
+    /**
+     * An {@code in} list above {@link io.kelta.runtime.query.FilterCondition#MAX_IN_LIST_SIZE}
+     * must surface as HTTP 400 from the gateway rather than be silently capped.
+     */
+    @Test
+    void testInOperatorOverCapReturns400() {
+        String token = authHelper.getAdminToken();
+        HttpEntity<Void> request = new HttpEntity<>(authHelper.createAuthHeaders(token));
+
+        StringBuilder csv = new StringBuilder();
+        for (int i = 0; i < 201; i++) {
+            if (i > 0) csv.append(',');
+            csv.append(java.util.UUID.randomUUID());
+        }
+
+        try {
+            ResponseEntity<Map> response = restTemplate.exchange(
+                GATEWAY_URL + "/api/tasks?filter[id][in]=" + csv,
+                HttpMethod.GET,
+                request,
+                Map.class
+            );
+            // Some HTTP clients deliver 4xx as a returned body rather than an
+            // exception — accept either path.
+            assertThat(response.getStatusCode().value())
+                    .isEqualTo(HttpStatus.BAD_REQUEST.value());
+        } catch (org.springframework.web.client.HttpClientErrorException e) {
+            assertThat(e.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        }
     }
 }

--- a/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/query/FilterCondition.java
+++ b/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/query/FilterCondition.java
@@ -1,18 +1,23 @@
 package io.kelta.runtime.query;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
 /**
  * Represents a filter condition for query filtering.
- * 
+ *
  * <p>Filter conditions are specified in the query using the format:
  * {@code filter[field][operator]=value}
- * 
+ *
  * <h2>Supported Operators</h2>
  * <ul>
  *   <li>{@code eq} - equals</li>
@@ -29,19 +34,39 @@ import java.util.regex.Pattern;
  *   <li>{@code istarts} - starts with (case-insensitive)</li>
  *   <li>{@code iends} - ends with (case-insensitive)</li>
  *   <li>{@code ieq} - equals (case-insensitive)</li>
+ *   <li>{@code in} (alias {@code any}) - match any of a set of values</li>
  * </ul>
- * 
+ *
+ * <h2>Multi-value lookups</h2>
+ * <p>Use {@code in} (or its alias {@code any}) to match a record against a set
+ * of values in a single query. Two equivalent wire formats are accepted:
+ * <ul>
+ *   <li>Comma-separated: {@code filter[id][in]=a,b,c}</li>
+ *   <li>Repeated key: {@code filter[id][in]=a&filter[id][in]=b&filter[id][in]=c}</li>
+ * </ul>
+ * Both forms produce a single {@code id IN (?, ?, ?)} SQL clause with the
+ * values bound as parameters. The combined list is capped at
+ * {@link #MAX_IN_LIST_SIZE} per condition; over-cap requests fail with
+ * {@link InvalidFilterException} (HTTP 400).
+ *
+ * <p><b>{@code eq} treats commas as literal characters.</b> A request like
+ * {@code filter[name][eq]=Smith,John} matches the single literal string
+ * {@code "Smith,John"} — not two values. Use {@code in} for multi-value
+ * lookups. This behavior is preserved deliberately so legitimate values
+ * containing commas (display names, descriptions) continue to round-trip.
+ *
  * <h2>Examples</h2>
  * <ul>
  *   <li>{@code filter[status][eq]=active} - status equals "active"</li>
  *   <li>{@code filter[price][gte]=100} - price >= 100</li>
  *   <li>{@code filter[name][icontains]=john} - name contains "john" (case-insensitive)</li>
+ *   <li>{@code filter[id][in]=u1,u2,u3} - id is one of u1, u2, u3</li>
  * </ul>
- * 
+ *
  * @param fieldName the name of the field to filter on
  * @param operator the filter operator
- * @param value the value to compare against
- * 
+ * @param value the value to compare against (a {@link Collection} for {@code in})
+ *
  * @see FilterOperator
  * @since 1.0.0
  */
@@ -54,7 +79,16 @@ public record FilterCondition(
      * Pattern to match filter parameters: filter[fieldName][operator]
      */
     private static final Pattern FILTER_PATTERN = Pattern.compile("filter\\[([^\\]]+)\\]\\[([^\\]]+)\\]");
-    
+
+    /**
+     * Maximum number of values accepted in a single {@code IN}/{@code ANY}
+     * list. Exceeding this throws {@link InvalidFilterException}, which the
+     * gateway maps to HTTP 400. The cap exists so an untrusted caller can't
+     * synthesize an arbitrarily large {@code IN (?, ?, …)} clause and exhaust
+     * the JDBC parameter budget or planner.
+     */
+    public static final int MAX_IN_LIST_SIZE = 200;
+
     /**
      * Compact constructor with validation.
      */
@@ -66,10 +100,10 @@ public record FilterCondition(
         Objects.requireNonNull(operator, "operator cannot be null");
         // value can be null for ISNULL operator
     }
-    
+
     /**
      * Creates a filter condition for equality.
-     * 
+     *
      * @param fieldName the field name
      * @param value the value to match
      * @return a new FilterCondition with EQ operator
@@ -77,10 +111,10 @@ public record FilterCondition(
     public static FilterCondition eq(String fieldName, Object value) {
         return new FilterCondition(fieldName, FilterOperator.EQ, value);
     }
-    
+
     /**
      * Creates a filter condition for not equals.
-     * 
+     *
      * @param fieldName the field name
      * @param value the value to not match
      * @return a new FilterCondition with NEQ operator
@@ -88,10 +122,10 @@ public record FilterCondition(
     public static FilterCondition neq(String fieldName, Object value) {
         return new FilterCondition(fieldName, FilterOperator.NEQ, value);
     }
-    
+
     /**
      * Creates a filter condition for greater than.
-     * 
+     *
      * @param fieldName the field name
      * @param value the value to compare against
      * @return a new FilterCondition with GT operator
@@ -99,10 +133,10 @@ public record FilterCondition(
     public static FilterCondition gt(String fieldName, Object value) {
         return new FilterCondition(fieldName, FilterOperator.GT, value);
     }
-    
+
     /**
      * Creates a filter condition for less than.
-     * 
+     *
      * @param fieldName the field name
      * @param value the value to compare against
      * @return a new FilterCondition with LT operator
@@ -110,10 +144,10 @@ public record FilterCondition(
     public static FilterCondition lt(String fieldName, Object value) {
         return new FilterCondition(fieldName, FilterOperator.LT, value);
     }
-    
+
     /**
      * Creates a filter condition for is null check.
-     * 
+     *
      * @param fieldName the field name
      * @param isNull true to check for null, false to check for not null
      * @return a new FilterCondition with ISNULL operator
@@ -121,10 +155,10 @@ public record FilterCondition(
     public static FilterCondition isNull(String fieldName, boolean isNull) {
         return new FilterCondition(fieldName, FilterOperator.ISNULL, isNull);
     }
-    
+
     /**
      * Creates a filter condition for contains (case-sensitive).
-     * 
+     *
      * @param fieldName the field name
      * @param value the substring to search for
      * @return a new FilterCondition with CONTAINS operator
@@ -132,10 +166,10 @@ public record FilterCondition(
     public static FilterCondition contains(String fieldName, String value) {
         return new FilterCondition(fieldName, FilterOperator.CONTAINS, value);
     }
-    
+
     /**
      * Creates a filter condition for contains (case-insensitive).
-     * 
+     *
      * @param fieldName the field name
      * @param value the substring to search for
      * @return a new FilterCondition with ICONTAINS operator
@@ -143,45 +177,131 @@ public record FilterCondition(
     public static FilterCondition icontains(String fieldName, String value) {
         return new FilterCondition(fieldName, FilterOperator.ICONTAINS, value);
     }
-    
+
     /**
-     * Parses filter conditions from HTTP query parameters.
-     * 
-     * <p>Looks for parameters matching the pattern {@code filter[field][operator]=value}.
-     * 
+     * Creates a filter condition for IN matching against a set of values.
+     *
+     * @param fieldName the field name
+     * @param values the candidate values
+     * @return a new FilterCondition with IN operator
+     */
+    public static FilterCondition in(String fieldName, Collection<?> values) {
+        return new FilterCondition(fieldName, FilterOperator.IN, List.copyOf(values));
+    }
+
+    /**
+     * Parses filter conditions from HTTP query parameters that may contain
+     * repeated keys (e.g. {@code filter[id][in]=a&filter[id][in]=b}).
+     *
+     * <p>Behavior:
+     * <ul>
+     *   <li>{@code in}/{@code any}: all repeated values are merged, each value
+     *       is additionally split on {@code ,}, blanks are trimmed and dropped,
+     *       and the result is de-duplicated. Yields a single
+     *       {@link FilterCondition} whose value is a {@link List}.</li>
+     *   <li>All other operators: the last value wins (matches Spring's
+     *       single-value {@code @RequestParam Map} semantics) and the raw
+     *       string is passed through.</li>
+     * </ul>
+     *
      * @param params the HTTP query parameters
      * @return list of filter conditions, or empty list if none found
+     * @throws InvalidFilterException if an operator is unrecognized, an
+     *         {@code in} list is blank, or the {@code in} list exceeds
+     *         {@link #MAX_IN_LIST_SIZE}
+     */
+    public static List<FilterCondition> fromParams(MultiValueMap<String, String> params) {
+        if (params == null || params.isEmpty()) {
+            return List.of();
+        }
+
+        List<FilterCondition> filters = new ArrayList<>();
+
+        for (Map.Entry<String, List<String>> entry : params.entrySet()) {
+            Matcher matcher = FILTER_PATTERN.matcher(entry.getKey());
+            if (!matcher.matches()) {
+                continue;
+            }
+            String fieldName = matcher.group(1);
+            String operatorToken = matcher.group(2).toUpperCase();
+
+            FilterOperator operator = resolveOperator(fieldName, operatorToken);
+            List<String> rawValues = entry.getValue();
+
+            if (operator == FilterOperator.IN) {
+                List<String> values = collectInValues(fieldName, rawValues);
+                filters.add(new FilterCondition(fieldName, operator, values));
+            } else {
+                String value = (rawValues == null || rawValues.isEmpty())
+                        ? null
+                        : rawValues.get(rawValues.size() - 1);
+                Object parsedValue = parseValue(value, operator);
+                filters.add(new FilterCondition(fieldName, operator, parsedValue));
+            }
+        }
+
+        return List.copyOf(filters);
+    }
+
+    /**
+     * Backwards-compatible adapter for callers that only have a single-value
+     * map (no repeated keys). Internal services that don't go through the
+     * gateway use this — e.g. {@code BulkOperationService}.
      */
     public static List<FilterCondition> fromParams(Map<String, String> params) {
         if (params == null || params.isEmpty()) {
             return List.of();
         }
-        
-        List<FilterCondition> filters = new ArrayList<>();
-        
-        for (Map.Entry<String, String> entry : params.entrySet()) {
-            Matcher matcher = FILTER_PATTERN.matcher(entry.getKey());
-            if (matcher.matches()) {
-                String fieldName = matcher.group(1);
-                String operatorStr = matcher.group(2).toUpperCase();
-                String value = entry.getValue();
-                
-                try {
-                    FilterOperator operator = FilterOperator.valueOf(operatorStr);
-                    Object parsedValue = parseValue(value, operator);
-                    filters.add(new FilterCondition(fieldName, operator, parsedValue));
-                } catch (IllegalArgumentException e) {
-                    // Unknown operator, skip this filter
+        MultiValueMap<String, String> multi = new LinkedMultiValueMap<>(params.size());
+        for (Map.Entry<String, String> e : params.entrySet()) {
+            multi.add(e.getKey(), e.getValue());
+        }
+        return fromParams(multi);
+    }
+
+    private static FilterOperator resolveOperator(String fieldName, String operatorToken) {
+        if ("ANY".equals(operatorToken)) {
+            return FilterOperator.IN;
+        }
+        try {
+            return FilterOperator.valueOf(operatorToken);
+        } catch (IllegalArgumentException e) {
+            throw new InvalidFilterException(
+                    fieldName, "unknown filter operator '" + operatorToken.toLowerCase() + "'");
+        }
+    }
+
+    private static List<String> collectInValues(String fieldName, List<String> rawValues) {
+        if (rawValues == null || rawValues.isEmpty()) {
+            throw new InvalidFilterException(fieldName, "'in' filter requires at least one value");
+        }
+        LinkedHashSet<String> deduped = new LinkedHashSet<>();
+        for (String raw : rawValues) {
+            if (raw == null) {
+                continue;
+            }
+            for (String part : raw.split(",")) {
+                String trimmed = part.trim();
+                if (!trimmed.isEmpty()) {
+                    deduped.add(trimmed);
                 }
             }
         }
-        
-        return List.copyOf(filters);
+        if (deduped.isEmpty()) {
+            throw new InvalidFilterException(fieldName, "'in' filter requires at least one non-blank value");
+        }
+        if (deduped.size() > MAX_IN_LIST_SIZE) {
+            throw new InvalidFilterException(
+                    fieldName,
+                    "'in' filter accepts at most " + MAX_IN_LIST_SIZE
+                            + " values, got " + deduped.size());
+        }
+        return List.copyOf(deduped);
     }
-    
+
     /**
      * Parses the filter value based on the operator.
-     * 
+     *
      * @param value the string value
      * @param operator the filter operator
      * @return the parsed value

--- a/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/query/InvalidFilterException.java
+++ b/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/query/InvalidFilterException.java
@@ -1,0 +1,18 @@
+package io.kelta.runtime.query;
+
+/**
+ * Thrown when a {@code filter[...]} query parameter cannot be parsed: unknown
+ * operator, blank value, or an {@code IN}/{@code ANY} list that exceeds
+ * {@link FilterCondition#MAX_IN_LIST_SIZE}. Extends {@link InvalidQueryException}
+ * so the gateway error handler maps it to HTTP 400 with no extra wiring.
+ */
+public class InvalidFilterException extends InvalidQueryException {
+
+    public InvalidFilterException(String message) {
+        super(message);
+    }
+
+    public InvalidFilterException(String fieldName, String reason) {
+        super(fieldName, reason);
+    }
+}

--- a/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/query/QueryRequest.java
+++ b/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/query/QueryRequest.java
@@ -4,6 +4,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import org.springframework.util.MultiValueMap;
+
 /**
  * Represents a query request with pagination, sorting, field selection, and filtering.
  * 
@@ -69,6 +71,26 @@ public record QueryRequest(
         Pagination pagination = Pagination.fromParams(params);
         List<SortField> sorting = SortField.fromParams(params.get("sort"));
         List<String> fields = parseFields(resolveFieldsParam(params));
+        List<FilterCondition> filters = FilterCondition.fromParams(params);
+
+        return new QueryRequest(pagination, sorting, fields, filters);
+    }
+
+    /**
+     * Variant of {@link #fromParams(Map)} that preserves repeated query
+     * parameters — needed so {@code filter[id][in]=a&filter[id][in]=b} is read
+     * as a list rather than collapsing to the last value. Scalar parameters
+     * (page, sort, fields, include) read the first value via
+     * {@link MultiValueMap#getFirst(Object)}.
+     *
+     * @param params the HTTP query parameters as a multi-value map
+     * @return a new QueryRequest parsed from the parameters
+     */
+    public static QueryRequest fromParams(MultiValueMap<String, String> params) {
+        Map<String, String> single = params != null ? params.toSingleValueMap() : Map.of();
+        Pagination pagination = Pagination.fromParams(single);
+        List<SortField> sorting = SortField.fromParams(single.get("sort"));
+        List<String> fields = parseFields(resolveFieldsParam(single));
         List<FilterCondition> filters = FilterCondition.fromParams(params);
 
         return new QueryRequest(pagination, sorting, fields, filters);

--- a/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/router/DynamicCollectionRouter.java
+++ b/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/router/DynamicCollectionRouter.java
@@ -20,6 +20,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.ArrayList;
@@ -155,7 +156,7 @@ public class DynamicCollectionRouter {
     @GetMapping("/{collectionName}")
     public ResponseEntity<Map<String, Object>> list(
             @PathVariable("collectionName") String collectionName,
-            @RequestParam(required = false) Map<String, String> params,
+            @RequestParam(required = false) MultiValueMap<String, String> params,
             HttpServletRequest request) {
 
         logger.debug("List request for collection '{}' with params: {}", collectionName, params);
@@ -227,7 +228,7 @@ public class DynamicCollectionRouter {
     public ResponseEntity<Map<String, Object>> get(
             @PathVariable("collectionName") String collectionName,
             @PathVariable("id") String id,
-            @RequestParam(required = false) Map<String, String> params,
+            @RequestParam(required = false) MultiValueMap<String, String> params,
             HttpServletRequest request) {
 
         logger.debug("Get request for collection '{}', id '{}'", collectionName, id);
@@ -520,7 +521,7 @@ public class DynamicCollectionRouter {
             @PathVariable("parentName") String parentName,
             @PathVariable("parentId") String parentId,
             @PathVariable("childName") String childName,
-            @RequestParam(required = false) Map<String, String> params,
+            @RequestParam(required = false) MultiValueMap<String, String> params,
             HttpServletRequest request) {
 
         logger.debug("List children request: parent='{}', parentId='{}', child='{}'",
@@ -1264,7 +1265,7 @@ public class DynamicCollectionRouter {
     private Map<String, Object> toJsonApiListResponse(QueryResult result, String type,
                                                        CollectionDefinition definition,
                                                        String requestPath,
-                                                       Map<String, String> params) {
+                                                       MultiValueMap<String, String> params) {
         List<Map<String, Object>> jsonApiData = new ArrayList<>();
         for (Map<String, Object> record : result.data()) {
             jsonApiData.add(toJsonApiResourceObject(record, type, definition));
@@ -1296,7 +1297,7 @@ public class DynamicCollectionRouter {
         response.put("metadata", metadata);
         response.put("links", PaginationLinks.build(
             requestPath,
-            params,
+            params != null ? params.toSingleValueMap() : null,
             result.metadata().currentPage(),
             effectivePageSize,
             result.metadata().totalPages()
@@ -1310,11 +1311,11 @@ public class DynamicCollectionRouter {
      * {@link Pagination#fromParams(Map)} clamped the caller's value so the
      * response can echo what was originally requested.
      */
-    private Integer parseRequestedPageSize(Map<String, String> params) {
+    private Integer parseRequestedPageSize(MultiValueMap<String, String> params) {
         if (params == null) {
             return null;
         }
-        String raw = params.get("page[size]");
+        String raw = params.getFirst("page[size]");
         if (raw == null || raw.isBlank()) {
             return null;
         }
@@ -1333,11 +1334,11 @@ public class DynamicCollectionRouter {
      * @param params the query parameters
      * @return list of include names, or empty list if not present
      */
-    private List<String> parseIncludeParam(Map<String, String> params) {
+    private List<String> parseIncludeParam(MultiValueMap<String, String> params) {
         if (params == null) {
             return List.of();
         }
-        String includeParam = params.get("include");
+        String includeParam = params.getFirst("include");
         if (includeParam == null || includeParam.isBlank()) {
             return List.of();
         }

--- a/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/storage/PhysicalTableStorageAdapter.java
+++ b/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/storage/PhysicalTableStorageAdapter.java
@@ -912,10 +912,22 @@ public class PhysicalTableStorageAdapter implements StorageAdapter {
         FilterOperator operator = filter.operator();
         Object value = filter.value();
 
-        // Coerce string filter values to match the field's database type (e.g., "false" → Boolean.FALSE)
+        // Coerce string filter values to match the field's database type (e.g., "false" → Boolean.FALSE).
+        // For IN/ANY the value is a Collection<String>; coerce each element so UUID columns receive
+        // java.util.UUID rather than the raw string.
         FieldDefinition fieldDef = definition.getField(filter.fieldName());
-        if (fieldDef != null && value instanceof String) {
-            value = TypeCoercionService.coerceValue(value, fieldDef.type());
+        if (fieldDef != null) {
+            if (value instanceof String) {
+                value = TypeCoercionService.coerceValue(value, fieldDef.type());
+            } else if (value instanceof Collection<?> coll) {
+                List<Object> coerced = new ArrayList<>(coll.size());
+                for (Object element : coll) {
+                    coerced.add(element instanceof String s
+                            ? TypeCoercionService.coerceValue(s, fieldDef.type())
+                            : element);
+                }
+                value = coerced;
+            }
         }
 
         // Detect array-backed columns (Postgres TEXT[]) so we emit ANY(...) /

--- a/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/query/FilterConditionTest.java
+++ b/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/query/FilterConditionTest.java
@@ -1,0 +1,239 @@
+package io.kelta.runtime.query;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests {@link FilterCondition#fromParams(MultiValueMap)} — the only path that
+ * understands the {@code in}/{@code any} operator and merges repeated query
+ * params. The single-value {@link FilterCondition#fromParams(java.util.Map)}
+ * adapter is exercised via {@link QueryRequestWithFiltersTest}.
+ */
+class FilterConditionTest {
+
+    private static MultiValueMap<String, String> params() {
+        return new LinkedMultiValueMap<>();
+    }
+
+    @Nested
+    @DisplayName("IN operator (and ANY alias)")
+    class InOperator {
+
+        @Test
+        void csvProducesSingleConditionWithListValue() {
+            MultiValueMap<String, String> p = params();
+            p.add("filter[id][in]", "a,b,c");
+
+            List<FilterCondition> filters = FilterCondition.fromParams(p);
+
+            assertEquals(1, filters.size());
+            FilterCondition c = filters.get(0);
+            assertEquals("id", c.fieldName());
+            assertEquals(FilterOperator.IN, c.operator());
+            Collection<?> value = assertInstanceOf(Collection.class, c.value());
+            assertEquals(List.of("a", "b", "c"), List.copyOf(value));
+        }
+
+        @Test
+        void repeatedParamsAreMerged() {
+            MultiValueMap<String, String> p = params();
+            p.add("filter[id][in]", "a");
+            p.add("filter[id][in]", "b");
+
+            List<FilterCondition> filters = FilterCondition.fromParams(p);
+
+            assertEquals(1, filters.size());
+            Collection<?> value = (Collection<?>) filters.get(0).value();
+            assertEquals(List.of("a", "b"), List.copyOf(value));
+        }
+
+        @Test
+        void csvAndRepeatedParamsCombine() {
+            MultiValueMap<String, String> p = params();
+            p.add("filter[id][in]", "a,b");
+            p.add("filter[id][in]", "c");
+
+            Collection<?> value = (Collection<?>) FilterCondition.fromParams(p).get(0).value();
+            assertEquals(List.of("a", "b", "c"), List.copyOf(value));
+        }
+
+        @Test
+        void duplicatesAreDeduped() {
+            MultiValueMap<String, String> p = params();
+            p.add("filter[id][in]", "a,b,a");
+            p.add("filter[id][in]", "b");
+
+            Collection<?> value = (Collection<?>) FilterCondition.fromParams(p).get(0).value();
+            assertEquals(List.of("a", "b"), List.copyOf(value));
+        }
+
+        @Test
+        void anyAliasResolvesToIn() {
+            MultiValueMap<String, String> p = params();
+            p.add("filter[id][any]", "a,b");
+
+            FilterCondition c = FilterCondition.fromParams(p).get(0);
+            assertEquals(FilterOperator.IN, c.operator());
+            assertEquals(List.of("a", "b"), List.copyOf((Collection<?>) c.value()));
+        }
+
+        @Test
+        void uppercaseOperatorTokenAccepted() {
+            MultiValueMap<String, String> p = params();
+            p.add("filter[id][IN]", "a,b");
+
+            FilterCondition c = FilterCondition.fromParams(p).get(0);
+            assertEquals(FilterOperator.IN, c.operator());
+        }
+
+        @Test
+        void blankAndWhitespaceValuesDropped() {
+            MultiValueMap<String, String> p = params();
+            p.add("filter[id][in]", " a , , b ");
+
+            Collection<?> value = (Collection<?>) FilterCondition.fromParams(p).get(0).value();
+            assertEquals(List.of("a", "b"), List.copyOf(value));
+        }
+
+        @Test
+        void emptyValueThrows400() {
+            MultiValueMap<String, String> p = params();
+            p.add("filter[id][in]", "");
+
+            InvalidFilterException ex = assertThrows(
+                    InvalidFilterException.class,
+                    () -> FilterCondition.fromParams(p));
+            assertTrue(ex.getMessage().contains("id"));
+            assertTrue(ex.getMessage().contains("in"));
+        }
+
+        @Test
+        void overCapThrows400() {
+            MultiValueMap<String, String> p = params();
+            StringBuilder csv = new StringBuilder();
+            for (int i = 0; i < FilterCondition.MAX_IN_LIST_SIZE + 1; i++) {
+                if (i > 0) csv.append(',');
+                csv.append(UUID.randomUUID());
+            }
+            p.add("filter[id][in]", csv.toString());
+
+            InvalidFilterException ex = assertThrows(
+                    InvalidFilterException.class,
+                    () -> FilterCondition.fromParams(p));
+            assertTrue(ex.getMessage().contains(String.valueOf(FilterCondition.MAX_IN_LIST_SIZE)));
+        }
+
+        @Test
+        void exactlyAtCapIsAccepted() {
+            MultiValueMap<String, String> p = params();
+            StringBuilder csv = new StringBuilder();
+            for (int i = 0; i < FilterCondition.MAX_IN_LIST_SIZE; i++) {
+                if (i > 0) csv.append(',');
+                csv.append(UUID.randomUUID());
+            }
+            p.add("filter[id][in]", csv.toString());
+
+            Collection<?> value = (Collection<?>) FilterCondition.fromParams(p).get(0).value();
+            assertEquals(FilterCondition.MAX_IN_LIST_SIZE, value.size());
+        }
+    }
+
+    @Nested
+    @DisplayName("Other operators")
+    class OtherOperators {
+
+        @Test
+        void eqWithCommaIsTreatedAsSingleLiteral() {
+            // Documented behavior — values containing commas (e.g. "Smith, John")
+            // must round-trip through EQ unchanged. Callers wanting multi-value
+            // semantics use the IN operator.
+            MultiValueMap<String, String> p = params();
+            p.add("filter[name][eq]", "Smith, John");
+
+            List<FilterCondition> filters = FilterCondition.fromParams(p);
+            assertEquals(1, filters.size());
+            assertEquals(FilterOperator.EQ, filters.get(0).operator());
+            assertEquals("Smith, John", filters.get(0).value());
+        }
+
+        @Test
+        void unknownOperatorThrows400() {
+            MultiValueMap<String, String> p = params();
+            p.add("filter[name][eqq]", "x");
+
+            InvalidFilterException ex = assertThrows(
+                    InvalidFilterException.class,
+                    () -> FilterCondition.fromParams(p));
+            assertTrue(ex.getMessage().contains("eqq"));
+            assertTrue(ex.getMessage().contains("name"));
+        }
+
+        @Test
+        void repeatedScalarOperatorTakesLastValue() {
+            // Matches Spring's @RequestParam Map<String, String> semantics that
+            // existing callers were built against.
+            MultiValueMap<String, String> p = params();
+            p.add("filter[name][eq]", "first");
+            p.add("filter[name][eq]", "second");
+
+            FilterCondition c = FilterCondition.fromParams(p).get(0);
+            assertEquals("second", c.value());
+        }
+
+        @Test
+        void nonFilterKeysAreIgnored() {
+            MultiValueMap<String, String> p = params();
+            p.add("page[size]", "10");
+            p.add("sort", "name");
+            p.add("filter[name][eq]", "x");
+
+            List<FilterCondition> filters = FilterCondition.fromParams(p);
+            assertEquals(1, filters.size());
+            assertEquals("name", filters.get(0).fieldName());
+        }
+
+        @Test
+        void emptyMapReturnsEmpty() {
+            assertEquals(List.of(), FilterCondition.fromParams(params()));
+        }
+
+        @Test
+        void nullMapReturnsEmpty() {
+            assertEquals(List.of(), FilterCondition.fromParams((MultiValueMap<String, String>) null));
+        }
+    }
+
+    @Nested
+    @DisplayName("Single-value Map adapter (legacy callers)")
+    class SingleValueMapAdapter {
+
+        @Test
+        void delegatesToMultiValuePath() {
+            List<FilterCondition> filters = FilterCondition.fromParams(
+                    java.util.Map.of("filter[id][in]", "a,b,c"));
+
+            assertEquals(1, filters.size());
+            assertEquals(FilterOperator.IN, filters.get(0).operator());
+            assertEquals(List.of("a", "b", "c"),
+                    List.copyOf((Collection<?>) filters.get(0).value()));
+        }
+
+        @Test
+        void unknownOperatorStillThrows() {
+            assertThrows(InvalidFilterException.class,
+                    () -> FilterCondition.fromParams(java.util.Map.of("filter[x][nope]", "y")));
+        }
+    }
+}

--- a/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/storage/PhysicalTableStorageAdapterTest.java
+++ b/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/storage/PhysicalTableStorageAdapterTest.java
@@ -678,12 +678,75 @@ class PhysicalTableStorageAdapterTest {
             );
             
             QueryResult result = adapter.query(testCollection, request);
-            
+
             // Apple (1.99, active), Date (5.99, active)
             assertEquals(2, result.data().size());
         }
+
+        @Test
+        @DisplayName("Should filter with IN operator returning all matches in one query")
+        void shouldFilterWithInOperator() {
+            QueryRequest request = new QueryRequest(
+                Pagination.defaults(),
+                List.of(),
+                List.of(),
+                List.of(new FilterCondition("name", FilterOperator.IN,
+                        List.of("Apple", "Cherry", "Elderberry")))
+            );
+
+            QueryResult result = adapter.query(testCollection, request);
+
+            assertEquals(3, result.data().size());
+            assertEquals(3L, result.metadata().totalCount());
+        }
+
+        @Test
+        @DisplayName("IN with a single value matches one row")
+        void inSingleValue() {
+            QueryRequest request = new QueryRequest(
+                Pagination.defaults(),
+                List.of(),
+                List.of(),
+                List.of(new FilterCondition("name", FilterOperator.IN, List.of("Banana")))
+            );
+
+            QueryResult result = adapter.query(testCollection, request);
+            assertEquals(1, result.data().size());
+            assertEquals("Banana", result.data().get(0).get("NAME"));
+        }
+
+        @Test
+        @DisplayName("IN with an empty list yields zero rows (1=0 short-circuit)")
+        void inEmptyList() {
+            QueryRequest request = new QueryRequest(
+                Pagination.defaults(),
+                List.of(),
+                List.of(),
+                List.of(new FilterCondition("name", FilterOperator.IN, List.of()))
+            );
+
+            QueryResult result = adapter.query(testCollection, request);
+            assertEquals(0, result.data().size());
+            assertEquals(0L, result.metadata().totalCount());
+        }
+
+        @Test
+        @DisplayName("IN on integer field coerces string elements to integers")
+        void inCoercesNumericElements() {
+            QueryRequest request = new QueryRequest(
+                Pagination.defaults(),
+                List.of(),
+                List.of(),
+                List.of(new FilterCondition("quantity", FilterOperator.IN,
+                        List.of("100", "30")))
+            );
+
+            QueryResult result = adapter.query(testCollection, request);
+            // Apple (100) and Date (30)
+            assertEquals(2, result.data().size());
+        }
     }
-    
+
     @Nested
     @DisplayName("Uniqueness Tests")
     class UniquenessTests {


### PR DESCRIPTION
## Summary

- New `in` operator (alias `any`) on the filter grammar — multi-id lookups in **one** parameterized query instead of N sequential GETs (e.g. couchpicks' `getTitlesByIds` page fan-out).
- Both wire formats work: `filter[id][in]=a,b,c` and `filter[id][in]=a&filter[id][in]=b`.
- Cap at 200 values per condition; unknown operators now return **400** instead of being silently skipped.
- Values are parameterized via PreparedStatement (`IN (?, ?, …)`) and per-element type-coerced — UUID/integer columns receive the right Java type.
- `eq` is documented to treat commas as literal characters (no breaking change for values like "Smith, John").

### What changed

| Layer | Change |
|------|--------|
| `FilterCondition` | New `fromParams(MultiValueMap)` overload; `IN`/`ANY` parser with CSV split + repeated-param merge + dedup + cap; unknown operators now throw `InvalidFilterException` |
| `QueryRequest` | New `fromParams(MultiValueMap)` overload; scalar params read via `getFirst` |
| `DynamicCollectionRouter` | Three `@RequestParam` sites switched to `MultiValueMap`; helper methods updated |
| `PhysicalTableStorageAdapter` | Collection-typed filter values get per-element type coercion |
| `InvalidFilterException` | New, extends `InvalidQueryException` → gateway error handler already maps to 400 |

### Out of scope

- SQL form kept as `IN (?, ?, …)` rather than `= ANY(?::uuid[])` — both are parameterized; the array form needs a params-binding refactor and wasn't worth the blast radius here.
- Updating the `couchpicks` consumer (lives outside this repo).

## Test plan

- [x] `FilterConditionTest` — 18 new unit tests covering CSV, repeated params, ANY alias, blanks, dedup, cap boundary, EQ literal-comma behavior, unknown-operator 400
- [x] `PhysicalTableStorageAdapterTest` — IN against H2 returns expected rows + totalCount; numeric coercion verified
- [x] `RelatedCollectionsIntegrationTest` — gateway integration: `filter[id][in]=u1,u2,u3` returns all rows, `metadata.totalCount` correct; 201-value list returns 400
- [x] Full `runtime-core` suite: **1307 tests pass**
- [x] Full `kelta-gateway` build/tests pass
- [x] Full `kelta-worker` suite: **1238 tests pass**
- [x] `kelta-web` lint + typecheck + format + 870 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)