### PR TITLE
feat(alm): metadata dependency graph + impact analysis

### DIFF
--- a/.claude/docs/architecture.md
+++ b/.claude/docs/architecture.md
@@ -209,6 +209,7 @@ controller after the mutation rather than via the BeforeSaveHook registry.
 | TenantContext | ThreadLocal tenant isolation | `runtime-core/.../context/TenantContext.java` |
 | BootstrapConfig | Gateway startup config (collections, routes, limits) | `kelta-gateway/.../config/BootstrapConfig.java` |
 | CompositeUniqueConstraintService | Issues `CREATE UNIQUE INDEX` over multi-column tuples; constraint state lives in Postgres (no separate registry) | `runtime-core/.../storage/CompositeUniqueConstraintService.java` |
+| MetadataDependencyService | Builds a per-tenant metadata dependency graph on demand (collections/fields/flows/layouts/rules/record-types/list-views/constraints/perms) for impact analysis + cycle detection; not persisted, so always current. Endpoints: `GET /api/metadata/impact`, `GET /api/metadata/graph` | `kelta-worker/.../service/MetadataDependencyService.java`, `.../dependency/MetadataDependencyGraph.java` |
 
 ### Unique constraints
 

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -452,6 +452,19 @@ Attach notes and files to any record in the system.
 
 ---
 
+### Metadata Dependency & Impact Analysis | Backend
+
+Answer "what breaks if I change this?" across a tenant's configuration before a delete or promotion.
+
+**Working:**
+- `MetadataDependencyService` builds a per-tenant dependency graph on demand from the live metadata — collections, fields (lookup / master-detail references), flows (collections + sub-flows referenced in the definition JSON), page layouts (collection, placed fields, related lists), validation rules, record types, list views, unique constraints, and profile object/field permissions. Each extractor is best-effort, so a single schema variance never fails the whole graph.
+- Impact API: `GET /api/metadata/impact?type=&id=&direction=dependents|dependencies` — `dependents` returns the transitive set that breaks if the node changes; `dependencies` returns what the node relies on. `GET /api/metadata/graph` returns the full nodes/edges plus detected cycles.
+- **Cycle detection** (Tarjan SCC) surfaces circular master-detail chains — reused by config-health governance.
+
+> **Next:** dependency-graph UI viewer (Phase 2) and diff-based deployment plans with conflict detection (Phase 2, on the existing Promotion/Environment controllers).
+
+---
+
 ### Page Builder | Partial
 
 A visual drag-and-drop page editor for building custom pages.

--- a/kelta-worker/src/main/java/io/kelta/worker/controller/MetadataDependencyController.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/controller/MetadataDependencyController.java
@@ -1,0 +1,82 @@
+package io.kelta.worker.controller;
+
+import io.kelta.jsonapi.JsonApiResponseBuilder;
+import io.kelta.worker.dependency.MetadataType;
+import io.kelta.worker.service.MetadataDependencyService;
+import io.kelta.worker.service.MetadataDependencyService.Direction;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Read-only metadata dependency / impact-analysis endpoints.
+ *
+ * <p>Responses use a {@code { "data": { ... } }} envelope whose body has no {@code attributes}
+ * or {@code relationships} keys, so the read-side field-security advice treats it as a non-record
+ * payload and leaves it untouched (these are configuration-graph results, not tenant records).
+ *
+ * @since 1.0.0
+ */
+@RestController
+@RequestMapping("/api/metadata")
+public class MetadataDependencyController {
+
+    private final MetadataDependencyService dependencyService;
+
+    public MetadataDependencyController(MetadataDependencyService dependencyService) {
+        this.dependencyService = dependencyService;
+    }
+
+    /**
+     * Impact analysis for a single metadata node.
+     *
+     * @param type      metadata type (COLLECTION, FIELD, FLOW, ...)
+     * @param id        the metadata object's id
+     * @param direction {@code dependents} (default — what breaks if it changes) or
+     *                  {@code dependencies} (what it relies on)
+     */
+    @GetMapping("/impact")
+    public ResponseEntity<Map<String, Object>> impact(
+            @RequestHeader("X-Tenant-ID") String tenantId,
+            @RequestParam("type") String type,
+            @RequestParam("id") String id,
+            @RequestParam(value = "direction", defaultValue = "dependents") String direction) {
+
+        MetadataType metadataType;
+        try {
+            metadataType = MetadataType.valueOf(type.trim().toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(JsonApiResponseBuilder.error(
+                    "400", "INVALID_TYPE", "Invalid metadata type",
+                    "Unknown metadata type '" + type + "'"));
+        }
+
+        Direction dir = "dependencies".equalsIgnoreCase(direction.trim())
+                ? Direction.DEPENDENCIES : Direction.DEPENDENTS;
+
+        Map<String, Object> result = dependencyService.impact(tenantId, metadataType, id, dir);
+        return ResponseEntity.ok(wrap(result));
+    }
+
+    /**
+     * The full dependency graph (nodes, edges, detected cycles) for the tenant.
+     */
+    @GetMapping("/graph")
+    public ResponseEntity<Map<String, Object>> graph(
+            @RequestHeader("X-Tenant-ID") String tenantId) {
+        return ResponseEntity.ok(wrap(dependencyService.graphSummary(tenantId)));
+    }
+
+    private static Map<String, Object> wrap(Map<String, Object> data) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("data", data);
+        return body;
+    }
+}

--- a/kelta-worker/src/main/java/io/kelta/worker/dependency/DependencyKind.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/dependency/DependencyKind.java
@@ -1,0 +1,42 @@
+package io.kelta.worker.dependency;
+
+/**
+ * The semantic reason one metadata node depends on another.
+ *
+ * <p>An edge always runs <em>from the dependent to the dependency</em>: {@code from} references,
+ * contains, or is otherwise broken by a change to {@code to}.
+ *
+ * @since 1.0.0
+ */
+public enum DependencyKind {
+    /** A field belongs to its parent collection. */
+    FIELD_OF_COLLECTION,
+    /** A LOOKUP field references a target collection. */
+    LOOKUP,
+    /** A MASTER_DETAIL field references its parent collection. */
+    MASTER_DETAIL,
+    /** A flow action or trigger references a collection. */
+    FLOW_REFERENCES_COLLECTION,
+    /** A flow invokes another flow as a sub-flow (InvokeFlow). */
+    FLOW_INVOKES_FLOW,
+    /** A page layout belongs to a collection. */
+    LAYOUT_OF_COLLECTION,
+    /** A page layout places a field. */
+    LAYOUT_USES_FIELD,
+    /** A page layout shows a related list backed by another collection. */
+    LAYOUT_RELATED_COLLECTION,
+    /** A validation rule belongs to a collection. */
+    VALIDATION_RULE_OF_COLLECTION,
+    /** A record type belongs to a collection. */
+    RECORD_TYPE_OF_COLLECTION,
+    /** A list view belongs to a collection. */
+    LIST_VIEW_OF_COLLECTION,
+    /** A unique constraint belongs to a collection. */
+    UNIQUE_CONSTRAINT_OF_COLLECTION,
+    /** A unique constraint covers a field. */
+    UNIQUE_CONSTRAINT_USES_FIELD,
+    /** A profile grants object permissions on a collection. */
+    OBJECT_PERMISSION,
+    /** A profile grants field permissions on a field. */
+    FIELD_PERMISSION
+}

--- a/kelta-worker/src/main/java/io/kelta/worker/dependency/MetadataDependencyGraph.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/dependency/MetadataDependencyGraph.java
@@ -1,0 +1,184 @@
+package io.kelta.worker.dependency;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * A directed graph of metadata dependencies for a single tenant.
+ *
+ * <p>Edges run from a dependent node to the node it depends on (see {@link MetadataEdge}). The
+ * graph answers two impact questions:
+ * <ul>
+ *   <li><b>dependents</b> — "what breaks if this changes?" — the transitive closure over
+ *       <em>incoming</em> edges (everything that points at the node).</li>
+ *   <li><b>dependencies</b> — "what does this rely on?" — the transitive closure over
+ *       <em>outgoing</em> edges.</li>
+ * </ul>
+ * and detects cycles (e.g. circular master-detail chains) via strongly-connected components.
+ *
+ * <p>Not thread-safe; build once, then query.
+ *
+ * @since 1.0.0
+ */
+public class MetadataDependencyGraph {
+
+    private final Map<String, MetadataNode> nodes = new HashMap<>();
+    private final List<MetadataEdge> edges = new ArrayList<>();
+    private final Map<String, List<MetadataEdge>> outgoing = new HashMap<>();
+    private final Map<String, List<MetadataEdge>> incoming = new HashMap<>();
+
+    /** Registers a node, filling in a name if a prior registration had none. */
+    public MetadataNode addNode(MetadataNode node) {
+        MetadataNode existing = nodes.get(node.key());
+        if (existing == null) {
+            nodes.put(node.key(), node);
+            return node;
+        }
+        if (existing.name() == null && node.name() != null) {
+            MetadataNode merged = new MetadataNode(node.type(), node.id(), node.name());
+            nodes.put(node.key(), merged);
+            return merged;
+        }
+        return existing;
+    }
+
+    /** Adds a dependency edge, registering both endpoints. Ignores self-edges to the same node. */
+    public void addEdge(MetadataNode from, MetadataNode to, DependencyKind kind) {
+        addNode(from);
+        addNode(to);
+        if (from.equals(to)) {
+            return;
+        }
+        MetadataEdge edge = new MetadataEdge(from, to, kind);
+        edges.add(edge);
+        outgoing.computeIfAbsent(from.key(), k -> new ArrayList<>()).add(edge);
+        incoming.computeIfAbsent(to.key(), k -> new ArrayList<>()).add(edge);
+    }
+
+    public List<MetadataNode> nodes() {
+        return new ArrayList<>(nodes.values());
+    }
+
+    public List<MetadataEdge> edges() {
+        return new ArrayList<>(edges);
+    }
+
+    public boolean contains(MetadataNode node) {
+        return nodes.containsKey(node.key());
+    }
+
+    public MetadataNode resolve(MetadataType type, String id) {
+        return nodes.get(type.name() + ":" + id);
+    }
+
+    /** Direct edges pointing at {@code node} (its immediate dependents). */
+    public List<MetadataEdge> directDependents(MetadataNode node) {
+        return new ArrayList<>(incoming.getOrDefault(node.key(), List.of()));
+    }
+
+    /** Direct edges leaving {@code node} (its immediate dependencies). */
+    public List<MetadataEdge> directDependencies(MetadataNode node) {
+        return new ArrayList<>(outgoing.getOrDefault(node.key(), List.of()));
+    }
+
+    /** Everything that transitively depends on {@code node} — "what breaks if it changes". */
+    public Set<MetadataNode> transitiveDependents(MetadataNode node) {
+        return traverse(node, incoming, true);
+    }
+
+    /** Everything {@code node} transitively depends on. */
+    public Set<MetadataNode> transitiveDependencies(MetadataNode node) {
+        return traverse(node, outgoing, false);
+    }
+
+    private Set<MetadataNode> traverse(MetadataNode start,
+                                       Map<String, List<MetadataEdge>> adjacency,
+                                       boolean followToFrom) {
+        Set<MetadataNode> visited = new LinkedHashSet<>();
+        Deque<MetadataNode> queue = new ArrayDeque<>();
+        queue.add(start);
+        Set<String> seen = new HashSet<>();
+        seen.add(start.key());
+        while (!queue.isEmpty()) {
+            MetadataNode current = queue.poll();
+            for (MetadataEdge edge : adjacency.getOrDefault(current.key(), List.of())) {
+                MetadataNode next = followToFrom ? edge.from() : edge.to();
+                if (seen.add(next.key())) {
+                    visited.add(next);
+                    queue.add(next);
+                }
+            }
+        }
+        return visited;
+    }
+
+    /**
+     * Returns strongly-connected components of size &gt; 1 — i.e. cycles such as circular
+     * master-detail chains. A graph with no cycles returns an empty list.
+     */
+    public List<List<MetadataNode>> findCycles() {
+        return new Tarjan().run();
+    }
+
+    public boolean hasCycle() {
+        return !findCycles().isEmpty();
+    }
+
+    /** Iterative Tarjan's strongly-connected-components, returning only components of size &gt; 1. */
+    private final class Tarjan {
+        private int index = 0;
+        private final Map<String, Integer> indexOf = new HashMap<>();
+        private final Map<String, Integer> lowLink = new HashMap<>();
+        private final Deque<MetadataNode> stack = new ArrayDeque<>();
+        private final Set<String> onStack = new HashSet<>();
+        private final List<List<MetadataNode>> cycles = new ArrayList<>();
+
+        List<List<MetadataNode>> run() {
+            for (MetadataNode node : nodes.values()) {
+                if (!indexOf.containsKey(node.key())) {
+                    strongConnect(node);
+                }
+            }
+            return cycles;
+        }
+
+        // Recursion depth is bounded by the metadata graph size (small per tenant).
+        private void strongConnect(MetadataNode v) {
+            indexOf.put(v.key(), index);
+            lowLink.put(v.key(), index);
+            index++;
+            stack.push(v);
+            onStack.add(v.key());
+
+            for (MetadataEdge edge : outgoing.getOrDefault(v.key(), List.of())) {
+                MetadataNode w = edge.to();
+                if (!indexOf.containsKey(w.key())) {
+                    strongConnect(w);
+                    lowLink.put(v.key(), Math.min(lowLink.get(v.key()), lowLink.get(w.key())));
+                } else if (onStack.contains(w.key())) {
+                    lowLink.put(v.key(), Math.min(lowLink.get(v.key()), indexOf.get(w.key())));
+                }
+            }
+
+            if (lowLink.get(v.key()).equals(indexOf.get(v.key()))) {
+                List<MetadataNode> component = new ArrayList<>();
+                MetadataNode w;
+                do {
+                    w = stack.pop();
+                    onStack.remove(w.key());
+                    component.add(w);
+                } while (!w.equals(v));
+                if (component.size() > 1) {
+                    cycles.add(component);
+                }
+            }
+        }
+    }
+}

--- a/kelta-worker/src/main/java/io/kelta/worker/dependency/MetadataEdge.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/dependency/MetadataEdge.java
@@ -1,0 +1,30 @@
+package io.kelta.worker.dependency;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * A directed edge in the metadata dependency graph, running from a dependent node to the node it
+ * depends on. "{@code from} {@code kind} {@code to}" reads as, e.g., "field LOOKUP collection".
+ *
+ * @param from the dependent node
+ * @param to   the node depended upon
+ * @param kind why the dependency exists
+ * @since 1.0.0
+ */
+public record MetadataEdge(MetadataNode from, MetadataNode to, DependencyKind kind) {
+
+    public MetadataEdge {
+        if (from == null || to == null || kind == null) {
+            throw new IllegalArgumentException("MetadataEdge requires non-null from, to, and kind");
+        }
+    }
+
+    public Map<String, Object> toMap() {
+        Map<String, Object> map = new LinkedHashMap<>();
+        map.put("from", from.toMap());
+        map.put("to", to.toMap());
+        map.put("kind", kind.name());
+        return map;
+    }
+}

--- a/kelta-worker/src/main/java/io/kelta/worker/dependency/MetadataNode.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/dependency/MetadataNode.java
@@ -1,0 +1,55 @@
+package io.kelta.worker.dependency;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * A node in the metadata dependency graph: one configuration object, identified by its
+ * {@link MetadataType} and id. Equality is by (type, id) so {@code name} is purely descriptive.
+ *
+ * @param type the kind of metadata
+ * @param id   the metadata object's id (stable identifier)
+ * @param name a human-friendly label (display name), may be null
+ * @since 1.0.0
+ */
+public record MetadataNode(MetadataType type, String id, String name) {
+
+    public MetadataNode {
+        if (type == null || id == null) {
+            throw new IllegalArgumentException("MetadataNode requires non-null type and id");
+        }
+    }
+
+    public static MetadataNode of(MetadataType type, String id, String name) {
+        return new MetadataNode(type, id, name);
+    }
+
+    /** A stable composite key for graph adjacency maps and de-duplication. */
+    public String key() {
+        return type.name() + ":" + id;
+    }
+
+    /** JSON:API-friendly map ({@code type}, {@code id}, {@code name}) for responses. */
+    public Map<String, Object> toMap() {
+        Map<String, Object> map = new LinkedHashMap<>();
+        map.put("type", type.name());
+        map.put("id", id);
+        map.put("name", name);
+        return map;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        return o instanceof MetadataNode other
+                && type == other.type
+                && id.equals(other.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return 31 * type.hashCode() + id.hashCode();
+    }
+}

--- a/kelta-worker/src/main/java/io/kelta/worker/dependency/MetadataType.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/dependency/MetadataType.java
@@ -1,0 +1,18 @@
+package io.kelta.worker.dependency;
+
+/**
+ * The kinds of configuration metadata that participate in the dependency graph.
+ *
+ * @since 1.0.0
+ */
+public enum MetadataType {
+    COLLECTION,
+    FIELD,
+    FLOW,
+    LAYOUT,
+    VALIDATION_RULE,
+    RECORD_TYPE,
+    LIST_VIEW,
+    UNIQUE_CONSTRAINT,
+    PROFILE
+}

--- a/kelta-worker/src/main/java/io/kelta/worker/service/MetadataDependencyService.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/service/MetadataDependencyService.java
@@ -1,0 +1,371 @@
+package io.kelta.worker.service;
+
+import io.kelta.worker.dependency.DependencyKind;
+import io.kelta.worker.dependency.MetadataDependencyGraph;
+import io.kelta.worker.dependency.MetadataEdge;
+import io.kelta.worker.dependency.MetadataNode;
+import io.kelta.worker.dependency.MetadataType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+
+/**
+ * Builds a tenant's metadata dependency graph on demand and answers impact-analysis queries
+ * ("what breaks if X changes?" / "what does X depend on?").
+ *
+ * <p>The graph is computed from the live configuration tables (collections, fields, flows,
+ * layouts, validation rules, record types, list views, unique constraints, profile permissions),
+ * not persisted — so it is always current. Each extractor is best-effort: a failure to read one
+ * metadata type is logged and skipped so a single schema variance never fails the whole graph.
+ *
+ * @since 1.0.0
+ */
+@Service
+public class MetadataDependencyService {
+
+    private static final Logger log = LoggerFactory.getLogger(MetadataDependencyService.class);
+
+    /** Forward = a node's dependencies; reverse = its dependents (impact). */
+    public enum Direction { DEPENDENTS, DEPENDENCIES }
+
+    private final JdbcTemplate jdbcTemplate;
+    private final ObjectMapper objectMapper;
+
+    public MetadataDependencyService(JdbcTemplate jdbcTemplate, ObjectMapper objectMapper) {
+        this.jdbcTemplate = jdbcTemplate;
+        this.objectMapper = objectMapper;
+    }
+
+    /**
+     * Builds the full dependency graph for a tenant.
+     */
+    public MetadataDependencyGraph buildGraph(String tenantId) {
+        MetadataDependencyGraph graph = new MetadataDependencyGraph();
+
+        Set<String> collectionIds = new LinkedHashSet<>();
+        Set<String> flowIds = new LinkedHashSet<>();
+
+        extract("collections", () -> extractCollections(tenantId, graph, collectionIds));
+        extract("fields", () -> extractFields(tenantId, graph));
+        extract("flows", () -> extractFlows(tenantId, graph, flowIds));
+        // Flow references depend on collection/flow node sets being loaded first.
+        extract("flow-references", () -> extractFlowReferences(tenantId, graph, collectionIds, flowIds));
+        extract("layouts", () -> extractLayouts(tenantId, graph));
+        extract("layout-fields", () -> extractLayoutFields(tenantId, graph));
+        extract("layout-related-lists", () -> extractLayoutRelatedLists(tenantId, graph));
+        extract("validation-rules", () -> extractValidationRules(tenantId, graph));
+        extract("record-types", () -> extractRecordTypes(tenantId, graph));
+        extract("list-views", () -> extractListViews(tenantId, graph));
+        extract("unique-constraints", () -> extractUniqueConstraints(tenantId, graph));
+        extract("object-permissions", () -> extractObjectPermissions(tenantId, graph));
+        extract("field-permissions", () -> extractFieldPermissions(tenantId, graph));
+
+        return graph;
+    }
+
+    /**
+     * Returns an impact-analysis result for one metadata node, in the requested direction.
+     */
+    public Map<String, Object> impact(String tenantId, MetadataType type, String id, Direction direction) {
+        MetadataDependencyGraph graph = buildGraph(tenantId);
+        MetadataNode node = graph.resolve(type, id);
+        if (node == null) {
+            node = MetadataNode.of(type, id, null);
+        }
+
+        List<MetadataEdge> direct = direction == Direction.DEPENDENTS
+                ? graph.directDependents(node)
+                : graph.directDependencies(node);
+        Set<MetadataNode> transitive = direction == Direction.DEPENDENTS
+                ? graph.transitiveDependents(node)
+                : graph.transitiveDependencies(node);
+
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("node", node.toMap());
+        result.put("direction", direction.name().toLowerCase());
+        result.put("found", graph.contains(node));
+        result.put("direct", direct.stream().map(MetadataEdge::toMap).toList());
+        result.put("transitive", transitive.stream().map(MetadataNode::toMap).toList());
+        result.put("transitiveCount", transitive.size());
+        return result;
+    }
+
+    /**
+     * Returns the full graph (nodes, edges, detected cycles) for visualization / governance.
+     */
+    public Map<String, Object> graphSummary(String tenantId) {
+        MetadataDependencyGraph graph = buildGraph(tenantId);
+        List<List<Map<String, Object>>> cycles = graph.findCycles().stream()
+                .map(cycle -> cycle.stream().map(MetadataNode::toMap).toList())
+                .toList();
+
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("nodes", graph.nodes().stream().map(MetadataNode::toMap).toList());
+        result.put("edges", graph.edges().stream().map(MetadataEdge::toMap).toList());
+        result.put("nodeCount", graph.nodes().size());
+        result.put("edgeCount", graph.edges().size());
+        result.put("cycles", cycles);
+        result.put("hasCycle", !cycles.isEmpty());
+        return result;
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Extractors — each best-effort, scoped to the tenant.
+    // ---------------------------------------------------------------------------------------
+
+    private void extract(String label, Runnable extractor) {
+        try {
+            extractor.run();
+        } catch (Exception e) {
+            log.warn("Dependency-graph extractor '{}' skipped: {}", label, e.getMessage());
+        }
+    }
+
+    private void extractCollections(String tenantId, MetadataDependencyGraph graph, Set<String> ids) {
+        forEachRow("SELECT id, name FROM collection WHERE tenant_id = ?", tenantId, row -> {
+            String id = (String) row.get("id");
+            graph.addNode(MetadataNode.of(MetadataType.COLLECTION, id, (String) row.get("name")));
+            ids.add(id);
+        });
+    }
+
+    private void extractFields(String tenantId, MetadataDependencyGraph graph) {
+        String sql = """
+                SELECT f.id, f.name, f.collection_id, f.relationship_type, f.reference_collection_id
+                FROM field f JOIN collection c ON f.collection_id = c.id
+                WHERE c.tenant_id = ?
+                """;
+        forEachRow(sql, tenantId, row -> {
+            String fieldId = (String) row.get("id");
+            String collectionId = (String) row.get("collection_id");
+            MetadataNode field = graph.addNode(
+                    MetadataNode.of(MetadataType.FIELD, fieldId, (String) row.get("name")));
+            MetadataNode collection = MetadataNode.of(MetadataType.COLLECTION, collectionId, null);
+            graph.addEdge(field, collection, DependencyKind.FIELD_OF_COLLECTION);
+
+            String refCollectionId = (String) row.get("reference_collection_id");
+            String relationshipType = (String) row.get("relationship_type");
+            if (refCollectionId != null && relationshipType != null) {
+                MetadataNode target = MetadataNode.of(MetadataType.COLLECTION, refCollectionId, null);
+                boolean masterDetail = "MASTER_DETAIL".equalsIgnoreCase(relationshipType);
+                graph.addEdge(field, target,
+                        masterDetail ? DependencyKind.MASTER_DETAIL : DependencyKind.LOOKUP);
+                if (masterDetail) {
+                    // Collection-level cascade edge so circular master-detail forms a cycle.
+                    graph.addEdge(collection, target, DependencyKind.MASTER_DETAIL);
+                }
+            }
+        });
+    }
+
+    private void extractFlows(String tenantId, MetadataDependencyGraph graph, Set<String> ids) {
+        forEachRow("SELECT id, name FROM flow WHERE tenant_id = ?", tenantId, row -> {
+            String id = (String) row.get("id");
+            graph.addNode(MetadataNode.of(MetadataType.FLOW, id, (String) row.get("name")));
+            ids.add(id);
+        });
+    }
+
+    private void extractFlowReferences(String tenantId, MetadataDependencyGraph graph,
+                                       Set<String> collectionIds, Set<String> flowIds) {
+        forEachRow("SELECT id, definition, trigger_config FROM flow WHERE tenant_id = ?", tenantId, row -> {
+            String flowId = (String) row.get("id");
+            MetadataNode flow = MetadataNode.of(MetadataType.FLOW, flowId, null);
+
+            Set<String> collectionRefs = new LinkedHashSet<>();
+            Set<String> flowRefs = new LinkedHashSet<>();
+            collectJsonRefs(asText(row.get("definition")), collectionRefs, flowRefs);
+            collectJsonRefs(asText(row.get("trigger_config")), collectionRefs, flowRefs);
+
+            for (String ref : collectionRefs) {
+                if (collectionIds.contains(ref)) {
+                    graph.addEdge(flow, MetadataNode.of(MetadataType.COLLECTION, ref, null),
+                            DependencyKind.FLOW_REFERENCES_COLLECTION);
+                }
+            }
+            for (String ref : flowRefs) {
+                if (flowIds.contains(ref) && !ref.equals(flowId)) {
+                    graph.addEdge(flow, MetadataNode.of(MetadataType.FLOW, ref, null),
+                            DependencyKind.FLOW_INVOKES_FLOW);
+                }
+            }
+        });
+    }
+
+    private void extractLayouts(String tenantId, MetadataDependencyGraph graph) {
+        forEachRow("SELECT id, name, collection_id FROM page_layout WHERE tenant_id = ?", tenantId, row -> {
+            MetadataNode layout = graph.addNode(
+                    MetadataNode.of(MetadataType.LAYOUT, (String) row.get("id"), (String) row.get("name")));
+            graph.addEdge(layout,
+                    MetadataNode.of(MetadataType.COLLECTION, (String) row.get("collection_id"), null),
+                    DependencyKind.LAYOUT_OF_COLLECTION);
+        });
+    }
+
+    private void extractLayoutFields(String tenantId, MetadataDependencyGraph graph) {
+        String sql = """
+                SELECT pl.id AS layout_id, lf.field_id
+                FROM layout_field lf
+                JOIN layout_section ls ON lf.section_id = ls.id
+                JOIN page_layout pl ON ls.layout_id = pl.id
+                WHERE pl.tenant_id = ?
+                """;
+        forEachRow(sql, tenantId, row -> graph.addEdge(
+                MetadataNode.of(MetadataType.LAYOUT, (String) row.get("layout_id"), null),
+                MetadataNode.of(MetadataType.FIELD, (String) row.get("field_id"), null),
+                DependencyKind.LAYOUT_USES_FIELD));
+    }
+
+    private void extractLayoutRelatedLists(String tenantId, MetadataDependencyGraph graph) {
+        String sql = """
+                SELECT lrl.layout_id, lrl.related_collection_id
+                FROM layout_related_list lrl
+                JOIN page_layout pl ON lrl.layout_id = pl.id
+                WHERE pl.tenant_id = ?
+                """;
+        forEachRow(sql, tenantId, row -> graph.addEdge(
+                MetadataNode.of(MetadataType.LAYOUT, (String) row.get("layout_id"), null),
+                MetadataNode.of(MetadataType.COLLECTION, (String) row.get("related_collection_id"), null),
+                DependencyKind.LAYOUT_RELATED_COLLECTION));
+    }
+
+    private void extractValidationRules(String tenantId, MetadataDependencyGraph graph) {
+        forEachRow("SELECT id, name, collection_id FROM validation_rule WHERE tenant_id = ?", tenantId, row ->
+                graph.addEdge(
+                        graph.addNode(MetadataNode.of(MetadataType.VALIDATION_RULE,
+                                (String) row.get("id"), (String) row.get("name"))),
+                        MetadataNode.of(MetadataType.COLLECTION, (String) row.get("collection_id"), null),
+                        DependencyKind.VALIDATION_RULE_OF_COLLECTION));
+    }
+
+    private void extractRecordTypes(String tenantId, MetadataDependencyGraph graph) {
+        forEachRow("SELECT id, name, collection_id FROM record_type WHERE tenant_id = ?", tenantId, row ->
+                graph.addEdge(
+                        graph.addNode(MetadataNode.of(MetadataType.RECORD_TYPE,
+                                (String) row.get("id"), (String) row.get("name"))),
+                        MetadataNode.of(MetadataType.COLLECTION, (String) row.get("collection_id"), null),
+                        DependencyKind.RECORD_TYPE_OF_COLLECTION));
+    }
+
+    private void extractListViews(String tenantId, MetadataDependencyGraph graph) {
+        forEachRow("SELECT id, name, collection_id FROM list_view WHERE tenant_id = ?", tenantId, row ->
+                graph.addEdge(
+                        graph.addNode(MetadataNode.of(MetadataType.LIST_VIEW,
+                                (String) row.get("id"), (String) row.get("name"))),
+                        MetadataNode.of(MetadataType.COLLECTION, (String) row.get("collection_id"), null),
+                        DependencyKind.LIST_VIEW_OF_COLLECTION));
+    }
+
+    private void extractUniqueConstraints(String tenantId, MetadataDependencyGraph graph) {
+        forEachRow("SELECT id, collection_id, field_id FROM unique_constraint WHERE tenant_id = ?", tenantId, row -> {
+            MetadataNode constraint = graph.addNode(
+                    MetadataNode.of(MetadataType.UNIQUE_CONSTRAINT, (String) row.get("id"), null));
+            String collectionId = (String) row.get("collection_id");
+            if (collectionId != null) {
+                graph.addEdge(constraint, MetadataNode.of(MetadataType.COLLECTION, collectionId, null),
+                        DependencyKind.UNIQUE_CONSTRAINT_OF_COLLECTION);
+            }
+            String fieldId = (String) row.get("field_id");
+            if (fieldId != null) {
+                graph.addEdge(constraint, MetadataNode.of(MetadataType.FIELD, fieldId, null),
+                        DependencyKind.UNIQUE_CONSTRAINT_USES_FIELD);
+            }
+        });
+    }
+
+    private void extractObjectPermissions(String tenantId, MetadataDependencyGraph graph) {
+        String sql = """
+                SELECT po.profile_id, po.collection_id, p.name AS profile_name
+                FROM profile_object_permission po
+                JOIN profile p ON po.profile_id = p.id
+                WHERE p.tenant_id = ?
+                """;
+        forEachRow(sql, tenantId, row -> graph.addEdge(
+                MetadataNode.of(MetadataType.PROFILE, (String) row.get("profile_id"),
+                        (String) row.get("profile_name")),
+                MetadataNode.of(MetadataType.COLLECTION, (String) row.get("collection_id"), null),
+                DependencyKind.OBJECT_PERMISSION));
+    }
+
+    private void extractFieldPermissions(String tenantId, MetadataDependencyGraph graph) {
+        String sql = """
+                SELECT pf.profile_id, pf.field_id, p.name AS profile_name
+                FROM profile_field_permission pf
+                JOIN profile p ON pf.profile_id = p.id
+                WHERE p.tenant_id = ?
+                """;
+        forEachRow(sql, tenantId, row -> graph.addEdge(
+                MetadataNode.of(MetadataType.PROFILE, (String) row.get("profile_id"),
+                        (String) row.get("profile_name")),
+                MetadataNode.of(MetadataType.FIELD, (String) row.get("field_id"), null),
+                DependencyKind.FIELD_PERMISSION));
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------------------------
+
+    private void forEachRow(String sql, String tenantId, Consumer<Map<String, Object>> consumer) {
+        List<Map<String, Object>> rows = jdbcTemplate.queryForList(sql, tenantId);
+        for (Map<String, Object> row : rows) {
+            consumer.accept(row);
+        }
+    }
+
+    private static String asText(Object jsonbValue) {
+        return jsonbValue == null ? null : jsonbValue.toString();
+    }
+
+    /**
+     * Recursively collects values of {@code collectionId} / {@code targetCollectionId} (collection
+     * references) and {@code flowId} (sub-flow references) from a flow definition / trigger JSON.
+     */
+    private void collectJsonRefs(String json, Set<String> collectionRefs, Set<String> flowRefs) {
+        if (json == null || json.isBlank()) {
+            return;
+        }
+        JsonNode root;
+        try {
+            root = objectMapper.readTree(json);
+        } catch (Exception e) {
+            log.debug("Could not parse flow JSON for refs: {}", e.getMessage());
+            return;
+        }
+        walk(root, collectionRefs, flowRefs);
+    }
+
+    private void walk(JsonNode node, Set<String> collectionRefs, Set<String> flowRefs) {
+        if (node == null) {
+            return;
+        }
+        if (node.isObject()) {
+            node.properties().forEach(entry -> {
+                String key = entry.getKey();
+                JsonNode value = entry.getValue();
+                if (value.isTextual()) {
+                    if ("collectionId".equals(key) || "targetCollectionId".equals(key)) {
+                        collectionRefs.add(value.asText());
+                    } else if ("flowId".equals(key)) {
+                        flowRefs.add(value.asText());
+                    }
+                }
+                walk(value, collectionRefs, flowRefs);
+            });
+        } else if (node.isArray()) {
+            for (JsonNode child : node) {
+                walk(child, collectionRefs, flowRefs);
+            }
+        }
+    }
+}

--- a/kelta-worker/src/test/java/io/kelta/worker/controller/MetadataDependencyControllerTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/controller/MetadataDependencyControllerTest.java
@@ -1,0 +1,86 @@
+package io.kelta.worker.controller;
+
+import io.kelta.worker.dependency.MetadataType;
+import io.kelta.worker.service.MetadataDependencyService;
+import io.kelta.worker.service.MetadataDependencyService.Direction;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("MetadataDependencyController")
+class MetadataDependencyControllerTest {
+
+    private static final String TENANT = "tenant-1";
+
+    @Mock
+    private MetadataDependencyService service;
+
+    private MetadataDependencyController controller;
+
+    @BeforeEach
+    void setUp() {
+        controller = new MetadataDependencyController(service);
+    }
+
+    @Test
+    @DisplayName("impact wraps the service result in a data envelope (no attributes -> FLS-safe)")
+    void impactReturnsWrappedResult() {
+        when(service.impact(eq(TENANT), eq(MetadataType.COLLECTION), eq("account"), eq(Direction.DEPENDENTS)))
+                .thenReturn(Map.of("node", Map.of("id", "account"), "transitive", java.util.List.of()));
+
+        ResponseEntity<Map<String, Object>> response =
+                controller.impact(TENANT, "collection", "account", "dependents");
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).containsKey("data");
+        // FLS-safe: the envelope's data carries no "attributes"/"relationships" keys.
+        @SuppressWarnings("unchecked")
+        Map<String, Object> data = (Map<String, Object>) response.getBody().get("data");
+        assertThat(data).doesNotContainKeys("attributes", "relationships");
+    }
+
+    @Test
+    @DisplayName("impact accepts the dependencies direction")
+    void impactDependenciesDirection() {
+        when(service.impact(eq(TENANT), eq(MetadataType.FIELD), eq("f1"), eq(Direction.DEPENDENCIES)))
+                .thenReturn(Map.of("node", Map.of("id", "f1")));
+
+        controller.impact(TENANT, "field", "f1", "dependencies");
+
+        verify(service).impact(eq(TENANT), eq(MetadataType.FIELD), eq("f1"), eq(Direction.DEPENDENCIES));
+    }
+
+    @Test
+    @DisplayName("impact rejects an unknown metadata type with 400")
+    void impactInvalidType() {
+        ResponseEntity<Map<String, Object>> response =
+                controller.impact(TENANT, "not-a-type", "x", "dependents");
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody()).containsKey("errors");
+    }
+
+    @Test
+    @DisplayName("graph wraps the graph summary in a data envelope")
+    void graphReturnsWrappedResult() {
+        when(service.graphSummary(TENANT)).thenReturn(Map.of("nodeCount", 3, "hasCycle", false));
+
+        ResponseEntity<Map<String, Object>> response = controller.graph(TENANT);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).containsKey("data");
+    }
+}

--- a/kelta-worker/src/test/java/io/kelta/worker/dependency/MetadataDependencyGraphTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/dependency/MetadataDependencyGraphTest.java
@@ -1,0 +1,126 @@
+package io.kelta.worker.dependency;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("MetadataDependencyGraph")
+class MetadataDependencyGraphTest {
+
+    private static MetadataNode collection(String id) {
+        return MetadataNode.of(MetadataType.COLLECTION, id, "Collection " + id);
+    }
+
+    private static MetadataNode field(String id) {
+        return MetadataNode.of(MetadataType.FIELD, id, "Field " + id);
+    }
+
+    @Test
+    @DisplayName("records direct dependents and dependencies with edge kinds")
+    void directEdges() {
+        MetadataDependencyGraph g = new MetadataDependencyGraph();
+        MetadataNode account = collection("account");
+        MetadataNode contactAccountFk = field("contact.account");
+        // contact.account (a lookup field) depends on the account collection
+        g.addEdge(contactAccountFk, account, DependencyKind.LOOKUP);
+
+        assertThat(g.directDependents(account)).singleElement()
+                .satisfies(e -> {
+                    assertThat(e.from()).isEqualTo(contactAccountFk);
+                    assertThat(e.kind()).isEqualTo(DependencyKind.LOOKUP);
+                });
+        assertThat(g.directDependencies(contactAccountFk)).singleElement()
+                .satisfies(e -> assertThat(e.to()).isEqualTo(account));
+    }
+
+    @Test
+    @DisplayName("transitive dependents answer 'what breaks if this changes'")
+    void transitiveDependents() {
+        MetadataDependencyGraph g = new MetadataDependencyGraph();
+        MetadataNode account = collection("account");
+        MetadataNode lookup = field("contact.account");
+        MetadataNode layout = MetadataNode.of(MetadataType.LAYOUT, "contact-layout", "Contact Layout");
+
+        // account <- lookup field <- a layout that places that field
+        g.addEdge(lookup, account, DependencyKind.LOOKUP);
+        g.addEdge(layout, lookup, DependencyKind.LAYOUT_USES_FIELD);
+
+        Set<MetadataNode> impacted = g.transitiveDependents(account);
+
+        assertThat(impacted).containsExactlyInAnyOrder(lookup, layout);
+        // The node itself is never in its own impact set.
+        assertThat(impacted).doesNotContain(account);
+    }
+
+    @Test
+    @DisplayName("transitive dependencies answer 'what does this rely on'")
+    void transitiveDependencies() {
+        MetadataDependencyGraph g = new MetadataDependencyGraph();
+        MetadataNode order = collection("order");
+        MetadataNode customer = collection("customer");
+        MetadataNode orderCustomerFk = field("order.customer");
+
+        g.addEdge(orderCustomerFk, order, DependencyKind.FIELD_OF_COLLECTION);
+        g.addEdge(orderCustomerFk, customer, DependencyKind.LOOKUP);
+
+        assertThat(g.transitiveDependencies(orderCustomerFk))
+                .containsExactlyInAnyOrder(order, customer);
+    }
+
+    @Test
+    @DisplayName("ignores self-edges")
+    void ignoresSelfEdges() {
+        MetadataDependencyGraph g = new MetadataDependencyGraph();
+        MetadataNode c = collection("a");
+        g.addEdge(c, c, DependencyKind.MASTER_DETAIL);
+        assertThat(g.edges()).isEmpty();
+        assertThat(g.hasCycle()).isFalse();
+    }
+
+    @Test
+    @DisplayName("detects circular master-detail at the collection level")
+    void detectsCircularMasterDetail() {
+        MetadataDependencyGraph g = new MetadataDependencyGraph();
+        MetadataNode a = collection("a");
+        MetadataNode b = collection("b");
+        // a is a detail of b, and b is a detail of a — a cascade cycle
+        g.addEdge(a, b, DependencyKind.MASTER_DETAIL);
+        g.addEdge(b, a, DependencyKind.MASTER_DETAIL);
+
+        List<List<MetadataNode>> cycles = g.findCycles();
+
+        assertThat(cycles).hasSize(1);
+        assertThat(cycles.get(0)).containsExactlyInAnyOrder(a, b);
+        assertThat(g.hasCycle()).isTrue();
+    }
+
+    @Test
+    @DisplayName("acyclic graph reports no cycles")
+    void acyclicHasNoCycles() {
+        MetadataDependencyGraph g = new MetadataDependencyGraph();
+        MetadataNode a = collection("a");
+        MetadataNode b = collection("b");
+        MetadataNode c = collection("c");
+        g.addEdge(a, b, DependencyKind.LOOKUP);
+        g.addEdge(b, c, DependencyKind.LOOKUP);
+
+        assertThat(g.findCycles()).isEmpty();
+        assertThat(g.hasCycle()).isFalse();
+    }
+
+    @Test
+    @DisplayName("merges a missing node name when a later edge supplies it")
+    void mergesNodeName() {
+        MetadataDependencyGraph g = new MetadataDependencyGraph();
+        MetadataNode namelessAccount = MetadataNode.of(MetadataType.COLLECTION, "account", null);
+        MetadataNode namedAccount = collection("account");
+        g.addNode(namelessAccount);
+        g.addNode(namedAccount);
+
+        assertThat(g.resolve(MetadataType.COLLECTION, "account").name()).isEqualTo("Collection account");
+    }
+}

--- a/kelta-worker/src/test/java/io/kelta/worker/service/MetadataDependencyServiceTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/service/MetadataDependencyServiceTest.java
@@ -1,0 +1,131 @@
+package io.kelta.worker.service;
+
+import io.kelta.worker.dependency.MetadataDependencyGraph;
+import io.kelta.worker.dependency.MetadataType;
+import io.kelta.worker.service.MetadataDependencyService.Direction;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.JdbcTemplate;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("MetadataDependencyService")
+class MetadataDependencyServiceTest {
+
+    private static final String TENANT = "tenant-1";
+
+    @Mock
+    private JdbcTemplate jdbcTemplate;
+
+    private MetadataDependencyService service;
+    private final ObjectMapper objectMapper = JsonMapper.builder().build();
+
+    private static Map<String, Object> row(Object... kv) {
+        var map = new java.util.LinkedHashMap<String, Object>();
+        for (int i = 0; i < kv.length; i += 2) {
+            map.put((String) kv[i], kv[i + 1]);
+        }
+        return map;
+    }
+
+    @BeforeEach
+    void setUp() {
+        service = new MetadataDependencyService(jdbcTemplate, objectMapper);
+
+        // Collections: account, contact
+        stub("id, name FROM collection", List.of(
+                row("id", "account", "name", "Account"),
+                row("id", "contact", "name", "Contact")));
+
+        // Fields: contact.accountId LOOKUP -> account; contact.masterAcct MASTER_DETAIL -> account;
+        //         account.masterContact MASTER_DETAIL -> contact (creates a master-detail cycle)
+        stub("FROM field f", List.of(
+                row("id", "contact.accountId", "name", "Account", "collection_id", "contact",
+                        "relationship_type", "LOOKUP", "reference_collection_id", "account"),
+                row("id", "contact.masterAcct", "name", "Master Account", "collection_id", "contact",
+                        "relationship_type", "MASTER_DETAIL", "reference_collection_id", "account"),
+                row("id", "account.masterContact", "name", "Master Contact", "collection_id", "account",
+                        "relationship_type", "MASTER_DETAIL", "reference_collection_id", "contact")));
+
+        // Flows: orderFlow + subFlow
+        stub("id, name FROM flow", List.of(
+                row("id", "orderFlow", "name", "Order Flow"),
+                row("id", "subFlow", "name", "Sub Flow")));
+
+        // Flow definitions: orderFlow references account collection + invokes subFlow
+        stub("definition, trigger_config FROM flow", List.of(
+                row("id", "orderFlow",
+                        "definition", "{\"nodes\":[{\"config\":{\"targetCollectionId\":\"account\","
+                                + "\"flowId\":\"subFlow\"}}]}",
+                        "trigger_config", null),
+                row("id", "subFlow", "definition", "{}", "trigger_config", null)));
+    }
+
+    private void stub(String sqlFragment, List<Map<String, Object>> rows) {
+        lenient().when(jdbcTemplate.queryForList(contains(sqlFragment), eq(TENANT))).thenReturn(rows);
+    }
+
+    @Test
+    @DisplayName("builds nodes and edges across collections, fields, and flows")
+    void buildsGraph() {
+        MetadataDependencyGraph graph = service.buildGraph(TENANT);
+
+        assertThat(graph.resolve(MetadataType.COLLECTION, "account")).isNotNull();
+        assertThat(graph.resolve(MetadataType.FIELD, "contact.accountId")).isNotNull();
+        assertThat(graph.resolve(MetadataType.FLOW, "orderFlow")).isNotNull();
+        // Flow -> account (referenced) and flow -> subFlow (invoked) edges exist.
+        assertThat(graph.directDependencies(graph.resolve(MetadataType.FLOW, "orderFlow")))
+                .extracting(e -> e.to().id())
+                .contains("account", "subFlow");
+    }
+
+    @Test
+    @DisplayName("impact (dependents) lists what breaks if a collection changes")
+    void impactDependents() {
+        Map<String, Object> result = service.impact(TENANT, MetadataType.COLLECTION, "account", Direction.DEPENDENTS);
+
+        assertThat(result.get("found")).isEqualTo(true);
+        assertThat(result.get("direction")).isEqualTo("dependents");
+
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> transitive = (List<Map<String, Object>>) result.get("transitive");
+        // The lookup field and the flow that references account both depend on it.
+        assertThat(transitive).extracting(m -> m.get("id"))
+                .contains("contact.accountId", "orderFlow");
+    }
+
+    @Test
+    @DisplayName("graph summary detects the circular master-detail between account and contact")
+    void detectsMasterDetailCycle() {
+        Map<String, Object> summary = service.graphSummary(TENANT);
+
+        assertThat(summary.get("hasCycle")).isEqualTo(true);
+        @SuppressWarnings("unchecked")
+        List<List<Map<String, Object>>> cycles = (List<List<Map<String, Object>>>) summary.get("cycles");
+        assertThat(cycles).isNotEmpty();
+        assertThat(cycles.get(0)).extracting(m -> m.get("id"))
+                .containsExactlyInAnyOrder("account", "contact");
+    }
+
+    @Test
+    @DisplayName("unknown node still returns a well-formed (empty) impact result")
+    void unknownNode() {
+        Map<String, Object> result = service.impact(TENANT, MetadataType.COLLECTION, "ghost", Direction.DEPENDENTS);
+
+        assertThat(result.get("found")).isEqualTo(false);
+        assertThat((List<?>) result.get("transitive")).isEmpty();
+    }
+}


### PR DESCRIPTION
## What
Adds dependency/impact analysis across a tenant's configuration — "what breaks if I change this?" — the intelligence layer the existing Package/Promotion/Environment controllers lack.

- **Graph core** (`io.kelta.worker.dependency`): `MetadataNode`, `MetadataEdge` (dependent → dependency), `MetadataType`, `DependencyKind`, and `MetadataDependencyGraph` with transitive dependents/dependencies traversal + Tarjan-SCC cycle detection (circular master-detail).
- **`MetadataDependencyService`** builds the graph **on demand** from the live metadata tables: collections, fields (lookup/master-detail refs + a collection-level cascade edge), flows (collections + sub-flows parsed from the definition JSON), page layouts (collection / placed fields / related lists), validation rules, record types, list views, unique constraints, and profile object/field permissions. Each extractor is **best-effort** — a schema variance is logged and skipped, never failing the whole graph. Not persisted, so always current.
- **`MetadataDependencyController`**: `GET /api/metadata/impact?type=&id=&direction=dependents|dependencies` and `GET /api/metadata/graph`. Responses use a `{ "data": {...} }` envelope with no `attributes`/`relationships` keys, so the read-side field-security advice treats them as non-record payloads and leaves them untouched.

## Why
Phase 1 (AI moat). Per the roadmap, Rec 5 splits: **dependency graph + impact analysis here (Phase 1)**; deployment-plan diff/rollback on the Promotion controllers is **Phase 2**. This graph is **shared infrastructure** for config-health governance (Rec 6 — circular master-detail + orphan detection) and safe deletes in the screen builder (Rec 1).

## Design notes
- Edge direction = dependent → dependency. "What breaks if X changes" = transitive **incoming** edges; "what X relies on" = transitive **outgoing**.
- Master-detail adds both a field→target edge and a collection→target cascade edge, so circular master-detail forms a real directed cycle detectable by Tarjan SCC.
- On-demand (not persisted) keeps it always-current and avoids edge-table sync across ~12 metadata types; persistence/caching is a possible later optimization.

## Tests
- `MetadataDependencyGraphTest` (7) — traversal, self-edge ignore, cycle detection, node-name merge.
- `MetadataDependencyServiceTest` (4) — graph built from mocked rows, impact dependents, master-detail cycle, unknown node.
- `MetadataDependencyControllerTest` (4) — wrapped/FLS-safe envelope, direction parsing, invalid-type 400.
- Full `kelta-worker` suite green: **1273 tests, 0 failures**.

## Docs
`FEATURES.md` (new ALM subsection), `.claude/docs/architecture.md` (Key Abstractions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)