### PR TITLE
fix(pages): render text node from props.content (Rec 1 follow-up)

### DIFF
--- a/kelta-ui/app/src/pages/app/CustomPage/CustomPage.test.tsx
+++ b/kelta-ui/app/src/pages/app/CustomPage/CustomPage.test.tsx
@@ -53,7 +53,7 @@ describe('CustomPage', () => {
     mockGet.mockResolvedValueOnce(
       contract([
         { id: 'h', type: 'heading', props: { text: 'Welcome' } },
-        { id: 't', type: 'text', props: { text: 'Hello there' } },
+        { id: 't', type: 'text', props: { content: 'Hello there' } },
         { id: 'b', type: 'button', props: { label: 'Go' } },
       ])
     )

--- a/kelta-ui/app/src/pages/app/CustomPage/PageTreeRenderer.tsx
+++ b/kelta-ui/app/src/pages/app/CustomPage/PageTreeRenderer.tsx
@@ -44,9 +44,10 @@ function PageNodeRenderer({
         </h2>
       )
     case 'text':
+      // The builder's text component stores its body in `content` (heading uses `text`).
       return (
         <p className="text-sm text-muted-foreground" data-testid="page-node-text">
-          {asString(props.text)}
+          {asString(props.content, asString(props.text))}
         </p>
       )
     case 'button': {


### PR DESCRIPTION
## What

Follow-up fix to the page renderer ([#1057](https://github.com/cklinker/emf/pull/1057)): **text nodes rendered empty.**

The builder's text component stores its body in `props.content` (heading uses `props.text`, button `props.label`, image `props.src`/`alt`). `PageTreeRenderer` read `props.text` for the `text` node, so published pages showed blank text blocks.

## Fix

Read `props.content` with a `props.text` fallback. Test updated to feed `content` (the real builder shape); 7 CustomPage tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)