### PR TITLE
feat(ai): emit pgvector HNSW index for VECTOR columns (RAG slice 3)

### DIFF
--- a/.claude/docs/status.md
+++ b/.claude/docs/status.md
@@ -45,7 +45,7 @@ ship a change that moves a row.
 | Integration | (see Complete) | **Script execution**: `ScriptExecutor` SPI is a no-op (no GraalVM/JS engine). Connected Apps: client-credentials works, full auth-code flow not |
 | Scheduled jobs | Flow-type cron triggers work | General `scheduled_jobs` dispatcher for SCRIPT / REPORT_EXPORT job types not built |
 | Page builder | Editor + runtime renderer + CRUD | `slug`/`published` fields missing from `ui-pages` system collection def; no server-side component resolution |
-| Semantic search / RAG | `EmbeddingService` SPI + dependency-free `HashingEmbeddingService` default (overridable via `@ConditionalOnMissingBean`); `VECTOR` field maps to `vector(N)`; `StorageAdapter.semanticSearch` cosine (`<=>`) query + `SemanticSearchService` + `POST /api/{collection}/semantic-search` (FLS-respecting; distances in `meta`) | HNSW index emission (currently a flat scan), embed-on-write population (vectors written manually for now), `semantic_search` MCP tool, governed agent runtime (next Rec 3 slices) |
+| Semantic search / RAG | `EmbeddingService` SPI + dependency-free `HashingEmbeddingService` default (overridable via `@ConditionalOnMissingBean`); `VECTOR` field maps to `vector(N)`; `StorageAdapter.semanticSearch` cosine (`<=>`) query + `SemanticSearchService` + `POST /api/{collection}/semantic-search` (FLS-respecting; distances in `meta`); **HNSW cosine index auto-emitted for VECTOR columns** at table init | embed-on-write population (vectors written manually for now), `semantic_search` MCP tool, governed agent runtime (next Rec 3 slices) |
 
 ## 🔴 UI Complete, backend MISSING (do not assume these work end-to-end)
 

--- a/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/storage/PhysicalTableStorageAdapter.java
+++ b/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/storage/PhysicalTableStorageAdapter.java
@@ -191,6 +191,16 @@ public class PhysicalTableStorageAdapter implements StorageAdapter {
                 );
             }
 
+            // HNSW index for VECTOR fields — turns the cosine-distance (<=>) similarity
+            // search in semanticSearch() from a flat scan into an approximate-nearest-neighbour
+            // lookup. Idempotent (IF NOT EXISTS), so re-initialization is safe.
+            if (field.type() == FieldType.VECTOR) {
+                String idxName = buildBoundedIdentifier(
+                        "hnsw_", sanitizeIdentifier(getBaseTableName(definition)),
+                        sanitizeIdentifier(columnName));
+                postCreateStatements.add(buildHnswIndexStatement(idxName, qualifiedName, columnName));
+            }
+
             // FK constraints for LOOKUP and MASTER_DETAIL
             if ((field.type() == FieldType.LOOKUP || field.type() == FieldType.MASTER_DETAIL)
                     && field.referenceConfig() != null) {
@@ -743,6 +753,21 @@ public class PhysicalTableStorageAdapter implements StorageAdapter {
             return definition.storageConfig().tableName();
         }
         return definition.name();
+    }
+
+    /**
+     * Builds the pgvector HNSW index DDL for a {@code VECTOR} column, using the cosine operator
+     * class so the index serves the {@code <=>} distance used by {@link #semanticSearch}.
+     *
+     * @param idxName       the (already length-bounded) index name
+     * @param qualifiedName the schema-qualified table name
+     * @param column        the vector column name (sanitized here)
+     * @return a {@code CREATE INDEX IF NOT EXISTS ... USING hnsw (...)} statement
+     */
+    static String buildHnswIndexStatement(String idxName, String qualifiedName, String column) {
+        return "CREATE INDEX IF NOT EXISTS " + idxName
+                + " ON " + qualifiedName
+                + " USING hnsw (" + sanitizeIdentifier(column) + " vector_cosine_ops)";
     }
 
     /**

--- a/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/storage/PhysicalTableStorageAdapterSemanticSearchTest.java
+++ b/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/storage/PhysicalTableStorageAdapterSemanticSearchTest.java
@@ -72,4 +72,14 @@ class PhysicalTableStorageAdapterSemanticSearchTest {
         assertThat(params.getValue()).containsExactly("[0.1,0.2]", 5);
         assertThat(rows).hasSize(1);
     }
+
+    @Test
+    @DisplayName("builds an HNSW cosine index DDL for a VECTOR column")
+    void buildsHnswIndexDdl() {
+        String ddl = PhysicalTableStorageAdapter.buildHnswIndexStatement(
+                "hnsw_docs_embedding", "public.docs", "embedding");
+        assertThat(ddl).isEqualTo(
+                "CREATE INDEX IF NOT EXISTS hnsw_docs_embedding ON public.docs"
+                        + " USING hnsw (embedding vector_cosine_ops)");
+    }
 }


### PR DESCRIPTION
## What
`semanticSearch` ([#1046](https://github.com/cklinker/emf/pull/1046)) ran a flat (exact) scan. Now, when a collection with a `VECTOR` field is initialized, `PhysicalTableStorageAdapter` also emits:

```
CREATE INDEX IF NOT EXISTS <hnsw_...> ON <table> USING hnsw (<col> vector_cosine_ops)
```

as a post-create statement — the **same mechanism as the existing EXTERNAL_ID unique index**. The `vector_cosine_ops` operator class matches the `<=>` distance used by `semanticSearch`, turning the similarity query into an approximate-nearest-neighbour lookup. Idempotent (`IF NOT EXISTS`), so re-initialization on worker startup safely ensures the index for any existing VECTOR column (including fields added after creation).

## Why
Phase 1 (AI moat), Rec 3 — performance: without the index, every semantic search scans all rows.

## Testability note
The DDL is extracted into a static `buildHnswIndexStatement` helper so it is **unit-testable**: the adapter's other tests run on **H2**, which can't execute pgvector DDL, so this asserts the generated statement string. Real execution is exercised against Postgres in CI/prod.

## Next slices
Embed-on-write population (vectors are still written manually — needs the `?::vector` write path, integration-tested against pgvector), the `semantic_search` MCP tool, then the governed agent runtime.

## Tests
`buildHnswIndexDdl` asserts the exact statement. Full runtime-core suite green: **1317**.

## Docs
`.claude/docs/status.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)