### PR TITLE
feat(ai): semantic-search query over VECTOR fields (RAG slice 2)

### DIFF
--- a/.claude/docs/status.md
+++ b/.claude/docs/status.md
@@ -45,7 +45,7 @@ ship a change that moves a row.
 | Integration | (see Complete) | **Script execution**: `ScriptExecutor` SPI is a no-op (no GraalVM/JS engine). Connected Apps: client-credentials works, full auth-code flow not |
 | Scheduled jobs | Flow-type cron triggers work | General `scheduled_jobs` dispatcher for SCRIPT / REPORT_EXPORT job types not built |
 | Page builder | Editor + runtime renderer + CRUD | `slug`/`published` fields missing from `ui-pages` system collection def; no server-side component resolution |
-| Semantic search / RAG | `EmbeddingService` SPI + dependency-free `HashingEmbeddingService` default (overridable via `@ConditionalOnMissingBean`); `VECTOR` field type maps to `vector(N)` | HNSW index emission, embed-on-write population, `POST /api/{collection}/semantic-search` + `semantic_search` MCP tool, governed agent runtime (next Rec 3 slices) |
+| Semantic search / RAG | `EmbeddingService` SPI + dependency-free `HashingEmbeddingService` default (overridable via `@ConditionalOnMissingBean`); `VECTOR` field maps to `vector(N)`; `StorageAdapter.semanticSearch` cosine (`<=>`) query + `SemanticSearchService` + `POST /api/{collection}/semantic-search` (FLS-respecting; distances in `meta`) | HNSW index emission (currently a flat scan), embed-on-write population (vectors written manually for now), `semantic_search` MCP tool, governed agent runtime (next Rec 3 slices) |
 
 ## 🔴 UI Complete, backend MISSING (do not assume these work end-to-end)
 

--- a/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/storage/PhysicalTableStorageAdapter.java
+++ b/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/storage/PhysicalTableStorageAdapter.java
@@ -323,6 +323,39 @@ public class PhysicalTableStorageAdapter implements StorageAdapter {
     }
 
     @Override
+    public List<Map<String, Object>> semanticSearch(CollectionDefinition definition,
+                                                     String vectorColumn,
+                                                     String queryVectorLiteral,
+                                                     int limit,
+                                                     List<FilterCondition> filters) {
+        TableRef tableRef = getTableRef(definition);
+        String vectorIdent = sanitizeIdentifier(vectorColumn);
+        List<Object> params = new ArrayList<>();
+
+        // Cosine distance (<=>) to the query vector; bound first so its '?' precedes any filter '?'.
+        StringBuilder sql = new StringBuilder("SELECT ");
+        sql.append(buildSelectClause(null, definition));
+        sql.append(", (").append(vectorIdent).append(" <=> CAST(? AS vector)) AS _distance");
+        params.add(queryVectorLiteral);
+        sql.append(" FROM ").append(tableRef.toSql());
+        sql.append(" WHERE ").append(vectorIdent).append(" IS NOT NULL");
+        if (filters != null && !filters.isEmpty()) {
+            sql.append(" AND ").append(buildWhereClause(filters, definition, params));
+        }
+        sql.append(" ORDER BY _distance ASC LIMIT ?");
+        params.add(limit);
+
+        try {
+            List<Map<String, Object>> data = jdbcTemplate.queryForList(sql.toString(), params.toArray());
+            remapColumnNames(definition, data);
+            reconstructCompanionColumns(definition, data);
+            return data;
+        } catch (DataAccessException e) {
+            throw new StorageException("Failed semantic search on collection: " + definition.name(), e);
+        }
+    }
+
+    @Override
     public Map<String, Object> aggregate(CollectionDefinition definition,
                                           List<FilterCondition> filters,
                                           List<AggregationSpec> specs) {

--- a/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/storage/StorageAdapter.java
+++ b/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/storage/StorageAdapter.java
@@ -97,7 +97,31 @@ public interface StorageAdapter {
     Map<String, Object> aggregate(CollectionDefinition definition,
                                    List<FilterCondition> filters,
                                    List<AggregationSpec> specs);
-    
+
+    /**
+     * Similarity search over a pgvector {@code VECTOR} column: returns the records whose vector is
+     * closest (by cosine distance, the {@code <=>} operator) to the supplied query vector, nearest
+     * first, each with an extra {@code _distance} entry.
+     *
+     * <p>Only rows with a non-null vector are considered. Optional {@code filters} narrow the set
+     * with the same semantics as {@link #query(CollectionDefinition, QueryRequest)}.
+     *
+     * @param definition         the collection definition
+     * @param vectorColumn       the physical column name of the {@code VECTOR} field
+     * @param queryVectorLiteral the query embedding as a pgvector literal ({@code [0.1,0.2,...]})
+     * @param limit              maximum rows to return
+     * @param filters            optional filter conditions (may be null/empty)
+     * @return matching records ordered nearest-first, each with a {@code _distance} value
+     * @throws UnsupportedOperationException if the adapter does not support vector search
+     */
+    default List<Map<String, Object>> semanticSearch(CollectionDefinition definition,
+                                                      String vectorColumn,
+                                                      String queryVectorLiteral,
+                                                      int limit,
+                                                      List<FilterCondition> filters) {
+        throw new UnsupportedOperationException("Vector search not supported by this storage adapter");
+    }
+
     /**
      * Gets a single record by its ID.
      * 

--- a/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/storage/PhysicalTableStorageAdapterSemanticSearchTest.java
+++ b/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/storage/PhysicalTableStorageAdapterSemanticSearchTest.java
@@ -1,0 +1,75 @@
+package io.kelta.runtime.storage;
+
+import io.kelta.runtime.model.CollectionDefinition;
+import io.kelta.runtime.model.CollectionDefinitionBuilder;
+import io.kelta.runtime.model.FieldDefinition;
+import io.kelta.runtime.model.FieldType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.JdbcTemplate;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("PhysicalTableStorageAdapter.semanticSearch")
+class PhysicalTableStorageAdapterSemanticSearchTest {
+
+    @Mock
+    private JdbcTemplate jdbcTemplate;
+
+    @Mock
+    private SchemaMigrationEngine migrationEngine;
+
+    private PhysicalTableStorageAdapter adapter;
+
+    private static CollectionDefinition docsWithVector() {
+        return new CollectionDefinitionBuilder().name("docs")
+                .addField(new FieldDefinition("embedding", FieldType.VECTOR,
+                        true, false, false, null, null, null, null, Map.of("dimension", 384), null))
+                .addField(FieldDefinition.requiredString("title"))
+                .build();
+    }
+
+    @BeforeEach
+    void setUp() {
+        adapter = new PhysicalTableStorageAdapter(jdbcTemplate, migrationEngine, JsonMapper.builder().build());
+    }
+
+    @Test
+    @DisplayName("builds a cosine-distance query ordered nearest-first with the vector bound first")
+    void buildsCosineQuery() {
+        when(jdbcTemplate.queryForList(anyString(), any(Object[].class)))
+                .thenReturn(new ArrayList<>(List.of(
+                        new HashMap<>(Map.of("id", "1", "title", "A", "_distance", 0.1)))));
+
+        List<Map<String, Object>> rows = adapter.semanticSearch(
+                docsWithVector(), "embedding", "[0.1,0.2]", 5, List.of());
+
+        ArgumentCaptor<String> sql = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Object[]> params = ArgumentCaptor.forClass(Object[].class);
+        verify(jdbcTemplate).queryForList(sql.capture(), params.capture());
+
+        assertThat(sql.getValue())
+                .contains("embedding <=> CAST(? AS vector)) AS _distance")
+                .contains("WHERE embedding IS NOT NULL")
+                .contains("ORDER BY _distance ASC LIMIT ?");
+        // Vector literal is bound before the limit (and before any filter params).
+        assertThat(params.getValue()).containsExactly("[0.1,0.2]", 5);
+        assertThat(rows).hasSize(1);
+    }
+}

--- a/kelta-worker/src/main/java/io/kelta/worker/controller/SemanticSearchController.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/controller/SemanticSearchController.java
@@ -1,0 +1,53 @@
+package io.kelta.worker.controller;
+
+import io.kelta.jsonapi.JsonApiResponseBuilder;
+import io.kelta.worker.service.SemanticSearchService;
+import io.kelta.worker.service.SemanticSearchService.SemanticSearchException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+/**
+ * Semantic (vector similarity) search over a collection's pgvector {@code VECTOR} field.
+ *
+ * <p>{@code POST /api/{collection}/semantic-search} with body {@code {"query": "...", "limit": 10}}.
+ * The literal {@code semantic-search} segment makes this handler more specific than the generic
+ * {@code /api/{collection}/{id}} router route, and it falls under the collection's existing gateway
+ * route — so no new static route is needed.
+ *
+ * @since 1.0.0
+ */
+@RestController
+@RequestMapping("/api/{collection}/semantic-search")
+public class SemanticSearchController {
+
+    private final SemanticSearchService semanticSearchService;
+
+    public SemanticSearchController(SemanticSearchService semanticSearchService) {
+        this.semanticSearchService = semanticSearchService;
+    }
+
+    @PostMapping
+    public ResponseEntity<Map<String, Object>> search(
+            @PathVariable("collection") String collection,
+            @RequestBody(required = false) Map<String, Object> body) {
+
+        Map<String, Object> request = body == null ? Map.of() : body;
+        Object queryObj = request.get("query");
+        String query = queryObj == null ? null : queryObj.toString();
+        int limit = request.get("limit") instanceof Number n ? n.intValue() : 10;
+
+        try {
+            return ResponseEntity.ok(semanticSearchService.search(collection, query, limit));
+        } catch (SemanticSearchException e) {
+            return ResponseEntity.badRequest().body(
+                    JsonApiResponseBuilder.error("400", "SEMANTIC_SEARCH_INVALID",
+                            "Semantic search failed", e.getMessage()));
+        }
+    }
+}

--- a/kelta-worker/src/main/java/io/kelta/worker/service/SemanticSearchService.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/service/SemanticSearchService.java
@@ -1,0 +1,124 @@
+package io.kelta.worker.service;
+
+import io.kelta.jsonapi.JsonApiResponseBuilder;
+import io.kelta.runtime.embedding.EmbeddingService;
+import io.kelta.runtime.model.CollectionDefinition;
+import io.kelta.runtime.model.FieldDefinition;
+import io.kelta.runtime.model.FieldType;
+import io.kelta.runtime.registry.CollectionRegistry;
+import io.kelta.runtime.storage.StorageAdapter;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Runs semantic (vector similarity) search over a collection's pgvector {@code VECTOR} field:
+ * embeds the query text with the configured {@link EmbeddingService} and ranks records by cosine
+ * distance via {@link StorageAdapter#semanticSearch}.
+ *
+ * <p>The response is a standard JSON:API collection so the read-side field-security advice strips
+ * denied fields automatically; per-record distances are returned under top-level {@code meta} (not
+ * stripped) keyed by record id.
+ *
+ * @since 1.0.0
+ */
+@Service
+public class SemanticSearchService {
+
+    private static final int DEFAULT_VECTOR_DIMENSION = 1536;
+    private static final int MAX_LIMIT = 100;
+
+    private final StorageAdapter storageAdapter;
+    private final CollectionRegistry collectionRegistry;
+    private final EmbeddingService embeddingService;
+
+    public SemanticSearchService(StorageAdapter storageAdapter,
+                                 CollectionRegistry collectionRegistry,
+                                 EmbeddingService embeddingService) {
+        this.storageAdapter = storageAdapter;
+        this.collectionRegistry = collectionRegistry;
+        this.embeddingService = embeddingService;
+    }
+
+    /** Thrown for client errors (unknown collection, no vector field, dimension mismatch). */
+    public static class SemanticSearchException extends RuntimeException {
+        public SemanticSearchException(String message) {
+            super(message);
+        }
+    }
+
+    /**
+     * Searches {@code collectionName} for the records most similar to {@code queryText}.
+     *
+     * @return a JSON:API document ({@code data} + {@code meta.distances})
+     */
+    public Map<String, Object> search(String collectionName, String queryText, int limit) {
+        if (queryText == null || queryText.isBlank()) {
+            throw new SemanticSearchException("'query' is required");
+        }
+        CollectionDefinition definition = collectionRegistry.get(collectionName);
+        if (definition == null) {
+            throw new SemanticSearchException("Unknown collection: " + collectionName);
+        }
+
+        FieldDefinition vectorField = definition.fields().stream()
+                .filter(f -> f.type() == FieldType.VECTOR)
+                .findFirst()
+                .orElseThrow(() -> new SemanticSearchException(
+                        "Collection '" + collectionName + "' has no VECTOR field to search"));
+
+        int fieldDimension = vectorDimension(vectorField);
+        if (fieldDimension != embeddingService.dimensions()) {
+            throw new SemanticSearchException(
+                    "VECTOR field '" + vectorField.name() + "' has dimension " + fieldDimension
+                            + " but the embedding provider (" + embeddingService.providerId()
+                            + ") produces dimension " + embeddingService.dimensions()
+                            + "; recreate the field with the matching dimension or configure a"
+                            + " matching embedding provider.");
+        }
+
+        int effectiveLimit = Math.max(1, Math.min(limit, MAX_LIMIT));
+        float[] queryEmbedding = embeddingService.embed(queryText);
+        String literal = EmbeddingService.toVectorLiteral(queryEmbedding);
+
+        List<Map<String, Object>> rows = storageAdapter.semanticSearch(
+                definition, vectorField.effectiveColumnName(), literal, effectiveLimit, List.of());
+
+        String vectorColumn = vectorField.effectiveColumnName();
+        Map<String, Object> distances = new LinkedHashMap<>();
+        List<Map<String, Object>> records = new ArrayList<>(rows.size());
+        for (Map<String, Object> row : rows) {
+            Object distance = row.remove("_distance");
+            row.remove(vectorColumn);            // never echo the raw embedding back
+            row.remove(vectorField.name());
+            Object id = row.get("id");
+            if (id != null && distance != null) {
+                distances.put(String.valueOf(id), distance);
+            }
+            records.add(row);
+        }
+
+        Map<String, Object> meta = new LinkedHashMap<>();
+        meta.put("distances", distances);
+        meta.put("count", records.size());
+        return JsonApiResponseBuilder.collection(collectionName, records, meta);
+    }
+
+    private static int vectorDimension(FieldDefinition field) {
+        Object configured = field.getConfigValue("dimension");
+        if (configured instanceof Number number) {
+            return number.intValue();
+        }
+        if (configured instanceof String s && !s.isBlank()) {
+            try {
+                return Integer.parseInt(s.trim());
+            } catch (NumberFormatException ignored) {
+                return DEFAULT_VECTOR_DIMENSION;
+            }
+        }
+        return DEFAULT_VECTOR_DIMENSION;
+    }
+}

--- a/kelta-worker/src/test/java/io/kelta/worker/controller/SemanticSearchControllerTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/controller/SemanticSearchControllerTest.java
@@ -1,0 +1,68 @@
+package io.kelta.worker.controller;
+
+import io.kelta.worker.service.SemanticSearchService;
+import io.kelta.worker.service.SemanticSearchService.SemanticSearchException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SemanticSearchController")
+class SemanticSearchControllerTest {
+
+    @Mock
+    private SemanticSearchService service;
+
+    private SemanticSearchController controller;
+
+    @BeforeEach
+    void setUp() {
+        controller = new SemanticSearchController(service);
+    }
+
+    @Test
+    @DisplayName("returns the service result on success")
+    void success() {
+        when(service.search("docs", "hello", 5)).thenReturn(Map.of("data", List.of()));
+
+        ResponseEntity<Map<String, Object>> response =
+                controller.search("docs", Map.of("query", "hello", "limit", 5));
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).containsKey("data");
+    }
+
+    @Test
+    @DisplayName("defaults the limit to 10 when omitted")
+    void defaultLimit() {
+        when(service.search("docs", "hello", 10)).thenReturn(Map.of("data", List.of()));
+
+        controller.search("docs", Map.of("query", "hello"));
+
+        verify(service).search(eq("docs"), eq("hello"), eq(10));
+    }
+
+    @Test
+    @DisplayName("maps a SemanticSearchException to 400")
+    void invalid() {
+        when(service.search("docs", null, 10)).thenThrow(new SemanticSearchException("'query' is required"));
+
+        ResponseEntity<Map<String, Object>> response = controller.search("docs", Map.of());
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody()).containsKey("errors");
+    }
+}

--- a/kelta-worker/src/test/java/io/kelta/worker/service/SemanticSearchServiceTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/service/SemanticSearchServiceTest.java
@@ -1,0 +1,133 @@
+package io.kelta.worker.service;
+
+import io.kelta.runtime.embedding.EmbeddingService;
+import io.kelta.runtime.model.CollectionDefinition;
+import io.kelta.runtime.model.CollectionDefinitionBuilder;
+import io.kelta.runtime.model.FieldDefinition;
+import io.kelta.runtime.model.FieldType;
+import io.kelta.runtime.registry.CollectionRegistry;
+import io.kelta.runtime.storage.StorageAdapter;
+import io.kelta.worker.service.SemanticSearchService.SemanticSearchException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SemanticSearchService")
+class SemanticSearchServiceTest {
+
+    @Mock private StorageAdapter storageAdapter;
+    @Mock private CollectionRegistry collectionRegistry;
+    @Mock private EmbeddingService embeddingService;
+
+    private SemanticSearchService service;
+
+    private static FieldDefinition vectorField(int dimension) {
+        return new FieldDefinition("embedding", FieldType.VECTOR,
+                true, false, false, null, null, null, null, Map.of("dimension", dimension), null);
+    }
+
+    private static CollectionDefinition collection(FieldDefinition... fields) {
+        CollectionDefinitionBuilder b = new CollectionDefinitionBuilder().name("docs");
+        for (FieldDefinition f : fields) {
+            b.addField(f);
+        }
+        return b.build();
+    }
+
+    @BeforeEach
+    void setUp() {
+        service = new SemanticSearchService(storageAdapter, collectionRegistry, embeddingService);
+        lenient().when(embeddingService.dimensions()).thenReturn(384);
+        lenient().when(embeddingService.providerId()).thenReturn("hashing-v1-d384");
+        lenient().when(embeddingService.embed(anyString())).thenReturn(new float[384]);
+    }
+
+    @Test
+    @DisplayName("ranks records and returns distances in meta, stripping the raw vector")
+    void happyPath() {
+        when(collectionRegistry.get("docs"))
+                .thenReturn(collection(vectorField(384), FieldDefinition.requiredString("title")));
+        when(storageAdapter.semanticSearch(any(), eq("embedding"), anyString(), eq(10), anyList()))
+                .thenReturn(new ArrayList<>(List.of(
+                        new HashMap<>(Map.of("id", "r1", "title", "Hello",
+                                "embedding", "[0.0]", "_distance", 0.05)))));
+
+        Map<String, Object> result = service.search("docs", "hello", 10);
+
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> data = (List<Map<String, Object>>) result.get("data");
+        assertThat(data).hasSize(1);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> attrs = (Map<String, Object>) data.get(0).get("attributes");
+        assertThat(attrs).containsKey("title").doesNotContainKeys("embedding", "_distance");
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> meta = (Map<String, Object>) result.get("meta");
+        @SuppressWarnings("unchecked")
+        Map<String, Object> distances = (Map<String, Object>) meta.get("distances");
+        assertThat(distances).containsEntry("r1", 0.05);
+    }
+
+    @Test
+    @DisplayName("rejects a blank query")
+    void blankQuery() {
+        assertThatThrownBy(() -> service.search("docs", "  ", 10))
+                .isInstanceOf(SemanticSearchException.class);
+    }
+
+    @Test
+    @DisplayName("rejects an unknown collection")
+    void unknownCollection() {
+        when(collectionRegistry.get("ghost")).thenReturn(null);
+        assertThatThrownBy(() -> service.search("ghost", "hi", 10))
+                .isInstanceOf(SemanticSearchException.class)
+                .hasMessageContaining("Unknown collection");
+    }
+
+    @Test
+    @DisplayName("rejects a collection with no VECTOR field")
+    void noVectorField() {
+        when(collectionRegistry.get("docs")).thenReturn(collection(FieldDefinition.requiredString("title")));
+        assertThatThrownBy(() -> service.search("docs", "hi", 10))
+                .isInstanceOf(SemanticSearchException.class)
+                .hasMessageContaining("no VECTOR field");
+    }
+
+    @Test
+    @DisplayName("rejects a dimension mismatch between the field and the embedding provider")
+    void dimensionMismatch() {
+        when(collectionRegistry.get("docs")).thenReturn(collection(vectorField(768)));
+        assertThatThrownBy(() -> service.search("docs", "hi", 10))
+                .isInstanceOf(SemanticSearchException.class)
+                .hasMessageContaining("dimension");
+    }
+
+    @Test
+    @DisplayName("clamps the limit to the maximum")
+    void clampsLimit() {
+        when(collectionRegistry.get("docs")).thenReturn(collection(vectorField(384)));
+        when(storageAdapter.semanticSearch(any(), anyString(), anyString(), eq(100), anyList()))
+                .thenReturn(new ArrayList<>());
+
+        service.search("docs", "hi", 5000);
+        // verified via the eq(100) stub matching — no exception means the clamp held
+    }
+}


### PR DESCRIPTION
## What
Builds on the `EmbeddingService` SPI ([#1045](https://github.com/cklinker/emf/pull/1045)) to make the dormant pgvector `VECTOR` field type **searchable by similarity**.

- **`StorageAdapter.semanticSearch`** (default unsupported) + `PhysicalTableStorageAdapter` impl: cosine-distance (`<=>`) query — `SELECT *, (col <=> CAST(? AS vector)) AS _distance ... WHERE col IS NOT NULL ORDER BY _distance ASC LIMIT ?` — reusing the existing select/where builders + tenant table-ref (RLS-scoped). The query vector is bound first so its `?` precedes any filter params.
- **`SemanticSearchService`** (kelta-worker): resolves the collection's `VECTOR` field, **validates the field dimension matches the embedding provider's**, embeds the query, calls the adapter, and returns a **standard JSON:API collection** — so the read-side field-security advice strips denied fields automatically — with the raw vector dropped and per-record cosine distances in `meta.distances`.
- **`POST /api/{collection}/semantic-search`** (body `{query, limit}`). The literal segment beats the generic `/api/{collection}/{id}` route and falls under the collection's existing gateway route, so no new static route needed.

## Why
Phase 1 (AI moat), Rec 3. This is the user-facing query path that turns the embedding foundation into actual semantic search, respecting tenant isolation (RLS) and field-level security.

## Notes / next slices
- **HNSW index** not yet emitted → currently a flat (exact) scan; fine for modest row counts, index comes next.
- **Population**: vectors must be written manually for now; embed-on-write (before-save hook) is the next slice.
- Then the `semantic_search` **MCP tool** and the governed **agent runtime**.
- Dimension contract: the `VECTOR` field's dimension must equal the embedding provider's (`HashingEmbeddingService` default = 384); mismatches return a clear 400.

## Tests
- `PhysicalTableStorageAdapterSemanticSearchTest` — SQL shape + param order (vector-first, limit-last).
- `SemanticSearchServiceTest` (6) — rank/meta/strip-vector, unknown collection, no vector field, dimension mismatch, blank query, limit clamp.
- `SemanticSearchControllerTest` (3) — success / default limit / 400.
- Full suites green: **runtime-core 1316, worker 1301**.

## Docs
`.claude/docs/status.md` (Semantic search / RAG row).

🤖 Generated with [Claude Code](https://claude.com/claude-code)