### PR TITLE
fix(security): strip hidden to-one relationship fields in read-side FLS

### DIFF
--- a/.claude/docs/architecture.md
+++ b/.claude/docs/architecture.md
@@ -128,6 +128,20 @@ by `sectionId IN (section ids)` after `layout-sections` resolves directly).
 Includes are skipped silently when the target is unresolvable — `200` with
 no `included` entry — never `5xx`.
 
+**Read-side field-level security** — `CerbosFieldSecurityAdvice`
+(`@ControllerAdvice`, order 10, after record-level authz) strips fields the
+caller cannot `read` from outgoing JSON:API responses. For the primary `data`
+and every `included[]` resource (grouped by type — JSON:API flattens all
+include depths into one array, so one batched Cerbos check per type covers
+them), it removes denied keys from **both** `attributes` and **to-one
+`relationships`** (lookup / master-detail fields are serialized into
+`relationships.<field>.data = { type, id }`, so an attributes-only strip would
+leak a hidden FK's id). Has-many inverse relationships (`data` is a list) are
+not collection fields and are preserved. System audit fields (`createdAt`,
+`updatedAt`, `createdBy`, `updatedBy`) are never stripped; `meta` (pagination)
+is untouched. Metadata/admin paths (`/api/collections`, `/api/admin/**`, etc.)
+are skipped. Gated by `kelta.gateway.security.permissions-enabled`.
+
 **Pagination contract** — every paginated REST endpoint uses JSON:API
 bracket syntax (`page[number]` / `page[size]`). Parsing lives in
 `runtime-core/.../query/Pagination.fromParams`, which clamps `page[size]`

--- a/kelta-worker/src/main/java/io/kelta/worker/interceptor/CerbosFieldSecurityAdvice.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/interceptor/CerbosFieldSecurityAdvice.java
@@ -17,7 +17,6 @@ import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
 
 import java.util.*;
-import java.util.stream.Collectors;
 
 /**
  * Strips fields from API responses based on Cerbos field-level security.
@@ -87,79 +86,32 @@ public class CerbosFieldSecurityAdvice implements ResponseBodyAdvice<Object> {
         String tenantId = permissionResolver.getTenantId(httpRequest);
         String collectionId = extractCollectionId(path);
 
+        // Primary data: one batched Cerbos check per collection, then strip denied
+        // fields from both attributes and to-one relationship linkage.
         if (data instanceof List<?> records) {
-            // Collect all unique field IDs across all records, then check once.
-            // Field permissions depend only on profile + collection, not record data,
-            // so one Cerbos call covers the entire response.
-            Set<String> allFieldIds = new LinkedHashSet<>();
-            List<Map<String, Object>> typedRecords = new ArrayList<>();
-            for (Object record : records) {
-                if (record instanceof Map<?, ?> recordMap) {
-                    Map<String, Object> typed = (Map<String, Object>) recordMap;
-                    typedRecords.add(typed);
-                    Object attrObj = typed.get("attributes");
-                    if (attrObj instanceof Map<?, ?> attrMap) {
-                        for (Object key : attrMap.keySet()) {
-                            if (key instanceof String fieldId && !isSystemField(fieldId)) {
-                                allFieldIds.add(fieldId);
-                            }
-                        }
-                    }
-                }
-            }
-
-            if (!allFieldIds.isEmpty()) {
-                List<String> allowedFields = authzService.batchCheckFieldAccess(
-                        email, profileId, tenantId, collectionId,
-                        new ArrayList<>(allFieldIds), "read");
-                Set<String> allowedSet = new HashSet<>(allowedFields);
-
-                for (Map<String, Object> typedRecord : typedRecords) {
-                    stripFieldsUsing(allowedSet, typedRecord);
-                }
-            }
+            stripCollection(email, profileId, tenantId, collectionId, toTypedRecords(records));
         } else if (data instanceof Map<?, ?> singleRecord) {
-            stripHiddenFields(email, profileId, tenantId, collectionId,
-                    (Map<String, Object>) singleRecord);
+            stripCollection(email, profileId, tenantId, collectionId,
+                    List.of((Map<String, Object>) singleRecord));
         }
 
-        // Also process included resources — group by type for one check per type
+        // Included resources — JSON:API flattens every included resource (at any
+        // relationship depth) into this one array, so grouping by type and checking
+        // once per type covers all of them.
         Object included = responseBody.get("included");
         if (included instanceof List<?> includedList) {
             Map<String, List<Map<String, Object>>> byType = new LinkedHashMap<>();
-            Map<String, Set<String>> fieldsByType = new LinkedHashMap<>();
-
             for (Object item : includedList) {
                 if (item instanceof Map<?, ?> includedRecord) {
                     Map<String, Object> typed = (Map<String, Object>) includedRecord;
                     String includedType = (String) typed.get("type");
                     if (includedType != null) {
                         byType.computeIfAbsent(includedType, k -> new ArrayList<>()).add(typed);
-                        Object attrObj = typed.get("attributes");
-                        if (attrObj instanceof Map<?, ?> attrMap) {
-                            Set<String> fields = fieldsByType.computeIfAbsent(includedType, k -> new LinkedHashSet<>());
-                            for (Object key : attrMap.keySet()) {
-                                if (key instanceof String fieldId && !isSystemField(fieldId)) {
-                                    fields.add(fieldId);
-                                }
-                            }
-                        }
                     }
                 }
             }
-
             for (Map.Entry<String, List<Map<String, Object>>> entry : byType.entrySet()) {
-                String type = entry.getKey();
-                Set<String> fields = fieldsByType.getOrDefault(type, Set.of());
-                if (!fields.isEmpty()) {
-                    List<String> allowed = authzService.batchCheckFieldAccess(
-                            email, profileId, tenantId, type,
-                            new ArrayList<>(fields), "read");
-                    Set<String> allowedSet = new HashSet<>(allowed);
-                    for (Map<String, Object> rec : entry.getValue()) {
-                        stripFieldsUsing(allowedSet, rec);
-                    }
-                }
+                stripCollection(email, profileId, tenantId, entry.getKey(), entry.getValue());
             }
         }
 
@@ -167,63 +119,112 @@ public class CerbosFieldSecurityAdvice implements ResponseBodyAdvice<Object> {
     }
 
     @SuppressWarnings("unchecked")
-    private void stripHiddenFields(String email, String profileId, String tenantId,
-                                    String collectionId, Map<String, Object> record) {
+    private List<Map<String, Object>> toTypedRecords(List<?> records) {
+        List<Map<String, Object>> typed = new ArrayList<>();
+        for (Object record : records) {
+            if (record instanceof Map<?, ?> recordMap) {
+                typed.add((Map<String, Object>) recordMap);
+            }
+        }
+        return typed;
+    }
+
+    /**
+     * Checks read access for every field that appears across {@code records} (one batched
+     * Cerbos call, since field permissions depend only on profile + collection, not record
+     * data) and removes denied fields from each record's {@code attributes} and to-one
+     * {@code relationships} linkage.
+     */
+    private void stripCollection(String email, String profileId, String tenantId,
+                                  String collectionId, List<Map<String, Object>> records) {
+        Set<String> fieldIds = new LinkedHashSet<>();
+        for (Map<String, Object> record : records) {
+            collectCheckableFieldIds(record, fieldIds);
+        }
+        if (fieldIds.isEmpty()) {
+            return;
+        }
+
+        List<String> allowed = authzService.batchCheckFieldAccess(
+                email, profileId, tenantId, collectionId, new ArrayList<>(fieldIds), "read");
+        Set<String> allowedSet = new HashSet<>(allowed);
+
+        if (log.isDebugEnabled() && allowedSet.size() < fieldIds.size()) {
+            log.debug("Field security: {}/{} fields allowed for {} (user={})",
+                    allowedSet.size(), fieldIds.size(), collectionId, email);
+        }
+
+        for (Map<String, Object> record : records) {
+            stripDenied(allowedSet, record);
+        }
+    }
+
+    /**
+     * Collects the non-system field ids that are subject to a field-access check: every key in
+     * {@code attributes}, plus every <em>to-one</em> relationship key (lookup / master-detail
+     * fields are serialized into {@code relationships}, not {@code attributes}). Has-many inverse
+     * relationships (added by {@code ?include=}) are not collection fields and are left alone.
+     */
+    private void collectCheckableFieldIds(Map<String, Object> record, Set<String> out) {
         Object attrObj = record.get("attributes");
-        if (!(attrObj instanceof Map<?, ?> attrMap)) {
-            return;
+        if (attrObj instanceof Map<?, ?> attrMap) {
+            for (Object key : attrMap.keySet()) {
+                if (key instanceof String fieldId && !isSystemField(fieldId)) {
+                    out.add(fieldId);
+                }
+            }
         }
-
-        Map<String, Object> attributes = (Map<String, Object>) attrMap;
-
-        // Collect non-system fields to check
-        List<String> fieldsToCheck = attributes.keySet().stream()
-                .filter(fieldId -> !isSystemField(fieldId))
-                .toList();
-
-        if (fieldsToCheck.isEmpty()) {
-            return;
-        }
-
-        // Single batched Cerbos call for all fields
-        List<String> allowedFields = authzService.batchCheckFieldAccess(
-                email, profileId, tenantId, collectionId, fieldsToCheck, "read");
-
-        Set<String> allowedSet = new HashSet<>(allowedFields);
-        List<String> fieldsToRemove = fieldsToCheck.stream()
-                .filter(f -> !allowedSet.contains(f))
-                .toList();
-
-        if (!fieldsToRemove.isEmpty()) {
-            log.debug("Stripping {} hidden fields from {} for user={}",
-                    fieldsToRemove.size(), collectionId, email);
-            for (String field : fieldsToRemove) {
-                attributes.remove(field);
+        Object relObj = record.get("relationships");
+        if (relObj instanceof Map<?, ?> relMap) {
+            for (Map.Entry<?, ?> entry : relMap.entrySet()) {
+                if (entry.getKey() instanceof String fieldId && !isSystemField(fieldId)
+                        && isToOneRelationship(entry.getValue())) {
+                    out.add(fieldId);
+                }
             }
         }
     }
 
     /**
-     * Strips fields from a record using a pre-computed allowed set.
-     * Used for list responses where field access is checked once for all records.
+     * Removes every denied (non-system) field from a record's {@code attributes} and its to-one
+     * {@code relationships} linkage. A hidden lookup / master-detail field would otherwise leak
+     * the related record's id through {@code relationships}, since the router serializes
+     * relationship fields there rather than in {@code attributes}.
      */
     @SuppressWarnings("unchecked")
-    private void stripFieldsUsing(Set<String> allowedFields, Map<String, Object> record) {
+    private void stripDenied(Set<String> allowedFields, Map<String, Object> record) {
         Object attrObj = record.get("attributes");
-        if (!(attrObj instanceof Map<?, ?> attrMap)) {
-            return;
+        if (attrObj instanceof Map<?, ?> attrMap) {
+            ((Map<String, Object>) attrMap).keySet().removeIf(
+                    key -> key instanceof String f && !isSystemField(f) && !allowedFields.contains(f));
         }
 
-        Map<String, Object> attributes = (Map<String, Object>) attrMap;
-        List<String> fieldsToRemove = attributes.keySet().stream()
-                .filter(f -> !isSystemField(f) && !allowedFields.contains(f))
-                .toList();
-
-        if (!fieldsToRemove.isEmpty()) {
-            for (String field : fieldsToRemove) {
-                attributes.remove(field);
+        Object relObj = record.get("relationships");
+        if (relObj instanceof Map<?, ?> relMapRaw) {
+            Map<String, Object> relationships = (Map<String, Object>) relMapRaw;
+            relationships.entrySet().removeIf(entry ->
+                    entry.getKey() instanceof String f
+                            && !isSystemField(f)
+                            && isToOneRelationship(entry.getValue())
+                            && !allowedFields.contains(f));
+            if (relationships.isEmpty()) {
+                record.remove("relationships");
             }
         }
+    }
+
+    /**
+     * A to-one relationship (lookup / master-detail field) is serialized as
+     * {@code {"data": {"type": ..., "id": ...}}}, or {@code {"data": null}} for an empty FK.
+     * Has-many inverse relationships serialize {@code data} as a list and must not be treated
+     * as collection fields.
+     */
+    private boolean isToOneRelationship(Object relValue) {
+        if (!(relValue instanceof Map<?, ?> relMap) || !relMap.containsKey("data")) {
+            return false;
+        }
+        Object relData = relMap.get("data");
+        return relData == null || relData instanceof Map;
     }
 
     private boolean isSystemField(String fieldId) {

--- a/kelta-worker/src/test/java/io/kelta/worker/interceptor/CerbosFieldSecurityAdviceTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/interceptor/CerbosFieldSecurityAdviceTest.java
@@ -196,4 +196,142 @@ class CerbosFieldSecurityAdviceTest {
         // Should be called once for all records (batched)
         verify(authzService, times(1)).batchCheckFieldAccess(any(), any(), any(), any(), anyList(), any());
     }
+
+    @Test
+    @DisplayName("Should strip a hidden to-one relationship field (lookup/master-detail) from relationships")
+    void shouldStripHiddenRelationshipField() {
+        var request = createRequest("/api/contacts/123");
+        // 'name' allowed; the 'account' lookup relationship is denied
+        when(authzService.batchCheckFieldAccess(any(), any(), any(), any(), anyList(), eq("read")))
+                .thenReturn(List.of("name"));
+
+        Map<String, Object> attributes = new LinkedHashMap<>();
+        attributes.put("name", "John");
+
+        Map<String, Object> relationships = new LinkedHashMap<>();
+        relationships.put("account", new LinkedHashMap<>(Map.of(
+                "data", new LinkedHashMap<>(Map.of("type", "accounts", "id", "acc-1")))));
+
+        Map<String, Object> record = new LinkedHashMap<>();
+        record.put("type", "contacts");
+        record.put("id", "123");
+        record.put("attributes", attributes);
+        record.put("relationships", relationships);
+        Map<String, Object> body = new LinkedHashMap<>(Map.of("data", record));
+
+        advice.beforeBodyWrite(body, null, MediaType.APPLICATION_JSON, null, request, null);
+
+        assertThat(attributes).containsKey("name");
+        // The denied relationship is stripped and the now-empty relationships block removed.
+        assertThat(record).doesNotContainKey("relationships");
+    }
+
+    @Test
+    @DisplayName("Should keep an allowed to-one relationship field")
+    void shouldKeepAllowedRelationshipField() {
+        var request = createRequest("/api/contacts/123");
+        when(authzService.batchCheckFieldAccess(any(), any(), any(), any(), anyList(), eq("read")))
+                .thenReturn(List.of("name", "account"));
+
+        Map<String, Object> attributes = new LinkedHashMap<>();
+        attributes.put("name", "John");
+        Map<String, Object> relationships = new LinkedHashMap<>();
+        relationships.put("account", new LinkedHashMap<>(Map.of(
+                "data", new LinkedHashMap<>(Map.of("type", "accounts", "id", "acc-1")))));
+        Map<String, Object> record = new LinkedHashMap<>();
+        record.put("type", "contacts");
+        record.put("id", "123");
+        record.put("attributes", attributes);
+        record.put("relationships", relationships);
+        Map<String, Object> body = new LinkedHashMap<>(Map.of("data", record));
+
+        advice.beforeBodyWrite(body, null, MediaType.APPLICATION_JSON, null, request, null);
+
+        assertThat(relationships).containsKey("account");
+    }
+
+    @Test
+    @DisplayName("Should not strip has-many inverse relationships (data is a list, not a collection field)")
+    void shouldNotStripHasManyInverse() {
+        var request = createRequest("/api/accounts/1");
+        when(authzService.batchCheckFieldAccess(any(), any(), any(), any(), anyList(), eq("read")))
+                .thenReturn(List.of("name"));
+
+        Map<String, Object> attributes = new LinkedHashMap<>();
+        attributes.put("name", "Acme");
+        Map<String, Object> relationships = new LinkedHashMap<>();
+        relationships.put("contacts", new LinkedHashMap<>(Map.of(
+                "data", List.of(
+                        Map.of("type", "contacts", "id", "c1"),
+                        Map.of("type", "contacts", "id", "c2")))));
+        Map<String, Object> record = new LinkedHashMap<>();
+        record.put("type", "accounts");
+        record.put("id", "1");
+        record.put("attributes", attributes);
+        record.put("relationships", relationships);
+        Map<String, Object> body = new LinkedHashMap<>(Map.of("data", record));
+
+        advice.beforeBodyWrite(body, null, MediaType.APPLICATION_JSON, null, request, null);
+
+        // The has-many inverse relationship is not a collection field and must survive.
+        assertThat(relationships).containsKey("contacts");
+    }
+
+    @Test
+    @DisplayName("Should strip hidden fields from included resources (by type)")
+    void shouldStripIncludedResources() {
+        var request = createRequest("/api/contacts/123");
+        when(authzService.batchCheckFieldAccess(any(), any(), any(), eq("contacts"), anyList(), eq("read")))
+                .thenReturn(List.of("name"));
+        when(authzService.batchCheckFieldAccess(any(), any(), any(), eq("accounts"), anyList(), eq("read")))
+                .thenReturn(List.of("accountName"));
+
+        Map<String, Object> attrs = new LinkedHashMap<>();
+        attrs.put("name", "John");
+        Map<String, Object> record = new LinkedHashMap<>();
+        record.put("type", "contacts");
+        record.put("id", "123");
+        record.put("attributes", attrs);
+
+        Map<String, Object> incAttrs = new LinkedHashMap<>();
+        incAttrs.put("accountName", "Acme");
+        incAttrs.put("accountSecret", "top-secret"); // denied — must be stripped
+        Map<String, Object> included = new LinkedHashMap<>();
+        included.put("type", "accounts");
+        included.put("id", "acc-1");
+        included.put("attributes", incAttrs);
+
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("data", record);
+        body.put("included", List.of(included));
+
+        advice.beforeBodyWrite(body, null, MediaType.APPLICATION_JSON, null, request, null);
+
+        assertThat(incAttrs).containsKey("accountName");
+        assertThat(incAttrs).doesNotContainKey("accountSecret");
+    }
+
+    @Test
+    @DisplayName("Should preserve the top-level meta block (pagination meta is not a field-leak vector)")
+    void shouldPreserveMetaBlock() {
+        var request = createRequest("/api/contacts");
+        when(authzService.batchCheckFieldAccess(any(), any(), any(), any(), anyList(), eq("read")))
+                .thenReturn(List.of("name"));
+
+        Map<String, Object> attrs = new LinkedHashMap<>();
+        attrs.put("name", "John");
+        attrs.put("secret", "x");
+        Map<String, Object> record = new LinkedHashMap<>(Map.of(
+                "type", "contacts", "id", "1", "attributes", attrs));
+        Map<String, Object> meta = new LinkedHashMap<>(Map.of("totalRecords", 1));
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("data", List.of(record));
+        body.put("meta", meta);
+
+        advice.beforeBodyWrite(body, null, MediaType.APPLICATION_JSON, null, request, null);
+
+        assertThat(attrs).doesNotContainKey("secret");
+        assertThat(body).containsKey("meta");
+        assertThat(meta).containsEntry("totalRecords", 1);
+    }
 }


### PR DESCRIPTION
## What
Closes a read-side field-level-security leak. `CerbosFieldSecurityAdvice` stripped denied fields only from JSON:API `attributes`, but the router serializes **lookup / master-detail** fields into a `relationships` block (`relationships.<field>.data = { type, id }`), not `attributes`. So a field marked **HIDDEN** for a profile still leaked the related record's id through `relationships`.

### Changes
- Unify the single / list / `included` paths through one `stripCollection` helper (still one batched Cerbos check per collection/type — JSON:API flattens all include depths into the single `included[]` array, so this covers every depth).
- Collect checkable field ids from `attributes` **and** to-one `relationships` keys; strip denied keys from both; drop an emptied `relationships` block.
- Distinguish **to-one** relationship fields (`data` is a resource-identifier object or `null`) from **has-many inverse** relationships added by `?include=` (`data` is a list) — the latter are not collection fields and are preserved.
- System audit fields (`createdAt`/`updatedAt`/`createdBy`/`updatedBy`) and the `meta` block are untouched.

## Why
Phase 0 hardening (strategic roadmap) — "verify + harden" read-side FLS. The advice and its tests already existed; verification found this genuine relationship-linkage leak. (Sparse fieldsets are already safe — denied fields are stripped post-query regardless of `?fields=`; nested includes are covered because JSON:API uses one flat `included[]` array.)

## Tests
`CerbosFieldSecurityAdviceTest` +5 (13 total):
- hidden to-one relationship stripped (+ empty `relationships` block removed)
- allowed relationship preserved
- has-many inverse relationship preserved
- included resources stripped by type
- `meta` block preserved

Full `kelta-worker` suite green: **1256 tests, 0 failures**.

## Docs
`.claude/docs/architecture.md` — read-side FLS contract documented alongside include resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)