### PR TITLE
fix(tenancy): transaction-scoped RLS tenant variable (PgBouncer-safe)

### DIFF
--- a/.claude/docs/concerns.md
+++ b/.claude/docs/concerns.md
@@ -71,20 +71,15 @@ at the bottom so reviewers can see what's already been addressed.
 
 ## Connection Pooler Compatibility
 
-**RLS tenant variable is session-scoped, not transaction-scoped:**
-- `TenantAwareDataSourceConfig` issues `SET app.current_tenant_id = '<id>'` on every connection borrowed from HikariCP. This is a Postgres **session** setting that persists until the connection is closed or reset.
-- File: `kelta-worker/src/main/java/io/kelta/worker/config/TenantAwareDataSourceConfig.java` (line 89)
-- Also: `kelta-ai/src/main/resources/application.yml` (`hikari.connection-init-sql: SET app.current_tenant_id = ''`)
+**kelta-worker RLS tenant variable is now transaction-scoped (PgBouncer-safe).** ✅ Resolved (Phase 0)
 
-**Impact under PgBouncer transaction-pool mode:**
-- PgBouncer's `pool_mode = transaction` returns a different physical Postgres connection per transaction. Session state set on a prior transaction is lost — RLS `current_setting('app.current_tenant_id', true)` returns the empty default, and the `admin_bypass` policy hits, returning rows for **all tenants**.
-- This is a tenant-isolation correctness bug, not just a perf issue.
+`TenantAwareDataSourceConfig.TenantAwareDataSource` scopes `app.current_tenant_id` per database operation:
+- **Tenant-scoped connection** (non-empty tenant in `TenantContext`): if the borrowed connection is in autocommit mode, autocommit is turned off (begins a transaction), `SET LOCAL app.current_tenant_id = '<id>'` is issued, and a thin commit-on-close proxy commits + restores autocommit when the connection is released. If a Spring-managed transaction already owns the connection, only `SET LOCAL` is issued and the proxy defers commit/rollback to the owner (it watches the owner's `commit()`/`rollback()` to avoid a double-commit). Because the variable is set per transaction on the same backend that serves the query, it survives PgBouncer `pool_mode = transaction`. Connection-hold time is unchanged — the connection is released right after the operation, exactly like the previous autocommit model.
+- **Admin/bypass connection** (no tenant — Flyway, internal, cross-tenant work): keeps the legacy session `SET app.current_tenant_id = ''`. Empty already maps to `admin_bypass`, so transaction scoping is irrelevant to isolation and these paths are unchanged.
 
-**Required configuration when deploying PgBouncer:**
-- Set `pool_mode = session` for all kelta workloads (worker, auth, ai). Lower pooling efficiency than transaction mode but preserves session state. Or:
-- Migrate every tenant-scoped DB callsite to issue `SET LOCAL app.current_tenant_id = '<id>'` inside an explicit transaction (requires refactor of all `JdbcTemplate` auto-commit calls + audit of `@Transactional` boundaries).
+Regression guard: `TenantAwareDataSourceTest` asserts tenant connections use transaction-local `SET LOCAL` (not session `SET`) and commit/restore correctly; the harness `TenantIsolationScenarioTest` exercises real-stack isolation over Postgres + RLS.
 
-**Followup**: dedicated rewrite to `SET LOCAL`-inside-transaction is tracked under Tier-2 DB scaling work.
+**Remaining caveat — kelta-ai:** `kelta-ai/src/main/resources/application.yml` still uses `hikari.connection-init-sql: SET app.current_tenant_id = ''` (a session-level set to the bypass value). kelta-ai runs in admin/bypass mode and filters tenants explicitly in SQL rather than relying on RLS tenant isolation, so it is not a leak vector — but if kelta-ai ever begins relying on RLS for tenant-scoped reads, it must adopt the same transaction-scoped `SET LOCAL` mechanism before being placed behind a transaction-pool. Tracked as a follow-up.
 
 ## Test Coverage Gaps
 

--- a/kelta-worker/src/main/java/io/kelta/worker/config/TenantAwareDataSourceConfig.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/config/TenantAwareDataSourceConfig.java
@@ -10,46 +10,54 @@ import org.springframework.context.annotation.Configuration;
 
 import javax.sql.DataSource;
 import java.io.PrintWriter;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Proxy;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
 
 /**
- * Configures a tenant-aware DataSource wrapper that sets the PostgreSQL session variable
- * {@code app.current_tenant_id} on each connection obtained from the pool.
+ * Configures a tenant-aware DataSource wrapper that scopes the PostgreSQL variable
+ * {@code app.current_tenant_id} to each database operation, transactionally.
  *
  * <p>This enables Row Level Security (RLS) policies on shared system tables to enforce
  * tenant isolation at the database level. RLS policies use
  * {@code current_setting('app.current_tenant_id', true)} to filter rows by tenant.
  *
- * <p>The tenant ID is read from {@link TenantContext} (ThreadLocal), which is set by
- * the DynamicCollectionRouter from the {@code X-Tenant-ID} request header.
+ * <p>The tenant ID is read from {@link TenantContext} (ThreadLocal), set by the
+ * tenant-context filter / DynamicCollectionRouter from the {@code X-Tenant-ID} header.
  *
- * <p>When no tenant context is set (e.g., during Flyway migrations or internal operations),
- * the variable is set to an empty string, which matches the {@code admin_bypass} RLS policy.
+ * <h2>Transaction-scoped tenant variable (PgBouncer-safe)</h2>
+ * <p>For <b>tenant-scoped</b> connections (a non-empty tenant in context) the variable is
+ * applied with {@code SET LOCAL} <i>inside an explicit transaction</i> rather than as a
+ * connection-session {@code SET}:
+ * <ol>
+ *   <li>If the borrowed connection is in autocommit mode (the common JdbcTemplate path with
+ *       no Spring-managed transaction), autocommit is turned off so a transaction begins,
+ *       {@code SET LOCAL app.current_tenant_id = '...'} is issued, and the connection is
+ *       returned through a thin proxy that commits and restores autocommit on
+ *       {@link Connection#close()}. The connection is held no longer than before — it is
+ *       released right after the operation, exactly like the previous autocommit model.</li>
+ *   <li>If the connection is already inside a Spring-managed transaction (autocommit already
+ *       off), only {@code SET LOCAL} is issued; Spring owns commit/rollback/close.</li>
+ * </ol>
  *
- * <p>Uses a {@link BeanPostProcessor} to wrap the auto-configured DataSource, avoiding
- * circular dependency issues that arise from declaring a {@code @Primary @Bean} DataSource
- * that injects another DataSource.
+ * <p>Because the variable is set <i>per transaction</i> on the same backend that serves the
+ * query, it survives PgBouncer's {@code pool_mode = transaction} (which recycles the physical
+ * backend per transaction). The previous session {@code SET} was lost under transaction
+ * pooling, causing {@code current_setting} to return the empty default and the
+ * {@code admin_bypass} policy to leak rows across tenants. That tenant-isolation hazard is
+ * now closed by default.
  *
- * <h2>WARNING: PgBouncer transaction-pool incompatibility</h2>
- * <p>The {@code SET app.current_tenant_id} issued here is a Postgres <b>session</b>
- * setting. Under PgBouncer's {@code pool_mode = transaction} the underlying physical
- * connection is recycled per transaction, so the session variable is lost — RLS then
- * sees the empty default and the {@code admin_bypass} policy lets a query return rows
- * for <b>all tenants</b>. This is a tenant-isolation correctness bug, not just a perf
- * issue.
+ * <p><b>Admin / bypass connections</b> (no tenant in context — Flyway migrations, internal
+ * and cross-tenant operations) keep the simple session {@code SET app.current_tenant_id = ''}
+ * with no transaction management, so those paths are unchanged. The empty value already maps
+ * to {@code admin_bypass}, so transaction scoping is irrelevant to their isolation.
  *
- * <p>When deploying PgBouncer (or any other transaction-level pooler) in front of
- * Postgres, you must either:
- * <ul>
- *   <li>Configure {@code pool_mode = session} (lower pooling efficiency but preserves
- *       session state — current default for kelta workloads), or
- *   <li>Migrate every tenant-scoped callsite to issue
- *       {@code SET LOCAL app.current_tenant_id = '...'} inside an explicit transaction.
- *       This requires rewriting all {@code JdbcTemplate} auto-commit calls and auditing
- *       {@code @Transactional} boundaries (tracked as Tier-2 DB scaling work).
- * </ul>
+ * <p>Uses a {@link BeanPostProcessor} to wrap the auto-configured DataSource, avoiding the
+ * circular dependency that a {@code @Primary @Bean} DataSource injecting another DataSource
+ * would create.
  *
  * <p>See {@code .claude/docs/concerns.md} → "Connection Pooler Compatibility".
  *
@@ -67,7 +75,8 @@ public class TenantAwareDataSourceConfig {
             public Object postProcessAfterInitialization(Object bean, String beanName)
                     throws BeansException {
                 if ("dataSource".equals(beanName) && bean instanceof DataSource ds) {
-                    log.info("Wrapping DataSource with tenant-aware RLS support");
+                    log.info("Wrapping DataSource with tenant-aware RLS support "
+                            + "(transaction-scoped SET LOCAL for tenant connections)");
                     return new TenantAwareDataSource(ds);
                 }
                 return bean;
@@ -76,7 +85,7 @@ public class TenantAwareDataSourceConfig {
     }
 
     /**
-     * DataSource decorator that sets {@code app.current_tenant_id} on each connection.
+     * DataSource decorator that scopes {@code app.current_tenant_id} to each operation.
      */
     static class TenantAwareDataSource implements DataSource {
 
@@ -88,26 +97,150 @@ public class TenantAwareDataSourceConfig {
 
         @Override
         public Connection getConnection() throws SQLException {
-            Connection conn = delegate.getConnection();
-            setTenantVariable(conn);
-            return conn;
+            return applyTenantScope(delegate.getConnection());
         }
 
         @Override
         public Connection getConnection(String username, String password) throws SQLException {
-            Connection conn = delegate.getConnection(username, password);
-            setTenantVariable(conn);
-            return conn;
+            return applyTenantScope(delegate.getConnection(username, password));
         }
 
-        private void setTenantVariable(Connection conn) throws SQLException {
+        /**
+         * Applies the tenant variable to a freshly borrowed connection and returns either the
+         * connection itself or a commit-on-close proxy, depending on the path.
+         */
+        private Connection applyTenantScope(Connection conn) throws SQLException {
             String tenantId = TenantContext.get();
-            // Use empty string when no tenant context is set — this matches the admin_bypass policy
-            String value = (tenantId != null && !tenantId.isBlank()) ? tenantId : "";
+
+            // No tenant in context (Flyway, internal, cross-tenant admin work): keep the
+            // legacy session SET '' behavior. Empty already maps to admin_bypass, so there is
+            // nothing to isolate and no need to manage a transaction.
+            if (tenantId == null || tenantId.isBlank()) {
+                setTenantSession(conn, "");
+                return conn;
+            }
+
+            boolean priorAutoCommit = conn.getAutoCommit();
+            if (priorAutoCommit) {
+                // Begin a transaction so SET LOCAL has a transaction to scope to.
+                conn.setAutoCommit(false);
+            }
+            setTenantLocal(conn, tenantId);
+
+            if (!priorAutoCommit) {
+                // A Spring-managed (or otherwise owned) transaction is in charge of
+                // commit/rollback/close. SET LOCAL applies to it; nothing more to do.
+                return conn;
+            }
+
+            // We started the transaction for an autocommit-style operation: commit it and
+            // restore autocommit when the caller releases the connection.
+            return wrapWithCommitOnClose(conn);
+        }
+
+        /** Issues a transaction-local {@code SET LOCAL} for a tenant-scoped connection. */
+        private static void setTenantLocal(Connection conn, String tenantId) throws SQLException {
             try (Statement stmt = conn.createStatement()) {
-                // Use SET SESSION so the variable persists for the duration of the connection use.
-                // The variable is SQL-injection safe because tenant IDs are UUIDs validated upstream.
-                stmt.execute("SET app.current_tenant_id = '" + value.replace("'", "''") + "'");
+                stmt.execute("SET LOCAL app.current_tenant_id = '" + escape(tenantId) + "'");
+            }
+        }
+
+        /** Issues a session-level {@code SET} for the admin/bypass (empty tenant) path. */
+        private static void setTenantSession(Connection conn, String value) throws SQLException {
+            try (Statement stmt = conn.createStatement()) {
+                stmt.execute("SET app.current_tenant_id = '" + escape(value) + "'");
+            }
+        }
+
+        // Tenant IDs are UUIDs validated upstream; escape defensively regardless.
+        private static String escape(String value) {
+            return value.replace("'", "''");
+        }
+
+        /**
+         * Wraps the connection so that {@code close()} commits the transaction we began (unless
+         * an owning transaction manager already ended it) and restores autocommit, then returns
+         * the connection to the pool. All other calls pass straight through to the real
+         * connection.
+         *
+         * <p>The same autocommit-off path is taken whether the borrow is a plain JdbcTemplate
+         * operation or the start of a Spring-managed transaction — at borrow time Spring has not
+         * yet flipped autocommit. To avoid committing twice, the proxy watches for the owner's
+         * own {@code commit()}/{@code rollback()}: if either fired, {@code close()} only restores
+         * autocommit. If neither did (the plain autocommit path), {@code close()} commits.
+         */
+        private static Connection wrapWithCommitOnClose(Connection real) {
+            final boolean[] ownerEndedTx = {false};
+            InvocationHandler handler = new InvocationHandler() {
+                @Override
+                public Object invoke(Object proxy, java.lang.reflect.Method method, Object[] args)
+                        throws Throwable {
+                    String name = method.getName();
+                    boolean noArgs = (args == null || args.length == 0);
+                    if (noArgs && ("commit".equals(name) || "rollback".equals(name))) {
+                        ownerEndedTx[0] = true;
+                        return method.invoke(real, args);
+                    }
+                    if (noArgs && "close".equals(name)) {
+                        if (ownerEndedTx[0]) {
+                            restoreAutoCommit(real);
+                        } else {
+                            finishTransaction(real);
+                        }
+                        return method.invoke(real, args);
+                    }
+                    try {
+                        return method.invoke(real, args);
+                    } catch (InvocationTargetException ite) {
+                        throw ite.getTargetException();
+                    }
+                }
+            };
+            return (Connection) Proxy.newProxyInstance(
+                    TenantAwareDataSource.class.getClassLoader(),
+                    new Class<?>[]{Connection.class},
+                    handler);
+        }
+
+        /**
+         * Commits the operation's transaction (a failed statement leaves the transaction in an
+         * aborted state, which Postgres turns COMMIT into ROLLBACK for, so no partial data
+         * persists) and restores autocommit before the connection returns to the pool.
+         */
+        private static void finishTransaction(Connection real) {
+            try {
+                if (!real.isClosed() && !real.getAutoCommit()) {
+                    try {
+                        real.commit();
+                    } catch (SQLException commitEx) {
+                        log.warn("Tenant transaction commit failed; rolling back: {}",
+                                commitEx.getMessage());
+                        safeRollback(real);
+                    }
+                }
+            } catch (SQLException e) {
+                log.warn("Failed to finalize tenant transaction before close: {}", e.getMessage());
+            } finally {
+                restoreAutoCommit(real);
+            }
+        }
+
+        private static void restoreAutoCommit(Connection real) {
+            try {
+                if (!real.isClosed()) {
+                    real.setAutoCommit(true);
+                }
+            } catch (SQLException e) {
+                log.warn("Failed to restore autocommit before returning connection: {}",
+                        e.getMessage());
+            }
+        }
+
+        private static void safeRollback(Connection real) {
+            try {
+                real.rollback();
+            } catch (SQLException rollbackEx) {
+                log.warn("Tenant transaction rollback failed: {}", rollbackEx.getMessage());
             }
         }
 

--- a/kelta-worker/src/test/java/io/kelta/worker/config/TenantAwareDataSourceTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/config/TenantAwareDataSourceTest.java
@@ -1,0 +1,162 @@
+package io.kelta.worker.config;
+
+import io.kelta.runtime.context.TenantContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.Statement;
+
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Verifies the tenant-aware DataSource scopes {@code app.current_tenant_id} correctly.
+ *
+ * <p>The load-bearing assertion for PgBouncer transaction-pool safety is that a
+ * <b>tenant-scoped</b> connection sets the variable with transaction-local {@code SET LOCAL}
+ * inside an explicit transaction (autocommit off, commit on close) — never a connection-session
+ * {@code SET}, which a transaction pooler would silently drop and leak rows across tenants via
+ * the {@code admin_bypass} policy.
+ */
+@DisplayName("TenantAwareDataSource — transaction-scoped tenant variable")
+class TenantAwareDataSourceTest {
+
+    private DataSource delegate;
+    private Connection conn;
+    private Statement stmt;
+    private TenantAwareDataSourceConfig.TenantAwareDataSource tenantDataSource;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        delegate = mock(DataSource.class);
+        conn = mock(Connection.class);
+        stmt = mock(Statement.class);
+        when(delegate.getConnection()).thenReturn(conn);
+        when(conn.createStatement()).thenReturn(stmt);
+        when(conn.isClosed()).thenReturn(false);
+        tenantDataSource = new TenantAwareDataSourceConfig.TenantAwareDataSource(delegate);
+        TenantContext.clear();
+    }
+
+    @AfterEach
+    void tearDown() {
+        TenantContext.clear();
+    }
+
+    @Test
+    @DisplayName("tenant-scoped connection uses SET LOCAL inside a transaction and commits on close")
+    void tenantScopedUsesSetLocalAndCommitsOnClose() throws Exception {
+        TenantContext.set("tenant-abc");
+        // Autocommit on borrow, then off once we begin the transaction (read twice).
+        when(conn.getAutoCommit()).thenReturn(true, false);
+
+        Connection borrowed = tenantDataSource.getConnection();
+
+        // Began a transaction and issued the transaction-local set — NOT a session SET.
+        verify(conn).setAutoCommit(false);
+        verify(stmt).execute("SET LOCAL app.current_tenant_id = 'tenant-abc'");
+        // The caller gets a proxy, not the raw connection.
+        assertNotSame(conn, borrowed);
+
+        // Releasing the connection commits the operation and restores autocommit.
+        borrowed.close();
+        verify(conn).commit();
+        verify(conn).setAutoCommit(true);
+        verify(conn).close();
+    }
+
+    @Test
+    @DisplayName("connection already inside a transaction only issues SET LOCAL")
+    void existingTransactionOnlySetsLocal() throws Exception {
+        TenantContext.set("tenant-xyz");
+        when(conn.getAutoCommit()).thenReturn(false); // already in a Spring-managed transaction
+
+        Connection borrowed = tenantDataSource.getConnection();
+
+        verify(stmt).execute("SET LOCAL app.current_tenant_id = 'tenant-xyz'");
+        // We must not toggle autocommit or take over commit/close from the owning transaction.
+        verify(conn, never()).setAutoCommit(anyBoolean());
+        verify(conn, never()).commit();
+        assertSame(conn, borrowed);
+    }
+
+    @Test
+    @DisplayName("no tenant in context keeps the legacy session SET '' (admin/bypass path unchanged)")
+    void noTenantUsesSessionSet() throws Exception {
+        TenantContext.clear();
+        when(conn.getAutoCommit()).thenReturn(true);
+
+        Connection borrowed = tenantDataSource.getConnection();
+
+        verify(stmt).execute("SET app.current_tenant_id = ''");
+        verify(conn, never()).setAutoCommit(anyBoolean());
+        verify(conn, never()).commit();
+        assertSame(conn, borrowed);
+    }
+
+    @Test
+    @DisplayName("when the owning transaction commits, close does not commit again")
+    void ownerCommitPreventsDoubleCommit() throws Exception {
+        TenantContext.set("tenant-abc");
+        when(conn.getAutoCommit()).thenReturn(true, false);
+
+        Connection borrowed = tenantDataSource.getConnection();
+        borrowed.commit(); // owner (e.g. Spring) commits the transaction
+        borrowed.close();
+
+        verify(conn).commit(); // exactly once — the owner's, not a second from close()
+        verify(conn).setAutoCommit(true);
+        verify(conn).close();
+    }
+
+    @Test
+    @DisplayName("when the owning transaction rolls back, close restores autocommit without committing")
+    void ownerRollbackPreventsCommit() throws Exception {
+        TenantContext.set("tenant-abc");
+        when(conn.getAutoCommit()).thenReturn(true, false);
+
+        Connection borrowed = tenantDataSource.getConnection();
+        borrowed.rollback();
+        borrowed.close();
+
+        verify(conn).rollback();
+        verify(conn, never()).commit();
+        verify(conn).setAutoCommit(true);
+        verify(conn).close();
+    }
+
+    @Test
+    @DisplayName("commit failure on close rolls back and still restores autocommit")
+    void commitFailureRollsBack() throws Exception {
+        TenantContext.set("tenant-abc");
+        when(conn.getAutoCommit()).thenReturn(true, false);
+        org.mockito.Mockito.doThrow(new java.sql.SQLException("commit boom")).when(conn).commit();
+
+        Connection borrowed = tenantDataSource.getConnection();
+        borrowed.close();
+
+        verify(conn).rollback();
+        verify(conn).setAutoCommit(true);
+        verify(conn).close();
+    }
+
+    @Test
+    @DisplayName("tenant id with a quote is escaped in the SET LOCAL statement")
+    void tenantIdIsEscaped() throws Exception {
+        TenantContext.set("ten'ant");
+        when(conn.getAutoCommit()).thenReturn(true, false);
+
+        tenantDataSource.getConnection();
+
+        verify(stmt).execute("SET LOCAL app.current_tenant_id = 'ten''ant'");
+    }
+}


### PR DESCRIPTION
## What
Makes the RLS tenant variable `app.current_tenant_id` **transaction-scoped** so tenant isolation survives PgBouncer `pool_mode = transaction`.

Previously `TenantAwareDataSourceConfig` set the variable as a Postgres **session** value on each borrowed connection. Under transaction pooling the backend is recycled per transaction, the session value is lost, `current_setting()` returns the empty default, and the `admin_bypass` policy returns rows for **all tenants** — a tenant-isolation hazard (latent today since we run session pooling, but it blocks transaction pooling at scale).

### Mechanism
- **Tenant-scoped connection** (non-empty `TenantContext`): if borrowed in autocommit mode, turn autocommit off (begin a transaction), issue `SET LOCAL app.current_tenant_id = '<id>'`, and return a thin commit-on-close proxy that commits + restores autocommit on release. If a Spring-managed transaction already owns the connection, only `SET LOCAL` is issued and the proxy defers to the owner (watches `commit()`/`rollback()` to avoid a double-commit).
- **Admin/bypass connection** (no tenant — Flyway, internal, cross-tenant): unchanged — keeps the legacy session `SET app.current_tenant_id = ''` (empty already maps to `admin_bypass`).

The variable is set **per transaction on the same backend that serves the query**, so it survives transaction pooling. **Connection-hold time is unchanged** vs the prior autocommit model (released right after the operation) — no extra pool pressure.

## Why
Phase 0 hardening gate (strategic roadmap): close the tenant-isolation correctness hazard before scaling behind a transaction pooler. Chosen approach: **default-on**, implemented at the DataSource layer so no controller changes are needed.

## Tests
- **Unit** — `TenantAwareDataSourceTest` (7): `SET LOCAL`-in-transaction for tenant connections (the pool-safety property), `SET LOCAL`-only when already in a tx, session `SET` for the empty-tenant path, commit + autocommit-restore on close, rollback on commit failure, **no double-commit when the owner ends the tx**, quote escaping.
- **Real-stack** — the harness `TenantIsolationScenarioTest` (CI Integration job) exercises tenant isolation + CRUD against real Postgres + RLS with the wrapped DataSource.
- Full `kelta-worker` suite green: **1245 tests, 0 failures**.

## Follow-up
`kelta-ai` still uses `hikari.connection-init-sql: SET app.current_tenant_id = ''` (session-level bypass). It runs in admin/bypass mode and filters tenants explicitly in SQL, so it is **not** a leak vector — but documented in `concerns.md` as a follow-up if it ever relies on RLS tenant isolation behind a transaction pool.

## Docs
`.claude/docs/concerns.md` → "Connection Pooler Compatibility" marked resolved, with the kelta-ai caveat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)