### PR TITLE
chore(messaging): remove remaining Kafka references (docs, config, PUBLISH_EVENT)

### DIFF
--- a/.claude/docs/concerns.md
+++ b/.claude/docs/concerns.md
@@ -40,7 +40,7 @@ at the bottom so reviewers can see what's already been addressed.
 ## Dependency Risks
 
 - Multiple BOM version overrides in worker POM increase transitive conflict risk (`kelta-worker/pom.xml`). Audit on every Spring Boot bump.
-- **Stale `spring-kafka` dependency retired** (Phase 0): `runtime-core/pom.xml` previously declared `spring-kafka`, `spring-kafka-test`, and `testcontainers-kafka` despite the platform using NATS JetStream exclusively. Removed; the misnamed `KafkaRecordEventPublisher` was renamed to `NatsRecordEventPublisher`. Remaining `Kafka`-worded comments across `kelta-worker`/`kelta-gateway`/`runtime` are cosmetic Kafka→NATS migration debt (the listeners are NATS, not Kafka) — slated for a separate doc-cleanup sweep.
+- **Stale `spring-kafka` dependency retired** (Phase 0): `runtime-core/pom.xml` previously declared `spring-kafka`, `spring-kafka-test`, and `testcontainers-kafka` despite the platform using NATS JetStream exclusively. Removed; the misnamed `KafkaRecordEventPublisher` was renamed to `NatsRecordEventPublisher`. The stale event-bus comments and docs that mislabeled NATS as the previous broker have since been corrected to NATS across the codebase.
 
 ## Postgres max_connections sizing
 

--- a/.claude/docs/conventions.md
+++ b/.claude/docs/conventions.md
@@ -16,7 +16,7 @@
 - Import order: (1) `io.kelta.*`, (2) external libs (`com.fasterxml.*`, `org.*`), (3) Java stdlib (`java.*`, `javax.*`)
 - Constructor injection preferred over field injection
 - `@Component` for beans, `@Service` for business logic, `@Repository` for data access
-- `@KafkaListener` with explicit topics and group IDs
+- NATS subscriptions registered explicitly via `NatsSubscriptionManager` (no annotation-based listeners)
 
 ### Logging
 - `private static final Logger logger = LoggerFactory.getLogger(ClassName.class)`

--- a/.claude/docs/integrations.md
+++ b/.claude/docs/integrations.md
@@ -42,7 +42,7 @@ Files attach to any record via the `attachments` system collection (backed by `f
 | `kelta.record.changed` | Record CRUD events |
 
 Event envelope: `PlatformEvent<T>` with `eventId`, `eventType`, `tenantId`, `correlationId`, `timestamp`, `payload`
-Publishing: `PlatformEventPublisher` (replaces former KafkaTemplate usage)
+Publishing: `PlatformEventPublisher` (replaces former PlatformEventPublisher usage)
 Subscriptions: `NatsSubscriptionConfig` registration (broadcast consumers for config changes, queue groups for load-balanced work)
 Location: `kelta-platform/runtime/runtime-events/src/main/java/io/kelta/event/`
 

--- a/.claude/docs/workflow.md
+++ b/.claude/docs/workflow.md
@@ -21,7 +21,7 @@ Examples: `feature/a1-field-type-migration`, `feature/b5-picklist-service`
 - All new JPA repositories extend `JpaRepository`
 - All new REST controllers follow existing `@RestController` patterns with `@RequestMapping`
 - Flyway migrations numbered sequentially (check `kelta-worker/src/main/resources/db/migration/` for next number)
-- Kafka events use `ConfigEventPublisher` pattern
+- NATS events use `ConfigEventPublisher` pattern
 - Java: No unused imports, no raw types, no unchecked casts
 - TypeScript: Must pass ESLint and Prettier checks
 

--- a/EPIC-WORKFLOWS.md
+++ b/EPIC-WORKFLOWS.md
@@ -51,7 +51,7 @@ The existing Workflow Rules system will be **fully migrated to Flows** and then 
                                  ▼
 ┌─────────────┐   ┌──────────────────────────────────┐   ┌────────────────┐
 │   Triggers   │──▶│     State Machine Engine          │──▶│  Execution DB  │
-│ Kafka events │   │  ┌──────┐ ┌──────┐ ┌──────────┐ │   │  flow_execution│
+│ NATS events │   │  ┌──────┐ ┌──────┐ ┌──────────┐ │   │  flow_execution│
 │ Record CRUD  │   │  │ Task │ │Choice│ │ Parallel │ │   │  flow_step_log │
 │ Scheduled    │   │  └──┬───┘ └──┬───┘ └────┬─────┘ │   │  flow_variables│
 │ Manual / API │   │     │        │           │       │   └────────────────┘
@@ -69,7 +69,7 @@ The existing Workflow Rules system will be **fully migrated to Flows** and then 
 1. **Durable Execution** — Every state transition persists to PostgreSQL. Executions survive pod restarts and can resume from any checkpoint.
 2. **State Data Flow** — Each step receives input state, produces output state. JSONPath expressions map data between steps (InputPath, OutputPath, ResultPath).
 3. **Unified Handler SPI** — The existing `ActionHandler` interface remains unchanged. All 15+ existing handlers become available as Task state resources.
-4. **Tenant-Scoped Runtime Modules** — JARs downloaded by URL, stored in S3, loaded via sandboxed ClassLoader, scoped to a tenant. Module lifecycle events (install, enable, disable, uninstall) propagate to all pods via Kafka (`kelta.config.module.changed`) — no process restarts required. Modules expose new `ActionHandler` implementations.
+4. **Tenant-Scoped Runtime Modules** — JARs downloaded by URL, stored in S3, loaded via sandboxed ClassLoader, scoped to a tenant. Module lifecycle events (install, enable, disable, uninstall) propagate to all pods via NATS (`kelta.config.module.changed`) — no process restarts required. Modules expose new `ActionHandler` implementations.
 5. **Visual-First Design** — Every flow is visually composable. The JSON definition is the source of truth; the visual builder is a bidirectional editor of that JSON.
 
 ---
@@ -169,7 +169,7 @@ Invoked when a record in a specific collection is created, updated, or deleted.
 | `synchronous` | boolean | No | Default `false`. If `true`, the flow executes synchronously during the save operation (before commit) and can return field updates. Used to replace `BEFORE_CREATE`/`BEFORE_UPDATE` workflow triggers. |
 
 **How it works:**
-1. `FlowEventListener` consumes `kelta.record.changed` Kafka topic
+1. `FlowEventListener` consumes `kelta.record.changed` NATS subject
 2. For each event, queries all ACTIVE flows for the tenant where `flow_type = 'RECORD_TRIGGERED'` and `trigger_config.collection` matches the event's collection
 3. Checks if the event's `changeType` is in `trigger_config.events`
 4. If `triggerFields` is specified and event is UPDATE, checks intersection with `changedFields`
@@ -178,9 +178,9 @@ Invoked when a record in a specific collection is created, updated, or deleted.
 
 **Initial state:** Source key = `record` containing `id`, `collectionName`, `data` (full record), `previousData` (changed fields only), `changedFields[]`. Steps reference: `$.record.data.status`, `$.record.previousData.status`, `$.record.id`, `$.context.tenantId`.
 
-#### 2. Kafka Message Flow (`KAFKA_TRIGGERED`)
+#### 2. NATS message Flow (`NATS_TRIGGERED`)
 
-Invoked when a message arrives on a specific Kafka topic matching filter criteria.
+Invoked when a message arrives on a specific NATS subject matching filter criteria.
 
 **trigger_config schema:**
 ```json
@@ -199,9 +199,9 @@ Invoked when a message arrives on a specific Kafka topic matching filter criteri
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `topic` | string | Yes | Kafka topic to subscribe to |
-| `consumerGroup` | string | No | Custom consumer group. Default: `kelta-flow-{flowId}` |
-| `keyFilter` | string | No | Glob pattern matched against the Kafka message key. If the key doesn't match, the message is skipped. |
+| `topic` | string | Yes | NATS subject to subscribe to |
+| `consumerGroup` | string | No | Custom queue group. Default: `kelta-flow-{flowId}` |
+| `keyFilter` | string | No | Glob pattern matched against the NATS message key. If the key doesn't match, the message is skipped. |
 | `messageFilter` | object | No | JSONPath-based filter on the message body. Only messages where the path matches the operator/value trigger the flow. |
 | `messageFilter.path` | string | Yes (if messageFilter) | JSONPath into the message body |
 | `messageFilter.operator` | string | Yes (if messageFilter) | One of: `equals`, `notEquals`, `contains`, `startsWith`, `exists`, `greaterThan`, `lessThan` |
@@ -209,7 +209,7 @@ Invoked when a message arrives on a specific Kafka topic matching filter criteri
 | `payloadFormat` | string | No | Default `"JSON"`. How to parse the message body: `"JSON"`, `"STRING"`, `"AVRO"` |
 
 **How it works:**
-1. `KafkaFlowTriggerManager` dynamically creates Kafka consumers for each active flow with `KAFKA_TRIGGERED` type
+1. `NatsFlowTriggerManager` dynamically creates NATS consumers for each active flow with `NATS_TRIGGERED` type
 2. When a message arrives, applies key filter (glob match) and message filter (JSONPath + operator)
 3. If filters pass, deserializes message body and starts a flow execution
 
@@ -292,7 +292,7 @@ All trigger types support filtering to determine whether the flow should actuall
 | Trigger Type | Filter Mechanism | Evaluated Against |
 |-------------|-----------------|-------------------|
 | `RECORD_TRIGGERED` | `events[]` + `triggerFields[]` + `filterFormula` | RecordChangeEvent data |
-| `KAFKA_TRIGGERED` | `keyFilter` (glob) + `messageFilter` (JSONPath + operator) | Kafka message key + body |
+| `NATS_TRIGGERED` | `keyFilter` (glob) + `messageFilter` (JSONPath + operator) | NATS message key + body |
 | `SCHEDULED` | Cron expression + timezone | Current timestamp |
 | `AUTOLAUNCHED` | `inputSchema` (JSON Schema validation) | API request body |
 
@@ -303,7 +303,7 @@ Every flow execution starts with a state object that follows a common envelope:
 ```json
 {
   "trigger": {
-    "type": "<RECORD_CHANGE|KAFKA_MESSAGE|SCHEDULED|API_INVOCATION>",
+    "type": "<RECORD_CHANGE|NATS_MESSAGE|SCHEDULED|API_INVOCATION>",
     "...trigger-specific metadata..."
   },
   "<source-specific-key>": {
@@ -321,13 +321,13 @@ Every flow execution starts with a state object that follows a common envelope:
 | Trigger Type | Source Key | Contains |
 |-------------|-----------|----------|
 | `RECORD_TRIGGERED` | `record` | `id`, `collectionName`, `data` (full record), `previousData`, `changedFields` |
-| `KAFKA_TRIGGERED` | `message` | `key`, `headers`, `payload` (parsed message body) |
+| `NATS_TRIGGERED` | `message` | `key`, `headers`, `payload` (parsed message body) |
 | `SCHEDULED` | `input` | Static data from `trigger_config.inputData` |
 | `AUTOLAUNCHED` | `input` | Caller-provided input from API request body |
 
 This means the first step of every flow can use `InputPath` to extract exactly what it needs. For example:
 - A record-triggered flow that only needs the record data: `"InputPath": "$.record.data"`
-- A Kafka-triggered flow that needs the whole message: `"InputPath": "$.message.payload"`
+- A NATS-triggered flow that needs the whole message: `"InputPath": "$.message.payload"`
 - A scheduled flow: `"InputPath": "$.input"`
 
 ### Custom State Mapping (Optional InputMapping)
@@ -362,7 +362,7 @@ New package: `io.kelta.runtime.flow`
 
 **Classes to create:**
 - `FlowEngine` — Core execution engine (async by default):
-  - `startExecution(tenantId, flowId, definition, initialInput, userId)` → creates `flow_execution` row, dispatches to a managed `ExecutorService` thread pool, returns `executionId` immediately. Kafka listener threads are never blocked.
+  - `startExecution(tenantId, flowId, definition, initialInput, userId)` → creates `flow_execution` row, dispatches to a managed `ExecutorService` thread pool, returns `executionId` immediately. NATS listener threads are never blocked.
   - `executeSynchronous(tenantId, flowId, definition, initialInput, userId)` → blocks until completion, returns final state data. Used for `synchronous: true` record-triggered flows (replaces BEFORE_CREATE/BEFORE_UPDATE triggers) where the caller needs the result before commit.
   - `resumeExecution(executionId)` → loads persisted state, resumes from `current_node_id` (async)
   - `cancelExecution(executionId)` → marks execution as CANCELLED
@@ -399,10 +399,10 @@ New package: `io.kelta.runtime.flow`
 New migration: `V71__flow_engine_enhancements.sql`
 
 ```sql
--- Expand flow_type to include KAFKA_TRIGGERED
+-- Expand flow_type to include NATS_TRIGGERED
 ALTER TABLE flow DROP CONSTRAINT chk_flow_type;
 ALTER TABLE flow ADD CONSTRAINT chk_flow_type CHECK (flow_type IN (
-    'RECORD_TRIGGERED', 'KAFKA_TRIGGERED', 'SCHEDULED', 'AUTOLAUNCHED', 'SCREEN'
+    'RECORD_TRIGGERED', 'NATS_TRIGGERED', 'SCHEDULED', 'AUTOLAUNCHED', 'SCREEN'
 ));
 
 -- Add scheduling columns for SCHEDULED flows
@@ -458,11 +458,11 @@ CREATE INDEX idx_flow_pending_resume_event ON flow_pending_resume(resume_event) 
 **New classes:**
 - `FlowTriggerEvaluator` — Evaluates whether a trigger event matches a flow's `trigger_config`:
   - `matchesRecordTrigger(RecordChangeEvent, triggerConfig)` → checks events[], triggerFields[], filterFormula
-  - `matchesKafkaTrigger(kafkaKey, kafkaPayload, triggerConfig)` → checks keyFilter, messageFilter
+  - `matchesMessageTrigger(messageKey, messagePayload, triggerConfig)` → checks keyFilter, messageFilter
   - Uses the existing `FormulaEvaluator` for filterFormula evaluation
 - `InitialStateBuilder` — Constructs the canonical initial state envelope from trigger data:
   - `buildFromRecordEvent(RecordChangeEvent, triggerConfig, flowId, executionId)` → builds `{trigger, record, context}` object
-  - `buildFromKafkaMessage(key, headers, payload, triggerConfig, flowId, executionId)` → builds `{trigger, message, context}` object
+  - `buildFromNatsMessage(key, headers, payload, triggerConfig, flowId, executionId)` → builds `{trigger, message, context}` object
   - `buildFromSchedule(triggerConfig, flowId, executionId)` → builds `{trigger, input, context}` object
   - `buildFromApiInvocation(inputPayload, userId, flowId, executionId)` → builds `{trigger, input, context}` object
   - Applies optional `inputMapping` from trigger_config to flatten/transform the initial state
@@ -483,20 +483,20 @@ CREATE INDEX idx_flow_pending_resume_event ON flow_pending_resume(resume_event) 
   - `GET /api/flows/executions/{executionId}` — Get execution detail with state data
   - `GET /api/flows/executions/{executionId}/steps` — Get step-level log
   - `POST /api/webhooks/{path}` — Webhook endpoint that looks up flow by `webhookPath` in trigger_config. Supports HMAC signature verification via `X-Kelta-Signature` header when `authentication = 'WEBHOOK_SECRET'` (secret stored per-flow, compared using constant-time comparison).
-- `FlowEventListener` — Kafka listener for `kelta.record.changed`:
+- `FlowEventListener` — NATS listener for `kelta.record.changed`:
   - Maintains an in-memory cache of active flow trigger configs per tenant (`ConcurrentHashMap<String, List<FlowTriggerConfig>>`), loaded from DB on startup and invalidated when flows are created/updated/deleted (via the existing system collection save hooks)
   - For each event, checks cached trigger configs — no DB query per event
   - Uses `FlowTriggerEvaluator.matchesRecordTrigger()` to filter
   - Uses `InitialStateBuilder.buildFromRecordEvent()` to construct initial state
   - Calls `FlowEngine.startExecution()` for each matching flow
-- `KafkaFlowTriggerManager` — Manages dynamic Kafka consumers for `KAFKA_TRIGGERED` flows:
-  - **On pod startup:** queries DB for all ACTIVE flows with `flow_type = 'KAFKA_TRIGGERED'`, creates a consumer for each
-  - **Consumer group strategy:** each flow uses consumer group `kelta-flow-{flowId}`. All pods join the same group, so Kafka distributes partitions — each message is processed by exactly one pod. No cross-pod activation events needed.
+- `NatsFlowTriggerManager` — Manages dynamic NATS consumers for `NATS_TRIGGERED` flows:
+  - **On pod startup:** queries DB for all ACTIVE flows with `flow_type = 'NATS_TRIGGERED'`, creates a consumer for each
+  - **queue group strategy:** each flow uses queue group `kelta-flow-{flowId}`. All pods join the same group, so NATS distributes partitions — each message is processed by exactly one pod. No cross-pod activation events needed.
   - On flow activation (via API on this pod), creates a consumer for the configured topic
-  - On message receipt, uses `FlowTriggerEvaluator.matchesKafkaTrigger()` to filter
-  - Uses `InitialStateBuilder.buildFromKafkaMessage()` for initial state
-  - On flow deactivation, closes the consumer on this pod. Other pods will close on next restart or when consumer group rebalances (the inactive flow's consumer will stop receiving messages since no new messages are acknowledged).
-  - Tracks active consumers in `ConcurrentHashMap<String, KafkaConsumer>` (flowId → consumer)
+  - On message receipt, uses `FlowTriggerEvaluator.matchesMessageTrigger()` to filter
+  - Uses `InitialStateBuilder.buildFromNatsMessage()` for initial state
+  - On flow deactivation, closes the consumer on this pod. Other pods will close on next restart or when queue group rebalances (the inactive flow's consumer will stop receiving messages since no new messages are acknowledged).
+  - Tracks active consumers in `ConcurrentHashMap<String, NatsSubscription>` (flowId → consumer)
 - `ScheduledFlowExecutor` — Two responsibilities:
   - Polls `flow` table for SCHEDULED flows due to run (cron evaluation, optimistic locking)
   - Polls `flow_pending_resume` table for Wait states ready to resume
@@ -516,7 +516,7 @@ Map existing ActionHandlers to Task `resource` keys. The following are available
 | `EMAIL_ALERT` | EmailAlertActionHandler | Send email |
 | `SEND_NOTIFICATION` | SendNotificationActionHandler | Send in-app notification |
 | `OUTBOUND_MESSAGE` | OutboundMessageActionHandler | Send webhook |
-| `PUBLISH_EVENT` | PublishEventActionHandler | Publish Kafka event |
+| `PUBLISH_EVENT` | PublishEventActionHandler | Publish NATS event |
 | `INVOKE_SCRIPT` | InvokeScriptActionHandler | Execute server-side script |
 | `LOG_MESSAGE` | LogMessageActionHandler | Write to execution log |
 
@@ -525,7 +525,7 @@ New built-in resources to add:
 |-------------|-------------|
 | `QUERY_RECORDS` | Query a collection with filters, return results as state data |
 | `TRANSFORM_DATA` | Apply a JSONPath/template transformation to state data |
-| `EMIT_KAFKA_EVENT` | Publish a custom event to a specified Kafka topic |
+| `EMIT_EVENT` | Publish a custom event to a specified NATS subject |
 
 ### 1.8 Action Handler Descriptors (UI Integration Contract)
 
@@ -592,9 +592,9 @@ Handlers that return `null` get a generic form (raw JSON config editor). Handler
 
 **Per-Tenant Rate Limiting:** Configurable max concurrent executions per tenant (`kelta.flow.max-concurrent-per-tenant`, default: 50). `FlowEngine` tracks active execution count per tenant in an `AtomicInteger` map. Exceeding the limit → execution rejected with HTTP 429 / error code `TenantRateLimitExceeded`. Queue overflow → execution marked FAILED.
 
-**Idempotency:** `FlowEventListener` deduplicates trigger events using a `(eventId, flowId)` composite key. Uses Redis SET with TTL (default: 5 minutes) for deduplication window. If Redis unavailable, falls back to a DB `flow_execution_dedup` table with periodic TTL cleanup. Prevents duplicate executions from Kafka at-least-once delivery.
+**Idempotency:** `FlowEventListener` deduplicates trigger events using a `(eventId, flowId)` composite key. Uses Redis SET with TTL (default: 5 minutes) for deduplication window. If Redis unavailable, falls back to a DB `flow_execution_dedup` table with periodic TTL cleanup. Prevents duplicate executions from NATS at-least-once delivery.
 
-**Emergency Pause (Kill Switch):** `POST /api/admin/flows/pause-all` — immediately stops all flow execution for a tenant. Sets a `flow_processing_paused` flag in the tenant config (persisted to DB, cached in-memory). All trigger listeners (`FlowEventListener`, `KafkaFlowTriggerManager`, `ScheduledFlowExecutor`) check this flag before starting new executions. In-flight executions complete but no new ones start. Resume via `POST /api/admin/flows/resume-all`. UI: Red "Pause All Flows" button on the Flow Settings page with confirmation dialog. Banner shown at top of Flows list when paused: "Flow processing is paused. No new executions will start."
+**Emergency Pause (Kill Switch):** `POST /api/admin/flows/pause-all` — immediately stops all flow execution for a tenant. Sets a `flow_processing_paused` flag in the tenant config (persisted to DB, cached in-memory). All trigger listeners (`FlowEventListener`, `NatsFlowTriggerManager`, `ScheduledFlowExecutor`) check this flag before starting new executions. In-flight executions complete but no new ones start. Resume via `POST /api/admin/flows/resume-all`. UI: Red "Pause All Flows" button on the Flow Settings page with confirmation dialog. Banner shown at top of Flows list when paused: "Flow processing is paused. No new executions will start."
 
 **Audit Trail:** All flow lifecycle events logged to `flow_audit_log` table:
 - Columns: `id`, `tenant_id`, `flow_id`, `action` (CREATED, UPDATED, ACTIVATED, DEACTIVATED, DELETED, EXECUTED, CANCELLED), `user_id`, `timestamp`, `details` (JSONB — captures before/after for edits)
@@ -639,15 +639,15 @@ CREATE TABLE flow_execution_dedup (
 - [ ] StateDataResolver (JSONPath transforms: InputPath, OutputPath, ResultPath)
 - [ ] FlowEngine with all 8 state executors
 - [ ] FlowStore interface and JdbcFlowStore implementation
-- [ ] FlowTriggerEvaluator (record trigger filtering, Kafka trigger filtering)
+- [ ] FlowTriggerEvaluator (record trigger filtering, NATS trigger filtering)
 - [ ] InitialStateBuilder (canonical state envelope for all trigger types)
 - [ ] InputMappingResolver (optional trigger_config.inputMapping transforms)
 - [ ] Database migration V71 (flow_type expansion, flow_step_log, flow_pending_resume)
 - [ ] FlowExecutionController REST endpoints (execute, cancel, resume, webhook, steps)
 - [ ] FlowEventListener for RECORD_TRIGGERED flows
-- [ ] KafkaFlowTriggerManager for KAFKA_TRIGGERED flows (dynamic consumer management)
+- [ ] NatsFlowTriggerManager for NATS_TRIGGERED flows (dynamic consumer management)
 - [ ] ScheduledFlowExecutor for SCHEDULED flows and Wait state resumption
-- [ ] QUERY_RECORDS, TRANSFORM_DATA, EMIT_KAFKA_EVENT task handlers
+- [ ] QUERY_RECORDS, TRANSFORM_DATA, EMIT_EVENT task handlers
 - [ ] ActionHandlerDescriptor interface and REST endpoint (`GET /api/flows/resources`)
 - [ ] Descriptors for all 15+ built-in handlers (configSchema, inputSchema, outputSchema)
 - [ ] Template expression resolver (`${$.path}` in config values)
@@ -695,7 +695,7 @@ Flows List Page                Create/Edit Flow
 
 Replaces existing `FlowsPage.tsx` following `CollectionsPage.tsx` patterns.
 
-**Columns:** Name (clickable → designer), Type (color-coded badge: Record/Scheduled/API/Kafka), Status (Active green/Draft gray/Disabled red dot), Health (sparkline showing last 24h success/failure ratio — green bar for healthy, yellow for degraded >5% failures, red for critical >20% failures; hover for tooltip with exact counts), Last Run (relative timestamp + status icon), Actions ("···" menu: Edit, Duplicate, View Executions, Enable/Disable, Delete).
+**Columns:** Name (clickable → designer), Type (color-coded badge: Record/Scheduled/API/NATS), Status (Active green/Draft gray/Disabled red dot), Health (sparkline showing last 24h success/failure ratio — green bar for healthy, yellow for degraded >5% failures, red for critical >20% failures; hover for tooltip with exact counts), Last Run (relative timestamp + status icon), Actions ("···" menu: Edit, Duplicate, View Executions, Enable/Disable, Delete).
 
 **Flow failure notifications:** When a flow execution fails, an in-app notification is created for the flow's creator (and optionally configured recipients). Notification includes flow name, error summary, and link to the debug view. Configurable per-flow: "Notify on failure" toggle in flow settings with recipient list. Uses the existing `SEND_NOTIFICATION` infrastructure.
 
@@ -709,14 +709,14 @@ Replaces existing `FlowsPage.tsx` following `CollectionsPage.tsx` patterns.
 
 Full-page, 3-step wizard (progressive disclosure — no blank canvas overwhelm):
 
-**Step 1: Choose Flow Type** — Card selector with 4 options: Record Change, Scheduled, API Call/Webhook, Kafka Message. Each card has icon, title, and brief description. Selected card gets blue border.
+**Step 1: Choose Flow Type** — Card selector with 4 options: Record Change, Scheduled, API Call/Webhook, NATS message. Each card has icon, title, and brief description. Selected card gets blue border.
 
 **Step 2: Configure Trigger** — Adapts form based on Step 1 selection:
 
 - **Record Change:** Collection (searchable dropdown), Events (checkboxes: Created/Updated/Deleted). Advanced (collapsed): triggerFields (multi-select from collection fields), filterFormula (formula editor with syntax highlighting), synchronous checkbox (with warning about execution time).
 - **Scheduled:** Quick presets (Hourly/Daily/Weekly/Monthly) OR cron expression input with human-readable preview. Timezone dropdown. Optional static inputData key-value editor.
 - **API Call/Webhook:** Optional webhook path input (shows full URL preview with copy-to-clipboard button). Authentication dropdown (Tenant API Key/Webhook Secret/None). When "Webhook Secret" is selected: auto-generated HMAC signing secret displayed once with copy button, "Regenerate Secret" action with confirmation. Optional input schema builder (field name, type, required — table with add/remove rows).
-- **Kafka Message:** Topic (text input), Consumer group (auto-generated default, editable). Payload format (JSON/String/Avro). Advanced (collapsed): key filter (glob pattern), message body filter (path + operator + value).
+- **NATS message:** Topic (text input), queue group (auto-generated default, editable). Payload format (JSON/String/Avro). Advanced (collapsed): key filter (glob pattern), message body filter (path + operator + value).
 
 **Step 3: Name & Description** — Name (required), Description (optional). "Open Designer" button creates the flow as draft and navigates to the visual designer.
 
@@ -837,7 +837,7 @@ After Phase 3 migration, "Workflow Rules" is removed and "Flows" becomes the sin
 
 - Component tests for each custom node (renders, selection, inline edit)
 - Component tests for each property panel variant (Task, Choice, Parallel, Map, Wait, Pass)
-- Component tests for trigger configuration forms (Record, Kafka, Scheduled, API)
+- Component tests for trigger configuration forms (Record, NATS, Scheduled, API)
 - Unit tests for Canvas ↔ JSON sync (round-trip fidelity for all state types)
 - Unit tests for validation engine (each rule)
 - Unit tests for input mapping preview generation
@@ -854,7 +854,7 @@ After Phase 3 migration, "Workflow Rules" is removed and "Flows" becomes the sin
 - [ ] Custom edge components (normal, choice-labeled, error/catch)
 - [ ] Steps Palette (left panel, draggable state type cards)
 - [ ] Properties Panel with type-specific forms for all 8 state types
-- [ ] Trigger configuration forms (Record, Kafka, Scheduled, API) in properties panel and wizard
+- [ ] Trigger configuration forms (Record, NATS, Scheduled, API) in properties panel and wizard
 - [ ] Input Mapping configuration UI with live preview
 - [ ] Flow Settings panel (execution timeout, sensitive fields, error handling default, max concurrent)
 - [ ] Webhook secret management (generation, display, regenerate) in API/Webhook trigger config
@@ -1108,7 +1108,7 @@ Implementation approach:
 
 ```
 Install → Download JAR from source URL → Verify SHA-256 checksum → Upload to S3 →
-Parse manifest from JAR → Update DB status → Publish Kafka event →
+Parse manifest from JAR → Update DB status → Publish NATS event →
 All pods: receive event → Download JAR from S3 → Load via sandboxed ClassLoader →
 Validate KeltaModule interface → Register handlers → Set status ACTIVE
 ```
@@ -1120,7 +1120,7 @@ Read ACTIVE modules from DB → Download JARs from S3 → Load ClassLoaders → 
 
 **New class:** `RuntimeModuleManager`
 
-- `installModule(tenantId, jarUrl, checksum, installedBy)` → Downloads JAR from source URL, verifies checksum, uploads to S3, parses manifest, updates DB, publishes `ModuleChangedEvent` to Kafka
+- `installModule(tenantId, jarUrl, checksum, installedBy)` → Downloads JAR from source URL, verifies checksum, uploads to S3, parses manifest, updates DB, publishes `ModuleChangedEvent` to NATS
 - `uninstallModule(tenantId, moduleId)` → Updates DB status, publishes `ModuleChangedEvent` (UNINSTALLED). All pods react: deregister handlers, close ClassLoader. Originating pod deletes JAR from S3 after event is published.
 - `enableModule(tenantId, moduleId)` / `disableModule(tenantId, moduleId)` → Updates DB status, publishes `ModuleChangedEvent` (ENABLED/DISABLED). All pods react: load/unload ClassLoader, register/deregister handlers.
 - `loadModule(tenantId, moduleId)` → Downloads JAR from S3, loads via sandboxed ClassLoader, registers handlers locally (called by event listener)
@@ -1135,25 +1135,25 @@ Extend `ActionHandlerRegistry` to support tenant-scoped handlers:
 - `getTenantHandler(tenantId, actionKey)` → Checks tenant handlers first, then falls back to global
 - `removeTenantHandlers(tenantId, moduleId)`
 
-### 4.5 Kafka-Based Module Event Propagation
+### 4.5 NATS-based Module Event Propagation
 
-Module lifecycle events propagate to **all running worker pods** without process restarts, following the existing `CollectionConfigEventPublisher` → `CollectionSchemaListener` Kafka pattern.
+Module lifecycle events propagate to **all running worker pods** without process restarts, following the existing `CollectionConfigEventPublisher` → `CollectionSchemaListener` NATS pattern.
 
-**Kafka topic:** `kelta.config.module.changed`
+**NATS subject:** `kelta.config.module.changed`
 
-**New event payload (runtime-events):** `ModuleChangedPayload` — fields: `id`, `tenantId`, `moduleId`, `name`, `version`, `s3Key`, `moduleClass`, `manifest` (JSON), `changeType` (INSTALLED/ENABLED/DISABLED/UNINSTALLED). Uses `ConfigEvent<ModuleChangedPayload>` envelope via `EventFactory.createEvent()`. Kafka key: `tenantId:moduleId`.
+**New event payload (runtime-events):** `ModuleChangedPayload` — fields: `id`, `tenantId`, `moduleId`, `name`, `version`, `s3Key`, `moduleClass`, `manifest` (JSON), `changeType` (INSTALLED/ENABLED/DISABLED/UNINSTALLED). Uses `ConfigEvent<ModuleChangedPayload>` envelope via `EventFactory.createEvent()`. NATS key: `tenantId:moduleId`.
 
 **New classes:**
-- `ModuleConfigEventPublisher` (kelta-worker) — Publishes to `kelta.config.module.changed` after DB updates. Uses `KafkaTemplate<String, String>` + `ObjectMapper` (same pattern as `CollectionConfigEventPublisher`).
-- `ModuleEventListener` (kelta-worker) — `@KafkaListener` on `kelta.config.module.changed`. On INSTALLED/ENABLED: calls `runtimeModuleManager.loadModule()`. On DISABLED/UNINSTALLED: calls `runtimeModuleManager.unloadModule()`. S3 cleanup only by originating pod.
-- `ModuleConfigEventListener` (kelta-gateway) — `@KafkaListener` that invalidates `resourceDescriptorCache` so `GET /api/flows/resources` returns updated list.
+- `ModuleConfigEventPublisher` (kelta-worker) — Publishes to `kelta.config.module.changed` after DB updates. Uses `PlatformEventPublisher` + `ObjectMapper` (same pattern as `CollectionConfigEventPublisher`).
+- `ModuleEventListener` (kelta-worker) — `NATS subscription` on `kelta.config.module.changed`. On INSTALLED/ENABLED: calls `runtimeModuleManager.loadModule()`. On DISABLED/UNINSTALLED: calls `runtimeModuleManager.unloadModule()`. S3 cleanup only by originating pod.
+- `ModuleConfigEventListener` (kelta-gateway) — `NATS subscription` that invalidates `resourceDescriptorCache` so `GET /api/flows/resources` returns updated list.
 
 **Design constraints:**
-1. **Fan-out consumer groups:** Each pod uses unique group ID (`${kelta.worker.id}-modules`) so every pod receives every event
+1. **Fan-out queue groups:** Each pod uses unique group ID (`${kelta.worker.id}-modules`) so every pod receives every event
 2. **Idempotent operations:** `loadModule`/`unloadModule` are no-ops if already in target state
 3. **Thread safety:** `ConcurrentHashMap<String, Map<String, LoadedModule>>` (tenantId → moduleId → LoadedModule)
-4. **DB as source of truth:** On pod startup, loads from DB. Kafka only for real-time propagation.
-5. **Ordering:** Kafka key partitioning (`tenantId:moduleId`) ensures in-order processing per module
+4. **DB as source of truth:** On pod startup, loads from DB. NATS only for real-time propagation.
+5. **Ordering:** NATS key partitioning (`tenantId:moduleId`) ensures in-order processing per module
 6. **Cache invalidation:** Gateway invalidates resource descriptors so UI autocomplete stays current
 
 ### 4.6 Module REST API
@@ -1261,15 +1261,15 @@ When a runtime module is active, its action handlers appear in the Task resource
 - [ ] Pod startup module loading from S3 (database as source of truth)
 - [ ] `ModuleChangedPayload` event class (runtime-events)
 - [ ] `ModuleConfigEventPublisher` — publishes to `kelta.config.module.changed` topic
-- [ ] `ModuleEventListener` (kelta-worker) — Kafka listener that loads/unloads modules on each pod
-- [ ] `ModuleConfigEventListener` (kelta-gateway) — Kafka listener that invalidates resource descriptor cache
-- [ ] Fan-out consumer group pattern (each pod receives all module events)
+- [ ] `ModuleEventListener` (kelta-worker) — NATS listener that loads/unloads modules on each pod
+- [ ] `ModuleConfigEventListener` (kelta-gateway) — NATS listener that invalidates resource descriptor cache
+- [ ] Fan-out queue group pattern (each pod receives all module events)
 - [ ] Idempotent load/unload with ConcurrentHashMap-based module tracking
 - [ ] Audit logging for module events
 - [ ] Security tests (verify sandbox prevents forbidden operations)
-- [ ] Integration tests (install module → S3 upload → Kafka event → all pods load ClassLoader → execute flow using module handler)
+- [ ] Integration tests (install module → S3 upload → NATS event → all pods load ClassLoader → execute flow using module handler)
 - [ ] S3 integration test with MinIO (testcontainers)
-- [ ] Kafka event propagation test (verify multi-pod load/unload without restart)
+- [ ] NATS event propagation test (verify multi-pod load/unload without restart)
 
 ---
 
@@ -1310,7 +1310,7 @@ Shows a filterable list of all executions for the current flow:
 │ exec-abc1  │ ✓ Success │ Record upd │  5/5  │  1.2s    │ 2m ago  │
 │ exec-abc2  │ ✕ Failed  │ Record cre │  3/5  │  0.8s    │ 5m ago  │
 │ exec-abc3  │ ● Running │ API call   │  2/5  │  —       │ 12s ago │
-│ exec-abc4  │ ◷ Waiting │ Kafka msg  │  4/5  │  —       │ 1h ago  │
+│ exec-abc4  │ ◷ Waiting │ NATS msg  │  4/5  │  —       │ 1h ago  │
 │────────────────────────────────────────────────────────────────── │
 │ Click any row to open the visual debug view in a new tab         │
 └──────────────────────────────────────────────────────────────────┘
@@ -1342,7 +1342,7 @@ Horizontal bar at bottom: each step as colored segment proportional to duration 
 
 ### 5.5 Live Execution Tracking
 
-For running executions: auto-refresh as steps complete. Worker publishes `FlowStepCompletedEvent` to Kafka topic `kelta.flow.step.completed` on each transition. Gateway subscribes and pushes to UI via SSE at `GET /api/flows/executions/{executionId}/events`. Canvas animates: current node pulsates, completed nodes transition to green check.
+For running executions: auto-refresh as steps complete. Worker publishes `FlowStepCompletedEvent` to NATS subject `kelta.flow.step.completed` on each transition. Gateway subscribes and pushes to UI via SSE at `GET /api/flows/executions/{executionId}/events`. Canvas animates: current node pulsates, completed nodes transition to green check.
 
 ### 5.6 Failed Execution Management & Retry
 
@@ -1369,7 +1369,7 @@ Migration `V74__flow_execution_viewer_support.sql`: Add `parent_execution_id`, `
 - [ ] Audit Log tab in flow designer (chronological change history per flow)
 - [ ] Execution timeline component with click-to-select and scrubber
 - [ ] Live execution tracking via SSE
-- [ ] `kelta.flow.step.completed` Kafka topic and gateway SSE endpoint
+- [ ] `kelta.flow.step.completed` NATS subject and gateway SSE endpoint
 - [ ] Manual retry API endpoints (retry from beginning, retry from failed step)
 - [ ] Retry UI in execution viewer and executions tab
 - [ ] Failed execution dashboard (cross-flow view with bulk retry)
@@ -1429,7 +1429,7 @@ New metrics registered in `FlowMetricsConfig`:
 - "Test" button in FlowDesignerPage toolbar opens a test configuration sheet:
   - **For RECORD_TRIGGERED flows:** "Pick a test record" — searchable dropdown of records from the trigger collection. Selecting a record populates the test input with that record's data as the initial state. Also supports manual JSON entry.
   - **For SCHEDULED/AUTOLAUNCHED flows:** JSON editor with schema-based autocomplete for inputData.
-  - **For KAFKA_TRIGGERED flows:** JSON editor for simulated message payload with key/headers/body fields.
+  - **For NATS_TRIGGERED flows:** JSON editor for simulated message payload with key/headers/body fields.
   - Mock handler configuration panel: toggle per-Task to use real handler or mock response. For each mocked handler, JSON editor for the mock result.
 - Step-through controls (Next Step, Run to End, Reset) — displayed as a floating toolbar at the bottom of the canvas during test execution
 - **Test result display:** When test completes, automatically opens a Debug tab for the test execution. Test executions are visually distinguished (dashed border on debug tab, "TEST" badge). Test runs are hidden by default in the Executions tab (toggle "Show test runs" to see them).
@@ -1481,8 +1481,8 @@ ALTER TABLE flow ADD COLUMN published_version INTEGER;
 
 - Propagate trace context through flow execution. Each flow execution creates a root span; each step creates a child span with `state_type`, `resource`, `duration_ms`, and `status` attributes.
 - HTTP callout handler (`HTTP_CALLOUT`) injects trace headers into outbound requests.
-- Kafka publish handlers inject trace headers into outbound messages.
-- Inbound triggers (Kafka listener, webhook) extract trace context from incoming requests/messages if present.
+- NATS publish handlers inject trace headers into outbound messages.
+- Inbound triggers (NATS listener, webhook) extract trace context from incoming requests/messages if present.
 - Trace ID stored in `flow_execution` table for correlation with external systems.
 
 ### 6.6 Data Retention & Sensitivity
@@ -1542,7 +1542,7 @@ New page: **Flow Settings** — registered in the **Automation** category of Set
 
 **Dependencies tab:**
 - **Collection → Flow impact analysis:** Shows which flows are triggered by or reference each collection. When editing a collection's schema (adding/removing/renaming fields), a warning banner shows affected flows. Example: "3 flows reference field 'status' on collection 'orders': Order Processing, Status Notification, Daily Report."
-- **Flow → Flow dependencies:** Shows which flows invoke other flows (via AUTOLAUNCHED triggers or Kafka events). Visualized as a simple directed graph.
+- **Flow → Flow dependencies:** Shows which flows invoke other flows (via AUTOLAUNCHED triggers or NATS events). Visualized as a simple directed graph.
 - **Module → Flow dependencies:** Shows which flows use action handlers from each runtime module. Warning before disabling/uninstalling a module: "This module provides handlers used by 5 active flows."
 
 ### 6.9 Polish & UX

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -34,7 +34,7 @@ Every collection automatically gets a fully compliant JSON:API endpoint. No boil
 - **Sorting**: `?sort=field,-field` for ascending/descending
 - **Pagination**: `?page[number]=1&page[size]=20`
 - **Sub-resources**: `/{parent}/{parentId}/{child}` for parent-child traversal
-- **Dynamic route registration**: Collection schema changes publish Kafka events that update gateway routes in real-time — no restart required
+- **Dynamic route registration**: Collection schema changes publish NATS events that update gateway routes in real-time — no restart required
 - **Atomic Operations**: `POST /{tenant}/_operations` for bulk CRUD per the JSON:API Atomic Operations spec — multiple create/update/delete operations in a single transactional request
 
 ---
@@ -45,7 +45,7 @@ Search across all your data with a single query. PostgreSQL `tsvector`-backed fu
 
 - Search endpoint: `GET /api/_search?q={query}` with prefix matching and relevance ranking via `ts_rank`
 - Per-field `searchable` flag controls which fields are indexed
-- Search index automatically maintained via Kafka record change events
+- Search index automatically maintained via NATS record change events
 - Tenant-isolated via PostgreSQL Row Level Security on the search index table
 - Async bulk re-index capability when searchable fields change
 
@@ -219,13 +219,13 @@ A full state-machine automation engine inspired by AWS Step Functions, with a vi
 | Record-Triggered (on create/update/delete with filter formulas) | Working |
 | API / Webhook (`POST /api/webhooks/{flowId}` with request body mapping, header capture) | Working |
 | Scheduled (cron expression with timezone) | Working |
-| Kafka-Triggered (key/message filter with dynamic consumer) | TODO |
+| NATS-triggered (key/message filter with dynamic consumer) | TODO |
 
 **Workflow Migration:**
 - `WorkflowMigrationController` migrates legacy workflow rules to modern flow definitions — migrate individual rules or all at once via `/api/admin/migrate-workflow-rules`
 
 > **TODO**
-> - KAFKA_TRIGGERED: No dynamic Kafka consumer created per flow
+> - NATS_TRIGGERED: No dynamic NATS consumer created per flow
 > - Wait state resume: `resumeExecution()` is not implemented — long-duration Wait states persist as WAITING but never resume
 
 ---
@@ -293,9 +293,9 @@ Connect Kelta to your existing systems with HTTP callouts, webhooks, event strea
 **Working:**
 - **HTTP Callout**: Generic HTTP requests from flows with header, method, and body templating via merge fields
 - **Outbound Message**: Structured webhook payloads (XML/JSON) to external systems
-- **Kafka Event Publishing**: Publish custom events to arbitrary Kafka topics from any flow
+- **NATS Event Publishing**: Publish custom events to arbitrary NATS subjects from any flow
 - **Inbound Webhooks**: Flows with AUTOLAUNCHED type get dedicated `POST /api/webhooks/{flowId}` endpoints with request body mapping and header capture (content-type, user-agent)
-- **Outbound Webhooks (Svix)**: Outbound webhook delivery via Svix with event type mapping (`collection.created`, `collection.updated`, etc.), multi-tenant isolation, management portal UI, and collection-scoped webhook filtering. `SvixWebhookPublisher` bridges Kafka config events to Svix. `SvixTenantLifecycleHook` initializes a Svix application per tenant on creation.
+- **Outbound Webhooks (Svix)**: Outbound webhook delivery via Svix with event type mapping (`collection.created`, `collection.updated`, etc.), multi-tenant isolation, management portal UI, and collection-scoped webhook filtering. `SvixWebhookPublisher` bridges NATS config events to Svix. `SvixTenantLifecycleHook` initializes a Svix application per tenant on creation.
 - **Email Delivery**: Standards-based email via `SmtpEmailProvider` with per-tenant SMTP settings stored in `tenant.settings` JSONB column. Async delivery via dedicated thread pool, email logging to `email_log` table, template management, configurable from address/name per tenant, and cached `JavaMailSender` instances (Caffeine, 5-min TTL).
 - **Push Notifications (SPI)**: `PushProvider` SPI with device registration API (`PushDeviceController`). Ships with a log-only default provider — plug in FCM, APNs, or any push backend.
 - **Embedded Analytics (Apache Superset)**: Embedded dashboards with guest token authentication, automatic dataset sync from collections, and tenant-isolated Superset management. `SupersetTenantLifecycleHook` initializes Superset resources on tenant creation. See Embedded Analytics section below.
@@ -313,7 +313,7 @@ Embed interactive dashboards and reports directly into the platform using Apache
 
 - **Guest token generation**: `SupersetController` at `/api/superset/guest-token` generates scoped guest tokens for embedding dashboards with tenant-level row-level security
 - **Dashboard discovery**: `GET /api/superset/dashboards` lists available dashboards for the current tenant
-- **Dataset sync**: `POST /api/superset/datasets/sync` synchronizes collection schemas to Superset datasets. `SupersetCollectionSyncListener` triggers sync automatically when collections change via Kafka events
+- **Dataset sync**: `POST /api/superset/datasets/sync` synchronizes collection schemas to Superset datasets. `SupersetCollectionSyncListener` triggers sync automatically when collections change via NATS events
 - **Tenant isolation**: `SupersetTenantService` manages per-tenant Superset resources. `SupersetTenantLifecycleHook` provisions Superset access on tenant creation
 - **Frontend embedding**: `SupersetEmbed` component renders dashboards inline. `AnalyticsPage` and `DashboardPage` provide dedicated analytics views in the admin UI
 
@@ -324,7 +324,7 @@ Embed interactive dashboards and reports directly into the platform using Apache
 Push real-time record change notifications to connected clients over WebSocket.
 
 - **WebSocket endpoint**: `/ws/realtime` with JWT authentication on upgrade — only authenticated users receive events
-- **Kafka bridge**: `RealtimeKafkaBridge` consumes `kelta.record.changed` Kafka events and routes them to subscribed WebSocket sessions
+- **NATS bridge**: `RealtimeBridge` consumes `kelta.record.changed` NATS events and routes them to subscribed WebSocket sessions
 - **Subscription management**: `SubscriptionManager` with thread-safe per-session subscription tracking. Subscribe to specific collections or record IDs.
 - **Tenant isolation**: Sessions only receive events scoped to their tenant
 - **Subscription limits**: 50 subscriptions per session, 100 connections per tenant — prevents resource exhaustion
@@ -360,7 +360,7 @@ Extend the platform with custom action handlers, before-save hooks, and frontend
 **Working:**
 - **Module SPI**: `KeltaModule` interface with `getActionHandlers()`, `getBeforeSaveHooks()`, `onStartup(ModuleContext)` lifecycle
 - **3 built-in compile-time modules**: Core Actions (8 handlers), Integration (7 handlers), Schema Lifecycle (hooks for tenant, collection, field, user, and profile lifecycle)
-- **Module lifecycle management**: Install, enable, disable, uninstall per tenant with status tracking and Kafka event propagation across pods
+- **Module lifecycle management**: Install, enable, disable, uninstall per tenant with status tracking and NATS event propagation across pods
 - **ModuleContext**: Provides QueryEngine, CollectionRegistry, FormulaEvaluator, and extensible service map to modules
 - **Frontend Plugin SDK** (`@kelta/plugin-sdk`): `BasePlugin` abstract class with `init`/`mount`/`unmount` lifecycle, `ComponentRegistry` for custom field renderers and page components
 
@@ -509,13 +509,13 @@ Production-ready infrastructure patterns baked into the platform.
 
 - **Graceful shutdown**: In-flight flow executions persisted to DB on SIGTERM for resume after restart
 - **Optimistic locking**: Scheduled tasks use `last_scheduled_run` column to prevent duplicate execution across pods
-- **Multi-layer caching**: Caffeine (in-process) -> Redis -> worker backend, with Kafka-driven cache invalidation
+- **Multi-layer caching**: Caffeine (in-process) -> Redis -> worker backend, with NATS-driven cache invalidation
 - **Dual-layer rate limiting**: Per-tenant fixed-window (Redis) + governor limit daily quota
-- **Dynamic route management**: Gateway routes updated in real-time via Kafka events — no restart on schema changes
+- **Dynamic route management**: Gateway routes updated in real-time via NATS events — no restart on schema changes
 - **Security hardening**: CSP headers, strict CORS policies, encrypted session cookies, JSON-only error responses (no stack traces leaked), and mandatory encryption for sensitive fields
 - **Dependency scanning**: Automated security audit pipeline for identifying vulnerable dependencies
 - **Security headers**: `SecurityHeadersFilter` adds standard security headers (X-Content-Type-Options, X-Frame-Options, X-XSS-Protection, Referrer-Policy, etc.) to all responses
-- **Health endpoints**: `/actuator/health` with Redis and Kafka connectivity checks, worker reachability monitoring from gateway
+- **Health endpoints**: `/actuator/health` with Redis and NATS connectivity checks, worker reachability monitoring from gateway
 - **Prometheus metrics**: Request counts, latency histograms, error counters, and active collection gauges for HPA autoscaling
 - **Kubernetes-native**: Deployed via ArgoCD with standard deployment manifests
 
@@ -533,7 +533,7 @@ Production-ready infrastructure patterns baked into the platform.
 | CLI | TypeScript, Commander.js | Command-line interface for collection and record management |
 | Database | PostgreSQL 15 | Primary data store (111 Flyway migrations) |
 | Cache | Redis 7 | Rate limiting, caching (routes, permissions, JSON:API responses), PAT revocation |
-| Messaging | Kafka 3.7 (KRaft) | Event streaming (record changes, config changes, module events, realtime bridge) |
+| Messaging | NATS 2.10 (JetStream) | Event streaming (record changes, config changes, module events, realtime bridge) |
 | Authorization | Cerbos PDP | Fine-grained ABAC policy evaluation with per-tenant resource policies and cache invalidation |
 | Observability | OpenSearch, Jaeger, OpenTelemetry | Traces, logs, audit events, metrics |
 | Analytics | Apache Superset | Embedded dashboards with guest token auth and automatic dataset sync |
@@ -558,7 +558,7 @@ What SMB and larger enterprises need from an application platform, and where Kel
 | **Personal Access Tokens** | SHA-256 hashed `klt_` tokens for API access, max 10 per user, Redis-backed revocation |
 | **Custom Domains** | CNAME-based custom tenant domains alongside slug-based URL routing |
 | **API-First Architecture** | Every collection auto-generates a JSON:API endpoint with filtering, sorting, pagination, includes, sparse fieldsets, and atomic bulk operations |
-| **Real-Time Data** | WebSocket subscriptions for live record change notifications with Kafka bridge and tenant isolation |
+| **Real-Time Data** | WebSocket subscriptions for live record change notifications with NATS bridge and tenant isolation |
 | **API Documentation** | Auto-generated OpenAPI 3.0 spec with embedded Swagger UI, dynamically reflecting collection schema |
 | **Workflow Automation** | Visual Flow Builder with 16 action handlers, 8 state types, retry/catch error handling, durable execution, and scheduled triggers |
 | **Email Delivery** | Standards-based SMTP with per-tenant settings, async delivery, email logging, and template management |
@@ -566,9 +566,9 @@ What SMB and larger enterprises need from an application platform, and where Kel
 | **Rate Limiting & Quotas** | Dual-layer rate limiting (per-route + daily governor quota) with configurable per-tenant limits |
 | **Embedded Analytics** | Apache Superset integration with guest tokens, automatic dataset sync, and tenant-isolated dashboards |
 | **Webhook Integrations** | Inbound webhooks (flow triggers) and outbound webhooks (Svix) with event type mapping and HMAC verification |
-| **Full-Text Search** | PostgreSQL tsvector-backed search with per-field indexing control, Kafka-driven index maintenance |
+| **Full-Text Search** | PostgreSQL tsvector-backed search with per-field indexing control, NATS-driven index maintenance |
 | **Observability** | OpenTelemetry tracing, OpenSearch log aggregation, Prometheus metrics, 7 monitoring pages in admin UI |
-| **Extensibility** | Module SPI for backend extensions, Plugin SDK for frontend customization, Kafka event streaming for integration |
+| **Extensibility** | Module SPI for backend extensions, Plugin SDK for frontend customization, NATS event streaming for integration |
 | **Internationalization** | Multi-language support with translation framework |
 | **Accessibility** | WCAG patterns: skip links, ARIA live regions, keyboard navigation, screen reader support |
 | **Dynamic Schema** | Runtime data model changes with no deployments — create collections, fields, relationships, and validation rules on the fly |
@@ -610,7 +610,7 @@ What SMB and larger enterprises need from an application platform, and where Kel
 ### High Priority — Core Platform Gaps
 
 - [ ] **Field-level security read-side stripping**: Write-side enforcement is complete — HIDDEN fields are blocked from create/update. Read-side stripping from API responses is still needed.
-- [ ] **Flow KAFKA_TRIGGERED trigger**: Wire dynamic Kafka consumers per flow with key/message filtering
+- [ ] **Flow NATS_TRIGGERED trigger**: Wire dynamic NATS consumers per flow with key/message filtering
 - [ ] **Flow Wait state resume**: Implement `resumeExecution()` to resume flows paused in Wait states
 - [x] **Permission enforcement default**: `permissions-enabled` now defaults to `true` for production deployments
 

--- a/HVAC-TEST-PLAN.md
+++ b/HVAC-TEST-PLAN.md
@@ -1964,7 +1964,7 @@ Now that collections exist, configure permissions for each profile.
 2. **Expected:** All services show green/healthy status:
    - Control Plane: ✅
    - Database: ✅
-   - Kafka: ✅
+   - NATS: ✅
    - Redis: ✅
 3. **Expected:** API metrics charts show request rate, error rate, and latency.
 

--- a/MARKETING.md
+++ b/MARKETING.md
@@ -54,10 +54,10 @@ Every collection automatically gets a fully compliant JSON:API endpoint. No boil
 
 - **Full CRUD** at `/{tenant}/{collection}` with relationship includes, sparse fieldsets, filtering, sorting, and pagination
 - **Atomic operations** for bulk create/update/delete in a single transactional request
-- **WebSocket realtime subscriptions** for live record change notifications with Kafka bridge and tenant isolation
+- **WebSocket realtime subscriptions** for live record change notifications with NATS bridge and tenant isolation
 - **Auto-generated OpenAPI 3.0 documentation** with embedded Swagger UI — dynamically reflecting your collection schema
 - **Global full-text search** across all collections via PostgreSQL tsvector with per-field indexing control
-- **Dynamic route registration** — schema changes update gateway routes in real-time via Kafka, no restart required
+- **Dynamic route registration** — schema changes update gateway routes in real-time via NATS, no restart required
 
 ### Visual Workflow Builder
 
@@ -122,7 +122,7 @@ Connect Kelta to your existing systems with standards-based integrations.
 - **HTTP callouts** from flows with header, method, and body templating via merge fields
 - **Inbound webhooks** — dedicated endpoints per flow with request body mapping and header capture
 - **Outbound webhooks** powered by Svix with event type mapping, HMAC verification, and collection-scoped filtering
-- **Kafka event streaming** — publish custom events to arbitrary topics from any flow
+- **NATS event streaming** — publish custom events to arbitrary topics from any flow
 - **Email delivery** — per-tenant SMTP with async delivery, email logging, and template management
 - **Push notifications** — SPI with device registration, ready for FCM/APNs integration
 - **Embedded analytics** — Apache Superset integration with guest tokens, automatic dataset sync, and tenant-isolated dashboards
@@ -177,7 +177,7 @@ Everything developers need to build on top of Kelta.
 | **SDK** | TypeScript | Client library, components, plugin SDK, CLI |
 | **PostgreSQL** | v15 | Primary data store with RLS, schema isolation, full-text search |
 | **Redis** | v7 | Rate limiting, caching, PAT revocation, session storage |
-| **Kafka** | v3.7 (KRaft) | Event streaming, realtime bridge, config propagation |
+| **NATS** | v3.7 (KRaft) | Event streaming, realtime bridge, config propagation |
 | **Cerbos** | PDP | Fine-grained ABAC policy engine with per-tenant policies |
 | **OpenSearch** | + Jaeger, OpenTelemetry | Traces, logs, audit events, metrics |
 | **Superset** | Apache | Embedded analytics dashboards |

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Kelta is a platform for building dynamic, runtime-configurable enterprise applic
 | Module | Description |
 |--------|-------------|
 | `kelta-platform/runtime/runtime-core` | Core runtime library — collection management, query engine, validation, dual storage modes |
-| `kelta-platform/runtime/runtime-events` | Shared Kafka event classes for lifecycle events |
+| `kelta-platform/runtime/runtime-events` | Shared NATS event classes for lifecycle events |
 | `kelta-platform/runtime/runtime-jsonapi` | Shared JSON:API model classes |
 | `kelta-platform/runtime/runtime-module-core` | Workflow action handlers (field updates, record CRUD, tasks, decisions) |
 | `kelta-platform/runtime/runtime-module-integration` | Integration action handlers (HTTP callouts, email, scripts, delays) |
@@ -41,7 +41,7 @@ Kelta is a platform for building dynamic, runtime-configurable enterprise applic
 
 **Frontend:** TypeScript, React, Vite, Vitest, Tailwind CSS
 
-**Infrastructure:** PostgreSQL 15, Redis 7, Kafka 3.7 (KRaft), Keycloak 23 (OIDC)
+**Infrastructure:** PostgreSQL 15, Redis 7, NATS 2.10 (JetStream), Keycloak 23 (OIDC)
 
 **Deployment:** Docker, Kubernetes, ArgoCD
 

--- a/kelta-gateway/README.md
+++ b/kelta-gateway/README.md
@@ -22,21 +22,21 @@ Client Request
 |---------|-------------|
 | `auth` | JWT validation, `GatewayPrincipal` extraction, public path matching |
 | `authz` | Route/field authorization filters, permission resolution from worker |
-| `config` | Spring configuration, bootstrap, Kafka/Redis/Security beans |
+| `config` | Spring configuration, bootstrap, NATS/Redis/Security beans |
 | `filter` | Tenant resolution, security headers, request logging |
 | `route` | `DynamicRouteLocator`, `RouteRegistry` (in-memory, thread-safe) |
 | `cache` | `GatewayCacheManager` -- Caffeine-backed tenant slug and governor limit caches |
 | `ratelimit` | `RedisRateLimiter` (sliding window) |
 | `jsonapi` | `IncludeResolver` -- fetches related resources from Redis cache with backend fallback |
-| `listener` | Kafka consumers for collection and worker assignment changes |
-| `health` | Health indicators for Redis, Kafka, and worker service |
+| `listener` | NATS consumers for collection and worker assignment changes |
+| `health` | Health indicators for Redis, NATS, and worker service |
 
 ## Configuration
 
 Key properties from `application.yml`:
 
 ```yaml
-spring.kafka.bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+nats.url: ${NATS_URL:nats://localhost:4222}
 spring.data.redis:
   host: ${REDIS_HOST:localhost}
   port: ${REDIS_PORT:6379}
@@ -52,7 +52,7 @@ kelta.gateway:
     permissions-enabled: ${PERMISSIONS_ENABLED:true}
     permissions-cache-ttl-minutes: ${PERMISSIONS_CACHE_TTL:5}
     public-paths: /api/ui-pages,/api/ui-menus,/api/oidc-providers,/api/tenants
-  kafka.topics:
+  nats.subjects:
     collection-changed: kelta.config.collection.changed
     worker-assignment-changed: kelta.worker.assignment.changed
     record-changed: kelta.record.changed
@@ -66,11 +66,11 @@ kelta.gateway:
 3. Populates `RouteRegistry` and publishes `RefreshRoutesEvent`
 
 **Runtime:**
-- Routes are **not** hardcoded -- they are discovered from the worker at startup and updated dynamically via Kafka events without restart
+- Routes are **not** hardcoded -- they are discovered from the worker at startup and updated dynamically via NATS events without restart
 - JSON:API resources are cached in Redis with a 10-minute TTL
 - Rate limits are enforced per-tenant using Redis sliding windows backed by governor limit configuration
 
-**Kafka topics consumed:**
+**NATS subjects consumed:**
 - `kelta.config.collection.changed` -- updates routes on collection create/update/delete
 - `kelta.worker.assignment.changed` -- updates routes on worker assignment changes
 - `kelta.record.changed` -- record change events
@@ -89,7 +89,7 @@ mvn verify -f kelta-gateway/pom.xml -B
 
 ## Running Locally
 
-Requires Redis, Kafka, Keycloak, and the worker service. Start infrastructure via Docker Compose from the repo root:
+Requires Redis, NATS, Keycloak, and the worker service. Start infrastructure via Docker Compose from the repo root:
 
 ```bash
 docker-compose up -d
@@ -101,7 +101,7 @@ The gateway starts on port **8080**.
 ## Testing
 
 - **Unit tests** -- JUnit 5 + Mockito, test classes in isolation
-- **Integration tests** -- Testcontainers for Kafka/Redis, MockWebServer for HTTP
+- **Integration tests** -- Testcontainers for NATS/Redis, MockWebServer for HTTP
 - **Property-based tests** -- JUnit QuickCheck for universal property validation
 
 ```bash
@@ -114,7 +114,7 @@ mvn verify -f kelta-gateway/pom.xml -B
 |----------|-------------|
 | `GET /actuator/health` | Overall health |
 | `GET /actuator/health/redis` | Redis connectivity |
-| `GET /actuator/health/kafka` | Kafka connectivity |
+| `GET /actuator/health/nats` | NATS connectivity |
 | `GET /actuator/metrics` | Micrometer metrics |
 
 ## Docker
@@ -127,4 +127,4 @@ Multi-stage build: `maven:3.9-eclipse-temurin-21` (build) -> `eclipse-temurin:21
 - `runtime-events`, `runtime-jsonapi` (Kelta platform modules)
 - Spring Cloud Gateway, Spring WebFlux (reactive)
 - Spring Security OAuth2 Resource Server
-- Spring Data Redis (reactive), Spring Kafka
+- Spring Data Redis (reactive), NATS (jnats)

--- a/kelta-gateway/pom.xml
+++ b/kelta-gateway/pom.xml
@@ -27,7 +27,7 @@
     </properties>
 
     <dependencies>
-        <!-- Kelta Platform Runtime Events (Shared Kafka Events) -->
+        <!-- Kelta Platform Runtime Events (Shared NATS Events) -->
         <dependency>
             <groupId>io.kelta</groupId>
             <artifactId>runtime-events</artifactId>

--- a/kelta-gateway/src/main/resources/application.yml
+++ b/kelta-gateway/src/main/resources/application.yml
@@ -110,8 +110,6 @@ management:
   health:
     redis:
       enabled: true
-    kafka:
-      enabled: false
   tracing:
     export:
       enabled: true

--- a/kelta-gateway/src/test/resources/application-test.yml
+++ b/kelta-gateway/src/test/resources/application-test.yml
@@ -1,19 +1,7 @@
 spring:
   application:
     name: kelta-gateway-test
-  
-  # Kafka configuration for integration tests
-  kafka:
-    bootstrap-servers: localhost:9094
-    consumer:
-      group-id: kelta-gateway-test
-      auto-offset-reset: earliest
-      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
-      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
-    producer:
-      key-serializer: org.apache.kafka.common.serialization.StringSerializer
-      value-serializer: org.apache.kafka.common.serialization.StringSerializer
-  
+
   # Redis configuration for integration tests
   data:
     redis:
@@ -32,9 +20,6 @@ spring:
 kelta:
   gateway:
     worker-service-url: http://emf-worker:80
-    kafka:
-      topics:
-        collection-changed: kelta.collection.changed
     # Rate limiting is driven by per-tenant governor limits from the worker
     security:
       permissions-enabled: true

--- a/kelta-platform/README.md
+++ b/kelta-platform/README.md
@@ -7,7 +7,7 @@ Shared runtime libraries for the Kelta platform. These modules provide the core 
 ```
 kelta-platform/runtime/
 ├── runtime-core                 # Core runtime library
-├── runtime-events               # Shared Kafka event classes
+├── runtime-events               # Shared NATS event classes
 ├── runtime-jsonapi              # JSON:API model classes
 ├── runtime-module-core          # Workflow action handlers (CRUD, tasks, decisions)
 ├── runtime-module-integration   # Integration action handlers (HTTP, email, scripts)
@@ -31,7 +31,7 @@ The foundational library providing dynamic, runtime-configurable collection mana
 - **DataPath resolution** -- Relationship traversal with prefix optimization for batch resolves
 - **Workflow engine** -- `ActionHandler` interface, `BeforeSaveHook` lifecycle, `WorkflowEngine` for rule execution
 - **Module system** -- `KeltaModule` plugin architecture for extending workflows
-- **Event publishing** -- Async Kafka events via `KafkaEventPublisher` for configuration and record changes
+- **Event publishing** -- Async NATS events via `PlatformEventPublisher` for configuration and record changes
 - **REST router** -- `DynamicCollectionRouter` auto-exposes JSON:API endpoints for registered collections
 
 **Configuration properties:**
@@ -41,7 +41,7 @@ The foundational library providing dynamic, runtime-configurable collection mana
 
 ### runtime-events
 
-Shared Kafka event classes used across Kelta services.
+Shared NATS event classes used across Kelta services.
 
 - `ConfigEvent<T>` -- Generic base event for configuration changes
 - `RecordChangeEvent` -- Record-level lifecycle events
@@ -74,7 +74,7 @@ Integration action handlers for external communication.
 
 - `HttpCalloutActionHandler` -- HTTP requests with response capture
 - `OutboundMessageActionHandler` -- Webhook messages
-- `PublishEventActionHandler` -- Kafka event publishing
+- `PublishEventActionHandler` -- NATS event publishing
 - `EmailAlertActionHandler` -- Email notifications
 - `InvokeScriptActionHandler` -- Server-side script execution
 - `DelayActionHandler` -- Workflow delays
@@ -112,6 +112,6 @@ mvn clean install -DskipTests -f kelta-platform/pom.xml \
 
 - Java 21
 - Spring Boot 3.2.2
-- Spring Kafka, Spring Data Redis, Spring Data JDBC
+- NATS (jnats), Spring Data Redis, Spring Data JDBC
 - PostgreSQL, Jackson
 - Mockito 5.21, Testcontainers 1.19.3, jqwik 1.8.2

--- a/kelta-platform/runtime/runtime-core/README.md
+++ b/kelta-platform/runtime/runtime-core/README.md
@@ -8,7 +8,7 @@ The Kelta Runtime Core is the foundational library for the Kelta that enables dy
 - **Dual Storage Modes**: Physical tables (Mode A) or JSONB document store (Mode B)
 - **Query Engine**: Full-featured query support with pagination, sorting, filtering, and field selection
 - **Validation Engine**: Comprehensive field-level validation with multiple constraint types
-- **Event Publishing**: Kafka-based lifecycle event publishing
+- **Event Publishing**: NATS-based lifecycle event publishing
 - **Thread-Safe**: All components support concurrent access
 
 ## Quick Start
@@ -236,12 +236,12 @@ Pros:
 
 ## Event Publishing
 
-Enable Kafka event publishing for collection lifecycle events:
+Enable NATS event publishing for collection lifecycle events:
 
 ```properties
 kelta.events.enabled=true
 kelta.events.topic-prefix=kelta.events
-spring.kafka.bootstrap-servers=localhost:9092
+nats.url=nats://localhost:4222
 ```
 
 Events are published to topics: `{prefix}.{collectionName}.{eventType}`

--- a/kelta-platform/runtime/runtime-core/src/main/resources/application.properties
+++ b/kelta-platform/runtime/runtime-core/src/main/resources/application.properties
@@ -17,10 +17,6 @@ spring.datasource.hikari.idle-timeout=300000
 spring.datasource.hikari.connection-timeout=20000
 spring.datasource.hikari.max-lifetime=1200000
 
-# Kafka Configuration
-spring.kafka.bootstrap-servers=localhost:9092
-spring.kafka.producer.key-serializer=org.apache.kafka.common.serialization.StringSerializer
-spring.kafka.producer.value-serializer=org.springframework.kafka.support.serializer.JsonSerializer
 
 # Redis Configuration
 spring.data.redis.host=localhost

--- a/kelta-platform/runtime/runtime-core/src/test/resources/application-test.properties
+++ b/kelta-platform/runtime/runtime-core/src/test/resources/application-test.properties
@@ -10,7 +10,6 @@ spring.datasource.driver-class-name=org.h2.Driver
 kelta.query.default-page-size=20
 kelta.query.max-page-size=1000
 
-spring.kafka.bootstrap-servers=localhost:9092
 
 # Disable Redis for unit tests
 spring.data.redis.host=localhost

--- a/kelta-platform/runtime/runtime-module-integration/src/main/java/io/kelta/runtime/module/integration/IntegrationModule.java
+++ b/kelta-platform/runtime/runtime-module-integration/src/main/java/io/kelta/runtime/module/integration/IntegrationModule.java
@@ -30,7 +30,7 @@ import java.util.List;
  *   <li><b>HTTP_CALLOUT</b> — Makes HTTP requests with response capture</li>
  *   <li><b>OUTBOUND_MESSAGE</b> — Sends outbound webhook messages</li>
  *   <li><b>SEND_NOTIFICATION</b> — Sends in-app notifications</li>
- *   <li><b>PUBLISH_EVENT</b> — Publishes custom events (e.g., Kafka)</li>
+ *   <li><b>PUBLISH_EVENT</b> — Publishes custom events (e.g., to NATS)</li>
  *   <li><b>DELAY</b> — Delays subsequent workflow actions</li>
  *   <li><b>EMAIL_ALERT</b> — Sends email notifications</li>
  *   <li><b>INVOKE_SCRIPT</b> — Invokes server-side scripts</li>

--- a/kelta-platform/runtime/runtime-module-integration/src/main/java/io/kelta/runtime/module/integration/handlers/PublishEventActionHandler.java
+++ b/kelta-platform/runtime/runtime-module-integration/src/main/java/io/kelta/runtime/module/integration/handlers/PublishEventActionHandler.java
@@ -13,7 +13,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Action handler that publishes a custom event (e.g., to Kafka).
+ * Action handler that publishes a custom event (e.g., to NATS).
  *
  * <p>Config format:
  * <pre>
@@ -25,7 +25,7 @@ import java.util.Map;
  * </pre>
  *
  * <p>Publishes a message containing event data, record information, and a timestamp.
- * The message key is {@code tenantId:collectionId} for consistent partitioning.
+ * The message key is {@code tenantId:collectionId} for consistent per-record ordering.
  *
  * <p>This handler uses an {@code EventPublisher} function obtained from ModuleContext
  * extensions. If no publisher is available, the event data is logged and returned
@@ -38,7 +38,7 @@ public class PublishEventActionHandler implements ActionHandler {
     private static final Logger log = LoggerFactory.getLogger(PublishEventActionHandler.class);
 
     /**
-     * Functional interface for event publishing. Implementations can use Kafka, SNS, etc.
+     * Functional interface for event publishing. Implementations can use NATS, SNS, etc.
      */
     @FunctionalInterface
     public interface EventPublisher {

--- a/kelta-worker/CLAUDE.md
+++ b/kelta-worker/CLAUDE.md
@@ -58,7 +58,7 @@ When a system collection config changes, broadcast via NATS JetStream so all pod
 > **Read-after-write exception (issue #910):** a hook MAY *additionally* trigger a synchronous local refresh so the originating pod is consistent for an immediate read-after-write (e.g. `addField` → `getById` on the same pod), **provided it still publishes the NATS config event** for all other pods. Use `CollectionLifecycleManager.refreshOrInitializeLocally(collectionId)` for this — see `FieldConfigEventPublisher`. Local-refresh-*only* (skipping the broadcast) remains forbidden.
 
 ### NATS Subscriptions
-Listeners are plain classes registered in `config/NatsSubscriptionConfig` at `@PostConstruct` time via `NatsSubscriptionManager`. There are no `@KafkaListener`-style annotations. A listener method typically takes the raw JSON message and extracts the `PlatformEvent` envelope.
+Listeners are plain classes registered in `config/NatsSubscriptionConfig` at `@PostConstruct` time via `NatsSubscriptionManager`. There are no annotation-based listener bindings. A listener method typically takes the raw JSON message and extracts the `PlatformEvent` envelope.
 
 **Reference**: `listener/CollectionSchemaListener.java`, `listener/FlowEventListener.java`, `config/NatsSubscriptionConfig.java`
 

--- a/kelta-worker/README.md
+++ b/kelta-worker/README.md
@@ -8,7 +8,7 @@ Generic collection hosting worker for the Kelta platform. Owns database migratio
                     ┌──────────────────────────┐
                     │       kelta-worker         │
                     ├──────────────────────────┤
-  Kafka ──────────► │ CollectionSchemaListener │ ◄── schema change events
+  NATS ──────────► │ CollectionSchemaListener │ ◄── schema change events
                     │ WorkflowEventListener    │ ◄── record change events
                     ├──────────────────────────┤
   HTTP  ──────────► │ DynamicCollectionRouter  │ ◄── JSON:API CRUD for all collections
@@ -21,7 +21,7 @@ Generic collection hosting worker for the Kelta platform. Owns database migratio
                     ├──────────────────────────┤
                     │ PostgreSQL (Flyway)       │ ◄── 67 versioned migrations
                     │ Redis (rate limit counts) │
-                    │ Kafka (event publishing)  │
+                    │ NATS (event publishing)  │
                     │ S3 (optional attachments) │
                     └──────────────────────────┘
 ```
@@ -32,12 +32,12 @@ Generic collection hosting worker for the Kelta platform. Owns database migratio
 |---------|-------------|
 | `controller` | `InternalBootstrapController` (gateway bootstrap, tenants, OIDC, permissions), `GovernorLimitsController` |
 | `service` | `WorkerBootstrapService` (startup init), `CollectionLifecycleManager` (collection lifecycle), `S3StorageService` (attachment URLs) |
-| `listener` | `CollectionSchemaListener` (Kafka schema events), `WorkflowEventListener` (record change → workflow) |
-| `event` | `KafkaRecordEventPublisher` -- publishes record CRUD events to `kelta.record.changed` |
+| `listener` | `CollectionSchemaListener` (NATS schema events), `WorkflowEventListener` (record change → workflow) |
+| `event` | `NatsRecordEventPublisher` -- publishes record CRUD events to `kelta.record.changed` |
 | `workflow` | `ScheduledWorkflowExecutor` -- polls for due rules every 60s with optimistic locking |
 | `filter` | `RequestMetricsFilter` -- Prometheus metrics per collection (request count, duration, errors) |
 | `advice` | `AttachmentUrlEnricher` -- enriches JSON:API responses with presigned S3 download URLs |
-| `config` | Kafka, storage, metrics, workflow, and S3 configuration beans |
+| `config` | NATS, storage, metrics, workflow, and S3 configuration beans |
 
 ## Internal API Endpoints
 
@@ -64,7 +64,7 @@ spring.flyway:
   enabled: ${FLYWAY_ENABLED:true}
   baseline-on-migrate: true
 
-spring.kafka.bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+nats.url: ${NATS_URL:nats://localhost:4222}
 spring.data.redis:
   host: ${REDIS_HOST:localhost}
   port: ${REDIS_PORT:6379}
@@ -136,7 +136,7 @@ mvn verify -f kelta-worker/pom.xml -B
 
 ## Running Locally
 
-Requires PostgreSQL, Redis, and Kafka. Start infrastructure via Docker Compose from the repo root:
+Requires PostgreSQL, Redis, and NATS. Start infrastructure via Docker Compose from the repo root:
 
 ```bash
 docker-compose up -d
@@ -161,5 +161,5 @@ Multi-stage build: `maven:3.9-eclipse-temurin-21` (build) -> `eclipse-temurin:21
 
 - Java 21, Spring Boot 3.2.2
 - All `runtime-*` modules (core, events, jsonapi, module-core, module-integration, module-schema)
-- PostgreSQL + Flyway, Spring Kafka, Spring Data Redis
+- PostgreSQL + Flyway, NATS (jnats), Spring Data Redis
 - AWS SDK S3 (optional, for attachment presigned URLs)


### PR DESCRIPTION
## What
Follow-on to the `*.java` comment sweep ([#1040](https://github.com/cklinker/emf/pull/1040)). Removes **all remaining** Kafka references — docs, dead config, and the PUBLISH_EVENT action javadoc. The platform uses **NATS JetStream exclusively**; there is **zero functional Kafka** (no Kafka enums/classes/consumers — `KAFKA_TRIGGERED` is not a real flow-trigger type; real types are RECORD_TRIGGERED/SCHEDULED/AUTOLAUNCHED/SCREEN; the realtime bridge class is `RealtimeBridge`, not `RealtimeKafkaBridge`).

- **PUBLISH_EVENT** (`PublishEventActionHandler`, `IntegrationModule`): javadoc now cites NATS. The handler is broker-agnostic (injected `EventPublisher`); the `topic` config key is kept for back-compat (its value is a NATS subject).
- **Markdown → NATS**: `FEATURES.md`, **`EPIC-WORKFLOWS.md`** (a design doc architected around Kafka — `KAFKA_TRIGGERED`→`NATS_TRIGGERED`, `EMIT_KAFKA_EVENT`→`EMIT_EVENT`, `@KafkaListener`/`KafkaTemplate`→NATS subscriptions/`PlatformEventPublisher`, topics→subjects, consumer groups→queue groups), `MARKETING.md`, `README.md`, `HVAC-TEST-PLAN.md`, service READMEs, `.claude/docs/*` (Kafka 3.7 → NATS 2.10), `kelta-worker/CLAUDE.md`.
- **Dead Kafka config removed**: `spring.kafka.*` + serializers in runtime-core `application(.test).properties`; the `spring.kafka` + `kelta.gateway.kafka.topics` blocks in gateway `application-test.yml`; the `management.health.kafka` toggle in gateway `application.yml`. (spring-kafka was removed in [#1035](https://github.com/cklinker/emf/pull/1035) — these bound to nothing; confirmed no gateway code reads them.)
- `gateway/pom.xml` comment "(Shared Kafka Events)" → "(Shared NATS Events)".

## Why
User asked to remove **all** Kafka references and make PUBLISH_EVENT use NATS. Investigation confirmed there's no real Kafka anywhere — it was all stale docs/comments/config from before the NATS migration.

## Relationship to #1040
**Disjoint** — no shared files. #1040 fixes the worker/gateway/runtime `.java` comments + 3 test files; this PR fixes everything else. After both merge, the tree has **zero Kafka references**. Merge order doesn't matter.

## Verified
`runtime-module-integration` compiles; no code references the removed config. Docs/config-only otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)