### PR TITLE
feat(ai): EmbeddingService SPI + dependency-free default (semantic-search slice 1)

### DIFF
--- a/.claude/docs/architecture.md
+++ b/.claude/docs/architecture.md
@@ -283,6 +283,7 @@ controller after the mutation rather than via the BeforeSaveHook registry.
 | BootstrapConfig | Gateway startup config (collections, routes, limits) | `kelta-gateway/.../config/BootstrapConfig.java` |
 | CompositeUniqueConstraintService | Issues `CREATE UNIQUE INDEX` over multi-column tuples; constraint state lives in Postgres (no separate registry) | `runtime-core/.../storage/CompositeUniqueConstraintService.java` |
 | MetadataDependencyService | Builds a per-tenant metadata dependency graph on demand (collections/fields/flows/layouts/rules/record-types/list-views/constraints/perms) for impact analysis + cycle detection; not persisted, so always current. Endpoints: `GET /api/metadata/impact`, `GET /api/metadata/graph` | `kelta-worker/.../service/MetadataDependencyService.java`, `.../dependency/MetadataDependencyGraph.java` |
+| EmbeddingService | SPI turning text → a fixed-dimension normalized vector for semantic search over `VECTOR` fields. Default `HashingEmbeddingService` (feature-hashing, dependency-free, deterministic) is registered `@ConditionalOnMissingBean` so a deployment can plug in an external/local embedding model. `toVectorLiteral` renders a pgvector `[...]` literal for `<=>` queries | `runtime-core/.../embedding/EmbeddingService.java`, `.../embedding/HashingEmbeddingService.java` |
 
 ### Unique constraints
 

--- a/.claude/docs/status.md
+++ b/.claude/docs/status.md
@@ -44,6 +44,7 @@ ship a change that moves a row.
 | Integration | (see Complete) | **Script execution**: `ScriptExecutor` SPI is a no-op (no GraalVM/JS engine). Connected Apps: client-credentials works, full auth-code flow not |
 | Scheduled jobs | Flow-type cron triggers work | General `scheduled_jobs` dispatcher for SCRIPT / REPORT_EXPORT job types not built |
 | Page builder | Editor + runtime renderer + CRUD | `slug`/`published` fields missing from `ui-pages` system collection def; no server-side component resolution |
+| Semantic search / RAG | `EmbeddingService` SPI + dependency-free `HashingEmbeddingService` default (overridable via `@ConditionalOnMissingBean`); `VECTOR` field type maps to `vector(N)` | HNSW index emission, embed-on-write population, `POST /api/{collection}/semantic-search` + `semantic_search` MCP tool, governed agent runtime (next Rec 3 slices) |
 
 ## 🔴 UI Complete, backend MISSING (do not assume these work end-to-end)
 

--- a/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/config/KeltaRuntimeAutoConfiguration.java
+++ b/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/config/KeltaRuntimeAutoConfiguration.java
@@ -3,6 +3,8 @@ package io.kelta.runtime.config;
 import io.kelta.runtime.credential.CredentialTemplateRegistry;
 import io.kelta.runtime.credential.CredentialType;
 import io.kelta.runtime.credential.CredentialTypeRegistry;
+import io.kelta.runtime.embedding.EmbeddingService;
+import io.kelta.runtime.embedding.HashingEmbeddingService;
 import io.kelta.runtime.events.RecordEventPublisher;
 import io.kelta.runtime.query.DefaultQueryEngine;
 import io.kelta.runtime.query.QueryEngine;
@@ -63,6 +65,17 @@ public class KeltaRuntimeAutoConfiguration {
     @ConditionalOnMissingBean
     public CollectionRegistry collectionRegistry() {
         return new ConcurrentCollectionRegistry();
+    }
+
+    /**
+     * Default text-embedding provider for semantic search over {@code VECTOR} fields. A deployment
+     * can register its own {@link EmbeddingService} bean (e.g. an external embedding API) and this
+     * dependency-free default backs off.
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    public EmbeddingService embeddingService() {
+        return new HashingEmbeddingService();
     }
     
     /**

--- a/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/embedding/EmbeddingService.java
+++ b/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/embedding/EmbeddingService.java
@@ -1,0 +1,53 @@
+package io.kelta.runtime.embedding;
+
+import java.util.List;
+
+/**
+ * Turns text into a dense vector embedding for semantic / similarity search over the pgvector
+ * {@code VECTOR} field type.
+ *
+ * <p>This is an SPI: the runtime ships a dependency-free default ({@link HashingEmbeddingService})
+ * so semantic search works out of the box, and a deployment can supply a higher-quality provider
+ * (e.g. an external embedding API) by registering its own {@code EmbeddingService} bean — the
+ * default backs off via {@code @ConditionalOnMissingBean}.
+ *
+ * <p>All embeddings from one provider share a fixed {@link #dimensions()} and should be
+ * L2-normalized so cosine distance ({@code <=>}) and inner product rank consistently.
+ *
+ * @since 1.0.0
+ */
+public interface EmbeddingService {
+
+    /**
+     * Embeds a single text into a vector of length {@link #dimensions()}. Blank input yields a
+     * zero vector.
+     */
+    float[] embed(String text);
+
+    /** The fixed dimensionality every embedding from this provider has. */
+    int dimensions();
+
+    /** A short stable identifier for the provider (for diagnostics / stored alongside vectors). */
+    String providerId();
+
+    /** Embeds several texts; default maps {@link #embed(String)} over the list. */
+    default List<float[]> embedBatch(List<String> texts) {
+        return texts.stream().map(this::embed).toList();
+    }
+
+    /**
+     * Renders an embedding as a pgvector literal ({@code [0.1,0.2,...]}) for binding into SQL such
+     * as {@code ORDER BY embedding <=> CAST(? AS vector)}.
+     */
+    static String toVectorLiteral(float[] embedding) {
+        StringBuilder sb = new StringBuilder(embedding.length * 8 + 2);
+        sb.append('[');
+        for (int i = 0; i < embedding.length; i++) {
+            if (i > 0) {
+                sb.append(',');
+            }
+            sb.append(embedding[i]);
+        }
+        return sb.append(']').toString();
+    }
+}

--- a/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/embedding/HashingEmbeddingService.java
+++ b/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/embedding/HashingEmbeddingService.java
@@ -1,0 +1,103 @@
+package io.kelta.runtime.embedding;
+
+/**
+ * Dependency-free default {@link EmbeddingService} using the feature-hashing ("hashing trick")
+ * technique: tokens (words plus character trigrams) are hashed into a fixed-dimension vector with
+ * signed accumulation, then L2-normalized.
+ *
+ * <p>It is deterministic, requires no external service or model, and captures lexical similarity —
+ * texts that share words/character-grams land closer in cosine space. It is not a semantic model;
+ * a deployment that wants true semantic embeddings registers its own {@link EmbeddingService} bean
+ * (an external API or local model) and this default backs off.
+ *
+ * @since 1.0.0
+ */
+public class HashingEmbeddingService implements EmbeddingService {
+
+    /** pgvector's default VECTOR dimension is 1536; the hashing default is smaller and cheaper. */
+    public static final int DEFAULT_DIMENSIONS = 384;
+
+    private static final int FNV_OFFSET = 0x811c9dc5;
+    private static final int FNV_PRIME = 0x01000193;
+
+    private final int dimensions;
+
+    public HashingEmbeddingService() {
+        this(DEFAULT_DIMENSIONS);
+    }
+
+    public HashingEmbeddingService(int dimensions) {
+        if (dimensions < 1) {
+            throw new IllegalArgumentException("dimensions must be >= 1, got " + dimensions);
+        }
+        this.dimensions = dimensions;
+    }
+
+    @Override
+    public int dimensions() {
+        return dimensions;
+    }
+
+    @Override
+    public String providerId() {
+        return "hashing-v1-d" + dimensions;
+    }
+
+    @Override
+    public float[] embed(String text) {
+        float[] vector = new float[dimensions];
+        if (text == null || text.isBlank()) {
+            return vector;
+        }
+        String normalized = text.toLowerCase();
+        for (String token : tokens(normalized)) {
+            int hash = fnv1a(token);
+            int bucket = Math.floorMod(hash, dimensions);
+            // A second, independent bit of the hash decides the sign so collisions can cancel.
+            float sign = (hash & 1) == 0 ? 1f : -1f;
+            vector[bucket] += sign;
+        }
+        normalize(vector);
+        return vector;
+    }
+
+    /** Word tokens plus character trigrams, so similar/misspelled words still share features. */
+    private Iterable<String> tokens(String normalized) {
+        java.util.List<String> tokens = new java.util.ArrayList<>();
+        for (String word : normalized.split("[^a-z0-9]+")) {
+            if (word.isEmpty()) {
+                continue;
+            }
+            tokens.add("w:" + word);
+            String padded = "#" + word + "#";
+            for (int i = 0; i + 3 <= padded.length(); i++) {
+                tokens.add("g:" + padded.substring(i, i + 3));
+            }
+        }
+        return tokens;
+    }
+
+    private static void normalize(float[] vector) {
+        double sumSquares = 0;
+        for (float v : vector) {
+            sumSquares += (double) v * v;
+        }
+        if (sumSquares == 0) {
+            return;
+        }
+        float norm = (float) Math.sqrt(sumSquares);
+        for (int i = 0; i < vector.length; i++) {
+            vector[i] /= norm;
+        }
+    }
+
+    /** FNV-1a 32-bit — a small, stable, well-distributed string hash (not String.hashCode). */
+    private static int fnv1a(String s) {
+        int hash = FNV_OFFSET;
+        for (int i = 0; i < s.length(); i++) {
+            hash ^= s.charAt(i);
+            hash *= FNV_PRIME;
+        }
+        return hash;
+    }
+}

--- a/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/embedding/HashingEmbeddingServiceTest.java
+++ b/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/embedding/HashingEmbeddingServiceTest.java
@@ -1,0 +1,99 @@
+package io.kelta.runtime.embedding;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+@DisplayName("HashingEmbeddingService")
+class HashingEmbeddingServiceTest {
+
+    private final HashingEmbeddingService service = new HashingEmbeddingService(256);
+
+    private static double cosine(float[] a, float[] b) {
+        double dot = 0;
+        double na = 0;
+        double nb = 0;
+        for (int i = 0; i < a.length; i++) {
+            dot += a[i] * b[i];
+            na += a[i] * a[i];
+            nb += b[i] * b[i];
+        }
+        return dot / (Math.sqrt(na) * Math.sqrt(nb));
+    }
+
+    private static double magnitude(float[] v) {
+        double sum = 0;
+        for (float f : v) {
+            sum += (double) f * f;
+        }
+        return Math.sqrt(sum);
+    }
+
+    @Test
+    @DisplayName("produces a normalized vector of the configured dimension")
+    void normalizedVector() {
+        float[] v = service.embed("the quick brown fox");
+        assertThat(v).hasSize(256);
+        assertThat(magnitude(v)).isCloseTo(1.0, within(1e-5));
+        assertThat(service.dimensions()).isEqualTo(256);
+    }
+
+    @Test
+    @DisplayName("is deterministic for the same input")
+    void deterministic() {
+        assertThat(service.embed("hello world")).containsExactly(service.embed("hello world"));
+    }
+
+    @Test
+    @DisplayName("blank input yields a zero vector")
+    void blankInput() {
+        assertThat(magnitude(service.embed("   "))).isZero();
+        assertThat(magnitude(service.embed(null))).isZero();
+    }
+
+    @Test
+    @DisplayName("lexically similar texts are closer in cosine space than dissimilar ones")
+    void capturesSimilarity() {
+        float[] base = service.embed("the quick brown fox jumps");
+        float[] similar = service.embed("the quick brown dog jumps");
+        float[] dissimilar = service.embed("quarterly revenue projections for finance");
+
+        assertThat(cosine(base, similar)).isGreaterThan(cosine(base, dissimilar));
+    }
+
+    @Test
+    @DisplayName("renders a pgvector literal")
+    void vectorLiteral() {
+        String literal = EmbeddingService.toVectorLiteral(new float[]{0.5f, -0.25f, 0f});
+        assertThat(literal).isEqualTo("[0.5,-0.25,0.0]");
+    }
+
+    @Test
+    @DisplayName("embedBatch embeds each text")
+    void batch() {
+        List<float[]> out = service.embedBatch(List.of("a", "b"));
+        assertThat(out).hasSize(2);
+        assertThat(out.get(0)).containsExactly(service.embed("a"));
+    }
+
+    @Test
+    @DisplayName("providerId reflects the dimension")
+    void providerId() {
+        assertThat(service.providerId()).isEqualTo("hashing-v1-d256");
+    }
+
+    @Test
+    @DisplayName("rejects a non-positive dimension")
+    void rejectsBadDimension() {
+        try {
+            new HashingEmbeddingService(0);
+            assertThat(false).as("expected IllegalArgumentException").isTrue();
+        } catch (IllegalArgumentException expected) {
+            assertThat(expected).hasMessageContaining("dimensions");
+        }
+    }
+}


### PR DESCRIPTION
## What
First slice of **Rec 3** (semantic search / RAG). Adds the text-embedding abstraction the platform lacked, so the dormant `VECTOR` field type can be searched by similarity.

- **`EmbeddingService` SPI** (runtime-core): text → fixed-dimension **L2-normalized** vector, with `dimensions()` / `providerId()` / `embedBatch`, and a `toVectorLiteral()` helper that renders a pgvector `[...]` literal for `ORDER BY embedding <=> CAST(? AS vector)`.
- **`HashingEmbeddingService` default**: feature-hashing (word tokens + character trigrams) into a fixed dimension (default 384), deterministic, **no external service**. Captures lexical similarity; a deployment can register its own `EmbeddingService` bean (external API / local model) and this default backs off via `@ConditionalOnMissingBean`. Wired in `KeltaRuntimeAutoConfiguration`.

## Why
Phase 1 (AI moat), the doc's highest-leverage area. This is the documented **first build-step** of Rec 3 ("EmbeddingService SPI"). Keeping it dependency-free means semantic search works out of the box and stays open-source-only, while real providers plug in cleanly.

## Next Rec 3 slices
HNSW index emission for `VECTOR` fields, embed-on-write population, `POST /api/{collection}/semantic-search` + `semantic_search` MCP tool, then the governed **agent runtime** (orchestration loop over MCP tools + Cerbos tool authz + PII masking + agent-action audit).

## Tests
`HashingEmbeddingServiceTest` (8): dimension, determinism, L2 normalization, blank→zero vector, **lexical similarity ordering** (similar texts closer than dissimilar), pgvector literal, batch, bad-dimension guard. runtime-core builds.

## Docs
`.claude/docs/architecture.md` (Key Abstractions), `.claude/docs/status.md` (Partial → Semantic search / RAG row).

🤖 Generated with [Claude Code](https://claude.com/claude-code)