### PR TITLE
feat(pages): table data-source editor in the page builder (Rec 1 slice 1e-ui)

### DIFF
--- a/kelta-ui/app/src/pages/PageBuilderPage/PageBuilderPage.test.tsx
+++ b/kelta-ui/app/src/pages/PageBuilderPage/PageBuilderPage.test.tsx
@@ -682,6 +682,36 @@ describe('PageBuilderPage', () => {
         expect(screen.getByTestId('save-page-button')).not.toBeDisabled()
       })
     })
+
+    it('shows the table data-source editor and binds a collection', async () => {
+      const user = userEvent.setup()
+      render(<PageBuilderPage />, { wrapper: createTestWrapper() })
+
+      await waitFor(() => {
+        expect(screen.getByText('dashboard')).toBeInTheDocument()
+      })
+
+      await user.click(screen.getByTestId('page-name-0'))
+
+      await waitFor(() => {
+        expect(screen.getByTestId('palette-item-table')).toBeInTheDocument()
+      })
+
+      // Add a table component — its data-source editor should appear
+      await user.click(screen.getByTestId('palette-item-table'))
+
+      await waitFor(() => {
+        expect(screen.getByTestId('property-collection')).toBeInTheDocument()
+        expect(screen.getByTestId('property-columns')).toBeInTheDocument()
+        expect(screen.getByTestId('property-limit')).toBeInTheDocument()
+      })
+
+      await user.type(screen.getByTestId('property-collection'), 'orders')
+
+      await waitFor(() => {
+        expect(screen.getByTestId('save-page-button')).not.toBeDisabled()
+      })
+    })
   })
 
   describe('Canvas', () => {

--- a/kelta-ui/app/src/pages/PageBuilderPage/PageBuilderPage.tsx
+++ b/kelta-ui/app/src/pages/PageBuilderPage/PageBuilderPage.tsx
@@ -255,6 +255,19 @@ function PropertyPanel({ component, onChange }: PropertyPanelProps): React.React
     })
   }
 
+  // Table data-source binding lives under props.dataView ({ collection, fields, limit }).
+  const dataView =
+    (component.props.dataView as
+      | { collection?: string; fields?: string[]; limit?: number }
+      | undefined) ?? {}
+  const handleDataViewChange = (patch: {
+    collection?: string
+    fields?: string[]
+    limit?: number
+  }) => {
+    handlePropChange('dataView', { ...dataView, ...patch })
+  }
+
   return (
     <div
       className="bg-background border border-border rounded-md p-4 overflow-y-auto"
@@ -398,6 +411,66 @@ function PropertyPanel({ component, onChange }: PropertyPanelProps): React.React
                 onChange={(e) => handlePropChange('alt', e.target.value)}
                 placeholder="Image description"
                 data-testid="property-alt"
+              />
+            </div>
+          </>
+        )}
+        {component.type === 'table' && (
+          <>
+            <div className="flex flex-col gap-1">
+              <label
+                className="text-xs font-medium text-muted-foreground"
+                htmlFor="prop-collection"
+              >
+                Collection
+              </label>
+              <input
+                id="prop-collection"
+                type="text"
+                className="p-2 text-sm text-foreground bg-background border border-border rounded transition-[border-color,box-shadow] focus:outline-none focus:border-primary focus:ring-2 focus:ring-primary/20"
+                value={dataView.collection || ''}
+                onChange={(e) => handleDataViewChange({ collection: e.target.value || undefined })}
+                placeholder="orders"
+                data-testid="property-collection"
+              />
+            </div>
+            <div className="flex flex-col gap-1">
+              <label className="text-xs font-medium text-muted-foreground" htmlFor="prop-columns">
+                Columns
+              </label>
+              <input
+                id="prop-columns"
+                type="text"
+                className="p-2 text-sm text-foreground bg-background border border-border rounded transition-[border-color,box-shadow] focus:outline-none focus:border-primary focus:ring-2 focus:ring-primary/20"
+                value={(dataView.fields ?? []).join(', ')}
+                onChange={(e) =>
+                  handleDataViewChange({
+                    fields: e.target.value
+                      .split(',')
+                      .map((f) => f.trim())
+                      .filter((f) => f.length > 0),
+                  })
+                }
+                placeholder="comma-separated, e.g. id, status, total"
+                data-testid="property-columns"
+              />
+            </div>
+            <div className="flex flex-col gap-1">
+              <label className="text-xs font-medium text-muted-foreground" htmlFor="prop-limit">
+                Row limit
+              </label>
+              <input
+                id="prop-limit"
+                type="number"
+                className="p-2 text-sm text-foreground bg-background border border-border rounded transition-[border-color,box-shadow] focus:outline-none focus:border-primary focus:ring-2 focus:ring-primary/20"
+                value={dataView.limit ?? ''}
+                onChange={(e) =>
+                  handleDataViewChange({
+                    limit: e.target.value ? Number(e.target.value) : undefined,
+                  })
+                }
+                placeholder="25"
+                data-testid="property-limit"
               />
             </div>
           </>


### PR DESCRIPTION
## What

Completes table data binding **end-to-end**: builders can now configure a table node's data source from the PropertyPanel (previously `props.dataView` was config-only — no UI).

## How

Adds a `table`-type editor block to the builder's PropertyPanel:
- **Collection** — which collection to read
- **Columns** — comma-separated field names
- **Row limit** — number

These write `props.dataView = { collection, fields, limit }` — the exact shape `DataTableNode` reads at render time ([#1061](https://github.com/cklinker/emf/pull/1061)). So: configure in the builder → persists in `config` → render contract serves it → `DataTableNode` fetches `/api/{collection}` (Cerbos/FLS-enforced) and renders the columns.

## Tests

`PageBuilderPage.test.tsx` +1 — adding a table shows the data-source editor (collection/columns/limit) and typing a collection enables Save. 62 pass / 2 skipped. Typecheck / ESLint / Prettier clean.

> The screen-builder `status.md` row update is deferred to the next slice to avoid a line-level conflict with the in-flight #1061 (which edits the same row).

## Rec 1 after this

Render contract + persistence + renderer + broadcast + **table binding (render + builder UI)** all done. Remaining: `form` input binding, per-page Cerbos authz, positive Playwright e2e (post-deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)