### PR TITLE
feat(attachments): complete S3 attachment lifecycle

### DIFF
--- a/.claude/docs/integrations.md
+++ b/.claude/docs/integrations.md
@@ -11,6 +11,15 @@
 | AWS S3 / Garage | Object storage | `aws-sdk-s3` 2.30.1 | `${KELTA_S3_ENDPOINT}` | `kelta-worker/.../service/S3StorageService.java` |
 | Keycloak | OIDC federation | Spring Security OAuth2 | Port 8180 (docker-compose) | `kelta-auth/.../federation/FederatedUserMapper.java` |
 
+### Attachment lifecycle (S3)
+
+Files attach to any record via the `attachments` system collection (backed by `file_attachment`, `S3StorageService`). The full lifecycle:
+
+1. **Upload** — `POST /api/attachments/upload-url` validates the file (type/size, per-tenant storage governor), creates a pending row, and returns a presigned S3 PUT URL. The client PUTs the bytes directly to S3, then `POST /api/attachments/{id}/finalize` verifies the object exists and records the storage key. (`AttachmentUploadController`)
+2. **List / read / download** — `attachments` is routed by `DynamicCollectionRouter` like any collection (`GET /api/attachments?filter[collectionId][eq]=…&filter[recordId][eq]=…`, get-by-id, `?include=attachments`). `AttachmentUrlEnricher` (`@ControllerAdvice`, `@ConditionalOnBean(S3StorageService)`) injects a presigned `downloadUrl` for any `attachments` resource with a `storageKey`. `FileController` (`GET /api/files/**`) streams objects server-side with `Range` support.
+3. **Delete** — `DELETE /api/attachments/{id}` (`AttachmentUploadController#deleteAttachment`) deletes the S3 object **and** the row. Its literal path beats the router's `/api/{collection}/{id}`, so the generic delete (which would orphan the S3 object) is bypassed. S3 deletion is best-effort and never blocks the metadata delete.
+4. **Cascade cleanup** — `AttachmentCleanupHook` (wildcard `afterDelete`, order 200) removes a record's `file_attachment` rows + S3 objects when the **parent** record is deleted. Lookup uses `idx_attachment_tenant_record` (Flyway V142). The `attachments` collection itself is skipped (handled by the dedicated delete above). S3 cleanup is gated on `S3StorageService.isEnabled()`; row cleanup always runs.
+
 ## Data Storage
 
 | Store | Purpose | Config Key | Details |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -427,17 +427,18 @@ Support for collection subtypes with type-specific picklist values and page layo
 
 ---
 
-### Notes & Attachments | Partial
+### Notes & Attachments | Full
 
 Attach notes and files to any record in the system.
 
 **Working:**
 - Notes: Full CRUD via standard collection API
-- Attachments: S3 presigned download URLs generated via `S3Presigner`, automatically enriched in JSON:API responses via `@ControllerAdvice`
+- Attachments — full lifecycle:
+  - **Upload**: presigned PUT flow — `POST /api/attachments/upload-url` (validates type/size, enforces the per-tenant storage governor, returns a presigned `S3Presigner` PUT URL) → client PUTs to S3 → `POST /api/attachments/{id}/finalize`
+  - **List / read**: `attachments` is a system collection, so list/get/filter come from `DynamicCollectionRouter` (e.g. `GET /api/attachments?filter[collectionId][eq]=…&filter[recordId][eq]=…`); presigned download URLs are auto-injected by `AttachmentUrlEnricher` (`@ControllerAdvice`)
+  - **Delete**: `DELETE /api/attachments/{id}` (dedicated handler that overrides the generic router delete) removes the S3 object **and** the metadata row, so storage is never orphaned
+  - **Cascade cleanup**: `AttachmentCleanupHook` (wildcard after-delete) removes a record's attachments (rows + S3 objects) when the parent record is deleted
 - Relationship includes: `?include=attachments` and `?include=notes` supported
-
-> **TODO**
-> - No upload endpoint: `S3StorageService` only generates presigned download URLs — no presigned PUT URL or multipart upload handler
 
 ---
 
@@ -570,7 +571,7 @@ What SMB and larger enterprises need from an application platform, and where Kel
 | **Report Execution** | Full UI built, config stored | Query engine to execute report definitions, export to CSV/PDF |
 | **OAuth Server (Connected Apps)** | Client credentials flow working | Full authorization code flow for third-party apps |
 | **Server-Side Scripting** | SPI defined, no-op implementation | GraalVM or equivalent script engine |
-| **File Uploads** | S3 download URLs + direct file serving work | Presigned PUT URL generation, upload endpoint |
+| **File Uploads** | Full lifecycle: presigned PUT upload + finalize, list/download (router + enricher), delete with S3 cleanup, cascade cleanup on record delete | Optional: virus scanning, multipart fallback |
 | **Configuration Packages** | Full UI built | Backend export/import/preview/history endpoints |
 | **Record Type Enforcement** | Data model and UI exist | Runtime picklist restriction and layout association |
 | **Push Notifications** | SPI + device registration working | Wire FCM, APNs, or other push provider |
@@ -603,7 +604,7 @@ What SMB and larger enterprises need from an application platform, and where Kel
 ### Medium Priority — Integration & Data Gaps
 
 - [ ] **Script execution**: Implement a real `ScriptExecutor` (GraalVM or similar) to replace the no-op logging stub
-- [ ] **Attachment uploads**: Add presigned PUT URL generation to `S3StorageService` and expose an upload endpoint
+- [x] **Attachment lifecycle**: Presigned PUT upload + finalize, list/download (router + `AttachmentUrlEnricher`), `DELETE /api/attachments/{id}` with S3 object cleanup, and `AttachmentCleanupHook` cascade cleanup on parent-record delete
 - [ ] **Configuration packages backend**: Implement `PackageController` and `PackageService` with export, import preview, import, and history endpoints
 - [ ] **Scheduled job runner (general)**: Build a dispatcher for SCRIPT and REPORT_EXPORT job types in the `scheduled_jobs` table (flow-type scheduling already works)
 - [ ] **Page Builder fields**: Add `slug` and `published` fields to the `ui-pages` system collection definition

--- a/kelta-worker/src/main/java/io/kelta/worker/config/FlowConfig.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/config/FlowConfig.java
@@ -488,6 +488,17 @@ public class FlowConfig {
     }
 
     @Bean
+    public io.kelta.worker.listener.AttachmentCleanupHook attachmentCleanupHook(
+            BeforeSaveHookRegistry hookRegistry,
+            JdbcTemplate jdbcTemplate,
+            io.kelta.worker.service.S3StorageService storageService) {
+        io.kelta.worker.listener.AttachmentCleanupHook hook =
+                new io.kelta.worker.listener.AttachmentCleanupHook(jdbcTemplate, storageService);
+        hookRegistry.register(hook);
+        return hook;
+    }
+
+    @Bean
     public RecordTypeEnforcementHook recordTypeEnforcementHook(
             BeforeSaveHookRegistry hookRegistry,
             JdbcTemplate jdbcTemplate,

--- a/kelta-worker/src/main/java/io/kelta/worker/controller/AttachmentUploadController.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/controller/AttachmentUploadController.java
@@ -63,6 +63,10 @@ public class AttachmentUploadController {
             FROM file_attachment WHERE id = ? AND tenant_id = ?
             """;
 
+    private static final String DELETE_ATTACHMENT = """
+            DELETE FROM file_attachment WHERE id = ? AND tenant_id = ?
+            """;
+
     private final S3StorageService storageService;
     private final GovernorLimitsRepository governorLimitsRepository;
     private final JdbcTemplate jdbcTemplate;
@@ -256,6 +260,56 @@ public class AttachmentUploadController {
         attributes.put("uploadedAt", OffsetDateTime.now().toString());
 
         return ResponseEntity.ok(JsonApiResponseBuilder.single("attachments", id, attributes));
+    }
+
+    /**
+     * Deletes an attachment: removes the underlying S3 object (if any) and the
+     * attachment metadata record.
+     *
+     * <p>This handler intentionally overrides the generic
+     * {@code DELETE /api/{collection}/{id}} route in {@code DynamicCollectionRouter}
+     * for the {@code attachments} collection. A literal path segment
+     * ({@code /api/attachments/{id}}) is more specific than the router's
+     * {@code /api/{collectionName}/{id}}, so Spring dispatches here. The generic
+     * router delete would drop the database row but orphan the S3 object; this
+     * handler cleans up storage too.
+     *
+     * <p>S3 deletion is best-effort: a storage failure is logged but never blocks
+     * the metadata delete (the row is the source of truth for what the user sees).
+     *
+     * @param id        the attachment ID
+     * @param tenantId  the tenant ID from gateway header
+     * @param userEmail the authenticated user's email
+     * @return 204 No Content on success, 404 if the attachment does not exist
+     */
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteAttachment(
+            @PathVariable String id,
+            @RequestHeader("X-Tenant-ID") String tenantId,
+            @RequestHeader("X-User-Email") String userEmail) {
+
+        List<Map<String, Object>> rows = jdbcTemplate.queryForList(SELECT_ATTACHMENT, id, tenantId);
+        if (rows.isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+
+        String storageKey = (String) rows.get(0).get("storage_key");
+
+        if (storageService.isEnabled() && storageKey != null && !storageKey.isBlank()) {
+            try {
+                storageService.deleteObject(storageKey);
+            } catch (Exception e) {
+                log.warn("Failed to delete S3 object '{}' for attachment {}: {}",
+                        storageKey, id, e.getMessage());
+            }
+        }
+
+        jdbcTemplate.update(DELETE_ATTACHMENT, id, tenantId);
+
+        securityLog.info("security_event=ATTACHMENT_DELETED user={} tenant={} attachment={} storageKey={}",
+                userEmail, tenantId, id, storageKey);
+
+        return ResponseEntity.noContent().build();
     }
 
     private static String sanitizeFileName(String fileName) {

--- a/kelta-worker/src/main/java/io/kelta/worker/listener/AttachmentCleanupHook.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/listener/AttachmentCleanupHook.java
@@ -1,0 +1,111 @@
+package io.kelta.worker.listener;
+
+import io.kelta.runtime.workflow.BeforeSaveHook;
+import io.kelta.worker.service.S3StorageService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Wildcard after-delete hook that cascades attachment cleanup when a record is removed.
+ *
+ * <p>When any record is deleted, this hook removes the record's
+ * {@code file_attachment} rows and deletes their underlying S3 objects so storage
+ * is not orphaned. It runs late (order {@code 200}) so it executes after other
+ * after-delete side effects.
+ *
+ * <p>Direct deletes of attachment records are handled by
+ * {@code AttachmentUploadController#deleteAttachment}, not this hook: {@code afterDelete}
+ * does not provide the deleted row, so the storage key cannot be recovered after the
+ * fact. This hook covers the <em>parent</em> record case, where the
+ * {@code file_attachment} rows still exist at delete time and can be looked up by
+ * {@code record_id}. The {@code attachments} collection is therefore skipped here.
+ *
+ * @since 1.0.0
+ */
+public class AttachmentCleanupHook implements BeforeSaveHook {
+
+    private static final Logger log = LoggerFactory.getLogger(AttachmentCleanupHook.class);
+    private static final Logger securityLog = LoggerFactory.getLogger("security.audit");
+
+    private static final String WILDCARD = "*";
+    private static final String ATTACHMENTS_COLLECTION = "attachments";
+
+    private static final String SELECT_BY_RECORD = """
+            SELECT id, storage_key FROM file_attachment
+            WHERE record_id = ? AND tenant_id = ?
+            """;
+
+    private static final String DELETE_BY_RECORD = """
+            DELETE FROM file_attachment WHERE record_id = ? AND tenant_id = ?
+            """;
+
+    private final JdbcTemplate jdbcTemplate;
+    private final S3StorageService storageService;
+
+    public AttachmentCleanupHook(JdbcTemplate jdbcTemplate, S3StorageService storageService) {
+        this.jdbcTemplate = jdbcTemplate;
+        this.storageService = storageService;
+    }
+
+    @Override
+    public String getCollectionName() {
+        return WILDCARD;
+    }
+
+    @Override
+    public int getOrder() {
+        return 200;
+    }
+
+    @Override
+    public void afterDelete(String collectionName, String id, String tenantId) {
+        // Attachment self-deletes are handled by the dedicated controller, which can
+        // recover the storage key before the row is gone. Skip them here to avoid a
+        // redundant lookup (and the row is already deleted at this point anyway).
+        if (ATTACHMENTS_COLLECTION.equals(collectionName) || tenantId == null || id == null) {
+            return;
+        }
+
+        List<Map<String, Object>> rows;
+        try {
+            rows = jdbcTemplate.queryForList(SELECT_BY_RECORD, id, tenantId);
+        } catch (Exception e) {
+            log.warn("Attachment cleanup lookup failed for record {} (tenant {}): {}",
+                    id, tenantId, e.getMessage());
+            return;
+        }
+        if (rows.isEmpty()) {
+            return;
+        }
+
+        if (storageService.isEnabled()) {
+            for (Map<String, Object> row : rows) {
+                String storageKey = (String) row.get("storage_key");
+                if (storageKey != null && !storageKey.isBlank()) {
+                    try {
+                        storageService.deleteObject(storageKey);
+                    } catch (Exception e) {
+                        log.warn("Failed to delete S3 object '{}' during record cleanup: {}",
+                                storageKey, e.getMessage());
+                    }
+                }
+            }
+        }
+
+        try {
+            int deleted = jdbcTemplate.update(DELETE_BY_RECORD, id, tenantId);
+            if (deleted > 0) {
+                securityLog.info(
+                        "security_event=ATTACHMENTS_CASCADE_DELETED tenant={} record={} count={}",
+                        tenantId, id, deleted);
+            }
+        } catch (Exception e) {
+            log.warn("Attachment cleanup delete failed for record {} (tenant {}): {}",
+                    id, tenantId, e.getMessage());
+        }
+    }
+}

--- a/kelta-worker/src/main/resources/db/migration/V142__add_file_attachment_record_index.sql
+++ b/kelta-worker/src/main/resources/db/migration/V142__add_file_attachment_record_index.sql
@@ -1,0 +1,9 @@
+-- V142: Index file_attachment by (tenant_id, record_id) to support cascade cleanup.
+--
+-- When a parent record is deleted, AttachmentCleanupHook removes the record's
+-- attachments by `WHERE record_id = ? AND tenant_id = ?`. The existing
+-- idx_attachment_record index leads with collection_id, which is not provided to
+-- the after-delete hook, so this composite index serves the lookup/delete directly.
+
+CREATE INDEX IF NOT EXISTS idx_attachment_tenant_record
+    ON file_attachment (tenant_id, record_id);

--- a/kelta-worker/src/test/java/io/kelta/worker/controller/AttachmentUploadControllerTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/controller/AttachmentUploadControllerTest.java
@@ -194,4 +194,65 @@ class AttachmentUploadControllerTest {
 
         assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
     }
+
+    @Test
+    void deleteAttachment_success_deletesS3AndRow() {
+        String attachmentId = "att-1";
+        Map<String, Object> row = new LinkedHashMap<>();
+        row.put("id", attachmentId);
+        row.put("storage_key", "tenant-1/col-1/rec-1/att-1/report.pdf");
+
+        when(jdbcTemplate.queryForList(anyString(), eq(attachmentId), eq(TENANT_ID)))
+                .thenReturn(List.of(row));
+
+        ResponseEntity<Void> response = controller.deleteAttachment(attachmentId, TENANT_ID, USER_EMAIL);
+
+        assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
+        verify(storageService).deleteObject("tenant-1/col-1/rec-1/att-1/report.pdf");
+        verify(jdbcTemplate).update(contains("DELETE FROM file_attachment"), eq(attachmentId), eq(TENANT_ID));
+    }
+
+    @Test
+    void deleteAttachment_notFound() {
+        when(jdbcTemplate.queryForList(anyString(), eq("bad-id"), eq(TENANT_ID)))
+                .thenReturn(Collections.emptyList());
+
+        ResponseEntity<Void> response = controller.deleteAttachment("bad-id", TENANT_ID, USER_EMAIL);
+
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+        verify(storageService, never()).deleteObject(anyString());
+    }
+
+    @Test
+    void deleteAttachment_s3Disabled_skipsS3ButDeletesRow() {
+        when(storageService.isEnabled()).thenReturn(false);
+        String attachmentId = "att-1";
+        Map<String, Object> row = new LinkedHashMap<>();
+        row.put("storage_key", "tenant-1/col-1/rec-1/att-1/report.pdf");
+
+        when(jdbcTemplate.queryForList(anyString(), eq(attachmentId), eq(TENANT_ID)))
+                .thenReturn(List.of(row));
+
+        ResponseEntity<Void> response = controller.deleteAttachment(attachmentId, TENANT_ID, USER_EMAIL);
+
+        assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
+        verify(storageService, never()).deleteObject(anyString());
+        verify(jdbcTemplate).update(contains("DELETE FROM file_attachment"), eq(attachmentId), eq(TENANT_ID));
+    }
+
+    @Test
+    void deleteAttachment_blankStorageKey_skipsS3() {
+        String attachmentId = "att-1";
+        Map<String, Object> row = new LinkedHashMap<>();
+        row.put("storage_key", "");
+
+        when(jdbcTemplate.queryForList(anyString(), eq(attachmentId), eq(TENANT_ID)))
+                .thenReturn(List.of(row));
+
+        ResponseEntity<Void> response = controller.deleteAttachment(attachmentId, TENANT_ID, USER_EMAIL);
+
+        assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
+        verify(storageService, never()).deleteObject(anyString());
+        verify(jdbcTemplate).update(contains("DELETE FROM file_attachment"), eq(attachmentId), eq(TENANT_ID));
+    }
 }

--- a/kelta-worker/src/test/java/io/kelta/worker/listener/AttachmentCleanupHookRegistryIntegrationTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/listener/AttachmentCleanupHookRegistryIntegrationTest.java
@@ -1,0 +1,79 @@
+package io.kelta.worker.listener;
+
+import io.kelta.runtime.workflow.BeforeSaveHookRegistry;
+import io.kelta.worker.service.S3StorageService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * Integration test verifying {@link AttachmentCleanupHook} is dispatched by a real
+ * {@link BeforeSaveHookRegistry} as a wildcard after-delete hook.
+ *
+ * <p>This exercises the wiring that makes attachment cascade-cleanup fire whenever
+ * any record is deleted: the worker delete path calls
+ * {@link BeforeSaveHookRegistry#invokeAfterDelete}, which must route to the wildcard
+ * hook. Unit-level behavior is covered separately in {@code AttachmentCleanupHookTest};
+ * this test covers the registration + dispatch contract.
+ */
+@ExtendWith(MockitoExtension.class)
+class AttachmentCleanupHookRegistryIntegrationTest {
+
+    @Mock
+    private JdbcTemplate jdbcTemplate;
+
+    @Mock
+    private S3StorageService storageService;
+
+    private BeforeSaveHookRegistry registry;
+
+    private static final String TENANT_ID = "tenant-1";
+
+    @BeforeEach
+    void setUp() {
+        registry = new BeforeSaveHookRegistry();
+        registry.register(new AttachmentCleanupHook(jdbcTemplate, storageService));
+    }
+
+    @Test
+    void registeredAsWildcardHookForEveryCollection() {
+        assertTrue(registry.hasHooks("orders"));
+        assertTrue(registry.hasHooks("any-other-collection"));
+    }
+
+    @Test
+    void recordDelete_dispatchesCascadeCleanupThroughRegistry() {
+        when(jdbcTemplate.queryForList(anyString(), eq("rec-1"), eq(TENANT_ID)))
+                .thenReturn(List.of(Map.of("id", "att-1", "storage_key", "k1")));
+        when(storageService.isEnabled()).thenReturn(true);
+        when(jdbcTemplate.update(anyString(), eq("rec-1"), eq(TENANT_ID))).thenReturn(1);
+
+        // Simulate the worker delete path firing after-delete hooks for a user collection.
+        registry.invokeAfterDelete("orders", "rec-1", TENANT_ID);
+
+        verify(storageService).deleteObject("k1");
+        verify(jdbcTemplate).update(contains("DELETE FROM file_attachment"), eq("rec-1"), eq(TENANT_ID));
+    }
+
+    @Test
+    void attachmentSelfDelete_isNotCascadedByHook() {
+        registry.invokeAfterDelete("attachments", "att-1", TENANT_ID);
+
+        verifyNoInteractions(jdbcTemplate);
+        verifyNoInteractions(storageService);
+    }
+}

--- a/kelta-worker/src/test/java/io/kelta/worker/listener/AttachmentCleanupHookTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/listener/AttachmentCleanupHookTest.java
@@ -1,0 +1,105 @@
+package io.kelta.worker.listener;
+
+import io.kelta.worker.service.S3StorageService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AttachmentCleanupHookTest {
+
+    @Mock
+    private JdbcTemplate jdbcTemplate;
+
+    @Mock
+    private S3StorageService storageService;
+
+    private AttachmentCleanupHook hook;
+
+    private static final String TENANT_ID = "tenant-1";
+    private static final String RECORD_ID = "rec-1";
+
+    @BeforeEach
+    void setUp() {
+        hook = new AttachmentCleanupHook(jdbcTemplate, storageService);
+    }
+
+    @Test
+    void isWildcardHookRunningLate() {
+        assertEquals("*", hook.getCollectionName());
+        assertEquals(200, hook.getOrder());
+    }
+
+    @Test
+    void afterDelete_cleansAttachmentRowsAndS3Objects() {
+        when(jdbcTemplate.queryForList(anyString(), eq(RECORD_ID), eq(TENANT_ID)))
+                .thenReturn(List.of(
+                        Map.of("id", "att-1", "storage_key", "k1"),
+                        Map.of("id", "att-2", "storage_key", "k2")));
+        when(storageService.isEnabled()).thenReturn(true);
+        when(jdbcTemplate.update(anyString(), eq(RECORD_ID), eq(TENANT_ID))).thenReturn(2);
+
+        hook.afterDelete("orders", RECORD_ID, TENANT_ID);
+
+        verify(storageService).deleteObject("k1");
+        verify(storageService).deleteObject("k2");
+        verify(jdbcTemplate).update(contains("DELETE FROM file_attachment"), eq(RECORD_ID), eq(TENANT_ID));
+    }
+
+    @Test
+    void afterDelete_skipsAttachmentsCollection() {
+        hook.afterDelete("attachments", "att-1", TENANT_ID);
+
+        verifyNoInteractions(jdbcTemplate);
+        verifyNoInteractions(storageService);
+    }
+
+    @Test
+    void afterDelete_noAttachments_doesNothing() {
+        when(jdbcTemplate.queryForList(anyString(), eq(RECORD_ID), eq(TENANT_ID)))
+                .thenReturn(Collections.emptyList());
+
+        hook.afterDelete("orders", RECORD_ID, TENANT_ID);
+
+        verify(storageService, never()).deleteObject(anyString());
+        verify(jdbcTemplate, never()).update(anyString(), eq(RECORD_ID), eq(TENANT_ID));
+    }
+
+    @Test
+    void afterDelete_s3Disabled_deletesRowsOnly() {
+        when(jdbcTemplate.queryForList(anyString(), eq(RECORD_ID), eq(TENANT_ID)))
+                .thenReturn(List.of(Map.of("id", "att-1", "storage_key", "k1")));
+        when(storageService.isEnabled()).thenReturn(false);
+        when(jdbcTemplate.update(anyString(), eq(RECORD_ID), eq(TENANT_ID))).thenReturn(1);
+
+        hook.afterDelete("orders", RECORD_ID, TENANT_ID);
+
+        verify(storageService, never()).deleteObject(anyString());
+        verify(jdbcTemplate).update(contains("DELETE FROM file_attachment"), eq(RECORD_ID), eq(TENANT_ID));
+    }
+
+    @Test
+    void afterDelete_nullIdentifiers_noop() {
+        hook.afterDelete("orders", null, TENANT_ID);
+        hook.afterDelete("orders", RECORD_ID, null);
+
+        verifyNoInteractions(jdbcTemplate);
+        verifyNoInteractions(storageService);
+    }
+}


### PR DESCRIPTION
## What
Closes the S3 **object-cleanup** gaps in the attachment lifecycle. The `attachments` system collection already had presigned-PUT upload + finalize and router-served list/get/download (with presigned `downloadUrl` enrichment). What was missing was storage hygiene on delete.

- **`DELETE /api/attachments/{id}`** (new dedicated handler) — deletes the S3 object **and** the metadata row. Its literal path out-prioritizes the generic router's `/api/{collection}/{id}` delete, which would otherwise drop the row and orphan the object. S3 deletion is best-effort (logged, never blocks the row delete).
- **`AttachmentCleanupHook`** (new wildcard `afterDelete`, order 200) — when a **parent record** is deleted, removes its `file_attachment` rows + S3 objects. The `attachments` collection itself is skipped (covered by the dedicated delete). Registered in `FlowConfig` alongside the existing hooks.
- **Flyway V142** — `idx_attachment_tenant_record (tenant_id, record_id)` to serve the cascade lookup (the existing index leads with `collection_id`, which `afterDelete` doesn't provide).

This also matches the existing frontend `AttachmentsSection`, which already calls `DELETE /api/attachments/{id}`.

## Why
Phase 0 hardening (strategic roadmap): complete the file lifecycle so deletes don't orphan S3 objects or leak storage quota.

## Tests
- **Unit**: `AttachmentUploadControllerTest` (delete: success/not-found/s3-disabled/blank-key), `AttachmentCleanupHookTest` (cascade / skip-attachments / empty / s3-disabled / null args).
- **Integration**: `AttachmentCleanupHookRegistryIntegrationTest` — verifies the hook is dispatched as a wildcard by a real `BeforeSaveHookRegistry.invokeAfterDelete` (the wiring that fires on real record deletes).
- Full `kelta-worker` suite green: **1251 tests, 0 failures**.

## Follow-up
A full-stack Playwright/MinIO attachment e2e is deferred — the e2e harness has no S3 backend today. The frontend `AttachmentsSection` retains its Vitest component tests.

## Docs
`FEATURES.md` (Notes & Attachments → Full; comparison + checklist), `.claude/docs/integrations.md` (attachment lifecycle subsection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)