### PR TITLE
docs(concerns): remove stale workflow_action_type tech-debt note

### DIFF
--- a/.claude/docs/concerns.md
+++ b/.claude/docs/concerns.md
@@ -31,7 +31,6 @@ at the bottom so reviewers can see what's already been addressed.
 - Hardcoded `emf_control_plane` DB name in `SupersetDatabaseUserService.java` (line 78) — env-driven via `kelta.worker.superset.database-name` default; cleanup is cosmetic.
 - Potential N+1 in `SearchIndexService.java` during reindex (per-collection queries) — harmless under normal load; matters at >1k collections.
 - **Email templates have two parallel lookup axes** — `EmailRepository.findTemplateByKey` resolves by the stable `template_key` column (V133 seeded eight `user.*` defaults); `findTemplateByName` resolves by the human-friendly `name` column (V141 seeded `password_reset`, `user_invite`, `welcome`). Both implement the same tenant-override → `'system'`-sentinel fallback, so callers picking the "wrong" axis still work but may land on a different seed row than intended. Pick one canonical axis once the calling code settles, and drop the unused seed set.
-- **Stale `workflow_action_type` catalog rows** — the `workflow_action_type` table is a **display-only catalog**; its `handler_class` column is never read by Java (flow execution dispatches via `ActionHandlerRegistry`, populated by the compile-time modules). Its seed rows still carry dead `com.emf.controlplane.*` class names and describe `PUBLISH_EVENT` as a "Kafka event" despite Kafka being fully removed. Cosmetic, but misleads anyone reading the table — re-seed accurately or drop `handler_class`.
 
 ## Fragile Areas
 


### PR DESCRIPTION
Removes a tech-debt bullet in `concerns.md` that described `workflow_action_type` as a live display-only catalog (stale `com.emf.controlplane.*` handler classes, PUBLISH_EVENT as a "Kafka event").

That table was **dropped in `V72__drop_legacy_workflow_tables.sql`** and never re-created (`V92` is a no-op confirming it) — so the concern referenced a non-existent table. Also clears the last non-guardrail "Kafka" mention in the docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)