### PR TITLE
docs(comments): correct stale Kafka references to NATS

### DIFF
--- a/kelta-gateway/src/main/java/io/kelta/gateway/authz/cerbos/CerbosAuthorizationService.java
+++ b/kelta-gateway/src/main/java/io/kelta/gateway/authz/cerbos/CerbosAuthorizationService.java
@@ -29,7 +29,7 @@ import java.util.concurrent.atomic.AtomicLong;
  * and a circuit breaker to prevent thread-pool exhaustion.
  *
  * <p>Authorization results are cached in-memory (Caffeine) and invalidated
- * via Kafka events when Cerbos policies change. A safety-net TTL of 10 minutes
+ * via NATS events when Cerbos policies change. A safety-net TTL of 10 minutes
  * handles edge cases like missed events.
  *
  * <h3>Fail-closed design</h3>

--- a/kelta-gateway/src/main/java/io/kelta/gateway/cache/GatewayCacheManager.java
+++ b/kelta-gateway/src/main/java/io/kelta/gateway/cache/GatewayCacheManager.java
@@ -30,7 +30,7 @@ import java.util.concurrent.TimeUnit;
  *       Populated on startup and refreshed periodically from the worker's
  *       {@code /internal/tenants/slug-map} endpoint. Expires after 10 minutes.</li>
  *   <li><strong>Governor limit cache</strong> — maps tenant IDs to daily API call limits.
- *       Populated from bootstrap configuration on startup and updated via Kafka when
+ *       Populated from bootstrap configuration on startup and updated via NATS when
  *       tenant governor limits change. No time-based expiration — entries persist until
  *       explicitly invalidated.</li>
  * </ul>
@@ -229,7 +229,7 @@ public class GatewayCacheManager {
     /**
      * Refreshes the governor limit cache from the worker service.
      *
-     * <p>Called when a tenant record change event is received via Kafka
+     * <p>Called when a tenant record change event is received via NATS
      * (e.g., governor limits updated via the admin UI). Fetches the
      * lightweight governor-limits map from the worker's
      * {@code /internal/governor-limits} endpoint and updates the cache.

--- a/kelta-gateway/src/main/java/io/kelta/gateway/filter/SystemCollectionResponseCacheFilter.java
+++ b/kelta-gateway/src/main/java/io/kelta/gateway/filter/SystemCollectionResponseCacheFilter.java
@@ -45,7 +45,7 @@ import java.util.regex.Pattern;
  * <p>Only caches GET requests to known system collection API paths that return
  * a 200 OK response with JSON content.
  *
- * <p>Cache invalidation is driven by Kafka events consumed by
+ * <p>Cache invalidation is driven by NATS events consumed by
  * {@link io.kelta.gateway.listener.SystemCollectionRouteListener}.
  *
  * @since 1.0.0
@@ -104,7 +104,7 @@ public class SystemCollectionResponseCacheFilter implements GlobalFilter, Ordere
         // For mutating requests (POST, PATCH, PUT, DELETE) on cacheable collections,
         // evict the gateway cache eagerly so the next GET returns fresh data.
         // This avoids the race condition where the UI refetches before the async
-        // Kafka cache-eviction event is consumed.
+        // NATS cache-eviction event is consumed.
         if (exchange.getRequest().getMethod() != HttpMethod.GET) {
             if (collectionName != null && CACHEABLE_COLLECTIONS.contains(collectionName)) {
                 log.debug("Mutating request on cacheable collection '{}', evicting gateway cache", collectionName);

--- a/kelta-gateway/src/main/java/io/kelta/gateway/listener/ConfigEventListener.java
+++ b/kelta-gateway/src/main/java/io/kelta/gateway/listener/ConfigEventListener.java
@@ -91,7 +91,7 @@ public class ConfigEventListener {
     }
 
     /**
-     * Parses the CollectionChangedPayload from the raw Kafka message.
+     * Parses the CollectionChangedPayload from the raw NATS message.
      * Handles both PlatformEvent wrapper format and flat JSON format.
      */
     private CollectionChangedPayload parseCollectionPayload(String message) {
@@ -195,7 +195,7 @@ public class ConfigEventListener {
     }
 
     /**
-     * Parses the worker assignment payload from the raw Kafka message.
+     * Parses the worker assignment payload from the raw NATS message.
      * Handles both PlatformEvent wrapper format and flat JSON format.
      */
     private Map<String, Object> parseWorkerAssignmentPayload(String message) {

--- a/kelta-gateway/src/main/java/io/kelta/gateway/route/DynamicRouteLocator.java
+++ b/kelta-gateway/src/main/java/io/kelta/gateway/route/DynamicRouteLocator.java
@@ -26,7 +26,7 @@ import java.util.stream.Collectors;
  * 
  * Routes are loaded dynamically from the RouteRegistry, which is updated through:
  * - Initial bootstrap from the worker service
- * - Real-time Kafka events for configuration changes
+ * - Real-time NATS events for configuration changes
  * 
  * Validates: Requirements 1.3
  */

--- a/kelta-gateway/src/main/java/io/kelta/gateway/route/RouteRegistry.java
+++ b/kelta-gateway/src/main/java/io/kelta/gateway/route/RouteRegistry.java
@@ -17,7 +17,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * 
  * This registry is updated dynamically through:
  * - Initial bootstrap from the worker service
- * - Real-time Kafka events for configuration changes
+ * - Real-time NATS events for configuration changes
  */
 @Component
 public class RouteRegistry {

--- a/kelta-gateway/src/main/java/io/kelta/gateway/websocket/RealtimeWebSocketHandler.java
+++ b/kelta-gateway/src/main/java/io/kelta/gateway/websocket/RealtimeWebSocketHandler.java
@@ -22,7 +22,7 @@ import java.util.Map;
  * WebSocket handler for realtime record change subscriptions.
  *
  * <p>Authenticates connections via JWT query parameter, processes subscribe/unsubscribe
- * messages, and delivers Kafka-bridged events to subscribed sessions.
+ * messages, and delivers NATS-bridged events to subscribed sessions.
  *
  * @since 1.0.0
  */

--- a/kelta-gateway/src/test/java/io/kelta/gateway/GatewayApplicationIntegrationTest.java
+++ b/kelta-gateway/src/test/java/io/kelta/gateway/GatewayApplicationIntegrationTest.java
@@ -7,7 +7,7 @@ import org.springframework.test.context.ActiveProfiles;
 
 /**
  * Integration test to verify the gateway application starts correctly with full context.
- * Requires Docker services (worker, Keycloak, Redis, Kafka) to be running.
+ * Requires Docker services (worker, Keycloak, Redis, NATS) to be running.
  */
 @SpringBootTest
 @ActiveProfiles("test")

--- a/kelta-gateway/src/test/java/io/kelta/gateway/integration/AuthorizationIntegrationTest.java
+++ b/kelta-gateway/src/test/java/io/kelta/gateway/integration/AuthorizationIntegrationTest.java
@@ -28,7 +28,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * - Users with admin role can access admin-only routes
  * - Users without admin role cannot access admin-only routes
  * - Field visibility changes based on user roles
- * - Authorization policies can be updated dynamically via Kafka events
+ * - Authorization policies can be updated dynamically via NATS events
  * 
  * This test class validates that:
  * - The gateway properly enforces authorization policies
@@ -349,17 +349,17 @@ public class AuthorizationIntegrationTest extends IntegrationTestBase {
      * Test that authorization policies can be updated dynamically.
      * 
      * This test verifies that when authorization policies are updated
-     * via the control plane, the gateway receives the update via Kafka
+     * via the control plane, the gateway receives the update via NATS
      * and enforces the new policies without requiring a restart.
      * 
      * Validates:
-     * - Requirement 6.8: Authorization policies can be updated dynamically via Kafka events
+     * - Requirement 6.8: Authorization policies can be updated dynamically via NATS events
      */
     @Test
     void testDynamicAuthorizationUpdates() {
-        // This test requires Kafka event processing which may take time
+        // This test requires NATS event processing which may take time
         // For now, we verify that the gateway can process authorization updates
-        // The actual Kafka event processing is tested in separate event tests
+        // The actual NATS event processing is tested in separate event tests
         
         // Act - verify access works with current policies
         String userToken = authHelper.getUserToken();
@@ -378,7 +378,7 @@ public class AuthorizationIntegrationTest extends IntegrationTestBase {
         
         // Note: Testing actual dynamic policy updates requires:
         // 1. Creating/updating a policy via control plane
-        // 2. Waiting for Kafka event to be published
+        // 2. Waiting for NATS event to be published
         // 3. Waiting for gateway to process the event
         // 4. Verifying the new policy is enforced
         // This is covered in the event-driven configuration tests

--- a/kelta-gateway/src/test/java/io/kelta/gateway/integration/CollectionManagementIntegrationTest.java
+++ b/kelta-gateway/src/test/java/io/kelta/gateway/integration/CollectionManagementIntegrationTest.java
@@ -19,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Tests the complete collection management lifecycle:
  * - Creating collections via the control plane
  * - Verifying collections are stored in the database
- * - Verifying collection change events are published to Kafka
+ * - Verifying collection change events are published to NATS
  * - Verifying the gateway creates routes for collections
  * - Querying collections via the gateway
  * - Validating invalid collection definitions are rejected
@@ -27,7 +27,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * This test class validates that:
  * - Collections can be created with custom field definitions
  * - Collections are persisted to the database
- * - Collection change events are published to Kafka
+ * - Collection change events are published to NATS
  * - The gateway receives and processes collection change events
  * - The gateway creates routes for new collections
  * - Requests are correctly routed to backend services

--- a/kelta-gateway/src/test/java/io/kelta/gateway/integration/EndToEndFlowIntegrationTest.java
+++ b/kelta-gateway/src/test/java/io/kelta/gateway/integration/EndToEndFlowIntegrationTest.java
@@ -24,7 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * 
  * This test extends IntegrationTestBase and tests against the actual running Docker services,
  * not mocked backends. It validates the complete integration of all platform components:
- * Gateway, Control Plane, Sample Service, Keycloak, PostgreSQL, Redis, and Kafka.
+ * Gateway, Control Plane, Sample Service, Keycloak, PostgreSQL, Redis, and NATS.
  * 
  * Validates: Requirements 10.1-10.8
  */

--- a/kelta-gateway/src/test/java/io/kelta/gateway/integration/ErrorHandlingIntegrationTest.java
+++ b/kelta-gateway/src/test/java/io/kelta/gateway/integration/ErrorHandlingIntegrationTest.java
@@ -25,7 +25,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * - Missing required fields return HTTP 400 with error details
  * - Invalid field types return HTTP 400 with error details
  * - Backend service errors are propagated correctly
- * - Infrastructure failures (database, Redis, Kafka) are handled gracefully
+ * - Infrastructure failures (database, Redis, NATS) are handled gracefully
  * - Error responses follow JSON:API error format
  * 
  * This test class validates that:
@@ -428,7 +428,7 @@ public class ErrorHandlingIntegrationTest extends IntegrationTestBase {
     }
     
     /**
-     * Test that Kafka connection failures are handled gracefully.
+     * Test that NATS connection failures are handled gracefully.
      * 
      * Note: Similar to other infrastructure failure tests, this requires
      * infrastructure manipulation. The expected behavior is:
@@ -438,11 +438,11 @@ public class ErrorHandlingIntegrationTest extends IntegrationTestBase {
      * - Service continues operating with stale configuration
      * 
      * Validates:
-     * - Requirement 13.7: Kafka connection failures are handled gracefully
+     * - Requirement 13.7: NATS connection failures are handled gracefully
      */
     @Test
-    void testKafkaFailureHandling() {
-        // This test documents expected behavior for Kafka failures.
+    void testNatsFailureHandling() {
+        // This test documents expected behavior for NATS failures.
         // 
         // Expected behavior:
         // - Configuration updates: Use last known good configuration
@@ -451,14 +451,14 @@ public class ErrorHandlingIntegrationTest extends IntegrationTestBase {
         // - Service continues operating with potentially stale configuration
         
         // For actual testing, you would need to:
-        // 1. Stop the Kafka container
+        // 1. Stop the NATS container
         // 2. Attempt to update configuration in control plane
         // 3. Verify gateway continues using existing configuration
         // 4. Verify errors are logged
-        // 5. Restart Kafka container
+        // 5. Restart NATS container
         // 6. Verify configuration updates resume
         
-        assertThat(true).as("Kafka failure handling documented").isTrue();
+        assertThat(true).as("NATS failure handling documented").isTrue();
     }
     
     /**

--- a/kelta-gateway/src/test/java/io/kelta/gateway/integration/HealthCheckIntegrationTest.java
+++ b/kelta-gateway/src/test/java/io/kelta/gateway/integration/HealthCheckIntegrationTest.java
@@ -13,7 +13,7 @@ import org.springframework.test.web.reactive.server.WebTestClient;
  * Tests:
  * - Overall health endpoint returns status
  * - Redis health indicator is included
- * - Kafka health indicator is included
+ * - NATS health indicator is included
  * - Worker health indicator is included
  * - Health endpoint is accessible without authentication
  * - Individual component health can be checked
@@ -67,16 +67,16 @@ class HealthCheckIntegrationTest {
     }
 
     @Test
-    void testHealthEndpoint_IncludesKafkaStatus() {
-        // Act & Assert - health response should include Kafka status
+    void testHealthEndpoint_IncludesNatsStatus() {
+        // Act & Assert - health response should include NATS status
         webTestClient.get()
                 .uri("/actuator/health")
                 .exchange()
                 .expectStatus().isOk()
                 .expectBody()
-                .jsonPath("$.components.kafka").exists();
+                .jsonPath("$.components.nats").exists();
 
-        // Kafka status will be UP if Kafka is available, DOWN otherwise
+        // NATS status will be UP if NATS is available, DOWN otherwise
         // Both are valid - the important thing is that the component is checked
     }
 
@@ -104,7 +104,7 @@ class HealthCheckIntegrationTest {
                 .expectBody()
                 .jsonPath("$.components").exists()
                 .jsonPath("$.components.redis.status").exists()
-                .jsonPath("$.components.kafka.status").exists()
+                .jsonPath("$.components.nats.status").exists()
                 .jsonPath("$.components.worker.status").exists();
     }
 
@@ -162,9 +162,9 @@ class HealthCheckIntegrationTest {
                 .expectBody()
                 .jsonPath("$.status").exists();
 
-        // Kafka health
+        // NATS health
         webTestClient.get()
-                .uri("/actuator/health/kafka")
+                .uri("/actuator/health/nats")
                 .exchange()
                 .expectStatus().isOk()
                 .expectBody()

--- a/kelta-gateway/src/test/java/io/kelta/gateway/listener/ConfigEventListenerTest.java
+++ b/kelta-gateway/src/test/java/io/kelta/gateway/listener/ConfigEventListenerTest.java
@@ -27,7 +27,7 @@ import static org.mockito.Mockito.*;
 /**
  * Unit tests for ConfigEventListener.
  *
- * Tests the Kafka event listener that updates gateway configuration in real-time.
+ * Tests the NATS event listener that updates gateway configuration in real-time.
  * The listener now accepts raw JSON strings and manually deserializes them.
  */
 @ExtendWith(MockitoExtension.class)

--- a/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/events/package-info.java
+++ b/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/events/package-info.java
@@ -1,7 +1,7 @@
 /**
  * Event publishing hooks for collection lifecycle events.
  * 
- * <p>This package provides integration points for publishing events to Kafka:
+ * <p>This package provides integration points for publishing events to NATS:
  * <ul>
  *   <li><b>Create events</b> - Published when a record is created</li>
  *   <li><b>Update events</b> - Published when a record is updated</li>

--- a/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/formula/FormulaEvaluator.java
+++ b/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/formula/FormulaEvaluator.java
@@ -95,7 +95,7 @@ public class FormulaEvaluator {
      * Clears all cached compiled formulas.
      * <p>
      * Called when workflow rules are bulk-invalidated (e.g., on live reload
-     * via Kafka event).
+     * via NATS event).
      */
     public void clearCache() {
         compilationCache.clear();

--- a/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/package-info.java
+++ b/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/package-info.java
@@ -10,7 +10,7 @@
  *   <li>{@code query} - Query engine with pagination, sorting, filtering, and field selection</li>
  *   <li>{@code validation} - Field-level validation engine</li>
  *   <li>{@code storage} - Storage adapter interface and implementations (Mode A/B)</li>
- *   <li>{@code events} - Event publishing hooks for Kafka integration</li>
+ *   <li>{@code events} - Event publishing hooks for NATS integration</li>
  *   <li>{@code config} - Spring Boot auto-configuration</li>
  * </ul>
  * 

--- a/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/registry/CollectionOnDemandLoader.java
+++ b/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/registry/CollectionOnDemandLoader.java
@@ -8,7 +8,7 @@ import io.kelta.runtime.model.CollectionDefinition;
  *
  * <p>Workers implement this to fetch collection definitions from the control
  * plane when a request arrives for a collection that hasn't been loaded yet.
- * This acts as a safety net in case the startup bootstrap or Kafka events
+ * This acts as a safety net in case the startup bootstrap or NATS events
  * missed a collection.
  *
  * @since 1.0.0

--- a/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/query/DefaultQueryEngineTest.java
+++ b/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/query/DefaultQueryEngineTest.java
@@ -778,7 +778,7 @@ class DefaultQueryEngineTest {
                     .thenReturn(io.kelta.runtime.validation.ValidationResult.success());
             when(storageAdapter.create(eq(testCollection), any()))
                     .thenAnswer(invocation -> invocation.getArgument(1));
-            doThrow(new RuntimeException("Kafka is down"))
+            doThrow(new RuntimeException("NATS is down"))
                     .when(recordEventPublisher).publish(any());
 
             // Should not throw despite publisher failure

--- a/kelta-platform/runtime/runtime-events/src/main/java/io/kelta/runtime/event/ModuleChangedPayload.java
+++ b/kelta-platform/runtime/runtime-events/src/main/java/io/kelta/runtime/event/ModuleChangedPayload.java
@@ -1,7 +1,7 @@
 package io.kelta.runtime.event;
 
 /**
- * Payload for module lifecycle change events published to Kafka.
+ * Payload for module lifecycle change events published to NATS.
  * Propagates module install/enable/disable/uninstall events to all worker pods.
  *
  * @since 1.0.0

--- a/kelta-platform/runtime/runtime-events/src/main/java/io/kelta/runtime/event/RecordChangedPayload.java
+++ b/kelta-platform/runtime/runtime-events/src/main/java/io/kelta/runtime/event/RecordChangedPayload.java
@@ -8,7 +8,7 @@ import java.util.Objects;
  * Payload for record change events (create, update, delete).
  *
  * <p>Carried inside a {@link PlatformEvent} envelope and published to the
- * {@code kelta.record.changed} Kafka topic, keyed by {@code tenantId:collectionName}.
+ * {@code kelta.record.changed} NATS subject, keyed by {@code tenantId:collectionName}.
  *
  * @since 1.0.0
  */

--- a/kelta-worker/src/main/java/io/kelta/worker/WorkerApplication.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/WorkerApplication.java
@@ -12,9 +12,9 @@ import org.springframework.scheduling.annotation.EnableScheduling;
  * <p>The worker service is a generic collection hosting service that:
  * <ul>
  *   <li>Loads all active collections from the control plane on startup</li>
- *   <li>Listens for collection schema changes via Kafka events</li>
+ *   <li>Listens for collection schema changes via NATS events</li>
  *   <li>Provides REST endpoints for all collections via DynamicCollectionRouter</li>
- *   <li>Executes workflow rules (after-save via Kafka, before-save in-process, scheduled via poll)</li>
+ *   <li>Executes workflow rules (after-save via NATS, before-save in-process, scheduled via poll)</li>
  * </ul>
  *
  * <p>Pod health is managed by Kubernetes (liveness/readiness probes).

--- a/kelta-worker/src/main/java/io/kelta/worker/config/NatsSubscriptionConfig.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/config/NatsSubscriptionConfig.java
@@ -25,9 +25,9 @@ import org.springframework.context.annotation.Profile;
 /**
  * Registers all worker NATS subscriptions with the {@link NatsSubscriptionManager}.
  *
- * <p>Replaces the previous Kafka listener annotations with explicit NATS
- * subscription registrations, supporting both queue-group (load-balanced)
- * and broadcast (all-pods) delivery modes.
+ * <p>Uses explicit NATS subscription registrations (rather than annotation-driven
+ * listeners), supporting both queue-group (load-balanced) and broadcast (all-pods)
+ * delivery modes.
  *
  * @since 1.0.0
  */

--- a/kelta-worker/src/main/java/io/kelta/worker/listener/CerbosCacheInvalidationListener.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/listener/CerbosCacheInvalidationListener.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component;
 import java.util.Map;
 
 /**
- * Kafka listener that invalidates the worker's Cerbos field access cache
+ * NATS listener that invalidates the worker's Cerbos field access cache
  * when policies are re-synced for a tenant.
  *
  * <p>Listens to {@code kelta.cerbos.policies.changed} events published by

--- a/kelta-worker/src/main/java/io/kelta/worker/listener/CollectionSchemaListener.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/listener/CollectionSchemaListener.java
@@ -12,7 +12,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 /**
- * Kafka listener for collection schema change events from the control plane.
+ * NATS listener for collection schema change events from the control plane.
  *
  * <p>When fields are added, removed, or modified on a collection, the control plane
  * publishes a {@code collection-changed} event. This listener picks up those events
@@ -52,7 +52,7 @@ public class CollectionSchemaListener {
      *   <li>The refresh triggers schema migration (ALTER TABLE) for any new fields</li>
      * </ol>
      *
-     * @param message the raw JSON message from Kafka
+     * @param message the raw JSON message from NATS
      */
     public void handleCollectionChanged(String message) {
         log.debug("Received collection changed event: {}", message);
@@ -141,7 +141,7 @@ public class CollectionSchemaListener {
     }
 
     /**
-     * Parses the CollectionChangedPayload from the raw Kafka message.
+     * Parses the CollectionChangedPayload from the raw NATS message.
      * Handles both PlatformEvent wrapper format and flat JSON format.
      */
     private CollectionChangedPayload parsePayload(String message) {

--- a/kelta-worker/src/main/java/io/kelta/worker/listener/FlowEventListener.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/listener/FlowEventListener.java
@@ -20,7 +20,7 @@ import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * Kafka listener that consumes record change events and evaluates flow triggers.
+ * NATS listener that consumes record change events and evaluates flow triggers.
  * <p>
  * Listens on the {@code kelta.record.changed} topic with consumer group
  * {@code kelta-worker-flows}. For each event, finds active RECORD_TRIGGERED flows
@@ -77,7 +77,7 @@ public class FlowEventListener {
     /**
      * Handles record change events by evaluating flow triggers.
      *
-     * @param message the raw JSON Kafka message
+     * @param message the raw JSON NATS message
      */
     public void handleRecordChanged(String message) {
         try {

--- a/kelta-worker/src/main/java/io/kelta/worker/listener/SearchIndexListener.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/listener/SearchIndexListener.java
@@ -15,7 +15,7 @@ import org.springframework.stereotype.Component;
 import java.util.Map;
 
 /**
- * Kafka listener that consumes record change events and updates the full-text search index.
+ * NATS listener that consumes record change events and updates the full-text search index.
  *
  * <p>Listens on the {@code kelta.record.changed} topic with consumer group
  * {@code kelta-worker-search-index}. For each event, builds search content from
@@ -49,7 +49,7 @@ public class SearchIndexListener {
     /**
      * Handles record change events by updating the search index.
      *
-     * @param message the raw JSON Kafka message
+     * @param message the raw JSON NATS message
      */
     public void handleRecordChanged(String message) {
         try {

--- a/kelta-worker/src/main/java/io/kelta/worker/listener/SupersetCollectionSyncListener.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/listener/SupersetCollectionSyncListener.java
@@ -7,7 +7,7 @@ import io.kelta.worker.service.SupersetDatasetService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 /**
- * Kafka listener that syncs Superset datasets when collections are
+ * NATS listener that syncs Superset datasets when collections are
  * created or updated.
  *
  * <p>Consumes from the {@code kelta.config.collection.changed} topic

--- a/kelta-worker/src/main/java/io/kelta/worker/module/ModuleEventListener.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/module/ModuleEventListener.java
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Component;
 import java.util.Optional;
 
 /**
- * Kafka listener for module lifecycle change events.
+ * NATS listener for module lifecycle change events.
  * <p>
  * When a module is installed/enabled/disabled/uninstalled on any pod,
  * this listener receives the event and updates the local handler registry.

--- a/kelta-worker/src/main/java/io/kelta/worker/service/CerbosAuthorizationService.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/service/CerbosAuthorizationService.java
@@ -34,7 +34,7 @@ import java.util.stream.Collectors;
  * and a circuit breaker to prevent thread-pool exhaustion.
  *
  * <p>Field access results are cached in-memory (Caffeine) and invalidated
- * via Kafka events when Cerbos policies change. Record access checks are
+ * via NATS events when Cerbos policies change. Record access checks are
  * NOT cached because they depend on record attributes (ABAC/CEL rules).
  *
  * <h3>Fail-closed design</h3>

--- a/kelta-worker/src/main/java/io/kelta/worker/service/WorkerBootstrapService.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/service/WorkerBootstrapService.java
@@ -21,7 +21,7 @@ import java.util.Map;
  *
  * <p>There is no control plane dependency. The worker reads collection definitions
  * directly from the shared database. Runtime schema changes are handled by the
- * existing Kafka {@code collection-changed} listener.
+ * existing NATS {@code collection-changed} listener.
  *
  * @since 1.0.0
  */

--- a/kelta-worker/src/test/java/io/kelta/worker/controller/GovernorLimitsControllerTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/controller/GovernorLimitsControllerTest.java
@@ -454,9 +454,9 @@ class GovernorLimitsControllerTest {
         }
 
         @Test
-        @DisplayName("Should publish Kafka event when limits are updated")
+        @DisplayName("Should publish NATS event when limits are updated")
         @SuppressWarnings("unchecked")
-        void publishesKafkaEventOnUpdate() {
+        void publishesNatsEventOnUpdate() {
             Map<String, Object> newLimits = new LinkedHashMap<>();
             newLimits.put("apiCallsPerDay", 200_000);
 
@@ -479,12 +479,12 @@ class GovernorLimitsControllerTest {
         }
 
         @Test
-        @DisplayName("Should not fail update if Kafka event publishing fails")
-        void doesNotFailIfKafkaPublishFails() {
+        @DisplayName("Should not fail update if NATS event publishing fails")
+        void doesNotFailIfNatsPublishFails() {
             Map<String, Object> newLimits = new LinkedHashMap<>();
             newLimits.put("apiCallsPerDay", 200_000);
 
-            doThrow(new RuntimeException("Kafka is down"))
+            doThrow(new RuntimeException("NATS is down"))
                     .when(recordEventPublisher).publish(any());
 
             when(repository.findEditionAndLimits("tenant-1")).thenReturn(Optional.of(new GovernorLimitsRepository.EditionAndLimits("PROFESSIONAL", "{\"apiCallsPerDay\":200000}")));

--- a/kelta-worker/src/test/java/io/kelta/worker/listener/SearchIndexListenerTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/listener/SearchIndexListenerTest.java
@@ -125,7 +125,7 @@ class SearchIndexListenerTest {
     }
 
     /**
-     * Builds a Kafka message in the PlatformEvent envelope format.
+     * Builds a NATS message in the PlatformEvent envelope format.
      */
     private String buildMessage(String tenantId, String collectionName, String recordId,
                                  ChangeType changeType, Map<String, Object> data) throws Exception {


### PR DESCRIPTION
## What
Corrects ~65 stale "Kafka"-worded comments / javadoc / test names across **worker, gateway, and runtime** that described the NATS JetStream event bus as "Kafka" (the platform migrated to NATS long ago; `spring-kafka` was already removed). **Comments-only — no behavior change.**

- Worker + gateway listeners/services/config: "Kafka listener/events" → "NATS".
- runtime-core / runtime-events javadoc + package-info; `RecordChangedPayload` "Kafka topic" → "NATS subject".
- Test naming: `GovernorLimitsControllerTest` methods/display + `DefaultQueryEngineTest`/`GovernorLimits` mock `"Kafka is down"` → `"NATS is down"`; `ErrorHandlingIntegrationTest.testKafkaFailureHandling` → `testNatsFailureHandling`.
- **`HealthCheckIntegrationTest`** asserted on `$.components.kafka` / `/actuator/health/kafka` — but the real gateway health indicator is **`nats`** (see `kelta-gateway/health/` — NATS/Redis/Worker). Corrected to `nats` so the assertions match the actual component (this was a latent wrong assertion, not just a comment).
- `NatsSubscriptionConfig`: reworded the migration note to drop the Kafka mention.

## Intentionally left as "Kafka"
- The **PUBLISH_EVENT** integration action's javadoc (`IntegrationModule`, `PublishEventActionHandler`) cites Kafka as an *external* broker example (alongside SNS) — a real integration target, not the internal bus.

## Out of scope (follow-up)
Stale Kafka references in **markdown docs** (`FEATURES.md`, `README.md`, `.claude/docs/*`, service `CLAUDE.md`, marketing/test-plan docs) — they mix internal-bus mislabels (e.g. "Messaging | Kafka 3.7" which is factually NATS 2.10) with a genuine **external-Kafka flow trigger** (`KAFKA_TRIGGERED`) and the PUBLISH_EVENT external example. Those need case-by-case review and are tracked separately.

## Verified
`GovernorLimitsControllerTest` (22) + `DefaultQueryEngineTest` pass; gateway `test-compile` clean; runtime builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)