### PR TITLE
fix(ci): reset mailpit + bootstrap container_name in e2e compose

### DIFF
--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -79,3 +79,13 @@ services:
         VITE_API_BASE_URL: http://kelta-gateway:8080
     container_name: !reset null
     ports: !reset []
+
+  # mailpit + bootstrap also carry fixed container_names in the base compose;
+  # reset them too or the hardcoded "kelta-mailpit" collides with leaked/overlapping
+  # CI runs ("container name already in use"), failing the whole e2e stack startup.
+  mailpit:
+    container_name: !reset null
+    ports: !reset []
+
+  kelta-bootstrap:
+    container_name: !reset null


### PR DESCRIPTION
## What

Fixes a recurring **e2e flake** that failed PR #1059 (and intermittently others): the stack wouldn't start with `Conflict. The container name "/kelta-mailpit" is already in use`.

## Cause

`docker-compose.ci.yml` resets `container_name: !reset null` for the 9 long-running services so each run gets `COMPOSE_PROJECT_NAME`-prefixed names — but **`mailpit` and `kelta-bootstrap` were missed**, keeping their hardcoded `kelta-mailpit` / `kelta-bootstrap` names from the base compose. When a prior run's container leaks or runs overlap, the fixed name collides and `docker compose up` aborts → the whole e2e job fails at "Start stack" (no spec even runs).

## Fix

Add `container_name: !reset null` (+ `ports: !reset []` for mailpit) for both, matching the file's stated rule #3.

No app code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)