### PR TITLE
chore(runtime): remove unused spring-kafka dependency

### DIFF
--- a/.claude/docs/concerns.md
+++ b/.claude/docs/concerns.md
@@ -40,6 +40,7 @@ at the bottom so reviewers can see what's already been addressed.
 ## Dependency Risks
 
 - Multiple BOM version overrides in worker POM increase transitive conflict risk (`kelta-worker/pom.xml`). Audit on every Spring Boot bump.
+- **Stale `spring-kafka` dependency retired** (Phase 0): `runtime-core/pom.xml` previously declared `spring-kafka`, `spring-kafka-test`, and `testcontainers-kafka` despite the platform using NATS JetStream exclusively. Removed; the misnamed `KafkaRecordEventPublisher` was renamed to `NatsRecordEventPublisher`. Remaining `Kafka`-worded comments across `kelta-worker`/`kelta-gateway`/`runtime` are cosmetic Kafka→NATS migration debt (the listeners are NATS, not Kafka) — slated for a separate doc-cleanup sweep.
 
 ## Postgres max_connections sizing
 

--- a/kelta-platform/runtime/runtime-core/pom.xml
+++ b/kelta-platform/runtime/runtime-core/pom.xml
@@ -56,12 +56,6 @@
             <scope>runtime</scope>
         </dependency>
         
-        <!-- Spring Kafka -->
-        <dependency>
-            <groupId>org.springframework.kafka</groupId>
-            <artifactId>spring-kafka</artifactId>
-        </dependency>
-        
         <!-- Spring Data Redis -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -108,13 +102,6 @@
             <scope>test</scope>
         </dependency>
         
-        <!-- Spring Kafka Test -->
-        <dependency>
-            <groupId>org.springframework.kafka</groupId>
-            <artifactId>spring-kafka-test</artifactId>
-            <scope>test</scope>
-        </dependency>
-        
         <!-- Testcontainers -->
         <dependency>
             <groupId>org.testcontainers</groupId>
@@ -124,11 +111,6 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>postgresql</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.testcontainers</groupId>
-            <artifactId>kafka</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/kelta-worker/src/main/java/io/kelta/worker/event/NatsRecordEventPublisher.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/event/NatsRecordEventPublisher.java
@@ -23,15 +23,15 @@ import org.springframework.stereotype.Component;
  * @since 1.0.0
  */
 @Component
-public class KafkaRecordEventPublisher implements RecordEventPublisher {
+public class NatsRecordEventPublisher implements RecordEventPublisher {
 
-    private static final Logger logger = LoggerFactory.getLogger(KafkaRecordEventPublisher.class);
+    private static final Logger logger = LoggerFactory.getLogger(NatsRecordEventPublisher.class);
 
     private static final String SUBJECT_PREFIX = "kelta.record.changed.";
 
     private final PlatformEventPublisher eventPublisher;
 
-    public KafkaRecordEventPublisher(PlatformEventPublisher eventPublisher) {
+    public NatsRecordEventPublisher(PlatformEventPublisher eventPublisher) {
         this.eventPublisher = eventPublisher;
     }
 

--- a/kelta-worker/src/test/java/io/kelta/worker/event/NatsRecordEventPublisherTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/event/NatsRecordEventPublisherTest.java
@@ -15,17 +15,17 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 /**
- * Unit tests for {@link KafkaRecordEventPublisher}.
+ * Unit tests for {@link NatsRecordEventPublisher}.
  */
-class KafkaRecordEventPublisherTest {
+class NatsRecordEventPublisherTest {
 
     private PlatformEventPublisher eventPublisher;
-    private KafkaRecordEventPublisher publisher;
+    private NatsRecordEventPublisher publisher;
 
     @BeforeEach
     void setUp() {
         eventPublisher = mock(PlatformEventPublisher.class);
-        publisher = new KafkaRecordEventPublisher(eventPublisher);
+        publisher = new NatsRecordEventPublisher(eventPublisher);
     }
 
     @Test


### PR DESCRIPTION
## What
Removes the stale `spring-kafka`, `spring-kafka-test`, and `testcontainers-kafka` dependencies from `runtime-core/pom.xml`. The platform uses **NATS JetStream** exclusively (`runtime-messaging-nats`); these Kafka deps had zero usage (no `@KafkaListener`, `KafkaTemplate`, or imports anywhere).

Also renames the misnamed production class `KafkaRecordEventPublisher` → `NatsRecordEventPublisher` (and its test) — it implements the NATS-based `RecordEventPublisher`, injected only by interface, so the rename is contained to those two files.

## Why
Phase 0 hardening (strategic roadmap): retire dead dependencies to shrink the dependency surface and remove a misleading identifier before scale.

## Scope note
~50 remaining `Kafka`-worded **comments** across `kelta-worker`/`kelta-gateway`/`runtime` are cosmetic Kafka→NATS migration debt (the listeners are NATS). Left for a separate doc-cleanup sweep to keep this diff focused.

## Tests
- `NatsRecordEventPublisherTest`: 4/4 pass.
- `runtime-core` builds clean with deps removed; no code referenced the removed test artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)