### PR TITLE
fix(test): raise testing-library asyncUtilTimeout to absorb CI-load flakes

### DIFF
--- a/kelta-web/vitest.setup.ts
+++ b/kelta-web/vitest.setup.ts
@@ -1,5 +1,13 @@
 import '@testing-library/jest-dom/vitest';
+import { configure } from '@testing-library/react';
 import { afterAll, afterEach, beforeAll } from 'vitest';
+
+// Raise the async-utility timeout (default 1000ms). The Build-and-Deploy
+// workflow runs the frontend suite concurrently with heavy container image
+// builds, so data-fetch `waitFor`/`findBy` assertions can exceed 1s under load
+// and flake (e.g. DataTable's "John Doe" row), even though they pass in the
+// standalone PR CI. 5s absorbs the load without masking real failures.
+configure({ asyncUtilTimeout: 5000 });
 
 // Clean up after each test
 afterEach(() => {


### PR DESCRIPTION
## Why

The **Build-and-Deploy** workflow's *Test Frontend* step runs the kelta-web suite **concurrently with heavy container image builds**, so async data-fetch `waitFor`/`findBy` assertions occasionally exceed testing-library's **1s default** and flake — e.g. `DataTable.test.tsx` `getByText('John Doe')`. The exact same 888-test suite passes in the standalone PR CI (no concurrent builds), which is why this only surfaces post-merge and broke the #1086 main deploy.

## Fix

Set `asyncUtilTimeout: 5000` globally in `kelta-web/vitest.setup.ts` (one place). Covers the whole class of async-render assertions; 5s absorbs CI load without masking real failures (a genuinely stuck render still fails, just later).

Verified: typecheck + format clean, DataTable suite green (31/31).

🤖 Generated with [Claude Code](https://claude.com/claude-code)