### PR TITLE
feat(ai): semantic_search MCP user tool (RAG — agent retrieval)

### DIFF
--- a/.claude/docs/status.md
+++ b/.claude/docs/status.md
@@ -45,7 +45,7 @@ ship a change that moves a row.
 | Integration | (see Complete) | **Script execution**: `ScriptExecutor` SPI is a no-op (no GraalVM/JS engine). Connected Apps: client-credentials works, full auth-code flow not |
 | Scheduled jobs | Flow-type cron triggers work | General `scheduled_jobs` dispatcher for SCRIPT / REPORT_EXPORT job types not built |
 | Page builder | Editor + runtime renderer + CRUD | `slug`/`published` fields missing from `ui-pages` system collection def; no server-side component resolution |
-| Semantic search / RAG | `EmbeddingService` SPI + dependency-free `HashingEmbeddingService` default (overridable via `@ConditionalOnMissingBean`); `VECTOR` field maps to `vector(N)`; `StorageAdapter.semanticSearch` cosine (`<=>`) query + `SemanticSearchService` + `POST /api/{collection}/semantic-search` (FLS-respecting; distances in `meta`); **HNSW cosine index auto-emitted for VECTOR columns** at table init | embed-on-write population (vectors written manually for now), `semantic_search` MCP tool, governed agent runtime (next Rec 3 slices) |
+| Semantic search / RAG | `EmbeddingService` SPI + dependency-free `HashingEmbeddingService` default (overridable via `@ConditionalOnMissingBean`); `VECTOR` field maps to `vector(N)`; `StorageAdapter.semanticSearch` cosine (`<=>`) query + `SemanticSearchService` + `POST /api/{collection}/semantic-search` (FLS-respecting; distances in `meta`); **HNSW cosine index auto-emitted for VECTOR columns** at table init; `semantic_search` MCP user tool | embed-on-write population (vectors written manually for now), governed agent runtime (next Rec 3 slices) |
 
 ## 🔴 UI Complete, backend MISSING (do not assume these work end-to-end)
 

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/SemanticSearchTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/SemanticSearchTool.java
@@ -1,0 +1,94 @@
+package io.kelta.mcp.tool.user;
+
+import io.kelta.mcp.client.GatewayHttpClient;
+import io.kelta.mcp.error.McpErrorMapper;
+import io.kelta.mcp.tool.Schemas;
+import io.kelta.mcp.tool.ToolHints;
+import io.kelta.mcp.tool.UserTool;
+import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import io.modelcontextprotocol.spec.McpSchema.Tool;
+import org.springframework.stereotype.Component;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * MCP user tool exposing vector similarity (semantic) search over a collection's {@code VECTOR}
+ * field, so an agent can retrieve records ranked by meaning rather than keyword match — the
+ * retrieval half of RAG.
+ *
+ * @since 1.0.0
+ */
+@Component
+public class SemanticSearchTool implements UserTool {
+
+    private final GatewayHttpClient gateway;
+
+    public SemanticSearchTool(GatewayHttpClient gateway) {
+        this.gateway = gateway;
+    }
+
+    @Override
+    public SyncToolSpecification toSpecification() {
+        Map<String, Object> properties = new LinkedHashMap<>();
+        properties.put("collection", Schemas.string(
+                "Collection name to search; it must define a VECTOR field."));
+        properties.put("query", Schemas.string(
+                "Natural-language text; records are ranked by semantic similarity to it."));
+        properties.put("limit", Schemas.integer("Maximum results to return (default 10).", 1, 100));
+
+        Tool tool = Tool.builder()
+                .name("semantic_search")
+                .title("Semantic Search")
+                .description("Vector similarity search over a collection's VECTOR field. Wraps POST "
+                        + "/api/{collection}/semantic-search; returns the nearest records by cosine "
+                        + "distance, with per-record distances under meta. Prefer this over `search` "
+                        + "when ranking by meaning rather than keyword match.")
+                .inputSchema(Schemas.object(properties, List.of("collection", "query")))
+                .annotations(ToolHints.read())
+                .build();
+
+        return SyncToolSpecification.builder()
+                .tool(tool)
+                .callHandler((context, request) -> {
+                    Map<String, Object> args = request.arguments();
+                    if (args == null) args = Map.of();
+                    Object cv = args.get("collection");
+                    Object qv = args.get("query");
+                    if (cv == null || cv.toString().isBlank()) {
+                        return error("Argument \"collection\" is required.");
+                    }
+                    if (qv == null || qv.toString().isBlank()) {
+                        return error("Argument \"query\" is required.");
+                    }
+
+                    Map<String, Object> body = new LinkedHashMap<>();
+                    body.put("query", qv.toString());
+                    Object limit = args.get("limit");
+                    if (limit != null) {
+                        body.put("limit", limit);
+                    }
+
+                    String path = "/api/" + URLEncoder.encode(cv.toString(), StandardCharsets.UTF_8)
+                            + "/semantic-search";
+                    try {
+                        return McpErrorMapper.toResult(gateway.post(path, body));
+                    } catch (RuntimeException e) {
+                        return McpErrorMapper.fromException(e);
+                    }
+                })
+                .build();
+    }
+
+    private static CallToolResult error(String message) {
+        return CallToolResult.builder()
+                .isError(true)
+                .content(List.of(new TextContent(message)))
+                .build();
+    }
+}

--- a/kelta-mcp/src/test/java/io/kelta/mcp/McpApplicationTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/McpApplicationTest.java
@@ -79,6 +79,7 @@ class McpApplicationTest {
                 "query_collection",
                 "get_record",
                 "search",
+                "semantic_search",
                 "describe_api",
                 "create_record",
                 "update_record",

--- a/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/SemanticSearchToolTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/SemanticSearchToolTest.java
@@ -1,0 +1,82 @@
+package io.kelta.mcp.tool.user;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import io.kelta.mcp.auth.RequestPatHolder;
+import io.kelta.mcp.client.GatewayHttpClient;
+import io.kelta.mcp.config.McpProperties;
+import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestClient;
+
+import java.util.Map;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SemanticSearchToolTest {
+
+    private WireMockServer wm;
+    private SemanticSearchTool tool;
+
+    @BeforeEach
+    void setUp() {
+        wm = new WireMockServer(0);
+        wm.start();
+        GatewayHttpClient client = new GatewayHttpClient(
+                RestClient.builder(),
+                new McpProperties("http://localhost:" + wm.port(), 30, 60_000, null));
+        tool = new SemanticSearchTool(client);
+        RequestPatHolder.set("klt_semsearch");
+    }
+
+    @AfterEach
+    void tearDown() {
+        RequestPatHolder.clear();
+        wm.stop();
+    }
+
+    @Test
+    void rejectsMissingCollectionOrQuery() {
+        assertThat(tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("semantic_search", Map.of("query", "hi"), null)).isError())
+                .isEqualTo(Boolean.TRUE);
+        assertThat(tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("semantic_search", Map.of("collection", "docs"), null)).isError())
+                .isEqualTo(Boolean.TRUE);
+        assertThat(tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("semantic_search",
+                        Map.of("collection", "docs", "query", "  "), null)).isError())
+                .isEqualTo(Boolean.TRUE);
+    }
+
+    @Test
+    void postsQueryToCollectionSemanticSearch() {
+        wm.stubFor(post(urlEqualTo("/api/docs/semantic-search"))
+                .willReturn(aResponse().withStatus(200).withBody("{\"data\":[],\"meta\":{\"count\":0}}")));
+
+        CallToolResult result = tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("semantic_search",
+                        Map.of("collection", "docs", "query", "annual report", "limit", 5), null));
+
+        assertThat(result.isError()).isNotEqualTo(Boolean.TRUE);
+        wm.verify(WireMock.postRequestedFor(urlEqualTo("/api/docs/semantic-search"))
+                .withHeader("Authorization", equalTo("Bearer klt_semsearch"))
+                .withRequestBody(matchingJsonPath("$.query", equalTo("annual report")))
+                .withRequestBody(matchingJsonPath("$.limit", equalTo("5"))));
+    }
+
+    @Test
+    void declaresAReadOnlyTool() {
+        var tool = this.tool.toSpecification().tool();
+        assertThat(tool.name()).isEqualTo("semantic_search");
+        assertThat(tool.inputSchema().required()).contains("collection", "query");
+    }
+}


### PR DESCRIPTION
## What
Exposes the semantic-search endpoint ([#1046](https://github.com/cklinker/emf/pull/1046)) to MCP clients and agents — the **retrieval half of RAG**, and the next step in turning the dual-MCP lead into a moat.

- **`SemanticSearchTool`** (`kelta-mcp` `tool/user`): wraps `POST /api/{collection}/semantic-search` via `GatewayHttpClient` (PAT/slug propagated like the other user tools). Inputs: `collection` + `query` (required) + optional `limit` (1–100, default 10). Read-only hint. **Auto-registered** by `McpServerConfig` (`List<UserTool>`), so it appears on `/mcp/user` — no hand-wiring.
- `McpApplicationTest`: add `semantic_search` to the discovered-user-tools assertion (now 15 user tools).

## Why
Phase 1 (AI moat), Rec 3. Agents/Claude can now retrieve records by meaning, grounding responses in tenant data — Kelta's Enterprise-Context-Graph equivalent, built on data it already stores.

## Tests
`SemanticSearchToolTest` (3): validation rejects missing collection/query; posts `query`+`limit` to the right path with the `Bearer` PAT (WireMock); tool metadata (name + required inputs). Full `kelta-mcp` suite green: **199**.

## Next Rec 3 slices
Embed-on-write population (the one remaining piece for "search just works" — needs the `?::vector` write path verified against real pgvector), then the governed **agent runtime** (orchestration loop over these MCP tools + Cerbos per-tool authz + PII masking + audit).

## Docs
`.claude/docs/status.md` (Semantic search / RAG row).

🤖 Generated with [Claude Code](https://claude.com/claude-code)