### PR TITLE
docs(specs): page-builder→OutSystems parity spec set

### DIFF
--- a/.claude/docs/specs/page-builder-parity.md
+++ b/.claude/docs/specs/page-builder-parity.md
@@ -1,0 +1,404 @@
+# Page Builder → OutSystems Parity — Parent Spec
+
+> **Status:** parent planning spec. This is the authoritative shared contract for the page-builder
+> parity effort. Each slice in the [Slice plan](#slice-plan) is expanded into its own detailed
+> feature spec under [`page-builder/`](./page-builder/). Child specs **extend, never contradict**
+> the [Reuse Map](#reuse-map), [shared model](#the-shared-model), [widget registry](#widget-registry),
+> and [config-JSON v2 schema](#page-level-config-v2) below.
+>
+> Source-verified against the codebase on 2026-06-22 (Flyway head V146). If code and this doc
+> disagree, trust the code and fix this doc.
+
+## How to use this document
+
+This parent spec defines the cross-cutting architecture once. The child specs in
+[`./page-builder/`](./page-builder/) each cover one PR-sized slice with acceptance criteria, UI
+samples, exact contracts, DB migrations (or an explicit "none"), and file-by-file code changes —
+per the [Child-spec template](#child-spec-template). Read this parent first; every child references
+it.
+
+| Slice | Child spec | Axis |
+|-------|-----------|------|
+| 1g — Render contract v2 | [page-builder/1g-render-contract-v2.md](./page-builder/1g-render-contract-v2.md) | foundation (backend) |
+| 2a — Widget registry + shared render | [page-builder/2a-widget-registry.md](./page-builder/2a-widget-registry.md) | foundation (FE) |
+| 2b — Schema-driven inspector + palette | [page-builder/2b-inspector-palette.md](./page-builder/2b-inspector-palette.md) | foundation (FE) |
+| 2c — Layout engine + dnd-kit canvas | [page-builder/2c-layout-engine.md](./page-builder/2c-layout-engine.md) | **Layout & grid** |
+| 2d — Data binding & expressions | [page-builder/2d-binding-expressions.md](./page-builder/2d-binding-expressions.md) | **Data binding** |
+| 2e — Events & actions | [page-builder/2e-events-actions.md](./page-builder/2e-events-actions.md) | **Logic & events** |
+| 2f — Typed form widgets | [page-builder/2f-typed-forms.md](./page-builder/2f-typed-forms.md) | **Widgets/typed forms** |
+| 2g — Widget breadth | [page-builder/2g-widget-breadth.md](./page-builder/2g-widget-breadth.md) | **Widgets** |
+| 1h — Per-page authz (optional) | [page-builder/1h-per-page-authz.md](./page-builder/1h-per-page-authz.md) | backend |
+
+## Context
+
+The last big dev push (OutSystems-parity roadmap, Recs 1–10) shipped a *functional* page
+builder — but "functional" means **read-a-table + create-a-record**. The current designer
+(`app.kelta.io/<tenant>/setup/pages`) is a thin shell: 8 static primitives (heading, text,
+button, image, form, table, card, container), a **vertical-stack-only** canvas (the `position`
+field is stored but ignored), native HTML5 drag that only appends to root, static props with no
+expressions, no page state/logic, buttons that only do `href`, and text-only form inputs. Against
+OutSystems' layout engine + data binding + reactive logic + widget library, it falls well short.
+
+This effort closes the gap across **all four axes**:
+1. **Layout & responsive grid** — grid/row/column containers, responsive spans, drop-into-container,
+   reorder, resize.
+2. **Data binding & expressions** — page variables, on-load data sources, bind *any* prop to a
+   record field / expression (`{{record.name}}`, `IF(...)`).
+3. **Logic & events/actions** — wire events (button click → run flow / navigate / create-update
+   record / refresh data / set var).
+4. **Widget library + typed forms** — a real widget set and typed/validated inputs
+   (date/number/picklist/lookup) instead of text-only.
+
+**Intended outcome:** a builder whose authored pages express genuine app behavior, with the runtime
+renderer and editor preview sharing one widget-render path, and all data access still flowing
+through the authorized JSON:API so Cerbos/FLS stay enforced server-side.
+
+## Key architecture decisions (verified against the code)
+
+- **The central move is a *widget descriptor registry*.** Today the component types are hardcoded in
+  **5 per-type `switch`/conditional sites** kept in lockstep: `AVAILABLE_COMPONENTS` palette,
+  `PropertyPanel`, `Canvas.renderComponent`, `Preview.renderPreviewComponent` (all in
+  [PageBuilderPage.tsx](../../../kelta-ui/app/src/pages/PageBuilderPage/PageBuilderPage.tsx)), and
+  `PageNodeRenderer` in
+  [PageTreeRenderer.tsx](../../../kelta-ui/app/src/pages/app/CustomPage/PageTreeRenderer.tsx).
+  Replace all five with **one registry** (`type → { label, icon, category, defaultProps, propSchema,
+  Render }`). Palette, inspector, editor preview, and runtime renderer all become schema-driven
+  loops. This is the keystone — every axis hangs off it.
+- **One shared render module** for editor preview *and* runtime (they duplicate today).
+- **Backend stays a pass-through.** The whole tree already lives in the `ui-pages.config` JSON
+  column; the render service returns it as-is. Keep that — **no server-side binding resolution**
+  (would fetch records outside the FLS path and leak read-denied fields) and **no Flyway migration**
+  (everything new nests inside `config`). Verified: flow-execute endpoint already exists; typed-form
+  field metadata already served by existing endpoints.
+- **Reuse-first** (most reuse is already built — see Reuse Map). Do not reinvent expression eval,
+  typed inputs, bound tables, the expression picker, or layouts.
+- **DnD: adopt `@dnd-kit/core` + `@dnd-kit/sortable`** (one new dep in `kelta-ui/app`), scoped to the
+  page canvas only. `PageLayoutsPage` stays on native DnD (no forced migration).
+
+## Reuse Map
+
+Use these — do not rebuild.
+
+| Need | Reuse | Path |
+|------|-------|------|
+| Expression evaluation | `FormulaEvaluator.evaluate(expr, flatScope)`, `extractFieldRefs` | `kelta-web/packages/formula/src/` |
+| Bound data table | `DataTable` (resourceName, columns, filters, pagination) | `kelta-web/packages/components/src/` |
+| Typed create/edit form | `ResourceForm` (schema-driven, Zod, typed inputs, field authz) | `kelta-web/packages/components/src/` |
+| Responsive layout chrome | `PageLayout`/`*ColumnLayout`, `ResponsiveBreakpoints`, `RuleEngine`/`useLayoutRules` | `kelta-web/packages/components/src/` |
+| Read-only bound value + 21 field types | `FieldRenderer` (plugin-overridable) | `kelta-ui/app/src/components/FieldRenderer/` |
+| Expression/field picker (literal↔expr) | `FieldExpressionPicker` (FieldsTab + FunctionsTab, StaticNamespace roots, emits dot-paths/fn stubs) | `kelta-ui/app/src/components/FieldExpressionPicker/` |
+| Typed inputs | `LookupSelect`, `MultiPicklistSelect`, `RichTextEditor`, `InlineEditCell` | `kelta-ui/app/src/components/` |
+| Variable insertion | `VariablePicker` | `kelta-ui/app/src/components/VariablePicker/` |
+| Collection/field schema fetch | `useCollectionSchema` → `fetchCollectionSchema` (`GET /api/collections/{name}?include=fields`); `CollectionStoreContext` | `kelta-ui/app/src/hooks/useCollectionSchema.ts` |
+| Plugin widget fallback | `componentRegistry.getPageComponent(type)` | `kelta-ui/app/src/services/componentRegistry.ts` |
+| Run a flow from an event | `POST /api/flows/{flowId}/execute` body `{ input }` (async → poll `GET /api/flows/executions/{id}`) | `kelta-worker/.../controller/FlowExecutionController.java` |
+| Create/update record from an event | JSON:API `POST /api/{collection}` / `PATCH /api/{collection}/{id}` (Cerbos/write-FLS enforced) | existing |
+| Form field types/picklists | `GET /api/fields?filter[collectionId][EQ]=…`, `GET /api/picklist-values?…`; `FieldType` enum | `runtime-core/.../model/FieldType.java` |
+
+Already-present deps usable by widgets: `recharts`, `@tiptap/*`, `@tanstack/react-virtual`,
+`radix-ui` (tabs/dropdown/checkbox/datepicker popover), `sonner`, `zod`.
+
+## The shared model
+
+New dir `kelta-ui/app/src/pages/PageBuilderPage/model/`:
+
+- **`pageModel.ts`** — the v2 component/page model:
+  ```ts
+  type Binding = { $bind: string; mode?: 'path' | 'expr' }  // {{...}} convention
+  type PropValue = string|number|boolean|null | Binding | PropValue[] | { [k:string]: PropValue }
+  function isBinding(v): v is Binding
+  type PageAction =
+    | { action:'runFlow'; flowId:string; input?:Record<string,PropValue>; awaitResult?:boolean }
+    | { action:'navigate'; to:string; params?:Record<string,PropValue>; newTab?:boolean }
+    | { action:'openUrl'; url:PropValue; newTab?:boolean }
+    | { action:'createRecord'|'updateRecord'; collection:string; attributes:Record<string,PropValue>; recordId?:PropValue }
+    | { action:'refreshData'; dataSource:string }
+    | { action:'setVar'; name:string; value:PropValue }
+    | { action:'showToast'; level:'info'|'success'|'error'; message:PropValue }
+  type EventHandlers = Partial<Record<'onClick'|'onChange'|'onSubmit'|'onLoad', PageAction[]>>
+  interface ResponsiveSpan { base:number; sm?:number; md?:number; lg?:number }  // 1..12
+  interface PageComponent { id; type; props:Record<string,PropValue>; events?:EventHandlers;
+                            span?:ResponsiveSpan; children?:PageComponent[] }  // `position` is dropped from the active model BY slices 2a/2c (tolerated/ignored on read until then)
+  ```
+- **`bindingScope.ts` / `resolveBindings.ts` / `interpolate.ts`** — scope `{ record, vars, page, item }`.
+  `mode:'path'` → `getPath(scope, "record.name")` walker (the formula parser is flat-key only, so
+  dotted paths resolve here). `mode:'expr'` → flatten referenced leaves (via `extractFieldRefs`) then
+  `FormulaEvaluator.evaluate`. `interpolate("Hi {{record.name}}", scope)` for templated strings.
+- **`treeOps.ts`** — pure tree mutations: `insertNode`, `moveNode`, `removeNode`, `updateProps`,
+  `setSpan` (unit-tested; fixes "drop only appends to root").
+- **`migrate.ts`** — legacy `position {row,column,width,height}` → container/grid tree (back-compat).
+
+### Page-level config (v2)
+
+Extend [pageConfig.ts](../../../kelta-ui/app/src/pages/PageBuilderPage/pageConfig.ts), still inside
+the `config` JSON column:
+```ts
+interface PageVariable { name; type:'string'|'number'|'boolean'|'json'; default?:PropValue }
+interface PageDataSource { name; collection; fields?; filter?; sort?; limit?; mode:'list'|'single'; recordId?:PropValue }
+interface PageConfig { layout?; components?; variables?:PageVariable[]; dataSources?:PageDataSource[]; access?:{requiredPermission?:string}; schemaVersion?:2 }
+```
+**Canonical storage (authoritative — all slices must agree):** the component tree lives at
+**`config.components`** — the location the existing builder already writes and `CustomPage` already
+reads. There is **NO `config.tree` wrapper.** `variables`, `dataSources`, `access`, and
+`schemaVersion` are **siblings of `components`** inside `config`. The render contract's `tree` field
+(below) carries the whole `config` map verbatim, so `tree.components` resolves; `variables`/`dataSources`
+are *also* surfaced as separate contract fields read from `config.*` top-level. Per-node `events` and
+`span` nest inside the `components` tree (so they persist with it); the page-level siblings
+(`variables`/`dataSources`/`access`/`schemaVersion`) do **not** persist unless the save call passes
+them — see [Save & persistence](#save--persistence-v2-round-trip).
+
+Binding namespace (authoritative): `record` (current record / repeat row via `item`), `vars` (page
+variables), `data.<sourceName>` (on-load data source result), `page` (route params/meta), `item`
+(per-row scope inside `list`/`repeater`). `$bind` is the single expression marker; everything else is
+a literal. The server never parses `$bind` — it round-trips untouched.
+
+## Widget registry
+
+New dir `kelta-ui/app/src/pages/PageBuilderPage/widgets/`:
+- **`types.ts`** — `WidgetDescriptor { type, label, icon, category, defaultProps, propSchema:PropFieldSchema[], acceptsChildren?, supportedEvents?:Array<keyof EventHandlers>, Render }`
+  and `PropFieldSchema { key, label, kind, options?, bindable?, group?, dependsOnCollection? }` where
+  `kind ∈ text|textarea|number|boolean|select|color|collection-picker|field-picker|expression|event-list|span|children`.
+  `supportedEvents` is declared here (in 2a) so the inspector's `event-list` field can render one
+  tabbed editor over the whole `EventHandlers` (see Inspector below) — 2e only adds the runtime.
+- **`registry.ts`** — `widgetRegistry` singleton (`register`, `get`, `list`, `listByCategory`).
+  `get(type)` falls back to wrapping `componentRegistry.getPageComponent(type)` in a synthetic
+  descriptor (plugins keep working with **zero changes**; the builder/runtime stop special-casing
+  "unknown type").
+- **`renderTree.tsx`** — `RenderTree({ components, scope, mode, tenantSlug })` + `renderNode`. The
+  **single** render path: look up descriptor, resolve `node.props`, call
+  `descriptor.Render({ node, scope, mode, tenantSlug, renderChild })`. Used by editor preview
+  (`mode:'editor'`) and runtime (`mode:'runtime'`).
+  **Resolved-node invariant (authoritative):** `WidgetRenderProps.node.props` handed to `Render` is
+  **always fully binding-resolved** (in 2a the resolver is an identity no-op; 2d makes it real).
+  Descriptors **must not** call `resolveBindings` themselves — the *only* exception is `list`/`repeater`,
+  which re-resolves its children under each per-row `item` scope. `renderChild` has signature
+  `(child: PageComponent, scope?: BindingScope) => ReactNode` from 2a onward (the optional `scope` lets
+  a repeater pass an `item`-augmented scope). The plugin shim therefore passes **resolved** props to
+  plugin components (never `$bind` markers) — an intentional part of the "zero plugin changes" guarantee.
+- **`builtins/*.tsx`** — one descriptor per widget. v1 set, each wrapping a reused component where one
+  exists. (Type strings are load-bearing — `table`/`form` keep their legacy strings for back-compat
+  with already-saved pages; do **not** rename to `data-table`.)
+  - Layout: `grid` (12-col), `row`, `column`, `container`, `card`, `divider`.
+  - Content: `heading`, `text`, `image`, `icon`, `link`, `button`.
+  - Data: `table` (→ `DataTable`), `list`/`repeater` (binds an array source, renders children per
+    `item`), `field-value` (→ `FieldRenderer`), `chart` (→ `recharts`).
+  - Input: `form` (→ `ResourceForm`; **category `input`** — fixed in 2a, not moved later), `text-input`,
+    `number-input`, `checkbox`, `dropdown` (picklist via schema), `datepicker`, `lookup` (→ `LookupSelect`),
+    `multi-picklist` (→ `MultiPicklistSelect`), `rich-text` (→ `RichTextEditor`).
+  - Navigation: `nav` (→ `Navigation`), `tabs` (→ radix).
+
+## Inspector + canvas
+
+- `inspector/Inspector.tsx` + `inspector/fields/*` — schema-driven property editor looping over
+  `descriptor.propSchema`, grouped by `group`. Each `bindable` field wraps in `BindableField` (the
+  `fx` literal↔expr toggle → opens `FieldExpressionPicker` with `record`/`vars`/`page` namespaces,
+  stores `{ $bind }` holding a **bare** token; `{{…}}` is added only for display). **`EventListField`
+  is one field of `kind:'event-list'` with `key:'events'`** — it edits the whole `node.events`
+  (`EventHandlers`) as tabs over `descriptor.supportedEvents`, each tab an ordered `PageAction[]`
+  (add/remove/reorder; flow picker from `/api/flows`). 2b ships the editor shell; 2e wires the runtime.
+- `canvas/Canvas.tsx` + `canvas/dnd/*` — `@dnd-kit` `DndContext` (PointerSensor + KeyboardSensor).
+  Palette items are draggable sources; every container is a droppable with a per-container
+  `SortableContext` for reorder (`closestCenter`). Drops/moves call `treeOps`. Grid-span resize drags
+  a child's handle and snaps `span` to the 12-col grid (no pixel coords). `SelectableNode` wraps each
+  node (selection outline, drag handle, resize handles).
+
+## Backend changes (small — pass-through only)
+
+- **Render contract v2** —
+  [PageRenderContract.java](../../../kelta-worker/src/main/java/io/kelta/worker/service/PageRenderContract.java) /
+  [PageRenderService.java](../../../kelta-worker/src/main/java/io/kelta/worker/service/PageRenderService.java):
+  bump `CONTRACT_VERSION` `"1.0"→"2.0"`; surface richer config:
+  ```java
+  record PageRenderContract(String version, String slug, String title, String path,
+      List<Map<String,Object>> variables, List<Map<String,Object>> dataSources, Map<String,Object> tree)
+  ```
+  `render()` parses `config` once; **`tree` = the whole `config` map verbatim** (so the FE reads
+  `tree.components` exactly as today — there is **no `config.tree` nesting**); `variables` =
+  `config.variables` (List) else `[]`; `dataSources` = `config.dataSources` else `[]`. Null-safe; both
+  a v1 page (no `variables`/`dataSources` keys) and a v2 page yield `version:"2.0"` with the arrays
+  empty-or-populated and `tree:<wholeConfig>`. **Remains a pass-through — no binding/dataSource
+  resolution server-side.** `CustomPage` reads `tree.components` plus the sibling `variables`/`dataSources`
+  contract fields.
+- **Per-page authz (optional, slice 1h).** In `render()`, if `config.access.requiredPermission` is
+  present, check it via the same in-controller Cerbos system-permission mechanism `/api/admin/**`
+  uses; deny → `Optional.empty()` → controller returns **404** (matches existing unknown-slug
+  privacy). Absent key ⇒ unchanged published+active+tenant gate. **No DB column, no migration, no
+  NATS change.**
+- **No change** to NATS (`UIPageConfigEventPublisher`/`UIPageSlugHook` already correct), the flow
+  endpoint, or field-metadata/picklist endpoints.
+
+## Save & persistence (v2 round-trip)
+
+**Mandatory — this is the #1 correctness risk.** The current `handleSavePage`
+([PageBuilderPage.tsx](../../../kelta-ui/app/src/pages/PageBuilderPage/PageBuilderPage.tsx)) saves only
+`mergeConfig(readConfig(currentPage), { components })`, and `mergeConfig` only overlays a key when it
+is passed. So any page-level sibling (`variables`/`dataSources`/`access`/`schemaVersion`) is **silently
+dropped on save** unless the save call passes it — the exact bug class the original `components`/`layout`
+drop (slice 1b) already hit.
+
+- **Slice 2c owns the canonical `handleSavePage` rewrite** (first slice that must persist
+  `schemaVersion:2` on migration): widen `mergeConfig` to overlay `variables`/`dataSources`/`access`/
+  `schemaVersion`, and change the one save call site to pass the full current set:
+  `mergeConfig(readConfig(currentPage), { components, variables, dataSources, schemaVersion: 2 })`.
+- **2d** adds `variables`/`dataSources` to that same call; **1h** adds `access`.
+- Per-node `events`/`span` ride inside `components` and need no extra wiring.
+- **Test the mutation payload, not just `mergeConfig`'s return** — assert the `updateMutation.mutate`
+  body contains every v2 key (see Testing → save round-trip).
+
+## Security — binding & action output safety
+
+New surfaces (bindings into the DOM, event-driven navigation/writes) require:
+- **URL scheme allow-list (2e + 2g).** `link.href`, `image.src`, and the `navigate`/`openUrl` action
+  targets are author/data-controlled (a `{ $bind }` can resolve to `javascript:`/`data:`). Reject any
+  scheme not in `{http, https, mailto, tel, relative}` before `assign`/`open`/render. Add a blocked-`javascript:`
+  test.
+- **Text bindings** are auto-escaped by React (safe). **`rich-text`/HTML output (2f)** must pass the
+  existing sanitizer (same one `FieldRenderer`'s `rich_text` path uses) — never `dangerouslySetInnerHTML`
+  on unsanitized bound HTML.
+- **Expression engine.** `@kelta/formula` is a custom AST evaluator with no `eval`/`Function`/`window`/
+  `globalThis` reach — state this guarantee in `conventions.md`. `getPath` (2d) must skip
+  `__proto__`/`constructor`/`prototype` tokens (return null) to avoid prototype-chain traversal.
+- **Abuse/governor.** `runFlow`/`createRecord`/`updateRecord` from a *published end-user* page ride
+  Cerbos/write-FLS (authz preserved) but consume per-tenant API governor quota per click — note in
+  `concerns.md`.
+
+## DoS / fan-out caps (2d)
+
+- `MAX_PAGE_DATA_SOURCES` (e.g. 12) — a page declaring more is rejected in the builder (each source
+  fires its own on-load fetch).
+- **Repeater render cap** (e.g. 200 rows) with a "showing N of M" truncation — `list`/`repeater` must
+  not render an unbounded child subtree ×N. (Existing `MAX_TABLE_ROWS=100`, `MAX_HTTP_PAGE_SIZE=200`
+  cap the bound table; the repeater needs its own cap.)
+- Each page view consuming governor quota proportional to its data sources is expected — document it.
+
+## Rollout & rollback
+
+- **Feature-flag the new runtime render path.** 2a replaces `PageTreeRenderer` for **every** custom
+  page across all tenants in one merge. Gate `CustomPage`'s use of `RenderTree` behind a system feature
+  flag (platform already has `kelta.config.feature.changed` infra) with fallback to the legacy
+  `PageNodeRenderer`; keep the legacy renderer in the tree until 2a soaks. The "move
+  `DataTableNode`/`FormNode` verbatim into descriptors" approach must preserve a clean revert.
+- **2a is split:** (a) introduce `model/` + `widgets/` + `RenderTree` + builtins behind the registry,
+  parity-tested with a **golden snapshot** of all 8 widgets captured *before* the refactor; (b) flip
+  the runtime/builder to consume it, gated on the parity suite green. The one deliberate behavior change
+  — runtime `heading` honoring `level` instead of hardcoded `<h2>` — must show as a reviewed snapshot diff.
+- **Rollback trigger:** page-render error rate / a spike in unknown-widget fallbacks → flip the flag.
+
+## End-to-end e2e ownership
+
+New admin routes can't get Playwright e2e in the introducing PR (route absent until deployed), but the
+full flow must have ONE owned spec — not a phantom "covered by the parent." **Add
+`e2e-tests/.../page-builder-v2.spec.ts`, owned by the terminal behavior slice (2e), authored post-deploy
+before the feature is declared done:** palette → drop into a grid column → bind a prop → wire a button
+`onClick` event → save → publish → open the runtime page → **assert a mutation succeeds** (a record is
+created via the button event and persists), not merely that the page renders. 1h adds a negative
+authz case (denied user → 404).
+
+## Parity gaps NOT covered in v1 (explicitly deferred)
+
+Tracked so they're acknowledged, not silently missing: **conditional visibility / `If` container**
+(show widget when an expression is true), **computed page variables** (`vars` derived from an expression,
+not just a literal `default`), **runtime list filter/sort UI** on `table`/`list`, **form-level
+validation-summary** beyond per-field Zod, and editor affordances **undo/redo, copy/paste, multi-select**.
+The **unsaved-changes guard** (today a `// Could show a confirmation dialog here` TODO) is in scope for 2c.
+
+## i18n
+
+All new user-facing strings (palette categories, inspector groups/field labels, the 8 action-type labels,
+empty/error/loading states, the 1h 404 hint) go through `useI18n`/`t()` with `builder.*` keys — the
+current builder is fully `useI18n`-driven; do not hardcode English. Each FE slice owns its strings.
+
+## Child-spec template
+
+Each `page-builder/<slice>.md` must include every section (sections that don't apply state
+"N/A — <reason>", never omit silently):
+
+1. **Goal & scope** — what the slice delivers, what it does *not*, parent-doc sections it conforms to.
+2. **UI samples** — ASCII/markdown wireframes of inspector/palette/canvas interactions and runtime
+   output; sample component trees as JSON; before/after of the affected screen. (Backend-only:
+   sample request/response payloads.)
+3. **Data & API contracts** — exact TS interfaces, JSON shapes, endpoint signatures, render-contract
+   delta, `config` JSON schema delta; versioning + back-compat.
+4. **DB migrations** — exact Flyway `V<n>__*.sql` if any; else **"None — stored in `ui-pages.config`
+   JSON, no DDL"**. Verify Flyway head before numbering (head **V146**, next **V147**).
+5. **File-by-file code changes** — every file created/modified, the specific functions/components,
+   before→after sketches, exact paths, and registration/wiring steps.
+6. **Test plan** — Vitest unit (FE), worker unit with mocked JdbcTemplate/QueryEngine (BE),
+   kelta-test-harness integration test (if DB-constraint-sensitive), post-deploy Playwright e2e.
+7. **Docs to update** — specific rows in `status.md` / `conventions.md` / `architecture.md` /
+   `integrations.md` (per CLAUDE.md Rule 6).
+8. **Risks & open questions** — fragile/oversized files (`concerns.md`), sequencing deps, decisions
+   needing the user.
+
+## Slice plan
+
+Backend keystone first (zero FE dependency, additive); FE slices build on the registry.
+
+- **1g — Render contract v2** (backend). New `PageRenderContract` shape, `version "2.0"`, `tree`=whole
+  config, v1/v2 both empty-or-populated arrays. `CustomPage` reads siblings. Worker unit test (mocked
+  QueryEngine) **+ a kelta-test-harness round-trip scenario** (PATCH a v2 `config` → GET render → assert
+  `variables`/`dataSources` surface from real Postgres — mock tests can't see a serialization drop).
+- **2a — Widget registry + shared render module + model** (FE). `model/*`, `widgets/types.ts` (incl.
+  `supportedEvents`), `registry.ts`, `renderTree.tsx` (resolved-node invariant; identity resolver);
+  migrate existing 8 types to descriptors (`table`/`form` keep legacy strings; `form` category `input`).
+  **Split into (a) introduce registry+RenderTree behind a flag with a golden snapshot of all 8 widgets
+  captured before the refactor; (b) flip `PageTreeRenderer`/preview to consume it, gated behind the
+  feature flag with fallback to legacy `PageNodeRenderer`.** The one deliberate change (runtime `heading`
+  honors `level`) is a reviewed snapshot diff. **Hard edge: 1g before 2a.**
+- **2b — Schema-driven inspector + palette** (FE). `inspector/*` (incl. `event-list` field = whole
+  `node.events` over `descriptor.supportedEvents`); palette from `widgetRegistry.listByCategory()`.
+  Delete the 4 hardcoded builder switch sites. All new strings via `useI18n`.
+- **2c — Layout engine + dnd-kit canvas** (FE). `canvas/*`, grid/row/column/divider widgets, responsive
+  `span`, drop-into-container, reorder, resize, `treeOps` (finalize), `migrate.ts`. Add `@dnd-kit/*` dep.
+  **Owns the `handleSavePage`/`mergeConfig` rewrite to persist `schemaVersion`/page-level siblings (see
+  Save & persistence)**, the **unsaved-changes guard**, and **deprecating the create-form layout select**
+  (`config.layout` becomes inert legacy). `migrate.ts` tested against a **real legacy page `config`** +
+  idempotency + migrate→save→reload round-trip.
+- **2d — Data binding & expressions** (FE). `BindableField` finalize + `fx` via `FieldExpressionPicker`;
+  `bindingScope`/`resolveBindings`/`interpolate` (make the resolver real; `getPath` skips
+  `__proto__`/`constructor`/`prototype`); **owns creating the page-settings drawer + Variables + Data
+  sources sections**; on-load fetch hook over JSON:API with `MAX_PAGE_DATA_SOURCES` + repeater render cap;
+  `field-value`, `list`/`repeater`. Extends the 2c save call with `variables`/`dataSources`. **Re-runs
+  2a's builtin parity suite unchanged** to prove the now-real resolver is identity on literal props.
+- **2e — Events & actions** (FE). `EventListField` runtime; action runtime (`runFlow` →
+  `/api/flows/{id}/execute` + optional poll reading `data.id`; `navigate`/`openUrl` with **URL scheme
+  allow-list**; `refreshData`/`setVar`/`showToast`; `createRecord`/`updateRecord` → JSON:API). **Owns the
+  post-deploy `page-builder-v2.spec.ts` e2e** (asserts a mutation, not just render).
+- **2f — Typed form widgets** (FE). `form` → `ResourceForm`; standalone typed inputs (`dropdown`,
+  `datepicker`, `checkbox`, `number-input`, `lookup`, `multi-picklist`) from `useCollectionSchema` +
+  picklist endpoint. `rich-text` output sanitized. Replaces text-only `FormNode`.
+- **2g — Widget breadth** (FE). `chart`, `tabs`, `nav`, `icon`, `link` (+`image`) — `link.href`/`image.src`
+  scheme-validated (same allow-list as 2e).
+- **1h — Per-page authz** (backend, optional, last). Config-driven `requiredPermission` gate (404-not-403)
+  + inspector Access field (into 2d's drawer). Worker unit test (allow/deny/absent) **+ a kelta-test-harness
+  `PageRenderAuthzScenarioTest`** (granted vs denied profile under real RLS → 200 vs 404).
+
+Dependency order (hard edges): **1g → 2a → {2b, 2c} → 2d → {2e, 2f, 2g}**; 1h after 1g (any time). 2a
+must tolerate a v1 contract (renders with empty scope) and is flag-gated so `main` is never half-broken.
+Ship 1g first, then 2a, behind the flag, soaked before the runtime flip.
+
+## Critical files
+
+**Refactor:** [PageBuilderPage.tsx](../../../kelta-ui/app/src/pages/PageBuilderPage/PageBuilderPage.tsx)
+(→ thin shell),
+[PageTreeRenderer.tsx](../../../kelta-ui/app/src/pages/app/CustomPage/PageTreeRenderer.tsx)
+(→ `<RenderTree>`), [pageConfig.ts](../../../kelta-ui/app/src/pages/PageBuilderPage/pageConfig.ts),
+[CustomPage.tsx](../../../kelta-ui/app/src/pages/app/CustomPage/CustomPage.tsx),
+[PageRenderContract.java](../../../kelta-worker/src/main/java/io/kelta/worker/service/PageRenderContract.java),
+[PageRenderService.java](../../../kelta-worker/src/main/java/io/kelta/worker/service/PageRenderService.java).
+
+**Create (FE):** `model/{pageModel,bindingScope,resolveBindings,interpolate,treeOps,migrate}.ts`,
+`widgets/{types,registry,renderTree}.tsx` + `widgets/builtins/*`, `inspector/*`, `canvas/*`,
+`hooks/{usePageDataSources,usePageVariables}.ts` — all under
+`kelta-ui/app/src/pages/PageBuilderPage/`.
+
+## Docs to update (per CLAUDE.md Rule 6)
+
+- `.claude/docs/status.md` — page-builder row: add slices; move "typed/validated form fields" (and
+  per-page authz if 1h ships) out of the gap column.
+- `.claude/docs/conventions.md` — document page config v2 as a contract: `$bind` marker + namespace,
+  `variables`/`dataSources`/`events`/`span` shape, v1→v2 back-compat rule.
+- `.claude/docs/architecture.md` — `PageRenderService` row: new contract shape, pass-through-preserves-FLS
+  note, the `requiredPermission` gate (if 1h).
+- `CLAUDE.md` reference-doc table — add a row pointing at `.claude/docs/specs/`.
+- `project_outsystems_roadmap.md` (memory) — record the builder-parity slices under Rec 1.

--- a/.claude/docs/specs/page-builder/1g-render-contract-v2.md
+++ b/.claude/docs/specs/page-builder/1g-render-contract-v2.md
@@ -1,0 +1,532 @@
+# Slice 1g — Render contract v2
+
+> Child spec of [page-builder-parity.md](../page-builder-parity.md). Extends, never contradicts, the
+> parent's [Backend changes (pass-through only)](../page-builder-parity.md#backend-changes-small--pass-through-only),
+> [Page-level config (v2)](../page-builder-parity.md#page-level-config-v2), and
+> [Child-spec template](../page-builder-parity.md#child-spec-template).
+>
+> Source-verified against the codebase on 2026-06-22 (Flyway head **V146**, next **V147**). Current
+> `PageRenderService.CONTRACT_VERSION = "1.0"`. If code and this doc disagree, trust the code and fix
+> this doc.
+
+This is the **backend keystone** of the page-builder parity effort — ship it first. It is additive and
+has **zero FE-feature dependency**: the only FE change is `CustomPage.tsx` reading two new sibling fields,
+which it can ignore until later slices populate them.
+
+---
+
+## 1. Goal & scope
+
+**Deliver** the v2 page render contract as a **pure pass-through** that surfaces the page's
+`variables` and `dataSources` as distinct top-level fields alongside `tree` (which carries the **whole
+`config` map verbatim**, so `tree.components` resolves exactly as today), and bumps the contract
+`version` from `"1.0"` → `"2.0"`, while remaining **fully back-compatible** with v1 pages already stored
+in `ui-pages.config`. The component tree stays at `config.components` — there is **no `config.tree`
+wrapper**.
+
+**In scope**
+- New `PageRenderContract` Java record shape (7 fields, per parent
+  [Backend changes](../page-builder-parity.md#backend-changes-small--pass-through-only)).
+- `PageRenderService.render()` parsing the page's `config` once and projecting it into
+  `{ variables, dataSources, tree }`, where `tree` is the whole parsed `config` map, `variables` =
+  `config.variables` (else `[]`), and `dataSources` = `config.dataSources` (else `[]`). Null-safe.
+- `CONTRACT_VERSION` constant `"1.0"` → `"2.0"`.
+- `CustomPage.tsx` TS type updated to the new shape and to read sibling `variables` / `dataSources`
+  (consumed for real in slices 2d/2e; surfaced here so the contract is stable from day one).
+- Worker unit tests (mocked `QueryEngine`/`CollectionRegistry`) covering v2, v1 fallback,
+  string-vs-Map config, null/missing config, and the unchanged 404 path. Existing
+  `PageRenderControllerTest` fixture updated to the new constructor arity.
+- A kelta-test-harness round-trip scenario (gateway → worker → real Postgres): PATCH a v2 `config`,
+  then `GET …/render` and assert `variables`/`dataSources` surface and `tree.components` is
+  byte-identical — a mocked-`QueryEngine` test can't catch a worker-side `config` JSON serialization
+  drop (§6.4).
+
+**Explicitly NOT in scope (hard constraints)**
+- **NO server-side binding/expression resolution and NO dataSource fetching.** The server never reads a
+  user record to resolve `{{record.name}}` or to execute a `dataSource` query. Doing so would fetch data
+  **outside** the JSON:API path and leak Cerbos/FLS read-denied fields. The contract round-trips the
+  `config` JSON untouched; `$bind` is never parsed server-side. (Parent
+  [Key architecture decisions](../page-builder-parity.md#key-architecture-decisions-verified-against-the-code).)
+- **NO DB migration / no schema change.** Everything new nests inside the existing `ui-pages.config`
+  JSON column (§4).
+- **NO data migration of existing v1 pages.** v1 pages are handled by a runtime fallback, not rewritten.
+- **NO NATS / BeforeSaveHook change.** This is a *read* path; the existing `UIPageConfigEventPublisher` /
+  `UIPageSlugHook` write-path broadcast is untouched (§5).
+- **NO per-page authz** — that is slice 1h.
+
+**Conforms to:** parent §"Backend changes (small — pass-through only)" (the 7-field record + version
+bump + v1 fallback rule), §"Page-level config (v2)" (`variables`/`dataSources` shapes + `$bind`
+round-trip rule), and §"Slice plan → 1g".
+
+---
+
+## 2. UI samples
+
+Backend slice — no UI. Samples are request/response payloads of
+`GET /api/pages/{slug}/render`.
+
+### Request
+
+```
+GET /api/pages/dashboard/render
+Host: app.<tenant>.kelta.io
+Authorization: Bearer <jwt|pat>          # tenant resolved by gateway; RLS scopes the query
+Accept: application/json
+```
+
+(No path/query params beyond `{slug}`. Tenant context is bound per request by `TenantContextFilter`;
+the service only returns `published=true` + `active=true` pages.)
+
+### (a) v2 page — `config` already authored in v2 shape
+
+Stored `ui-pages.config` (object inside the JSON column — the tree lives at `config.components`;
+`variables`/`dataSources`/`schemaVersion` are **siblings**, not nested under a `tree` key):
+
+```json
+{
+  "schemaVersion": 2,
+  "variables": [
+    { "name": "statusFilter", "type": "string", "default": "open" }
+  ],
+  "dataSources": [
+    { "name": "tickets", "collection": "tickets", "mode": "list",
+      "filter": { "status": { "$bind": "vars.statusFilter", "mode": "path" } }, "limit": 25 }
+  ],
+  "layout": { "kind": "grid", "columns": 12 },
+  "components": [
+    { "id": "h1", "type": "heading", "props": { "text": "Open tickets" } },
+    { "id": "t1", "type": "table",
+      "props": { "source": { "$bind": "data.tickets", "mode": "path" } } }
+  ]
+}
+```
+
+Response `200 application/json` — `tree` is the **whole `config` map verbatim** (so `tree.components`
+resolves); `variables`/`dataSources` are *also* surfaced as separate sibling fields read from
+`config.*`:
+
+```json
+{
+  "version": "2.0",
+  "slug": "dashboard",
+  "title": "Support Dashboard",
+  "path": "/dashboard",
+  "variables": [
+    { "name": "statusFilter", "type": "string", "default": "open" }
+  ],
+  "dataSources": [
+    { "name": "tickets", "collection": "tickets", "mode": "list",
+      "filter": { "status": { "$bind": "vars.statusFilter", "mode": "path" } }, "limit": 25 }
+  ],
+  "tree": {
+    "schemaVersion": 2,
+    "variables": [
+      { "name": "statusFilter", "type": "string", "default": "open" }
+    ],
+    "dataSources": [
+      { "name": "tickets", "collection": "tickets", "mode": "list",
+        "filter": { "status": { "$bind": "vars.statusFilter", "mode": "path" } }, "limit": 25 }
+    ],
+    "layout": { "kind": "grid", "columns": 12 },
+    "components": [
+      { "id": "h1", "type": "heading", "props": { "text": "Open tickets" } },
+      { "id": "t1", "type": "table",
+        "props": { "source": { "$bind": "data.tickets", "mode": "path" } } }
+    ]
+  }
+}
+```
+
+Note: `tree` carries the entire `config` (siblings included); the FE reads `tree.components` exactly as
+today. `$bind` markers are echoed verbatim — the server does not resolve them.
+
+### (b) legacy v1 page — no `variables`/`dataSources` siblings
+
+Stored `ui-pages.config` (the legacy shape — `components`/`layout` at the top level, no
+`variables`/`dataSources` keys; structurally identical to a v2 page that simply has no page-level
+siblings yet):
+
+```json
+{
+  "components": [
+    { "id": "c1", "type": "heading", "props": { "text": "Welcome" } },
+    { "id": "c2", "type": "text", "props": { "content": "Legacy page" } }
+  ],
+  "layout": { "kind": "stack" }
+}
+```
+
+Response `200 application/json` — `tree` is the **whole `config` map verbatim** (same pass-through as
+the v2 case); `variables`/`dataSources` default to `[]` because the keys are absent; `version` is
+`"2.0"`:
+
+```json
+{
+  "version": "2.0",
+  "slug": "welcome",
+  "title": "Welcome",
+  "path": "/welcome",
+  "variables": [],
+  "dataSources": [],
+  "tree": {
+    "components": [
+      { "id": "c1", "type": "heading", "props": { "text": "Welcome" } },
+      { "id": "c2", "type": "text", "props": { "content": "Legacy page" } }
+    ],
+    "layout": { "kind": "stack" }
+  }
+}
+```
+
+The FE still reads `tree.components`, so v1 pages render byte-identically — the v1 and v2 responses are
+produced by the **same** pass-through (`tree:<wholeConfig>`); the only difference is whether
+`variables`/`dataSources` are empty or populated. Unknown/unpublished slug → `404` with no body
+(unchanged).
+
+---
+
+## 3. Data & API contracts
+
+### 3.1 Endpoint (unchanged)
+
+`GET /api/pages/{slug}/render` →
+- `200` `application/json` body = `PageRenderContract` (new shape below), or
+- `404` (no body) when the slug is unknown, unpublished, inactive, or blank.
+
+Controller (`PageRenderController.render`) is unchanged — it maps `Optional.empty()` → `notFound()`.
+
+### 3.2 New `PageRenderContract` Java record (7 fields)
+
+Matches parent §"Backend changes" exactly:
+
+```java
+public record PageRenderContract(
+        String version,
+        String slug,
+        String title,
+        String path,
+        List<Map<String, Object>> variables,
+        List<Map<String, Object>> dataSources,
+        Map<String, Object> tree
+) {
+}
+```
+
+Field semantics:
+
+| Field | Type | Source | v1 fallback |
+|-------|------|--------|-------------|
+| `version` | `String` | `CONTRACT_VERSION` constant | `"2.0"` (always — version describes the *contract*, not the stored config) |
+| `slug` | `String` | `page.get("slug")` | unchanged |
+| `title` | `String` | `page.get("title")` | unchanged |
+| `path` | `String` | `page.get("path")` | unchanged |
+| `variables` | `List<Map<String,Object>>` | `config.get("variables")` if a `List` | `[]` |
+| `dataSources` | `List<Map<String,Object>>` | `config.get("dataSources")` if a `List` | `[]` |
+| `tree` | `Map<String,Object>` | the **whole parsed `config` map** (verbatim — both v1 and v2) | whole config |
+
+`variables` and `dataSources` are surfaced as raw `List<Map<String,Object>>` — **no typed DTO**, no
+parsing of their internals (consistent with the existing `tree` being raw `Map<String,Object>`). The
+server treats them as opaque JSON to round-trip.
+
+### 3.3 Version transition
+
+`PageRenderService.CONTRACT_VERSION`: **`"1.0"` → `"2.0"`** (string literal). Bumped because the
+contract is evolving (new sibling `variables`/`dataSources` fields surfaced from `config`). Every
+response — including a v1 page with no such keys — reports `"2.0"`.
+
+### 3.4 Parsing rules in `render()` (authoritative)
+
+Given the page row's `config` value (which the runtime delivers as **either** a `Map<String,Object>`
+**or** a JSON `String`, per the existing config-parse handling absorbed by `parseConfig` — see §5):
+
+1. **Parse `config` once** into a `Map<String,Object>` (`parsedConfig`):
+   - `config instanceof Map` → cast directly.
+   - `config instanceof String` and non-blank → `objectMapper.readValue(str, MAP_TYPE)`; on parse failure
+     log a warning and treat as empty (`Map.of()`) — preserves the current resilient behavior.
+   - `null` / blank / unparseable → `Map.of()`.
+2. **`tree`** = the **whole `parsedConfig` map, verbatim** — for **both** v1 and v2 pages. There is no
+   `config.tree` key to unwrap; the tree always lives at `config.components`, so handing the FE the whole
+   `config` makes `tree.components` resolve. Never `null` — defaults to `Map.of()`.
+3. **`variables`** = `parsedConfig.get("variables")` **if it is a `List`**, coerced to
+   `List<Map<String,Object>>`, **else** `List.of()`.
+4. **`dataSources`** = `parsedConfig.get("dataSources")` **if it is a `List`**, coerced likewise, **else**
+   `List.of()`.
+5. Everything is null-safe: a missing/null/empty/garbage `config` yields
+   `version:"2.0", variables:[], dataSources:[], tree:{}`.
+
+**Back-compat rule (precise):** There is **no v1-vs-v2 discriminator** — both kinds run through the
+identical projection. `tree` is always the whole parsed `config`; `variables`/`dataSources` are whatever
+those `config` keys hold (empty for a legacy page that lacks them, populated for a v2 page). The contract
+never inspects `schemaVersion` and never looks for a `tree` key. This keeps every existing v1 page
+rendering byte-identically through `tree.components` while v2 pages additionally surface their
+page-level siblings.
+
+### 3.5 FE TypeScript contract (consumed in `CustomPage`)
+
+```ts
+/** Versioned page render contract returned by GET /api/pages/{slug}/render. */
+interface PageRenderContract {
+  version: string
+  slug: string
+  title: string | null
+  path: string | null
+  variables: PageVariable[]
+  dataSources: PageDataSource[]
+  tree: { components?: PageNode[]; layout?: unknown }
+}
+```
+
+`PageVariable` / `PageDataSource` are the parent's
+[Page-level config (v2)](../page-builder-parity.md#page-level-config-v2) types
+(`pageConfig.ts`). For 1g, importing them (or typing the two arrays as those interfaces) is sufficient;
+this slice does **not** wire them into rendering — it only stops them from being dropped on the floor.
+`tree.components` continues to drive `PageTreeRenderer`, so runtime output is unchanged.
+
+---
+
+## 4. DB migrations
+
+**None — stored in `ui-pages.config` JSON, no DDL.**
+
+Verified: `ui-pages` (`SystemCollectionDefinitions.uiPages()`,
+`runtime-core/.../model/system/SystemCollectionDefinitions.java:341`) already declares
+`FieldDefinition.json("config")`. `variables`, `dataSources`, and `components` all nest inside that
+single JSON column (and `tree` is just that whole `config` map echoed back, not a stored key) — no new
+columns, no Flyway migration. Flyway head confirmed **V146**
+(`V146__add_saml_provider.sql` is the highest in
+`kelta-worker/src/main/resources/db/migration/`); next available is **V147**, but this slice adds none.
+
+---
+
+## 5. File-by-file code changes
+
+Java 25, records, JDBC (no JPA). This is a **read** path (no system-collection *write*), so **no new
+NATS subject and no `BeforeSaveHook`** are required — the existing `UIPageConfigEventPublisher` /
+`UIPageSlugHook` write-path broadcast is untouched. No gateway route change (`/api/pages/**` already
+registered).
+
+### 5.1 `kelta-worker/src/main/java/io/kelta/worker/service/PageRenderContract.java` — modify
+
+Old (5 fields):
+
+```java
+public record PageRenderContract(
+        String version, String slug, String title, String path,
+        Map<String, Object> tree) {}
+```
+
+New (7 fields — add `List` import):
+
+```java
+import java.util.List;
+import java.util.Map;
+
+public record PageRenderContract(
+        String version,
+        String slug,
+        String title,
+        String path,
+        List<Map<String, Object>> variables,
+        List<Map<String, Object>> dataSources,
+        Map<String, Object> tree
+) {}
+```
+
+Update the Javadoc to note `variables`/`dataSources` are pass-through page-level config and that the
+server never resolves bindings.
+
+### 5.2 `kelta-worker/src/main/java/io/kelta/worker/service/PageRenderService.java` — modify
+
+- Bump the constant:
+
+```java
+static final String CONTRACT_VERSION = "2.0";   // was "1.0"
+```
+
+- Replace the `extractTree(...)`-only projection with a single parse + project. Sketch of the new
+  `render()` tail and helpers (keeps the existing query/filter block exactly as-is):
+
+```java
+Map<String, Object> page = result.data().getFirst();
+Map<String, Object> config = parseConfig(page.get("config"));   // never null
+return Optional.of(new PageRenderContract(
+        CONTRACT_VERSION,
+        asString(page.get("slug")),
+        asString(page.get("title")),
+        asString(page.get("path")),
+        extractObjectList(config.get("variables")),
+        extractObjectList(config.get("dataSources")),
+        config));                                                // tree = whole config, verbatim
+```
+
+```java
+/** Parse the page's {@code config} JSON (delivered as a Map or a serialized String) once. */
+@SuppressWarnings("unchecked")
+private Map<String, Object> parseConfig(Object config) {
+    if (config instanceof Map<?, ?> map) {
+        return (Map<String, Object>) map;
+    }
+    if (config instanceof String str && !str.isBlank()) {
+        try {
+            return objectMapper.readValue(str, MAP_TYPE);
+        } catch (RuntimeException e) {
+            log.warn("Failed to parse ui-page config JSON: {}", e.getMessage());
+        }
+    }
+    return Map.of();
+}
+
+/** Page-level {@code variables}/{@code dataSources}; opaque pass-through, default empty. */
+@SuppressWarnings("unchecked")
+private static List<Map<String, Object>> extractObjectList(Object value) {
+    if (value instanceof List<?> list) {
+        return (List<Map<String, Object>>) (List<?>) list;
+    }
+    return List.of();
+}
+```
+
+Notes:
+- The `tree` field is the parsed `config` map handed back **verbatim** — no `tree`-key unwrap, no
+  v1-vs-v2 branch. `parseConfig` absorbs and generalizes the old `extractTree(Object)` (which combined
+  parse + cast); the former `extractTree(Map)` discriminator is **deleted** (there is no `config.tree`).
+- `MAP_TYPE`, `objectMapper`, `asString`, `log`, the `QueryEngine`/`CollectionRegistry` lookup, the
+  `slug+published+active` `FilterCondition`s, and the `result.data().isEmpty()` → `Optional.empty()`
+  guard are **unchanged**.
+- Still returns `Optional.empty()` for blank slug, missing `ui-pages` collection, and zero matches →
+  controller still 404s.
+
+### 5.3 `kelta-ui/app/src/pages/app/CustomPage/CustomPage.tsx` — modify
+
+- Update the local `PageRenderContract` interface to the 7-field shape (§3.5), typing `variables` /
+  `dataSources` as `PageVariable[]` / `PageDataSource[]` (import from
+  `@/pages/PageBuilderPage/pageConfig` once those types land, or `unknown[]` as an interim if 1g ships
+  before 2d — prefer the typed import; the types already exist per parent §"Page-level config (v2)").
+- Rendering is unchanged: still
+  `<PageTreeRenderer components={contract.tree?.components ?? []} tenantSlug={...} />`. Reading the two
+  new siblings is wired up by slices 2d/2e; 1g only widens the type so they are not lost. Do **not**
+  resolve bindings or fetch data sources here.
+
+### 5.4 No other production code changes
+
+Confirmed by grep: the only consumers of `PageRenderContract` are `CustomPage.tsx`,
+`PageRenderController.java` (unchanged — it is generic over the record), and the two worker test classes.
+`PageTreeRenderer.tsx` reads `tree.components` and is untouched.
+
+---
+
+## 6. Test plan
+
+Worker unit tests — mocked `QueryEngine` + `CollectionRegistry`, real `JsonMapper` (no DB), matching the
+existing idiom in
+`kelta-worker/src/test/java/io/kelta/worker/service/PageRenderServiceTest.java`
+(`@ExtendWith(MockitoExtension.class)`, `JsonMapper.builder().build()`, `QueryResult.of(...)` helper) per
+`.claude/docs/testing.md`.
+
+### 6.1 `PageRenderServiceTest` (extend existing class)
+
+| Test | Setup | Assert |
+|------|-------|--------|
+| `rendersV2Page` (new) | `config` Map with top-level `components`, `variables`(1), `dataSources`(1) | `version=="2.0"`; `tree` == whole config (contains `components`, `variables`, `dataSources`); `tree.get("components")` is the components list; `variables` size 1; `dataSources` size 1 |
+| `v1WholeConfigToTree` (new) | `config` Map with `components` but **no** `variables`/`dataSources` keys | `tree` == whole config (contains `components`); `variables` empty; `dataSources` empty; `version=="2.0"` |
+| `parsesStringConfig` (update existing) | `config` as JSON **String** `{"components":[...]}` | `tree` contains `components`; lists default empty — proves String path parses once |
+| `v1StringConfigToTree` (new) | `config` as JSON **String** with top-level `components`, no siblings | whole parsed config → `tree`; lists empty |
+| `nullConfig` (new) | `config` == `null` | `tree` empty map; `variables`/`dataSources` empty; `version=="2.0"` (no NPE) |
+| `garbageStringConfig` (new) | `config` == `"not json"` | `tree` empty; lists empty; warns, no throw |
+| `rendersPublishedPage` (update existing) | as today | bump expected `version` to `"2.0"`; keep the `slug+published+active` filter assertions verbatim |
+| `notFoundWhenNoMatch` (keep) | zero rows | `Optional.empty()` |
+| `emptyWhenNoCollection` (keep) | `collectionRegistry.get("ui-pages")==null` | empty; `verifyNoInteractions(queryEngine)` |
+| `blankSlug` (keep) | `"  "` | empty; registry never touched |
+
+The existing `slug+published+active` `FilterCondition` assertions stay — this slice does not change the
+query.
+
+### 6.2 `PageRenderControllerTest` (update existing fixture — compile fix)
+
+The current test constructs `new PageRenderContract("1.0", "home", "Home", "/home", Map.of(...))` — the
+5-arg form. The new record is 7-arg, so this **will not compile** until updated. Change the fixture to:
+
+```java
+PageRenderContract contract = new PageRenderContract(
+        "2.0", "home", "Home", "/home", List.of(), List.of(),
+        Map.of("components", List.of()));
+```
+
+Keep both controller tests (`rendersPage` 200, `notFound` 404) otherwise unchanged — controller behavior
+is identical.
+
+### 6.3 FE
+
+No new Vitest needed for 1g (no behavior change in `CustomPage` — type-only widening). `npm run typecheck`
+in `kelta-ui/app` must pass with the new interface. The runtime-render Vitest coverage arrives with slice
+2a. Playwright: existing custom-page e2e must stay green (v1 pages render unchanged); no new e2e required
+for this pass-through slice.
+
+### 6.4 Integration (kelta-test-harness)
+
+**Add `PageRenderV2ScenarioTest`** (mirror `UiPageCreateScenarioTest`'s style:
+`extends ScenarioBase`, `auth.loginAsAdmin()`, `tenants.slugForTenantId(...)`,
+`gatewayClientWithToken(token)`, `waitForStatus(...)` before the first call). The mocked worker unit
+tests prove the *parsing* matrix but run with no DB — they cannot catch a worker-side `config` JSON
+serialization drop on the round-trip through real Postgres. Per the project's
+[DB-constraint / serialization test-gap convention](../../../projects/-Users-craigklinker-GitHub-emf/memory/feedback_db-constraint-test-gap.md)
+(mocked-QueryEngine tests can't see persistence drift), this slice adds **exactly one** real-DB
+round-trip:
+
+1. Wait for `/{slug}/api/ui-pages` to be live, then **PATCH** (or create) a page whose `config` is a
+   **v2** shape: a `variables` array (≥1), a `dataSources` array (≥1), and a `components` tree (with a
+   `layout` sibling) — all inside the single `config` JSON column. Set `published=true` + `active=true`
+   so the render gate passes.
+2. **`GET /{slug}/api/pages/{pageSlug}/render`** through the gateway.
+3. Assert: `version == "2.0"`; the response `variables`/`dataSources` arrays surface with the authored
+   contents (proves they survived JSON (de)serialization in Postgres → worker); and
+   `tree.get("components")` is **byte-identical** to the components list that was written
+   (`assertThat(tree.get("components")).isEqualTo(authoredComponents)`), proving the whole-`config`
+   pass-through round-trips with no drop or reordering.
+
+This is the read-side analogue of `UiPageCreateScenarioTest`'s write-path guard, scoped to the v2
+`config` serialization that the unit tests structurally cannot exercise.
+
+---
+
+## 7. Docs to update (same PR)
+
+| Doc | Change |
+|-----|--------|
+| `.claude/docs/architecture.md` | `PageRenderService` row: new 7-field contract shape (`version, slug, title, path, variables, dataSources, tree`); `version "2.0"`; note it stays a **pass-through that resolves no bindings/dataSources, preserving Cerbos/FLS** (all data still flows through JSON:API in later slices). |
+| `.claude/docs/status.md` | Page-builder row: note render contract is at **v2** (`variables`/`dataSources`/`tree` surfaced, v1 back-compat); subsystem still UI-stub for binding/logic until 2d/2e. |
+
+(Per parent §"Docs to update", `conventions.md` documents the full page-config-v2 `$bind`/namespace
+contract — that lands with the FE binding slices 2a/2d, not 1g. This backend slice touches only the two
+rows above.)
+
+---
+
+## 8. Risks & open questions
+
+- **Renderer must tolerate `version:"2.0"` with empty arrays.** Every v1 page now reports `"2.0"` with
+  `variables:[]` / `dataSources:[]` and the whole config as `tree`. Any FE consumer that branches on
+  `version` must treat `"2.0"` + empty arrays as the normal/legacy case — **not** assume `"2.0"` implies
+  populated config. `CustomPage` already renders purely off `tree.components`, so it is safe; document this
+  invariant so slices 2a–2e don't add a brittle `version === '2.0'` gate.
+- **Pass-through is load-bearing for security.** Resolving bindings or executing `dataSources` server-side
+  would bypass Cerbos/`CerbosFieldSecurityAdvice` FLS and leak read-denied fields. Keep `render()` a
+  projection only; all record access must remain on the JSON:API path (enforced in 2d/2e on the client via
+  the authorized API). Reviewers should reject any server-side `$bind`/dataSource evaluation in this or
+  downstream slices.
+- **Known breaking consumer of the old shape:** `PageRenderControllerTest` constructs the 5-arg record and
+  **will fail to compile** until updated (§6.2). This is the only such site (grep-verified) — production
+  code (`PageRenderController`) is generic over the record and needs no change.
+- **`config` shape (resolved — no discriminator):** the contract does **not** branch on `schemaVersion`
+  or on a `tree` key; `tree` is always the whole parsed `config`, and `variables`/`dataSources` are
+  whatever those `config` keys hold. The component tree stays at `config.components` (per parent
+  §"Page-level config (v2) → Canonical storage") — there is **no `config.tree` wrapper**, so 2c's
+  `migrate.ts` and the builder's `handleSavePage` must keep writing `components` (plus
+  `variables`/`dataSources`/`schemaVersion` as siblings) at the top level of `config`, never nest a
+  `tree` key. 1g needs no change for that; the slices simply share the `config.components` convention.
+- **Coercion is unchecked-cast pass-through.** `extractObjectList` does a `(List<Map<String,Object>>)`
+  cast without per-element validation (consistent with `tree`'s existing raw-`Map` cast). Acceptable
+  because the values are opaque JSON serialized straight back to the client; no element is dereferenced
+  server-side. No `@Entity`/JPA involved (Critical Rule 2 upheld).
+- **`PageRenderService` size:** small (~96 lines) and not flagged in `concerns.md`; this change keeps it
+  small. No oversized-file hazard.

--- a/.claude/docs/specs/page-builder/1h-per-page-authz.md
+++ b/.claude/docs/specs/page-builder/1h-per-page-authz.md
@@ -1,0 +1,576 @@
+# Slice 1h — Per-page authorization (optional)
+
+> Child spec of [page-builder-parity.md](../page-builder-parity.md). Extends, never contradicts, the
+> parent's [Backend changes (pass-through only)](../page-builder-parity.md#backend-changes-small--pass-through-only)
+> (the "Per-page authz (optional, slice 1h)" bullet) and [Page-level config (v2)](../page-builder-parity.md#page-level-config-v2)
+> (the `access?: { requiredPermission?: string }` key). Builds directly on
+> [1g — Render contract v2](./1g-render-contract-v2.md) — that slice's 7-field `PageRenderContract`
+> and `parseConfig` helper are assumed to already be in place.
+>
+> Source-verified against the codebase on 2026-06-22 (Flyway head **V146**, next **V147**). If code
+> and this doc disagree, trust the code and fix this doc.
+
+This is the **optional, last** backend slice. It is additive and **config-driven**: a page with no
+`config.access.requiredPermission` behaves exactly as today (the published+active+tenant gate is the
+only visibility check). A page that declares a required permission is gated on that **system
+permission**, checked at render time with the **same in-controller `profile_system_permission` lookup
+that `/api/admin/**` controllers use** — and a denial returns **404, not 403**, to match the existing
+unknown-slug privacy posture (we do not leak that a restricted page exists).
+
+---
+
+## 1. Goal & scope
+
+**Deliver** an opt-in per-page authorization gate. When a page's stored `config` contains
+`access.requiredPermission` (a `profile_system_permission.permission_name` value such as `VIEW_SETUP`),
+`PageRenderService.render()` resolves the caller's profile, checks whether that profile is **granted**
+the permission, and on denial returns `Optional.empty()` so `PageRenderController` returns **404** with
+no body — indistinguishable from an unknown/unpublished slug. When the key is absent, behavior is
+**byte-identical to 1g** (the existing slug + `published` + `active` filter is the whole gate).
+
+**In scope**
+
+- A new `config.access.requiredPermission` (optional `String`) key, nested inside the existing
+  `ui-pages.config` JSON column (no DB change).
+- `PageRenderService.render(...)` gaining the caller's `profileId` and, **only when
+  `requiredPermission` is present**, performing the system-permission check via
+  `BootstrapRepository.findProfileSystemPermissions(profileId)` — the exact pattern
+  `TenantOtlpTargetController` and `UserPermissionsController` use (architecture.md
+  ["Worker-side system-permission check"](../../architecture.md)).
+- `PageRenderController` resolving `profileId` from the gateway-forwarded `X-User-Profile-Id` header
+  via the existing `CerbosPermissionResolver`, and passing it into `render(...)`.
+- A small FE inspector control — a **page-settings "Access" field** (permission picker) — that writes
+  `config.access.requiredPermission` from the tenant's system-permission catalog. It is hosted **inside
+  the page-settings drawer that slice 2d creates** (1h does not introduce its own panel and must not
+  assume a pre-existing one), and reuses the 2b inspector field-kind machinery (a `select`-kind
+  page-settings field). **The FE control therefore depends on 2d**; the backend gate (§3.3, §5.1–5.2)
+  is independent of the FE and can ship first.
+- Worker unit tests: allow → contract present; deny → `Optional.empty()` (404); absent key →
+  unchanged back-compat (no permission lookup at all).
+- A **kelta-test-harness `PageRenderAuthzScenarioTest`** (real Postgres + RLS, gateway → worker):
+  a restricted page + a granted and a denied profile in one tenant → `200` vs `404` through the real
+  stack, proving RLS-scoped grant reads and `X-User-Profile-Id` forwarding (§6.3, per the DB-constraint
+  test-gap convention).
+- i18n for the FE Access field label, the "Anyone (published)" option, and the 404 privacy-hint string
+  (no hardcoded author-facing literals — §5.4).
+
+**Explicitly NOT in scope (hard constraints)**
+
+- **NO DB column, NO Flyway migration, NO data migration.** `requiredPermission` lives inside the
+  existing `config` JSON. Promoting it to a real `ui_page` column is the **only** thing that would
+  justify a future `V147`, and is deliberately **not** done here (§4).
+- **NO NATS / BeforeSaveHook change.** This is a **read** path. The existing
+  `UIPageConfigEventPublisher` (`kelta.config.page.changed.<pageId>`) / `UIPageSlugHook` write-path
+  broadcast is untouched; no new subject.
+- **NO Cerbos PDP call.** Per architecture.md, system permissions are **not** checked via a Cerbos
+  `CheckResources` call in the worker — they are a DB lookup against `profile_system_permission`.
+  We reuse that DB lookup; we do **not** introduce a Cerbos request.
+- **NO 403.** A denial must be a **404** (privacy parity with unknown slug). Returning 403 would leak
+  the existence of a restricted page; reviewers should reject any 403 path here.
+- **NO server-side binding/dataSource resolution** (the 1g invariant stands — `render()` remains a
+  projection over the `config` JSON; the only new behavior is the gate).
+- **NO gateway route change.** `/api/pages/**` is already a registered static route; this slice adds
+  no new top-level path.
+
+**Conforms to:** parent §"Backend changes" (the 1h bullet — "check it via the same in-controller Cerbos
+system-permission mechanism `/api/admin/**` uses; deny → `Optional.empty()` → 404"),
+§"Page-level config (v2)" (`access?: { requiredPermission?: string }`), and architecture.md
+§"Authorizing a new endpoint → Worker-side system-permission check".
+
+---
+
+## 2. UI samples
+
+### 2.1 Inspector — page-settings "Access" control
+
+A new **page-settings** field (not a per-widget prop) hosted **inside the page-settings drawer that
+slice 2d creates** (1h adds no panel of its own and does not assume one pre-exists), rendered by the
+same schema-driven inspector loop introduced in 2b. It is a `select`-kind field whose options are
+the tenant's system-permission catalog (the 15 permissions in
+[`SystemPermissionChecklist.tsx`](../../../../kelta-ui/app/src/components/SecurityEditor/SystemPermissionChecklist.tsx) —
+`VIEW_SETUP`, `MANAGE_USERS`, `MANAGE_REPORTS`, …), plus a default "Anyone (published)" no-restriction
+option that clears the key.
+
+```
+┌─ Page settings ─────────────────────────────────┐
+│  Name        [ Support Dashboard            ]    │
+│  Slug        [ dashboard                    ]    │
+│  Path        [ /dashboard                   ]    │
+│  Published   [x]                                 │
+│                                                  │
+│  ── Access ──────────────────────────────────   │
+│  Required permission                             │
+│  ┌────────────────────────────────────────────┐ │
+│  │ Anyone (published)                       ▾ │ │  ← default; clears access.requiredPermission
+│  └────────────────────────────────────────────┘ │
+│    Options (grouped, from SystemPermissionChecklist):
+│      Anyone (published)                          │
+│      ── Application Setup ──                      │
+│      View Setup            (VIEW_SETUP)           │
+│      Customize Application (CUSTOMIZE_APPLICATION)│
+│      ── User & Group Management ──                │
+│      Manage Users         (MANAGE_USERS)         │
+│      …                                           │
+│  ⓘ Users without this permission get a 404 — the │
+│     page is hidden, not shown as forbidden.      │
+└──────────────────────────────────────────────────┘
+```
+
+Selecting **"View Setup"** writes `config.access.requiredPermission = "VIEW_SETUP"`; selecting
+**"Anyone (published)"** deletes the `access` key (or sets `access.requiredPermission` to `undefined`,
+which is stripped on save). The label/description shown come from the catalog entry
+(`label: 'View Setup'`), the stored value is the raw `name` (`VIEW_SETUP`).
+
+### 2.2 Stored `config` deltas
+
+**Restricted page** (stored `config` excerpt — v2 shape from 1g, with the new `access` sibling).
+Per the parent's [canonical storage](../page-builder-parity.md#page-level-config-v2), the tree lives
+at **`config.components`** — there is **no `config.tree` wrapper** in stored config; `access`,
+`variables`, `dataSources`, and `schemaVersion` are siblings of `components`:
+
+```json
+{
+  "schemaVersion": 2,
+  "access": { "requiredPermission": "VIEW_SETUP" },
+  "variables": [],
+  "dataSources": [],
+  "components": [
+    { "id": "h1", "type": "heading", "props": { "text": "Admin Dashboard" } }
+  ]
+}
+```
+
+**Unrestricted page** — no `access` key at all (identical to a 1g page):
+
+```json
+{
+  "schemaVersion": 2,
+  "variables": [],
+  "dataSources": [],
+  "components": [ { "id": "h1", "type": "heading", "props": { "text": "Home" } } ]
+}
+```
+
+(The render *contract* below still carries a `tree` field — it is the whole `config` map verbatim, so
+`tree.components` resolves — but that `tree` is a contract field, **not** a stored-config wrapper.)
+
+### 2.3 Render responses (`GET /api/pages/{slug}/render`)
+
+Tenant + JWT/PAT resolved by the gateway; `X-User-Profile-Id` forwarded on every request.
+
+**(a) Allowed** — caller's profile **is granted** `VIEW_SETUP` → `200`, the full 1g v2 contract:
+
+```http
+GET /api/pages/dashboard/render        # X-User-Profile-Id: <profile-with-VIEW_SETUP>
+→ 200 application/json
+{
+  "version": "2.0",
+  "slug": "dashboard",
+  "title": "Admin Dashboard",
+  "path": "/dashboard",
+  "variables": [],
+  "dataSources": [],
+  "tree": { "components": [ { "id": "h1", "type": "heading", "props": { "text": "Admin Dashboard" } } ] }
+}
+```
+
+The `access` key is **not** echoed in the contract — it is consumed server-side, not part of the render
+output (the FE never needs it at render time; the editor reads it from the page record it already
+fetches for editing).
+
+**(b) Denied** — caller's profile is **not** granted `VIEW_SETUP` → `404`, **no body** (identical to an
+unknown slug — page existence is not leaked):
+
+```http
+GET /api/pages/dashboard/render        # X-User-Profile-Id: <profile-without-VIEW_SETUP>
+→ 404 Not Found
+(no body)
+```
+
+**(c) Absent key** — page has no `access.requiredPermission` → unchanged 1g behavior; the
+permission lookup is **never performed** (no DB hit), the published+active+tenant gate is the whole
+check:
+
+```http
+GET /api/pages/home/render             # any authenticated profile
+→ 200 application/json
+{ "version": "2.0", "slug": "home", ... }   # exactly as 1g
+```
+
+---
+
+## 3. Data & API contracts
+
+### 3.1 `config.access` shape (inside `ui-pages.config` JSON)
+
+```ts
+// pageConfig.ts — extends the v2 PageConfig (parent §"Page-level config (v2)")
+interface PageAccess {
+  /** A profile_system_permission.permission_name value, e.g. "VIEW_SETUP". Absent ⇒ no restriction. */
+  requiredPermission?: string
+}
+interface PageConfig {
+  layout?: PageLayout
+  components?: PageComponent[]
+  // v2 (1g):
+  variables?: PageVariable[]
+  dataSources?: PageDataSource[]
+  tree?: PageTree
+  schemaVersion?: 2
+  // 1h:
+  access?: PageAccess
+}
+```
+
+The value is an **opaque string** server-side — the worker compares it against
+`profile_system_permission.permission_name`; it does not validate it against the catalog. (An unknown
+permission name simply matches no granted row ⇒ deny ⇒ 404, which is the safe default.) The
+`access` key is **not** surfaced on `PageRenderContract` (it is consumed, not projected).
+
+### 3.2 Endpoint (unchanged signature, new gate)
+
+`GET /api/pages/{slug}/render` →
+- `200` `application/json` = `PageRenderContract` (7-field, from 1g) when the slug matches a
+  published+active page in the tenant **and** (no `requiredPermission`, **or** the caller's profile is
+  granted it), else
+- `404` (no body) when the slug is unknown / unpublished / inactive / blank **or** the caller lacks the
+  required permission. **No new status code; no 403.**
+
+### 3.3 `render(...)` change (authoritative)
+
+The check inserts **after** the existing slug+published+active query succeeds (so an unknown page still
+404s before any permission work) and **after** `parseConfig` (1g), but **before** building the
+`PageRenderContract`. The current 1g tail:
+
+```java
+Map<String, Object> page = result.data().getFirst();
+Map<String, Object> config = parseConfig(page.get("config"));   // 1g helper, never null
+return Optional.of(new PageRenderContract(
+        CONTRACT_VERSION,
+        asString(page.get("slug")), asString(page.get("title")), asString(page.get("path")),
+        extractObjectList(config.get("variables")),
+        extractObjectList(config.get("dataSources")),
+        extractTree(config)));
+```
+
+becomes (signature gains `profileId`; gate inserted before the `return`):
+
+```java
+public Optional<PageRenderContract> render(String slug, String profileId) {
+    // ... unchanged blank-slug guard, ui-pages lookup, slug+published+active query ...
+    Map<String, Object> page = result.data().getFirst();
+    Map<String, Object> config = parseConfig(page.get("config"));
+
+    // --- 1h: optional per-page authorization gate ---------------------------
+    String requiredPermission = extractRequiredPermission(config);
+    if (requiredPermission != null && !hasSystemPermission(profileId, requiredPermission)) {
+        // Deny is a 404, not a 403 — never leak that a restricted page exists.
+        return Optional.empty();
+    }
+    // ------------------------------------------------------------------------
+
+    return Optional.of(new PageRenderContract(
+            CONTRACT_VERSION,
+            asString(page.get("slug")), asString(page.get("title")), asString(page.get("path")),
+            extractObjectList(config.get("variables")),
+            extractObjectList(config.get("dataSources")),
+            extractTree(config)));
+}
+```
+
+New private helpers in `PageRenderService` (the permission check is the **same** pattern as
+`TenantOtlpTargetController.requireSetupPermission` and `SupersetGuestTokenService.hasSystemPermission`,
+but returning `Optional.empty()` instead of throwing):
+
+```java
+/** config.access.requiredPermission, or null when the page declares no restriction. */
+@SuppressWarnings("unchecked")
+private static String extractRequiredPermission(Map<String, Object> config) {
+    if (config.get("access") instanceof Map<?, ?> access
+            && access.get("requiredPermission") instanceof String perm && !perm.isBlank()) {
+        return perm;
+    }
+    return null;
+}
+
+/**
+ * True iff {@code profileId} is granted {@code permission} in profile_system_permission.
+ * Same lookup admin controllers use — BootstrapRepository.findProfileSystemPermissions —
+ * NOT a Cerbos PDP call (system permissions are a DB grant, per architecture.md).
+ */
+private boolean hasSystemPermission(String profileId, String permission) {
+    if (profileId == null || profileId.isBlank()) {
+        return false;                              // no identity ⇒ deny ⇒ 404
+    }
+    return bootstrapRepository.findProfileSystemPermissions(profileId).stream()
+            .anyMatch(p -> permission.equals(p.get("permission_name"))
+                    && Boolean.TRUE.equals(p.get("granted")));
+}
+```
+
+**Permission-check helper found in the real code (reuse this exact mechanism):**
+
+- Identity: [`CerbosPermissionResolver.getProfileId(HttpServletRequest)`](../../../../kelta-worker/src/main/java/io/kelta/worker/service/CerbosPermissionResolver.java)
+  reads `request.getHeader("X-User-Profile-Id")` (set by the gateway's
+  `RouteAuthorizationFilter.forwardWithHeaders` on **every** forwarded request, including
+  `/api/pages/**`).
+- Grant lookup: [`BootstrapRepository.findProfileSystemPermissions(String profileId)`](../../../../kelta-worker/src/main/java/io/kelta/worker/repository/BootstrapRepository.java)
+  → `List<Map<String,Object>>` rows of
+  `SELECT permission_name, granted FROM profile_system_permission WHERE profile_id = ?`. The exact
+  `.anyMatch(p -> PERMISSION.equals(p.get("permission_name")) && Boolean.TRUE.equals(p.get("granted")))`
+  predicate is copied verbatim from
+  [`TenantOtlpTargetController.requireSetupPermission`](../../../../kelta-worker/src/main/java/io/kelta/worker/controller/TenantOtlpTargetController.java)
+  (lines 102–104) — the canonical reference for an `/api/admin/**` in-controller system-permission gate.
+  The only behavioral difference: that controller **throws** `ResponseStatusException(FORBIDDEN)`;
+  here we return `Optional.empty()` so the controller maps to **404** (privacy posture).
+
+### 3.4 `PageRenderController` change
+
+Inject `CerbosPermissionResolver`, accept `HttpServletRequest`, resolve `profileId`, pass it through.
+The `Optional.empty() → notFound()` mapping is **unchanged** — a permission denial flows through the
+exact same `.orElseGet(() -> ResponseEntity.notFound().build())` branch that an unknown slug uses, which
+is precisely why deny is a 404 for free.
+
+```java
+@GetMapping("/{slug}/render")
+public ResponseEntity<PageRenderContract> render(@PathVariable String slug, HttpServletRequest request) {
+    String profileId = permissionResolver.getProfileId(request);
+    return pageRenderService.render(slug, profileId)
+            .map(ResponseEntity::ok)
+            .orElseGet(() -> ResponseEntity.notFound().build());
+}
+```
+
+### 3.5 Back-compat
+
+- A page with **no** `access` key ⇒ `extractRequiredPermission` returns `null` ⇒ the gate is skipped
+  entirely (no DB lookup, no behavior change). Every existing v1 and 1g-v2 page renders unchanged.
+- `render(String slug)` becomes `render(String slug, String profileId)`. The only production caller is
+  `PageRenderController` (grep-verified); both worker test classes are updated (§6). No overload is
+  kept — a single 2-arg method avoids an ambiguous "which gate runs" path.
+
+---
+
+## 4. DB migrations
+
+**None — stored in `ui-pages.config` JSON, no DDL.**
+
+`requiredPermission` nests under `config.access` inside the existing `FieldDefinition.json("config")`
+column on `ui-pages` (declared in `SystemCollectionDefinitions.uiPages()`,
+[`runtime-core/.../model/system/SystemCollectionDefinitions.java`](../../../../kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/model/system/SystemCollectionDefinitions.java)).
+The grant data it is checked against (`profile_system_permission`) already exists. No new column, no
+constraint, no Flyway migration.
+
+> **Deliberate non-goal:** promoting `requiredPermission` to a real `ui_page` **column** (e.g.
+> `ui_page.required_permission TEXT`) would be the **only** reason to add a future **`V147`** (Flyway
+> head is **V146**; verify the directory before numbering). That would let the database filter
+> restricted pages in the `QueryEngine` query itself and index on it. It is **intentionally not done in
+> 1h** — the JSON key keeps the slice a pure config addition with zero schema/migration risk, consistent
+> with the whole page-builder effort's "everything nests in `config`" rule. Revisit only if per-page
+> authz needs DB-level filtering or reporting.
+
+---
+
+## 5. File-by-file code changes
+
+Java 25, records, JDBC (no JPA). Read path — **no** new NATS subject, **no** `BeforeSaveHook`, **no**
+gateway route change. `BootstrapRepository` is a `@Repository` bean and is already injected across the
+worker, so wiring it into `PageRenderService` is a constructor add only.
+
+### 5.1 `kelta-worker/src/main/java/io/kelta/worker/service/PageRenderService.java` — modify
+
+- Add constructor dependency `BootstrapRepository bootstrapRepository` (field + assignment).
+- Change `render(String slug)` → `render(String slug, String profileId)`.
+- Insert the gate (after `parseConfig`, before building the contract) per §3.3.
+- Add `extractRequiredPermission(Map<String,Object>)` and `hasSystemPermission(String,String)` private
+  helpers per §3.3.
+- The 1g `parseConfig`/`extractTree`/`extractObjectList`/`asString` helpers, the
+  `slug+published+active` query, and the `Optional.empty()` guards are **unchanged**.
+- Update the class Javadoc to note the optional `config.access.requiredPermission` gate and that a
+  denial resolves to empty (→ 404, deliberately not 403).
+
+### 5.2 `kelta-worker/src/main/java/io/kelta/worker/controller/PageRenderController.java` — modify
+
+- Inject `CerbosPermissionResolver permissionResolver` (constructor + field).
+- `render(@PathVariable String slug)` → `render(@PathVariable String slug, HttpServletRequest request)`;
+  resolve `profileId = permissionResolver.getProfileId(request)` and pass it to the service (§3.4).
+- The `Optional → 200/404` mapping is unchanged.
+
+### 5.3 `kelta-ui/app/src/pages/PageBuilderPage/pageConfig.ts` — modify
+
+- Add the `PageAccess` interface and the optional `access?: PageAccess` key to `PageConfig` (§3.1).
+- Extend `mergeConfig` (or add a small `setRequiredPermission(config, perm | undefined)` helper) so the
+  page-settings field can write/clear `access.requiredPermission` while preserving untouched keys.
+  Clearing (selecting "Anyone (published)") deletes the `access` key so the stored config stays clean.
+- Unit-test the helper in `pageConfig.test.ts` (set, clear, preserve-siblings).
+
+### 5.4 FE inspector — page-settings "Access" field
+
+> **Host dependency: slice 2d.** This field lives **inside the page-settings drawer that 2d creates** —
+> 1h does not build a settings panel of its own and must not assume a pre-existing one. The backend gate
+> (§5.1–5.2) is independent and can ship first; this FE control is sequenced **after 2d**.
+
+Reuses the **2b** schema-driven inspector field-kind machinery (the parent's
+[Inspector + canvas](../page-builder-parity.md#inspector--canvas) `PropFieldSchema` with
+`kind ∈ … | select | …`). This is a **page-settings** field (page-level, not a widget prop), so it is
+registered in the page-settings schema list (alongside name/slug/path/published) rather than a widget's
+`propSchema`.
+
+- **Path:** the **2d page-settings drawer** (the panel 2d extracts under
+  `kelta-ui/app/src/pages/PageBuilderPage/inspector/`, hosting name/slug/path/published). One new
+  `select`-kind page-settings field, `key: 'access.requiredPermission'`, added to that drawer's schema
+  list. (Do **not** add it directly to `PageBuilderPage.tsx` — 1h ships after 2d so it lands
+  schema-driven in the drawer from the start.)
+- **Options source:** import the permission catalog from
+  [`SystemPermissionChecklist.tsx`](../../../../kelta-ui/app/src/components/SecurityEditor/SystemPermissionChecklist.tsx).
+  Export its `PERMISSION_CATEGORIES` (or a flattened `SYSTEM_PERMISSIONS` list) so the picker reuses the
+  single canonical catalog instead of duplicating the 15 names. Prepend an "Anyone (published)" option
+  whose value clears the key. (Per architecture.md, this FE constant **is** the canonical permission
+  catalog — there is no Java enum to fetch.)
+- **On change:** call the `pageConfig.ts` helper to set/clear `config.access.requiredPermission`, then
+  persist via the existing page-save path (writes the `config` JSON — no new endpoint).
+- **i18n (required):** both author-facing strings go through the existing `t(...)` translation layer
+  (same convention as 2d's builder strings), not hardcoded literals:
+  - the field **label** — `t('builder.pageSettings.access.label')` ("Required permission"), with the
+    "Anyone (published)" no-restriction option as `t('builder.pageSettings.access.anyone')`;
+  - the **404 privacy-hint** line under the control —
+    `t('builder.pageSettings.access.hint')` ("Users without this permission get a 404 — the page is
+    hidden, not shown as forbidden") — so authors understand the privacy posture.
+  Add the keys to the page-builder i18n resource bundle alongside the other `builder.*` strings.
+
+### 5.5 No other production code changes
+
+`CustomPage.tsx`/`PageTreeRenderer.tsx` are **untouched** — a restricted page simply 404s at fetch time
+(the renderer already handles a 404 render-contract fetch as "page not found", same as an unknown slug).
+The `access` key is consumed server-side and not present on the contract, so the runtime renderer needs
+no awareness of it.
+
+---
+
+## 6. Test plan
+
+### 6.1 `PageRenderServiceTest` (extend existing class)
+
+Mocked `QueryEngine` + `CollectionRegistry` + **`BootstrapRepository`**, real `JsonMapper` — matching
+the existing idiom
+([`PageRenderServiceTest`](../../../../kelta-worker/src/test/java/io/kelta/worker/service/PageRenderServiceTest.java):
+`@ExtendWith(MockitoExtension.class)`, `JsonMapper.builder().build()`, the `oneRow(page)` helper). The
+service factory gains the mocked `bootstrapRepository`; all existing tests call
+`service().render("home", "p-1")` (a profile id is now required).
+
+| Test | Setup | Assert |
+|------|-------|--------|
+| `allowsWhenProfileGranted` (new) | `config.access.requiredPermission = "VIEW_SETUP"`; `findProfileSystemPermissions("p-1")` → `[{permission_name:"VIEW_SETUP", granted:true}]` | contract **present**; `version=="2.0"`; `tree` contains `components`; `verify(bootstrapRepository).findProfileSystemPermissions("p-1")` |
+| `deniesWith404WhenProfileNotGranted` (new) | same `access`; `findProfileSystemPermissions("p-1")` → `[]` (or `granted:false`) | `render(...)` is `Optional.empty()` (controller → 404); lookup was invoked |
+| `deniesWhenPermissionGrantedFalse` (new) | `access` set; row `{permission_name:"VIEW_SETUP", granted:false}` | `Optional.empty()` — `granted:false` is not a grant |
+| `deniesWhenNoProfileId` (new) | `access` set; `profileId == null` | `Optional.empty()`; `verifyNoInteractions(bootstrapRepository)` (short-circuit, no lookup) |
+| `absentAccessKeySkipsCheck` (new, back-compat) | `config` with **no** `access` key | contract present; `verifyNoInteractions(bootstrapRepository)` — proves no DB lookup when unrestricted |
+| `blankRequiredPermissionSkipsCheck` (new) | `config.access = {requiredPermission:""}` | treated as no restriction; contract present; no lookup |
+| `notFoundWhenNoMatch` / `emptyWhenNoCollection` / `blankSlug` (keep) | as 1g | unchanged — permission gate is never reached for an unknown/blank slug or missing collection; `verifyNoInteractions(bootstrapRepository)` where the query never runs |
+| `rendersPublishedPage` / v1+v2 1g cases (keep) | pass a `profileId`; no `access` key | unchanged; `version=="2.0"`; no lookup |
+
+Key assertions to lock the design: **(a)** unknown slug and permission-deny both yield
+`Optional.empty()` (controller returns the same 404 for both — privacy parity); **(b)** an unrestricted
+page never calls `findProfileSystemPermissions` (no per-render DB cost regression for the common case).
+
+### 6.2 `PageRenderControllerTest` (update existing fixture)
+
+The controller now takes `HttpServletRequest` and calls `render(slug, profileId)`. Update both tests to
+pass a `MockHttpServletRequest` (or mock) with `X-User-Profile-Id` set, and stub
+`pageRenderService.render(eq("home"), any())`. The contract fixture already moves to the 7-arg form in
+1g; keep that. Add one controller-level test: when the service returns `Optional.empty()` (deny), the
+controller responds **404** (reuses the existing `notFound` assertion — no new branch).
+
+### 6.3 kelta-test-harness integration test — `PageRenderAuthzScenarioTest` (required)
+
+**Add a real-DB scenario.** Per the
+[DB-constraint test-gap guard](../../../projects/-Users-craigklinker-GitHub-emf/memory/feedback_db-constraint-test-gap.md),
+the convention extends to any path whose correctness depends on a **real-Postgres + RLS** behavior that
+mocked worker tests cannot observe. 1h's gate is exactly that: it reads `profile_system_permission`
+under RLS (`app.current_tenant_id`) and **gates page visibility** (404-not-403). Mocked-permission
+worker unit tests stub `findProfileSystemPermissions` and so **cannot catch an RLS misconfiguration**
+(e.g. the lookup returning rows it should not, or zero rows because the tenant scoping is wrong) — they
+would pass while the real grant read is broken. They also can't prove the gateway actually forwards
+`X-User-Profile-Id` to the worker, which the whole gate hinges on. A real-stack scenario closes that gap.
+
+Add `PageRenderAuthzScenarioTest` to **kelta-test-harness** (Testcontainers full mini-stack — real
+Postgres + RLS, gateway → worker). Setup and assertions:
+
+- Seed, in **one real tenant**, a **restricted page** (`config.access.requiredPermission = "VIEW_SETUP"`,
+  published + active) and two profiles: **`grantedProfile`** with a `profile_system_permission` row
+  `{permission_name:"VIEW_SETUP", granted:true}` and **`deniedProfile`** with no such grant (or
+  `granted:false`).
+- Hit `GET /api/pages/{slug}/render` **through the gateway → worker path** (so the real
+  `X-User-Profile-Id` forwarding is exercised, not stubbed), once authenticated as each profile.
+- **Assert 200** (full v2 contract) for `grantedProfile` and **404** (no body) for `deniedProfile`,
+  against **real Postgres + RLS** — proving the grant read is correctly tenant-scoped and the deny path
+  yields a privacy-preserving 404, not a 403 and not a leak.
+- Optionally also seed an **unrestricted** page and assert it renders 200 for `deniedProfile` (back-compat
+  under the real stack).
+
+**Keep the §6.1 worker unit tests too** (allow / deny / `granted:false` / absent-key / blank / no-profile)
+— they cover the branch logic fast and in isolation; the harness scenario covers what they structurally
+cannot (real RLS + real header forwarding). Both layers are required.
+
+### 6.4 FE
+
+- **Vitest:** `pageConfig.test.ts` — set/clear/preserve-siblings for `access.requiredPermission`.
+  The **2d page-settings drawer** test — selecting a permission in the "Access" field writes
+  `config.access.requiredPermission`; selecting "Anyone (published)" clears it; the option list matches
+  the `SystemPermissionChecklist` catalog; assert the label/hint render via their `t('builder.pageSettings.access.*')`
+  keys (not hardcoded strings).
+- **Playwright (post-deploy):** as a profile **without** the permission, navigating to a restricted
+  page's `/:tenant/app/p/:slug` shows the not-found state (404 contract). As a profile **with** it, the
+  page renders. (Positive + negative e2e per the project's UI+tests memory standard.)
+
+---
+
+## 7. Docs to update (same PR)
+
+| Doc | Change |
+|-----|--------|
+| `.claude/docs/status.md` | Page-builder row: **move per-page authz out of the gap column** — it now reads "per-page authz: optional `config.access.requiredPermission` gates render on a `profile_system_permission` grant (same in-controller lookup as `/api/admin/**`); deny → **404** (page existence not leaked); absent key ⇒ published+active+tenant gate unchanged". Remove the "per-page Cerbos authz" gap note. |
+| `.claude/docs/architecture.md` | `PageRenderService` row + Authz section: document the render-time gate — optional `config.access.requiredPermission` checked via `BootstrapRepository.findProfileSystemPermissions` (the same worker-side system-permission pattern admin controllers use; **not** a Cerbos PDP call), and the **404-not-403 rationale** (denial is indistinguishable from an unknown slug to avoid leaking that a restricted page exists). Note `profileId` is resolved by `CerbosPermissionResolver.getProfileId` from `X-User-Profile-Id`. |
+
+(Per parent §"Docs to update": `conventions.md` page-config-v2 contract is owned by the FE binding
+slices; this backend slice touches only the two rows above. No `integrations.md` change — no external
+service or NATS subject added.)
+
+---
+
+## 8. Risks & open questions
+
+- **404-vs-403 is a deliberate privacy choice, and load-bearing.** Returning 403 would confirm a
+  restricted page exists at that slug. We return 404 — identical to an unknown slug — by routing the
+  denial through the same `Optional.empty()` the unknown-slug path uses. Reviewers must reject any 403
+  here. Trade-off: a legitimately-restricted user gets a generic "not found", not "you lack permission";
+  the inspector hint (§5.4) makes this explicit to authors. (If a future product decision wants a
+  "request access" affordance, that is a separate FE concern that must still not change the 404 wire
+  behavior.)
+- **Per-render DB lookup only when restricted.** `findProfileSystemPermissions` is one extra
+  RLS-scoped `SELECT` **only** for pages that declare `requiredPermission`; unrestricted pages do zero
+  extra work (asserted in §6.1). Acceptable. If restricted pages become hot, the existing
+  `WorkerCacheManager` profile-permission cache (which already caches `systemPermissions`) is the reuse
+  target — but **do not** pre-optimize in 1h; wire the cache only if profiling shows a need.
+- **Service signature change ripples to tests.** `render(String, String)` breaks both worker test
+  classes' call sites until updated (§6). Grep-verified the only production caller is
+  `PageRenderController`. No overload retained (avoids an ambiguous gate path).
+- **`requiredPermission` is an unvalidated string.** The worker compares it as-is against
+  `permission_name`; an unknown/misspelled name matches no grant ⇒ everyone is denied ⇒ 404. This is the
+  safe-by-default failure mode. The FE picker constrains authoring to the catalog, so bad values only
+  arise from API/MCP edits — acceptable; a future hardening could validate on write in `UIPageSlugHook`,
+  but that is out of scope.
+- **Catalog is a frontend constant, not a DB list.** The permission picker reuses
+  `SystemPermissionChecklist.PERMISSION_CATEGORIES` (architecture.md confirms there is **no Java enum**;
+  the catalog is the FE source of truth). Keep the export single-sourced so adding a permission updates
+  both the profile editor and this picker at once.
+- **Sequencing:** the **backend gate** depends only on 1g's `parseConfig`/`extractObjectList` and the
+  7-field contract, so it can land any time after 1g (independent of the FE). The **FE page-settings
+  "Access" field** depends on **2d** — it is hosted inside the page-settings drawer 2d creates and
+  reuses 2b's inspector field-kind machinery. Order the FE control after 2d so it lands schema-driven in
+  the drawer from the start; do not add it to `PageBuilderPage.tsx` directly. (Backend-first, FE-after-2d
+  is the recommended split.)
+- **File sizes.** `PageRenderService` stays small (~120 lines after this); not in `concerns.md`.
+  `PageBuilderPage.tsx` is already large (~71 KB) and **is** a known bloat hazard — add the single
+  page-settings field minimally, or (preferred) land it in the 2b-extracted `inspector/` to avoid
+  growing the monolith.

--- a/.claude/docs/specs/page-builder/2a-widget-registry.md
+++ b/.claude/docs/specs/page-builder/2a-widget-registry.md
@@ -1,0 +1,1011 @@
+# 2a — Widget registry + shared render module + model
+
+> **Slice:** 2a (FE foundation keystone). **Axis:** foundation.
+> **Parent:** [`../page-builder-parity.md`](../page-builder-parity.md). This child spec **extends, never
+> contradicts** the parent's [The shared model](../page-builder-parity.md#the-shared-model),
+> [Widget registry](../page-builder-parity.md#widget-registry), and
+> [Page-level config (v2)](../page-builder-parity.md#page-level-config-v2) sections. The
+> `WidgetDescriptor` / `PropFieldSchema` / `PageComponent` v2 / `Binding` / `PropValue` types are
+> **defined here once** for the whole effort; later slices consume them.
+> Source-verified against the codebase on 2026-06-22 (Flyway head V146; this slice adds no migration).
+> If code and this doc disagree, trust the code and fix this doc.
+
+---
+
+## 1. Goal & scope
+
+### What this slice delivers
+
+The keystone **pure refactor** of the page-builder front end. Today the 8 built-in component types
+are hardcoded across **five per-type `switch`/conditional sites** that must be kept in lockstep:
+
+| # | Site | File | Lines (2026-06-22) |
+|---|------|------|--------------------|
+| 1 | `AVAILABLE_COMPONENTS` palette array | `PageBuilderPage.tsx` | ~101–110 |
+| 2 | `PropertyPanel` per-type `&&` blocks | `PageBuilderPage.tsx` | ~301–479 |
+| 3 | `Canvas.renderComponent` per-type previews | `PageBuilderPage.tsx` | ~798–838 |
+| 4 | `Preview.renderPreviewComponent` `switch` | `PageBuilderPage.tsx` | ~521–631 |
+| 5 | `PageNodeRenderer` runtime `switch` + `DataTableNode`/`FormNode` | `PageTreeRenderer.tsx` | ~238–304 |
+
+This slice introduces:
+
+1. **`widgets/types.ts`** — the `WidgetDescriptor` + `PropFieldSchema` + `WidgetRenderProps` contract.
+2. **`widgets/registry.ts`** — the `widgetRegistry` singleton (`register` / `get` / `list` /
+   `listByCategory`), with a **plugin fallback shim**: `get(type)` wraps any plugin component from the
+   existing `componentRegistry.getPageComponent(type)` in a synthetic descriptor, so plugins keep
+   working with **zero changes**, and an **unknown-type default descriptor** so neither builder nor
+   runtime special-case "unknown type" anymore.
+3. **`widgets/renderTree.tsx`** — `RenderTree` + `renderNode`: the **single** render path shared by the
+   editor preview (`mode:'editor'`) and the runtime (`mode:'runtime'`).
+4. **`widgets/builtins/*.tsx`** — one descriptor per existing built-in type
+   (`heading`, `text`, `button`, `image`, `form`, `table`, `card`, `container`), migrated **at parity**
+   (no behavior change — same DOM, same `data-testid`s, same data-fetch path). Type strings are
+   load-bearing: the bound grid registers as `type:'table'` and the form as `type:'form'` (the legacy
+   strings already in saved pages — do **not** rename to `data-table`). `form`'s palette category is
+   `input` (parent §"Widget registry"), so the `input` palette category is **non-empty from 2a onward**.
+5. **`model/pageModel.ts`** — the v2 `PageComponent` / `Binding` / `PropValue` / `PageAction` /
+   `EventHandlers` / `ResponsiveSpan` types (defined now; `events`/`span`/bindings are *carried through*
+   the model but not yet authored — that's 2b–2e).
+6. **`model/treeOps.ts`** — pure tree mutations. This slice ships **working**
+   `insertNode`/`removeNode`/`updateProps` (used by the existing builder add/delete/prop handlers) so the
+   refactor compiles and `treeOps` is unit-tested. `moveNode`/`setSpan` ship as **no-op stubs that return
+   the input tree unchanged** (finished in **2c** alongside the dnd canvas) — they do **not** throw.
+   **Guarantee:** no code path reaches `moveNode`/`setSpan` before 2c — there is no reorder/resize/span UI
+   yet, and the 2b inspector edits props via `updateProps` only, never `moveNode`/`setSpan`.
+
+It then **refactors the two render surfaces to share one module**:
+
+- `PageBuilderPage.tsx`'s `Preview` (and the `Canvas` per-type preview blocks) → render via
+  `<RenderTree mode="editor">`.
+- `PageTreeRenderer.tsx` → becomes a thin `<RenderTree mode="runtime">` wrapper. The `DataTableNode`
+  and `FormNode` logic is **moved verbatim** into the `table` and `form` builtin descriptors (so the
+  Cerbos/FLS-enforcing JSON:API fetch path is preserved exactly).
+
+And **folds the plugin registry in** via the fallback shim (no change to `componentRegistry.ts` or the
+`PageComponentProps` contract).
+
+> **The slice ships in two phases (split for safe rollout — parent §"Rollout & rollback"):**
+> - **Phase A** — introduce `model/` + `widgets/` + `RenderTree` + the 8 builtin descriptors *behind the
+>   registry*, parity-tested with a **golden snapshot** (Vitest/Playwright DOM snapshot) of all 8 built-ins
+>   rendered from a fixed JSON fixture, captured **before** the refactor. Nothing user-visible flips yet.
+> - **Phase B** — flip `PageBuilderPage.tsx`'s preview/canvas and `PageTreeRenderer.tsx`/`CustomPage` to
+>   consume `RenderTree`. The **runtime** flip is gated behind a **system feature flag** (platform already
+>   has `kelta.config.feature.changed` infra) with fallback to the legacy `PageNodeRenderer`; the legacy
+>   renderer stays in the tree until 2a soaks. The single deliberate behavior change (runtime `heading`
+>   honoring `level` instead of hardcoded `<h2>`) is a **reviewed snapshot diff**, not a silent change.
+> - **Rollback trigger:** a spike in page-render error rate or unknown-widget-fallback rate → flip the flag
+>   back to `PageNodeRenderer` (see §8).
+>
+> **Hard edge — 1g ships before 2a.** 2a is FE-only and **tolerates a v1 render contract**: when 1g's
+> `version "2.0"` siblings aren't present, `CustomPage` passes `scope={}` and everything renders as today
+> (see §3.6). The flag gating keeps `main` from ever being half-broken.
+
+### What this slice explicitly does NOT do
+
+| Out of scope | Lands in |
+|--------------|----------|
+| New widgets (grid/row/column/divider/chart/tabs/nav/icon/link/list/repeater/field-value, typed inputs) | 2c / 2f / 2g |
+| Bindings **UI** + expression resolution (`BindableField`, `resolveBindings`, `interpolate`, data sources) | 2d |
+| Events/actions authoring + action runtime | 2e |
+| dnd-kit canvas (drop-into-container, reorder, resize, `span`) + full `treeOps`/`migrate` | 2c |
+| Inspector redesign (schema-driven `Inspector` looping over `propSchema`, palette from registry) | 2b |
+
+> **Important:** the descriptor's `propSchema` field **is defined and populated here** for every built-in
+> (so 2b can build the schema-driven inspector by looping over it). But in 2a the existing hardcoded
+> `PropertyPanel` keeps editing props — it is **not** deleted until 2b. 2a is the data plumbing; 2b is
+> the consumer. This keeps 2a a true no-behavior-change refactor.
+
+### Acceptance criteria
+
+- The builder palette, editor preview, and runtime renderer all resolve component types through
+  `widgetRegistry` — there is **one** lookup table, not five.
+- Editor preview and runtime render **the same tree identically** (same descriptor `Render`), proven by a
+  Vitest test that renders the same JSON in both modes and asserts equivalent output.
+- All 8 built-ins render byte-for-byte as before (same `data-testid`, same classes) — proven against a
+  **golden snapshot** of all 8 built-ins captured from a fixed JSON fixture **before** the refactor
+  (Phase A); the only allowed diff is the reviewed runtime `heading` `level` fix (Phase B).
+- The runtime render flip (`CustomPage` → `RenderTree`) is **behind a system feature flag** with fallback
+  to the legacy `PageNodeRenderer`; the legacy renderer stays in the tree until 2a soaks.
+- Plugin page components registered via `componentRegistry.registerPageComponent(...)` still render in
+  builder canvas, preview, and runtime with **zero plugin code changes**; `PageComponentProps` is
+  unchanged (and the shim hands plugins **binding-resolved** props — see §3.4).
+- Unknown component types render the existing "Unknown component: <type>" fallback (now via the default
+  descriptor, not a `default:` switch arm).
+- The `form` built-in registers under palette category **`input`** (not `data`); the `input` palette
+  category is non-empty from 2a.
+- `/verify` green (lint + typecheck + `test:coverage` ≥ existing kelta-ui gate).
+
+---
+
+## 2. UI samples
+
+### 2.1 Sample `WidgetDescriptor` — `heading` (concrete TS)
+
+```tsx
+// widgets/builtins/heading.tsx
+import type { WidgetDescriptor } from '../types'
+
+export const headingWidget: WidgetDescriptor = {
+  type: 'heading',
+  label: 'Heading',
+  icon: 'H',
+  category: 'content',
+  acceptsChildren: false,
+  defaultProps: { text: 'Heading', level: 'h1' },
+  // propSchema is DEFINED here for 2b; 2a's PropertyPanel still does the editing.
+  propSchema: [
+    { key: 'text', label: 'Text', kind: 'text', bindable: true, group: 'Content' },
+    {
+      key: 'level',
+      label: 'Level',
+      kind: 'select',
+      options: [
+        { value: 'h1', label: 'H1' },
+        { value: 'h2', label: 'H2' },
+        { value: 'h3', label: 'H3' },
+        { value: 'h4', label: 'H4' },
+      ],
+      group: 'Content',
+    },
+  ],
+  // Render is the SINGLE source of truth used by editor preview AND runtime.
+  Render: ({ node }) => {
+    const level = (node.props.level as string) || 'h1'
+    const text = (node.props.text as string) || 'Heading'
+    const HeadingTag = level as keyof JSX.IntrinsicElements
+    return (
+      <HeadingTag className="m-0 text-foreground" data-testid="page-node-heading">
+        {text}
+      </HeadingTag>
+    )
+  },
+}
+```
+
+> Parity note: the **editor preview** (`Preview.renderPreviewComponent`) today renders `heading` exactly
+> like this (`<HeadingTag className="m-0 text-foreground">`). The **runtime** (`PageNodeRenderer`) today
+> hardcodes `<h2 className="text-2xl …">` regardless of `level`. The descriptor unifies on the *editor*
+> behavior (honor `level`), which is a strict improvement and the de-dup goal — call this out in the PR;
+> the runtime parity test asserts the new (level-honoring) output and a migration note is added to
+> `status.md`. All other built-ins are byte-identical across the two surfaces today and migrate cleanly.
+
+### 2.2 Sample `WidgetDescriptor` — `table` (concrete TS, moves `DataTableNode` in)
+
+```tsx
+// widgets/builtins/table.tsx
+import type { WidgetDescriptor } from '../types'
+import { DataTableNode, readDataView } from './dataTableNode' // DataTableNode moved out of PageTreeRenderer
+
+export const tableWidget: WidgetDescriptor = {
+  type: 'table',
+  label: 'Table',
+  icon: '⊞',
+  category: 'data',
+  acceptsChildren: false,
+  defaultProps: {},
+  propSchema: [
+    { key: 'dataView.collection', label: 'Collection', kind: 'collection-picker', group: 'Data' },
+    { key: 'dataView.fields', label: 'Columns', kind: 'field-picker', dependsOnCollection: true, group: 'Data' },
+    { key: 'dataView.limit', label: 'Row limit', kind: 'number', group: 'Data' },
+  ],
+  Render: ({ node, mode }) => {
+    // Editor preview historically showed a placeholder box; runtime fetched live rows.
+    // Parity: keep BOTH behaviors keyed on mode (see §5.4 "preserve mode-specific table behavior").
+    if (mode === 'editor') {
+      return (
+        <div className="w-full" data-testid="preview-table-placeholder">
+          {/* …existing Grid3x3 placeholder box… */}
+        </div>
+      )
+    }
+    return <DataTableNode dataView={readDataView(node.props)} />
+  },
+}
+```
+
+> The Cerbos/FLS-enforcing fetch (`apiClient.getList('/api/{collection}?page[size]=…')`) inside
+> `DataTableNode` is **moved verbatim** — not rewritten — so server-side field-stripping is preserved.
+> Same for `FormNode` → `form` widget (`apiClient.postResource('/api/{collection}', values)`).
+
+### 2.3 Sample component-tree JSON (v2-compatible, what `config.components` holds)
+
+```json
+[
+  { "id": "c1", "type": "heading", "props": { "text": "Orders", "level": "h1" } },
+  { "id": "c2", "type": "text", "props": { "content": "Recent orders below." } },
+  {
+    "id": "c3",
+    "type": "container",
+    "props": {},
+    "children": [
+      {
+        "id": "c4",
+        "type": "table",
+        "props": { "dataView": { "collection": "orders", "fields": ["id", "status", "total"], "limit": 25 } }
+      }
+    ]
+  },
+  { "id": "c5", "type": "acme_kpi_widget", "props": { "metric": "mrr" } }
+]
+```
+
+`c5` resolves through the plugin fallback shim (`componentRegistry.getPageComponent('acme_kpi_widget')`).
+The optional v2 fields (`events?`, `span?`) are absent here and round-trip untouched.
+
+### 2.4 Before / after render path
+
+```
+TODAY (5 duplicated switch sites, two render surfaces):
+
+  Palette ─────────► AVAILABLE_COMPONENTS[]            (PageBuilderPage.tsx ~101)
+  Inspector ───────► PropertyPanel  type==='heading' ? …  (PageBuilderPage.tsx ~301)
+  Editor preview ──► Canvas.renderComponent  switch(type) (PageBuilderPage.tsx ~798)
+                     Preview.renderPreviewComponent switch (PageBuilderPage.tsx ~521)
+  Runtime ─────────► PageNodeRenderer switch(type) + DataTableNode/FormNode (PageTreeRenderer.tsx ~238)
+                     └─ default: componentRegistry.getPageComponent(type)
+
+  → 5 lists hand-synced; editor preview and runtime DUPLICATE the per-type JSX.
+
+
+AFTER 2a (one registry, one render module):
+
+                        ┌───────────────────────────┐
+                        │   widgetRegistry (single) │
+                        │  type → WidgetDescriptor  │
+                        │  .get() falls back to     │
+                        │  plugin componentRegistry │
+                        │  then default descriptor  │
+                        └───────────┬───────────────┘
+                                    │ list / listByCategory / get
+            ┌───────────────────────┼───────────────────────┐
+            │                       │                        │
+       Palette*               Inspector**            RenderTree (shared)
+   (still array in 2a,    (still PropertyPanel    mode:'editor' → builder preview/canvas
+    becomes registry      in 2a, becomes          mode:'runtime' → CustomPage
+    loop in 2b)           propSchema loop in 2b)  ── one renderNode() looks up descriptor,
+                                                     calls descriptor.Render(props)
+```
+
+No visual redesign in this slice — pixels are identical (modulo the heading-`level` runtime fix noted
+in §2.1).
+
+---
+
+## 3. Data & API contracts
+
+All TS lives under `kelta-ui/app/src/pages/PageBuilderPage/`. No backend/API change in 2a.
+
+### 3.1 `model/pageModel.ts` — v2 model (matches parent §"The shared model")
+
+```ts
+/** A bound value: {{...}} convention. `mode:'path'` walks scope dot-paths; `mode:'expr'` evaluates. */
+export interface Binding {
+  $bind: string
+  mode?: 'path' | 'expr'
+}
+
+export type PropValue =
+  | string
+  | number
+  | boolean
+  | null
+  | Binding
+  | PropValue[]
+  | { [key: string]: PropValue }
+
+export function isBinding(v: unknown): v is Binding {
+  return typeof v === 'object' && v !== null && typeof (v as Binding).$bind === 'string'
+}
+
+export type PageAction =
+  | { action: 'runFlow'; flowId: string; input?: Record<string, PropValue>; awaitResult?: boolean }
+  | { action: 'navigate'; to: string; params?: Record<string, PropValue>; newTab?: boolean }
+  | { action: 'openUrl'; url: PropValue; newTab?: boolean }
+  | { action: 'createRecord' | 'updateRecord'; collection: string; attributes: Record<string, PropValue>; recordId?: PropValue }
+  | { action: 'refreshData'; dataSource: string }
+  | { action: 'setVar'; name: string; value: PropValue }
+  | { action: 'showToast'; level: 'info' | 'success' | 'error'; message: PropValue }
+
+export type EventHandlers = Partial<
+  Record<'onClick' | 'onChange' | 'onSubmit' | 'onLoad', PageAction[]>
+>
+
+export interface ResponsiveSpan {
+  base: number // 1..12
+  sm?: number
+  md?: number
+  lg?: number
+}
+
+/**
+ * v2 component node. `position` (legacy {row,column,width,height}) is DROPPED from the active model —
+ * `migrate.ts` (2c) converts legacy trees. In 2a, `position` is tolerated on read (ignored) so existing
+ * saved pages load; new nodes are created without it.
+ */
+export interface PageComponent {
+  id: string
+  type: string
+  props: Record<string, PropValue>
+  events?: EventHandlers
+  span?: ResponsiveSpan
+  children?: PageComponent[]
+}
+```
+
+> **Compat with the existing `PageComponent` (PageBuilderPage.tsx ~61).** The current interface is
+> `{ id; type; props: Record<string, unknown>; children?; position: ComponentPosition }` with `position`
+> **required**. The v2 type makes `position` absent and `props` typed as `Record<string, PropValue>`
+> (a narrowing of `unknown`). To avoid a big-bang rename in 2a, the existing
+> `export interface PageComponent` in `PageBuilderPage.tsx` is **replaced by a re-export** of the model
+> type (`export type { PageComponent } from './model/pageModel'`), and `ComponentPosition` is kept as a
+> deprecated legacy interface only used by `migrate.ts`/back-compat readers. `handleAddComponent` stops
+> writing `position` (see §5.3).
+
+### 3.2 `widgets/types.ts` — descriptor + prop-schema contract (matches parent §"Widget registry")
+
+```ts
+import type { ComponentType, ReactNode } from 'react'
+import type { PageComponent, EventHandlers } from '../model/pageModel'
+
+export type WidgetCategory = 'layout' | 'content' | 'data' | 'input' | 'navigation'
+
+export type PropFieldKind =
+  | 'text'
+  | 'textarea'
+  | 'number'
+  | 'boolean'
+  | 'select'
+  | 'color'
+  | 'collection-picker'
+  | 'field-picker'
+  | 'expression'
+  | 'event-list'
+  | 'span'
+  | 'children'
+
+/** One editable property, consumed by the schema-driven inspector in 2b. */
+export interface PropFieldSchema {
+  /** Dot-path into props, e.g. 'text' or 'dataView.collection'. */
+  key: string
+  label: string
+  kind: PropFieldKind
+  /** For kind:'select'. */
+  options?: Array<{ value: string; label: string }>
+  /** If true, the inspector wraps this field in BindableField (fx toggle) in 2d. */
+  bindable?: boolean
+  /** Inspector section grouping. */
+  group?: string
+  /** field-picker fields depend on a sibling collection-picker value. */
+  dependsOnCollection?: boolean
+}
+
+/** Props handed to every descriptor's Render — the SAME object in editor and runtime. */
+export interface WidgetRenderProps {
+  /**
+   * **Resolved-node invariant (authoritative — parent §"Widget registry"):** `node.props` is **always
+   * fully binding-resolved** before it reaches `Render`. In 2a the resolver is an **identity no-op**;
+   * 2d makes it real. Descriptors **must NOT** call `resolveBindings` themselves — the *only* exception
+   * is `list`/`repeater` (2d), which re-resolves its children under each per-row `item` scope. So a
+   * descriptor never sees a `$bind` marker in `node.props`.
+   */
+  node: PageComponent
+  /** Binding scope; `{}` in 2a (bindings resolve starting 2d). */
+  scope: Record<string, unknown>
+  mode: 'editor' | 'runtime'
+  tenantSlug: string
+  /**
+   * Render a child node through the shared path (used by container/card and later list/repeater).
+   * Signature is `(child, scope?) => ReactNode` **from 2a onward** — the optional `scope` lets a
+   * repeater (2d) pass an `item`-augmented scope; omitted ⇒ inherit the current scope.
+   * (`scope` is typed `Record<string, unknown>` here; 2d aliases this as `BindingScope`.)
+   */
+  renderChild: (child: PageComponent, scope?: Record<string, unknown>) => ReactNode
+}
+
+export interface WidgetDescriptor {
+  type: string
+  label: string
+  /** Short glyph or lucide icon name; rendered by palette (kept as today's single-char glyphs in 2a). */
+  icon: string
+  category: WidgetCategory
+  /** Defaults applied when a node of this type is added. */
+  defaultProps: Record<string, unknown>
+  /** Editable props (consumed by 2b inspector). */
+  propSchema: PropFieldSchema[]
+  /** Whether this widget renders `node.children`. */
+  acceptsChildren?: boolean
+  /**
+   * Events this widget can emit. **Declared in 2a** so the 2b inspector's `kind:'event-list'` field can
+   * render one tabbed editor over exactly these handlers, and the 2e runtime can wire only these.
+   * Defined here, consumed by 2b (`event-list` field) and 2e (runtime). E.g. `button` → `['onClick']`.
+   */
+  supportedEvents?: Array<keyof EventHandlers>
+  Render: ComponentType<WidgetRenderProps>
+}
+```
+
+### 3.3 `widgets/registry.ts` — registry API + plugin fallback shim
+
+```ts
+import type { ComponentType } from 'react'
+import { componentRegistry, type PageComponentProps } from '@/services/componentRegistry'
+import type { WidgetDescriptor, WidgetCategory } from './types'
+
+class WidgetRegistry {
+  private widgets = new Map<string, WidgetDescriptor>()
+
+  register(descriptor: WidgetDescriptor): void {
+    this.widgets.set(descriptor.type, descriptor)
+  }
+
+  /**
+   * Resolve a descriptor for a type. Resolution order:
+   *  1. a registered built-in,
+   *  2. a plugin page component (wrapped in a synthetic descriptor — plugins keep working unchanged),
+   *  3. the unknown-type default descriptor.
+   * Never returns undefined — callers (builder + runtime) stop special-casing missing types.
+   */
+  get(type: string): WidgetDescriptor {
+    const builtin = this.widgets.get(type)
+    if (builtin) return builtin
+
+    const PluginComp = componentRegistry.getPageComponent(type)
+    if (PluginComp) return wrapPluginComponent(type, PluginComp)
+
+    return defaultDescriptor(type)
+  }
+
+  /** True if a real descriptor exists (built-in or plugin) — used to flag "custom" in the canvas. */
+  has(type: string): boolean {
+    return this.widgets.has(type) || componentRegistry.hasPageComponent(type)
+  }
+
+  list(): WidgetDescriptor[] {
+    return [...this.widgets.values()]
+  }
+
+  listByCategory(category: WidgetCategory): WidgetDescriptor[] {
+    return this.list().filter((w) => w.category === category)
+  }
+
+  /** Test helper. */
+  clear(): void {
+    this.widgets.clear()
+  }
+}
+
+/** Wrap a plugin component (PageComponentProps contract UNCHANGED) in a descriptor. */
+function wrapPluginComponent(
+  type: string,
+  PluginComp: ComponentType<PageComponentProps>,
+): WidgetDescriptor {
+  return {
+    type,
+    label: type,
+    icon: '◆',
+    category: 'content',
+    defaultProps: {},
+    propSchema: [],
+    Render: ({ node, tenantSlug }) =>
+      // EXACT call shape preserved from PageTreeRenderer/Canvas/Preview today:
+      // <Comp config={node.props} tenantSlug={tenantSlug} />
+      <PluginComp config={node.props as Record<string, unknown>} tenantSlug={tenantSlug} />,
+  }
+}
+
+function defaultDescriptor(type: string): WidgetDescriptor {
+  return {
+    type,
+    label: type,
+    icon: '?',
+    category: 'content',
+    defaultProps: {},
+    propSchema: [],
+    Render: () => (
+      <div className="text-xs text-muted-foreground" data-testid="page-node-unknown">
+        Unknown component: {type}
+      </div>
+    ),
+  }
+}
+
+export const widgetRegistry = new WidgetRegistry()
+
+/** Eagerly register all built-ins. Imported once at module load (see registerBuiltins.ts). */
+export { registerBuiltins } from './builtins'
+```
+
+> **The plugin contract `PageComponentProps` (`componentRegistry.ts` ~50) is NOT modified.** The shim
+> calls `<PluginComp config={node.props} tenantSlug={tenantSlug} />` — the identical signature used today
+> by `PageNodeRenderer` (`React.createElement(Comp, { config: props, tenantSlug })`),
+> `Canvas.renderComponent` (`<CustomComponent config={comp.props} />`), and
+> `Preview.renderPreviewComponent` (`<CustomComponent config={comp.props} />`). Note today's builder
+> sites omit `tenantSlug`; the shim passes it (harmless — it's optional-in-practice and the runtime
+> already passes it). This is a strict superset, not a contract change. **`node.props` here is already
+> binding-resolved** — `renderNode` resolves before calling `Render` (§3.4), so plugins always receive
+> resolved values; in 2a the resolver is identity, so this is identical to today.
+
+### 3.4 `widgets/renderTree.tsx` — the single render path
+
+**Resolved-node invariant (authoritative — parent §"Widget registry").** `renderNode` resolves
+`node.props` against the current `scope` **before** handing the node to `descriptor.Render`. So the
+`node` a descriptor receives is **always fully binding-resolved** — a descriptor never sees a `$bind`
+marker and **must NOT** call `resolveBindings` itself. The single exception is `list`/`repeater` (2d),
+which calls `renderChild(child, itemScope)` to re-resolve its subtree per row. In 2a the resolver is an
+**identity no-op** (`scope` is `{}`, props pass through untouched), so this is a pure-structure change
+that 2d turns real with a one-line swap. `renderChild` takes an **optional `scope`** from 2a onward; when
+omitted it inherits the node's scope.
+
+```ts
+import type { ReactNode } from 'react'
+import type { PageComponent } from '../model/pageModel'
+import { widgetRegistry } from './registry'
+
+export interface RenderTreeProps {
+  components: PageComponent[]
+  mode: 'editor' | 'runtime'
+  tenantSlug: string
+  /** Binding scope; defaults to {} (bindings resolve from 2d). */
+  scope?: Record<string, unknown>
+}
+
+/**
+ * 2a identity resolver. Returns props untouched. 2d replaces this with real `$bind` resolution against
+ * `scope`. Centralizing it here is what makes the resolved-node invariant hold for every descriptor.
+ */
+function resolveBindings(
+  props: PageComponent['props'],
+  _scope: Record<string, unknown>,
+): PageComponent['props'] {
+  return props // 2a: no-op. 2d: walk props, resolve {$bind} against scope.
+}
+
+/** Render one node: look up descriptor, resolve props against scope, call descriptor.Render. */
+export function renderNode(
+  node: PageComponent,
+  ctx: { mode: 'editor' | 'runtime'; tenantSlug: string; scope: Record<string, unknown> },
+): ReactNode {
+  const descriptor = widgetRegistry.get(node.type) // never undefined
+  // Resolve props ONCE, here — descriptors receive a fully-resolved node (resolved-node invariant).
+  const resolvedNode = { ...node, props: resolveBindings(node.props, ctx.scope) }
+  // renderChild accepts an optional scope (used by list/repeater in 2d); omitted ⇒ inherit ctx.scope.
+  const renderChild = (child: PageComponent, scope?: Record<string, unknown>) =>
+    renderNode(child, scope ? { ...ctx, scope } : ctx)
+  return (
+    <descriptor.Render
+      key={node.id}
+      node={resolvedNode}
+      scope={ctx.scope}
+      mode={ctx.mode}
+      tenantSlug={ctx.tenantSlug}
+      renderChild={renderChild}
+    />
+  )
+}
+
+export function RenderTree({ components, mode, tenantSlug, scope = {} }: RenderTreeProps): ReactNode {
+  return components.map((node) => renderNode(node, { mode, tenantSlug, scope }))
+}
+```
+
+> **Plugin shim receives RESOLVED props (intentional).** Because resolution happens in `renderNode`
+> *before* `descriptor.Render`, the plugin fallback shim (§3.3) hands plugin components fully-resolved
+> `config={node.props}` — never `$bind` markers. This is a deliberate part of the **"zero plugin changes"**
+> guarantee: plugins authored against the v1 `PageComponentProps` contract keep receiving plain values and
+> need no binding-awareness. In 2a the resolver is identity, so this is observably identical to today; from
+> 2d on, plugins transparently benefit from binding resolution.
+
+### 3.5 Extended `PageConfig` (still inside the `config` JSON column)
+
+`pageConfig.ts` extends `PageConfig` per parent §"Page-level config (v2)". The new fields are **optional**
+and absent on v1 pages — 2a reads/round-trips them but does not yet author or consume them (variables &
+data sources flow in 2d, gated on the 1g render contract v2 actually surfacing them).
+
+```ts
+import type { PageComponent, PropValue } from './model/pageModel'
+
+export interface PageVariable {
+  name: string
+  type: 'string' | 'number' | 'boolean' | 'json'
+  default?: PropValue
+}
+
+export interface PageDataSource {
+  name: string
+  collection: string
+  fields?: string[]
+  filter?: Record<string, unknown>
+  sort?: string[]
+  limit?: number
+  mode: 'list' | 'single'
+  recordId?: PropValue
+}
+
+export interface PageConfig {
+  layout?: PageLayout
+  components?: PageComponent[]
+  variables?: PageVariable[]   // NEW (2a defines; 2d authors/consumes)
+  dataSources?: PageDataSource[] // NEW (2a defines; 2d authors/consumes)
+  schemaVersion?: 2            // NEW marker; absent ⇒ v1, present ⇒ v2 (set when builder saves under 2c+)
+}
+```
+
+`readComponents`/`readConfig` are unchanged in behavior. `mergeConfig` is widened to overlay
+`variables`/`dataSources`/`schemaVersion` (preserving untouched keys) so future slices can persist them:
+
+```ts
+export function mergeConfig(
+  existing: PageConfig,
+  changes: Partial<Pick<PageConfig, 'components' | 'layout' | 'variables' | 'dataSources' | 'schemaVersion'>>,
+): PageConfig {
+  const merged: PageConfig = { ...existing }
+  for (const k of ['layout', 'components', 'variables', 'dataSources', 'schemaVersion'] as const) {
+    if (changes[k] !== undefined) (merged as Record<string, unknown>)[k] = changes[k]
+  }
+  return merged
+}
+```
+
+### 3.6 Dependency on 1g (hard edge — 1g ships before 2a, but 2a tolerates a v1 contract)
+
+Per the parent dependency order, **1g ships before 2a** (`1g → 2a`). But the edge is a *sequencing*
+edge, not a build-break: **2a is FE-only and tolerates a v1 render contract**. The 1g slice (backend)
+bumps the render contract to `version "2.0"` and surfaces sibling `variables`/`dataSources`. 2a's
+`RenderTree` accepts a `scope` prop (defaulting `{}`) so that when 2d wires those in, no `RenderTree`
+signature changes. **If the runtime is still on the v1 contract, `CustomPage` simply passes `scope={}` and
+every node renders with an empty scope — identical to today** (the 2a resolver is identity anyway, so an
+empty scope changes nothing). This — together with the runtime feature flag (§5.4) — is what guarantees
+`main` is never half-broken regardless of 1g/2a merge order.
+
+---
+
+## 4. DB migrations
+
+**None — FE only.** Everything new nests inside the existing `ui-pages.config` JSON column (no DDL, no
+Flyway version consumed; head remains V146). No NATS subject or payload change.
+
+---
+
+## 5. File-by-file code changes
+
+All paths under `kelta-ui/app/src/`.
+
+### 5.1 New files — `model/`
+
+| File | Contents |
+|------|----------|
+| `pages/PageBuilderPage/model/pageModel.ts` | The v2 types from §3.1: `Binding`, `PropValue`, `isBinding`, `PageAction`, `EventHandlers`, `ResponsiveSpan`, `PageComponent`. Keep a deprecated `ComponentPosition` (`{row,column,width,height}`) export used only by back-compat readers. |
+| `pages/PageBuilderPage/model/treeOps.ts` | Pure tree mutations. **Implement now** (used by the refactored builder handlers): `insertNode(tree, node, parentId?, index?)`, `removeNode(tree, id)`, `updateProps(tree, id, patch)`. **Stub now, finish in 2c** (canvas dnd): `moveNode(tree, id, toParentId, index)`, `setSpan(tree, id, span)` — ship as typed **no-op stubs that return the input tree unchanged** (so the surface exists and is import-stable) — they do **not** throw. **No code path reaches them before 2c**: there is no reorder/resize/span UI yet, and 2b's inspector mutates props via `updateProps` only. All return new trees (immutable). |
+
+### 5.2 New files — `widgets/`
+
+| File | Contents |
+|------|----------|
+| `pages/PageBuilderPage/widgets/types.ts` | §3.2 — `WidgetDescriptor`, `PropFieldSchema`, `WidgetRenderProps`, `WidgetCategory`, `PropFieldKind`. |
+| `pages/PageBuilderPage/widgets/registry.ts` | §3.3 — `widgetRegistry` singleton + `wrapPluginComponent` + `defaultDescriptor`. |
+| `pages/PageBuilderPage/widgets/renderTree.tsx` | §3.4 — `RenderTree` + `renderNode`. |
+| `pages/PageBuilderPage/widgets/builtins/index.ts` | `registerBuiltins()` — calls `widgetRegistry.register(...)` for all 8. Imported once (from `App.tsx` bootstrap or a `widgets/registerBuiltins.ts` side-effect import in `PageBuilderPage.tsx` **and** `CustomPage.tsx`, so both surfaces populate the registry). |
+| `pages/PageBuilderPage/widgets/builtins/heading.tsx` | §2.1 — honors `level`, `props.text`. `data-testid="page-node-heading"`. |
+| `pages/PageBuilderPage/widgets/builtins/text.tsx` | Renders `props.content` (falling back to `props.text`, matching the runtime's existing `asString(props.content, asString(props.text))`). `data-testid="page-node-text"`. |
+| `pages/PageBuilderPage/widgets/builtins/button.tsx` | Label `props.label`, variant `props.variant` (primary/secondary/danger styling from preview), and `props.href` → `<a>` else `<button>` (runtime behavior). `data-testid="page-node-button"`. Declares **`supportedEvents:['onClick']`** (consumed by 2b's `event-list` field + 2e runtime; no event wiring in 2a). |
+| `pages/PageBuilderPage/widgets/builtins/image.tsx` | `props.src`/`props.alt`; placeholder box when no `src` (editor) / `<img>` (both). `data-testid="page-node-image"`. |
+| `pages/PageBuilderPage/widgets/builtins/card.tsx` | `acceptsChildren:true`; `<div className="rounded-lg border …">{children.map(renderChild)}</div>`. `data-testid="page-node-card"`. |
+| `pages/PageBuilderPage/widgets/builtins/container.tsx` | `acceptsChildren:true`; renders `node.children` via `renderChild`, placeholder when empty (editor). `data-testid="page-node-container"`. |
+| `pages/PageBuilderPage/widgets/builtins/dataTableNode.tsx` | **Moved verbatim** from `PageTreeRenderer.tsx`: `DataTableNode`, `readDataView`, `asString`, `asStringList`, `MAX_TABLE_ROWS`, `DataViewConfig`. Same `apiClient.getList('/api/{collection}?page[size]=…')` fetch (Cerbos/FLS preserved). `data-testid="page-node-table"`. |
+| `pages/PageBuilderPage/widgets/builtins/table.tsx` | §2.2 — `Render` keyed on `mode`: `editor` → placeholder box (matching today's `Preview`/`Canvas`), `runtime` → `<DataTableNode>`. `propSchema` for the `dataView` fields. |
+| `pages/PageBuilderPage/widgets/builtins/formNode.tsx` | **Moved verbatim** from `PageTreeRenderer.tsx`: `FormNode` (the `apiClient.postResource('/api/{collection}', values)` create path). `data-testid="page-node-form"`/`form-submit`/`form-success`/`form-error`. |
+| `pages/PageBuilderPage/widgets/builtins/form.tsx` | `category: 'input'` (**not `data`** — parent §"Widget registry"; this makes the `input` palette category non-empty from 2a). `Render` keyed on `mode`: `editor` → placeholder box, `runtime` → `<FormNode>`. `propSchema` for collection/fields. |
+
+### 5.3 Refactor — `pages/PageBuilderPage/PageBuilderPage.tsx`
+
+Delete the 4 builder switch sites; wire palette/preview/canvas to the registry + `RenderTree`. Key edits:
+
+**(a) Replace the local `PageComponent`/`ComponentPosition` interfaces** with re-exports so external
+importers (`pageConfig.ts`, tests, SDK) keep working:
+
+```ts
+// BEFORE (~61–77): full interface definitions of PageComponent + ComponentPosition
+// AFTER:
+export type { PageComponent } from './model/pageModel'
+export type { ComponentPosition } from './model/pageModel' // deprecated, back-compat only
+```
+
+**(b) `AVAILABLE_COMPONENTS` (~101)** — keep the array in 2a (palette becomes registry-driven in 2b), but
+source labels/icons from the registry to start the de-dup:
+
+```ts
+// AFTER: derive from the registry instead of a second hand-maintained list
+const AVAILABLE_COMPONENTS = widgetRegistry.list().map((w) => ({
+  type: w.type, label: w.label, icon: w.icon,
+}))
+```
+
+> **i18n (parent §i18n).** Any **new** user-facing string introduced by 2a — palette item labels and the
+> new `input` **palette-category** label (and any other category headers the palette surfaces) — goes
+> through `useI18n`/`t()` with `builder.*` keys; never hardcode English. The builder is already fully
+> `useI18n`-driven; descriptor `label`/category strings are rendered through `t()` at the palette call
+> site (the descriptor stores the i18n key or a stable label that the palette resolves via `t()`).
+
+**(c) `Preview.renderPreviewComponent` (~505–632)** — delete the entire `switch` (incl. the plugin
+`getPageComponent` special-case and `default:`). Replace the preview body:
+
+```tsx
+// BEFORE: components.map(renderPreviewComponent)  with a 110-line switch
+// AFTER:
+<div className="flex flex-col gap-4">
+  <RenderTree components={components} mode="editor" tenantSlug={tenantSlug} />
+</div>
+```
+
+The `getPageComponent` prop on `Preview`/`Canvas` is **removed** — plugin resolution now happens inside
+`widgetRegistry.get()`. (Drop the `usePlugins()` `getPageComponent` wiring at the call sites ~1611/1622.)
+
+**(d) `Canvas.renderComponent` (~734–842)** — keep the selection/delete chrome (outline, ×, custom badge),
+but replace the inner per-type preview block (~798–838 and the `CustomComponent` branch) with a single
+`RenderTree`/`renderNode` call for the node's body:
+
+```tsx
+// BEFORE: isCustomComponent ? <CustomComponent .../> : <>{comp.type === 'heading' && …}</>
+// AFTER:
+<div className="text-sm text-foreground">{renderNode(comp, { mode: 'editor', tenantSlug, scope: {} })}</div>
+```
+
+The "Custom" badge now keys off `widgetRegistry.has(comp.type) && !isBuiltinType(comp.type)` (or simply
+`componentRegistry.hasPageComponent(comp.type)` — unchanged semantics).
+
+**(e) `handleAddComponent` (~1374)** — apply `defaultProps` from the descriptor and stop writing `position`:
+
+```ts
+// AFTER:
+const descriptor = widgetRegistry.get(componentType)
+const newComponent: PageComponent = {
+  id: generateId(),
+  type: componentType,
+  props: { ...descriptor.defaultProps },
+}
+```
+
+**(f)** `PropertyPanel` (~233–483) is **left as-is in 2a** (the parent sequencing keeps the hardcoded
+inspector until 2b deletes it and replaces it with the `propSchema` loop). Add a `// TODO(2b): replace with
+schema-driven Inspector looping over widgetRegistry.get(type).propSchema` marker.
+
+**(g)** Add `tenantSlug` to the editor: read it from the existing route/`useParams` or `usePlugins`/auth
+context the page already has, threaded into `Preview`/`Canvas` (builder runs under `/:tenantSlug/setup/...`).
+If unavailable in 2a, pass `''` — editor preview built-ins don't depend on `tenantSlug`; only plugin
+components receive it (and they handle empty slugs today).
+
+### 5.4 Refactor — `pages/app/CustomPage/PageTreeRenderer.tsx` (flag-gated, legacy kept)
+
+The runtime flip is the highest-blast-radius change (every custom page, all tenants, one merge), so it is
+**gated behind a system feature flag with a fallback to the legacy `PageNodeRenderer`** (parent §"Rollout
+& rollback"). `DataTableNode`/`FormNode`/helpers are **copied** into `widgets/builtins/` (the descriptors'
+verbatim source); the **legacy `PageNodeRenderer` switch + its `DataTableNode`/`FormNode` stay in this
+file** until 2a soaks behind the flag, so a flag flip reverts cleanly with zero redeploy. `PageTreeRenderer`
+becomes a **flag selector**:
+
+```tsx
+import { RenderTree } from '@/pages/PageBuilderPage/widgets/renderTree'
+import { registerBuiltins } from '@/pages/PageBuilderPage/widgets/builtins'
+import type { PageComponent } from '@/pages/PageBuilderPage/model/pageModel'
+import { useFeatureFlag } from '@/hooks/useFeatureFlag' // existing kelta.config.feature infra
+
+registerBuiltins() // idempotent; safe to call from both surfaces
+
+export type PageNode = PageComponent // back-compat alias for CustomPage's import
+
+export function PageTreeRenderer({
+  components,
+  tenantSlug,
+}: {
+  components: PageNode[]
+  tenantSlug: string
+}): React.ReactElement {
+  // Flag OFF (default until soak) → legacy renderer; flag ON → shared RenderTree.
+  const useRenderTree = useFeatureFlag('page-builder.render-tree-v2')
+  if (!components || components.length === 0) {
+    return (
+      <p className="py-8 text-center text-sm text-muted-foreground" data-testid="page-empty">
+        This page has no content yet.
+      </p>
+    )
+  }
+  if (!useRenderTree) {
+    return <LegacyPageTreeRenderer components={components} tenantSlug={tenantSlug} /> // kept verbatim
+  }
+  return (
+    <div className="flex flex-col gap-4" data-testid="page-tree">
+      <RenderTree components={components} mode="runtime" tenantSlug={tenantSlug} />
+    </div>
+  )
+}
+```
+
+`LegacyPageTreeRenderer` is **today's `PageNodeRenderer` switch + `DataTableNode`/`FormNode`/`readDataView`/
+`renderChildren`, kept in place** (renamed only). It is **deleted in a follow-up cleanup once 2a has soaked
+behind the flag** — not in this PR. `CustomPage.tsx` is unchanged (still imports `PageTreeRenderer` +
+`PageNode`) — the `PageNode` alias preserves its `import { PageTreeRenderer, type PageNode }`.
+
+> **Editor preview is not flag-gated.** The Phase-B editor flip (`PageBuilderPage.tsx` preview/canvas →
+> `RenderTree`, §5.3) is internal to the builder and covered by the golden snapshot; only the **runtime**
+> path (published end-user pages) rides the flag, because that is where a regression reaches real users.
+
+> **De-dup guarantee (explicit):** once the runtime flag is **on**, the editor preview
+> (`RenderTree mode="editor"` in `PageBuilderPage.tsx`) and the runtime (`RenderTree mode="runtime"` in
+> `PageTreeRenderer.tsx`) call the **same `renderNode` → same descriptor `Render`**. There is exactly
+> **one** module that knows how each widget renders (the kept `LegacyPageTreeRenderer` is dead code behind
+> the flag, removed after soak). The only intentional per-surface difference is the `mode` flag the
+> `table`/`form` descriptors read to choose placeholder (editor) vs live data fetch (runtime) — which
+> reproduces today's behavior exactly.
+
+### 5.5 Refactor — `pages/PageBuilderPage/pageConfig.ts`
+
+- Extend `PageConfig` with `variables?`/`dataSources?`/`schemaVersion?` (§3.5).
+- Widen `mergeConfig` to overlay the new keys (§3.5).
+- `readComponents`/`readConfig` unchanged. Update the import of `PageComponent` to come from
+  `./model/pageModel` (it currently imports from `./PageBuilderPage`, which now re-exports the model type
+  — either works; prefer the model source).
+
+### 5.6 Registry bootstrap
+
+`registerBuiltins()` must run before either surface renders. Call it as a side-effect:
+- in `widgets/builtins/index.ts`, export `registerBuiltins()` (idempotent — guards against double-register).
+- invoke it at module scope in both `PageBuilderPage.tsx` and `PageTreeRenderer.tsx` (or once in
+  `App.tsx`). Idempotency: `register()` overwrites by `type`, and `registerBuiltins` is wrapped in a
+  `let done = false` guard.
+
+---
+
+## 6. Test plan
+
+Vitest + Testing Library + MSW, matching the existing idiom in `PageBuilderPage.test.tsx` (MSW `server`
+from `vitest.setup`, `createTestWrapper`) and `pageConfig.test.ts` (pure-function tests).
+
+The suite mirrors the **two-phase split** (§1): the golden snapshot is the gate for Phase A; the flag
+fallback is the gate for Phase B.
+
+### 6.0 New — `widgets/builtins.golden.test.tsx` (the Phase-A parity gate — BLOCKER for rollout)
+
+The safety net for the whole refactor. **Capture a golden snapshot BEFORE the refactor:** render all 8
+built-ins from a single fixed JSON fixture (`__fixtures__/golden-page.json` — one node of each type:
+`heading`/`text`/`button`/`image`/`form`/`table`/`card`/`container`, plus a plugin node and an
+unknown-type node) through **today's** render path and commit the serialized DOM as the snapshot baseline
+(Vitest `toMatchSnapshot`, or a Playwright component-DOM snapshot if richer fidelity is needed).
+
+- **Phase A** introduces `widgets/*` behind the registry; this test re-renders the same fixture through
+  `RenderTree` (both `mode`) and asserts it matches the pre-refactor snapshot **byte-for-byte**, with
+  **exactly one reviewed diff**: the runtime `heading` now emits `<h1>`/`<h3>`/… per `level` instead of a
+  hardcoded `<h2>`. That diff is approved in the PR (snapshot updated deliberately, called out in the
+  description) — it is **not** silent. Every other built-in is unchanged.
+- The fixture and snapshot live with the test so 2b–2g re-run it unchanged to prove later slices don't
+  regress built-in rendering (2d explicitly re-runs it to prove the now-real resolver is identity on
+  literal props).
+
+### 6.0b New — `PageTreeRenderer.flag.test.tsx` (Phase-B fallback gate)
+
+Asserts the runtime flip is reversible: with the system feature flag **on**, `CustomPage`/runtime renders
+via `RenderTree`; with it **off**, it falls back to the **legacy `PageNodeRenderer`** and produces the
+pre-2a output (same fixture/snapshot as today, including the legacy hardcoded-`h2` heading). Mock the
+feature-flag hook both ways. This proves the rollback trigger (§8) actually rolls back.
+
+### 6.1 New — `widgets/registry.test.ts`
+
+- `register` + `get` returns the registered built-in descriptor by type.
+- `list` / `listByCategory` return the registered set filtered by `category`.
+- **Plugin fallback shim:** `componentRegistry.registerPageComponent('acme', Stub)`; `widgetRegistry.get('acme')`
+  returns a descriptor whose `Render` mounts `Stub` with `config={node.props}` + `tenantSlug` (assert the
+  `PageComponentProps` shape is passed unchanged). `has('acme') === true`.
+- **Unknown-type default descriptor:** `get('nope')` returns a descriptor rendering
+  `data-testid="page-node-unknown"` with text `Unknown component: nope`; `has('nope') === false`.
+- `clear()` resets built-ins (test isolation).
+
+### 6.2 New — `widgets/renderTree.test.tsx`
+
+- **Editor vs runtime identical:** render the §2.3 tree (minus data widgets) with `mode="editor"` and
+  `mode="runtime"`; assert the produced DOM for `heading`/`text`/`button`/`image`/`card`/`container` is
+  equivalent (snapshot or per-node `data-testid` assertions).
+- **Data widgets mock `apiClient`:** mock `useApi().apiClient.getList` (MSW `/api/orders`) and assert
+  `table` in `runtime` mode fetches and renders rows; in `editor` mode renders the placeholder (no fetch).
+- `form` in `runtime` mode renders one input per `dataView.fields`, submits via `postResource` (MSW assert
+  the POST body), shows `form-success`.
+- Plugin node inside the tree renders through the shim.
+
+### 6.3 New — `widgets/builtins.parity.test.tsx`
+
+One test per migrated built-in asserting it renders as before (same `data-testid` + key classes/text):
+`heading` (honors `level` — the one intentional runtime change, asserted on the new output),
+`text`, `button` (href→`<a>`, no-href→`<button>`), `image` (src + placeholder), `card`/`container`
+(children via `renderChild`), `table` (placeholder/editor + fetch/runtime), `form` (placeholder + create).
+
+### 6.4 New — `model/treeOps.test.ts`
+
+`insertNode`/`removeNode`/`updateProps` immutability + correctness (append, nested insert by `parentId`,
+remove by id at any depth, prop patch merge). `moveNode`/`setSpan` assert they are **no-op stubs that
+return the input tree unchanged** (not throwing) — so 2c can flip them from no-op to real behavior, and a
+test documents that 2a never relies on them.
+
+### 6.5 Extend — `PageBuilderPage.test.tsx`
+
+- Palette still renders the 8 items (`palette-item-heading` … now sourced from the registry).
+- Adding a component applies `defaultProps` (e.g. add `heading` → preview shows "Heading").
+- Preview overlay renders via `RenderTree` (existing preview tests keep passing — same `data-testid`s).
+- A plugin page component registered before mount still shows the "Custom" badge in the canvas and renders
+  in preview (port the existing custom-component tests to the shim).
+
+### 6.6 Extend — `pageConfig.test.ts`
+
+- `mergeConfig` overlays `variables`/`dataSources`/`schemaVersion` while preserving `components`/`layout`.
+- `readComponents`/`readConfig` unchanged (existing tests stay green; the `comp()` helper drops `position`
+  to match the v2 model, or keeps it to prove `position` is tolerated on read).
+
+### 6.7 e2e
+
+Playwright e2e is **post-deploy only** (project convention) — the parent spec's positive page-render e2e
+runs once deployed. No new e2e file in this slice; the refactor is covered by the Vitest golden-snapshot +
+parity suite (§6.0). Because the runtime flip rides a **feature flag** (default off until soak), the
+post-deploy e2e first runs against the legacy path, then is re-run with the flag flipped on as part of the
+soak before the legacy renderer is removed.
+
+---
+
+## 7. Docs to update (same PR)
+
+| Doc | Change |
+|-----|--------|
+| `.claude/docs/status.md` (line ~48, "Page builder / screen builder" row) | Add: "slice 2a — **widget descriptor registry + shared `RenderTree`**: the 5 hardcoded per-type switch sites (`AVAILABLE_COMPONENTS`, `PropertyPanel`, `Canvas.renderComponent`, `Preview.renderPreviewComponent`, `PageNodeRenderer`) collapse to one `widgetRegistry` (`widgets/registry.ts`) + one shared render module (`widgets/renderTree.tsx`) used by both builder preview and runtime; 8 built-ins migrated to descriptors at parity; plugin `componentRegistry` folded in via a fallback shim (zero plugin changes); `model/pageModel.ts` defines the v2 `PageComponent`/`Binding`/`PropValue` types; runtime `heading` now honors `level` (was hardcoded `h2`) — a reviewed golden-snapshot diff; the runtime flip ships **behind a feature flag** with fallback to the legacy `PageNodeRenderer` until soak." Keep the gap column ("typed/validated form fields", "per-page Cerbos authz") unchanged — those move out in 2f/1h. |
+| `.claude/docs/playbooks.md` | **Add a new recipe "Add a page component / widget"** (there is none today; recipes 3 and 6 are the closest). The registration step changes from *editing five switches* to *one descriptor*: create `widgets/builtins/<type>.tsx` exporting a `WidgetDescriptor`, register it in `widgets/builtins/index.ts` `registerBuiltins()`. Note plugins still use `componentRegistry.registerPageComponent(...)` and are auto-wrapped by the registry shim — no builtin needed. |
+| `.claude/docs/conventions.md` | If/when it documents page components or the `componentRegistry`: add the **widget descriptor** as the canonical extension point (descriptor over switch), and the rule that editor preview + runtime must go through `RenderTree` (never re-implement per-type JSX). Document the v2 `config` shape stub (`variables`/`dataSources`/`schemaVersion`, `$bind` marker) as defined-but-not-yet-authored, deferring the full contract write-up to 2d. |
+| `.claude/docs/concerns.md` ("Large files needing decomposition" table, ~23) | Update the `PageBuilderPage.tsx` situation: it is **not** currently in that table; note in the same PR that this slice shrinks it from ~1832 lines by extracting the render path (preview/canvas body, the 4 switch sites) into `widgets/*`. Once 2b extracts the inspector, add a tracking note if it's still oversized. **Also note the temporary `LegacyPageTreeRenderer` kept behind the `page-builder.render-tree-v2` feature flag** (dead code until the post-soak cleanup removes it) so it isn't mistaken for live duplication. |
+
+Per CLAUDE.md Rule 6 these doc edits ship **in the same PR** as the code.
+
+---
+
+## 8. Risks & open questions
+
+- **`PageBuilderPage.tsx` size (1832 lines).** It is large but **not** currently listed in
+  `concerns.md`'s "Large files" table (which tops out at `SystemCollectionDefinitions.java` @ 1,434).
+  This refactor is net-shrinking: deleting the 4 switch sites and the per-type preview JSX (~300+ lines)
+  and moving render logic to `widgets/*`. 2b (inspector extraction) shrinks it further. **Mitigation:** do
+  the extraction widget-by-widget with the parity suite green at each step; don't combine with a visual
+  redesign.
+- **Plugin fallback shim must NOT change `PageComponentProps`.** The risk is "improving" the contract while
+  wrapping. The shim's `Render` calls `<PluginComp config={node.props} tenantSlug={tenantSlug} />` —
+  exactly the three existing call shapes (`PageNodeRenderer`/`Canvas`/`Preview`). `componentRegistry.ts`
+  and `types/plugin.ts` are **untouched**. A registry test asserts the exact props handed to a stub plugin.
+  The only superset is that builder sites now also pass `tenantSlug` (previously omitted) — verify no
+  plugin in the repo asserts `tenantSlug` is absent (it's an optional-in-practice nav hint).
+- **Runtime `table`/`form` data-fetch behavior must be preserved verbatim.** `DataTableNode`/`FormNode`
+  are **moved, not rewritten** — same `apiClient.getList`/`postResource` calls so the gateway+worker keep
+  enforcing Cerbos/FLS (denied fields stripped server-side). The `mode` flag preserves the
+  editor-placeholder vs runtime-fetch split exactly. **Open question:** should the editor preview *also*
+  fetch live data (it doesn't today)? Decision: **no** in 2a (keep parity); revisit in 2d when bindings/data
+  sources exist and a live preview is meaningful.
+- **Intentional behavior change: runtime `heading` now honors `level`.** Today `PageNodeRenderer` renders
+  every `heading` as `<h2 className="text-2xl …">`; the editor preview honors `level`. Unifying on the
+  descriptor makes the runtime honor `level` too — a strict improvement and the whole point of de-dup, but
+  it *is* a render-output change for already-published pages with non-`h2` headings. It surfaces as the
+  **one reviewed diff in the golden snapshot** (§6.0) — not a silent change — and is called out in the PR +
+  `status.md`. **Open question for the user:** acceptable, or should we freeze runtime headings at `h2` for
+  back-compat? (Recommended: take the fix.)
+- **Rollout & rollback (BLOCKER for safe rollout).** The runtime flip touches **every** custom page across
+  all tenants in one merge. Mitigations, all required: (1) the slice is **split** — Phase A introduces
+  `widgets/*`/`RenderTree`/builtins behind the registry with the **golden snapshot** captured before the
+  refactor as the gate; Phase B flips the surfaces. (2) The **runtime** flip is gated behind a **system
+  feature flag** (`page-builder.render-tree-v2`, default off) with fallback to the legacy `PageNodeRenderer`,
+  which is **kept in the tree until 2a soaks** (deleted in a follow-up cleanup). (3) **Rollback trigger:** a
+  spike in page-render error rate or in unknown-widget fallback renders → flip the flag back to the legacy
+  renderer (instant, no redeploy). A `PageTreeRenderer.flag.test.tsx` proves both branches render and the
+  fallback reproduces pre-2a output.
+- **Registry bootstrap ordering.** Both surfaces must call `registerBuiltins()` before render.
+  `registerBuiltins` is idempotent (guard flag); calling it at module scope in `PageBuilderPage.tsx` and
+  `PageTreeRenderer.tsx` (or once in `App.tsx`) covers both. Tests must `clear()` + `registerBuiltins()` in
+  `beforeEach` for isolation.
+- **`PageComponent` interface relocation.** Moving `PageComponent` out of `PageBuilderPage.tsx` into
+  `model/pageModel.ts` (and re-exporting) touches every importer (`pageConfig.ts`, tests, possibly
+  `@kelta/sdk` typings via `as unknown as import('@kelta/sdk').UIPage` casts). The re-export keeps the
+  public import path stable; verify the SDK `UIPage` cast in the mutation handlers still typechecks (it's
+  already a double-cast, so it's tolerant).
+- **Sequencing — 2a is the hard prerequisite.** 2b (inspector/palette from `propSchema`/registry), 2c
+  (canvas/treeOps/span), 2d (bindings/scope), 2e (events), 2f (typed forms) all build on `widgets/*`,
+  `model/*`, and `RenderTree`. Land 2a first (and ideally 1g for the contract siblings). Nothing else in the
+  parent plan should start until the registry + `RenderTree` are merged and green.

--- a/.claude/docs/specs/page-builder/2b-inspector-palette.md
+++ b/.claude/docs/specs/page-builder/2b-inspector-palette.md
@@ -1,0 +1,1044 @@
+# 2b — Schema-driven inspector + palette
+
+> **Slice:** 2b (FE foundation). **Axis:** foundation.
+> **Parent:** [`../page-builder-parity.md`](../page-builder-parity.md). This child spec **extends, never
+> contradicts** the parent's [Widget registry](../page-builder-parity.md#widget-registry),
+> [Inspector + canvas](../page-builder-parity.md#inspector--canvas), and
+> [Child-spec template](../page-builder-parity.md#child-spec-template) sections.
+> **Builds on:** [`2a-widget-registry.md`](./2a-widget-registry.md) — consumes the `WidgetDescriptor`,
+> `PropFieldSchema`, `PropFieldKind`, `WidgetCategory`, and `widgetRegistry` defined there. The
+> `model/pageModel.ts` types (`PageComponent`/`Binding`/`PropValue`/`PageAction`/`EventHandlers`) are
+> **defined in 2a**; this slice only consumes them.
+> Source-verified against the codebase on 2026-06-22 (Flyway head V146; this slice adds no migration).
+> If code and this doc disagree, trust the code and fix this doc.
+
+---
+
+## 1. Goal & scope
+
+### What this slice delivers
+
+This slice makes the **inspector and palette schema-driven**, finishing the consumption side of the 2a
+registry:
+
+1. **Palette from the registry.** Replace the hand-maintained `AVAILABLE_COMPONENTS` array
+   (`PageBuilderPage.tsx` ~101) and the `ComponentPalette` component (~190) with a palette that renders
+   from `widgetRegistry.listByCategory(...)`, grouped by `WidgetCategory`
+   (`layout` · `content` · `data` · `input` · `navigation`).
+2. **Schema-driven inspector.** Replace the per-type `PropertyPanel` (`PageBuilderPage.tsx` ~233, the
+   `component.type === '…' && (…)` blocks at ~301–479) with `inspector/Inspector.tsx`, which loops over
+   `widgetRegistry.get(node.type).propSchema` and maps each `PropFieldSchema.kind` to a field-editor
+   component, grouping fields by `PropFieldSchema.group`.
+3. **One field-editor component per `PropFieldKind`** under `inspector/fields/*`:
+   `text` · `textarea` · `number` · `boolean` · `select` · `color` · `collection-picker` ·
+   `field-picker` · `expression` · `event-list` · `span` · `children`.
+4. **`inspector/BindableField.tsx`** — the `fx` literal↔expression toggle shell that wraps any
+   `bindable` field. It writes a literal `PropValue` in literal mode and a `{ $bind, mode:'expr' }`
+   `Binding` in expression mode, opening `FieldExpressionPicker` to author the expression.
+5. **`inspector/fields/EventListField.tsx` (SHELL)** — **one** `kind:'event-list'` field (`key:'events'`)
+   that edits the whole `node.events` (`EventHandlers`), rendered as **tabs over
+   `descriptor.supportedEvents`** (declared on the descriptor in 2a), each tab an ordered `PageAction[]`
+   you add / remove / reorder with a type selector. The **action runtime** (executing
+   `runFlow`/`navigate`/etc.) is **out of scope — lands in 2e**; this slice defines the authoring
+   surface and its `onChange` write contract only.
+6. **Delete the 4 hardcoded builder switch sites.** Per 2a the render switches were already migrated to
+   descriptors; here the **inspector + palette** consumption is finalized so the only remaining
+   per-type knowledge lives in `widgets/builtins/*` descriptors.
+
+### What this slice explicitly does NOT do
+
+| Out of scope | Lands in |
+|--------------|----------|
+| Binding **resolution** (`resolveBindings`/`interpolate`/`bindingScope`), live `record`/`vars`/`data` scope, the `expression`/`BindableField` runtime that actually evaluates `{ $bind }` | **2d** |
+| `EventListField` **action runtime** (dispatching `runFlow`→`/api/flows/{id}/execute`, `navigate`, `createRecord`, etc.) | **2e** |
+| dnd-kit canvas, drop-into-container, reorder, resize; the `span` field-editor's *visual grid* wiring (the `span` field-editor component itself ships here as a numeric editor, but the canvas resize handles are 2c) | **2c** |
+| New widgets (grid/row/column/divider/chart/tabs/nav/icon/link/list/repeater/field-value, typed inputs) | 2c / 2f / 2g |
+| `model/*` type definitions (defined in 2a) | (already 2a) |
+
+> **Consumed-from boundary (explicit).** The `expression` field kind and the `fx` toggle in
+> `BindableField` **produce** `{ $bind, mode:'expr' }` values and persist them to `props[key]`. They do
+> **not** resolve or evaluate those values — that is 2d. Likewise `EventListField` **produces** the whole
+> `EventHandlers` map (per-event `PageAction[]`) and persists it wholesale to `node.events`; executing
+> those actions is 2e. This slice's
+> contract is purely *authoring + value-write*; the descriptor `Render` functions in 2a continue to
+> render the literal/placeholder output until 2d/2e wire resolution and runtime in.
+
+### Parent-doc sections this conforms to
+
+- [Widget registry](../page-builder-parity.md#widget-registry) — `PropFieldKind` enumeration,
+  `PropFieldSchema` shape, `listByCategory`.
+- [Inspector + canvas](../page-builder-parity.md#inspector--canvas) — "schema-driven property editor
+  looping over `descriptor.propSchema`, grouped by `group`", "each `bindable` field wraps in
+  `BindableField`", "`EventListField` edits `PageAction[]` (add/remove/reorder)".
+- [Reuse Map](../page-builder-parity.md#reuse-map) — `FieldExpressionPicker`, `VariablePicker`,
+  `useCollectionSchema`, `CollectionStoreContext`.
+
+### Acceptance criteria
+
+- The palette renders every registered built-in by reading `widgetRegistry.list()` /
+  `listByCategory(...)`; there is **no** standalone `AVAILABLE_COMPONENTS` array left in
+  `PageBuilderPage.tsx`. Adding a component still calls the existing `handleAddComponent` path.
+- Selecting a node renders an inspector whose fields are produced **only** by looping over that node's
+  `descriptor.propSchema` — there are **zero** `component.type === '…'` conditionals left in
+  `PageBuilderPage.tsx`.
+- Each `PropFieldKind` maps to exactly one field-editor component under `inspector/fields/`.
+- A `bindable` field shows an `fx` toggle; toggling to expression mode and inserting an expression writes
+  `props[key] = { $bind: '<expr>', mode: 'expr' }`; toggling back to literal restores a scalar write.
+  Proven by Vitest.
+- `EventListField` presents one tab per `descriptor.supportedEvents` entry, and within the active tab can
+  add, remove, and reorder `PageAction` rows; it writes the whole `node.events` (`EventHandlers`) map
+  wholesale. Proven by Vitest (runtime execution is asserted in 2e, not here).
+- Existing builder behavior is preserved at parity for the 8 built-ins: editing text/level/content/
+  label/variant/src/alt/collection/fields/limit produces the same `props` (and `props.dataView`) shape as
+  the old `PropertyPanel`. Existing `PageBuilderPage.test.tsx` prop-edit assertions pass (with `data-testid`
+  updated to the new scheme — see §5.6).
+- All new inspector/palette chrome (group + field labels, palette category headers, empty-state and hint
+  strings) is rendered through `useI18n`/`t()` with `builder.*` keys — no hardcoded English (§3.7).
+- `/verify` green (lint + typecheck + `test:coverage` ≥ existing kelta-ui gate).
+
+---
+
+## 2. UI samples
+
+### 2.1 Palette — grouped by category (replaces `ComponentPalette`)
+
+After 2a, the 8 built-ins carry a `category`. The palette renders one section per non-empty category, in
+declaration order (`layout`, `content`, `data`, `input`, `navigation`):
+
+```
+┌─ Components ───────────────────────────────┐
+│                                            │
+│  LAYOUT                                    │
+│  ┌──────┐ ┌──────┐                         │
+│  │  ▢   │ │  ◻   │                         │   ← card, container
+│  │ Card │ │Cont… │                         │
+│  └──────┘ └──────┘                         │
+│                                            │
+│  CONTENT                                   │
+│  ┌──────┐ ┌──────┐ ┌──────┐ ┌──────┐       │
+│  │  H   │ │  T   │ │  B   │ │  I   │       │   ← heading, text, button, image
+│  │Head… │ │ Text │ │Butt… │ │Image │       │
+│  └──────┘ └──────┘ └──────┘ └──────┘       │
+│                                            │
+│  DATA                                      │
+│  ┌──────┐                                  │
+│  │  ⊞   │                                  │   ← table
+│  │Table │                                  │
+│  └──────┘                                  │
+│                                            │
+│  INPUT                                     │
+│  ┌──────┐                                  │
+│  │  F   │                                  │   ← form (category `input` per 2a §5.2)
+│  │ Form │                                  │
+│  └──────┘                                  │
+│                                            │
+└────────────────────────────────────────────┘
+```
+
+- Each tile keeps today's affordances: `draggable`, `onDragStart(comp.type)`, `onClick → onAddComponent(comp.type)`,
+  `aria-label="Add <label> component"`, and **`data-testid="palette-item-<type>"`** (unchanged — existing
+  e2e/Vitest selectors keep working).
+- Section header `data-testid="palette-category-<category>"`.
+- Empty categories are omitted. In 2a's 8-widget set the categories are `layout` (card, container),
+  `content` (heading, text, button, image), `data` (table), and `input` (`form` — **category `input`**
+  per 2a §5.2, the fixed assignment). So `layout`/`content`/`data`/`input` all render; only `navigation`
+  is empty until 2f/2g add widgets.
+
+### 2.2 Inspector — `heading` (text + level)
+
+```
+┌─ Properties ───────────────────────────────┐
+│ Component Type   heading                    │   ← read-only (data-testid="property-type")
+│ ID               comp_… (disabled)          │   ← read-only (data-testid="property-id")
+│                                             │
+│ ── Content ──────────────────────────────── │   ← group header (PropFieldSchema.group)
+│ Text                              [ fx ]    │   ← bindable → fx toggle (BindableField)
+│ ┌─────────────────────────────────────────┐ │
+│ │ Orders                                  │ │   ← TextField, data-testid="property-field-text"
+│ └─────────────────────────────────────────┘ │
+│                                             │
+│ Level                                       │   ← not bindable, no fx
+│ ┌─────────────────────────────────────────┐ │
+│ │ H1                                   ▼  │ │   ← SelectField, data-testid="property-field-level"
+│ └─────────────────────────────────────────┘ │
+└─────────────────────────────────────────────┘
+```
+
+### 2.3 Inspector — `button` with events
+
+`button`'s descriptor (extended in this slice — see §5.3) adds one `kind:'event-list'` prop with
+`key:'events'`. The `EventListField` shell renders a tab per `descriptor.supportedEvents` entry (for
+`button`, just `onClick`) and the action rows inside the active tab:
+
+```
+┌─ Properties ───────────────────────────────┐
+│ Component Type   button                     │
+│ ── Content ──────────────────────────────── │
+│ Label                             [ fx ]    │   ← bindable
+│ ┌─────────────────────────────────────────┐ │
+│ │ Save                                    │ │
+│ └─────────────────────────────────────────┘ │
+│ Variant                                     │
+│ ┌─────────────────────────────────────────┐ │
+│ │ Primary                              ▼  │ │
+│ └─────────────────────────────────────────┘ │
+│                                             │
+│ ── Events ────────────────────────────────  │   ← EventListField, data-testid="property-field-events"
+│ ┌ On Click ┐──────────────────────────────  │   ← tabs over descriptor.supportedEvents (here: onClick)
+│ │ ⠿  Run Flow      ▼   [flow: create_…▼]│ ✕ │   ← row 0: drag handle · action type · params · remove
+│ ├───────────────────────────────────────┤   │
+│ │ ⠿  Show Toast    ▼   [success] [Done!]│ ✕ │   ← row 1
+│ └───────────────────────────────────────┘   │
+│ [ + Add action ]                            │   ← data-testid="event-add-onClick"
+└─────────────────────────────────────────────┘
+```
+
+- Each row: drag handle (`⠿`, reorder), an action-type `<Select>` (`runFlow`/`navigate`/`openUrl`/
+  `createRecord`/`updateRecord`/`refreshData`/`setVar`/`showToast` from `PageAction`), action-specific
+  param inputs, and a remove `✕`. Row testid `event-row-onClick-<index>`; remove `event-remove-onClick-<index>`.
+- **Param inputs render but their values are stored verbatim into the `PageAction` object** — the runtime
+  that *consumes* them is 2e. The flow picker for `runFlow` lists flows from `/api/flows` (the same source
+  the parent spec names); in 2b a plain `<Select>` of flow `{id,name}` is sufficient (full async picker can
+  harden in 2e).
+
+### 2.4 Inspector — `table` (collection + field pickers)
+
+`table`'s `propSchema` (defined in 2a §5.2) is:
+`dataView.collection` → `collection-picker`, `dataView.fields` → `field-picker` (`dependsOnCollection`),
+`dataView.limit` → `number`.
+
+```
+┌─ Properties ───────────────────────────────┐
+│ Component Type   table                      │
+│ ── Data ─────────────────────────────────── │
+│ Collection                                  │
+│ ┌─────────────────────────────────────────┐ │
+│ │ Orders                               ▼  │ │   ← CollectionPickerField, data-testid="property-field-dataView.collection"
+│ └─────────────────────────────────────────┘ │   (lists CollectionStore.collections)
+│                                             │
+│ Columns                                     │
+│ ┌─────────────────────────────────────────┐ │
+│ │ ☑ id        ☑ status     ☑ total       │ │   ← FieldPickerField (multi-check of the collection's fields)
+│ │ ☐ createdAt ☐ customerId                │ │   data-testid="property-field-dataView.fields"
+│ └─────────────────────────────────────────┘ │   (disabled with hint until a collection is chosen)
+│                                             │
+│ Row limit                                   │
+│ ┌─────────────────────────────────────────┐ │
+│ │ 25                                      │ │   ← NumberField, data-testid="property-field-dataView.limit"
+│ └─────────────────────────────────────────┘ │
+└─────────────────────────────────────────────┘
+```
+
+- `field-picker` reads the sibling collection value at the schema's *parent dot-path* (for key
+  `dataView.fields`, the sibling collection lives at `dataView.collection`) and calls
+  `useCollectionSchema(collectionName)` to list checkboxes. When no collection is selected it renders a
+  disabled state with the hint "Select a collection first." (matches `dependsOnCollection: true`). That
+  hint — like every visible string here — is resolved via `t('builder.…')`, not a hardcoded literal (§3.7).
+
+### 2.5 `fx` literal↔expression toggle states (`BindableField`)
+
+```
+LITERAL MODE (default)                         EXPRESSION MODE (after clicking fx)
+┌─────────────────────────────┐                ┌─────────────────────────────┐
+│ Text                 [ fx ] │                │ Text                 [·fx·] │  ← toggle active (filled)
+│ ┌─────────────────────────┐ │                │ ┌─────────────────────────┐ │
+│ │ Orders                  │ │   click fx →   │ │ {{record.name}}     [✎] │ │  ← shows the $bind string,
+│ └─────────────────────────┘ │                │ └─────────────────────────┘ │     read-only chip + edit (✎)
+│  writes props.text="Orders" │   ← click fx → │  writes props.text =        │     button opens the picker
+└─────────────────────────────┘                │   { $bind:"record.name",    │
+                                               │     mode:"expr" }           │
+                                               └─────────────────────────────┘
+```
+
+Write transitions (the load-bearing contract):
+
+| User action | `onChange(key, value)` payload written to `props[key]` |
+|-------------|--------------------------------------------------------|
+| Type "Orders" in literal mode | `"Orders"` (raw scalar) |
+| Click `fx` (literal → expr) with no expr yet | `{ $bind: "", mode: "expr" }` (empty binding; picker opens) |
+| Insert `record.name` via `FieldExpressionPicker` | `{ $bind: "record.name", mode: "expr" }` |
+| Click `fx` again (expr → literal) | the descriptor's `defaultProps[key]` if present, else `""` (binding dropped) |
+
+- The `fx` button is rendered **only** when `PropFieldSchema.bindable === true`. Non-bindable fields
+  (`level`, `variant`, `dataView.limit`, …) render the bare editor with no toggle.
+- `data-testid`s: toggle `bindable-fx-<key>`, expr chip `bindable-expr-<key>`, edit button
+  `bindable-edit-<key>`.
+
+### 2.6 Before / after of the affected screen
+
+```
+TODAY (PageBuilderPage.tsx)                  AFTER 2b
+────────────────────────────                 ─────────────────────────────
+ComponentPalette                             <Palette>                         reads widgetRegistry.listByCategory()
+  └ AVAILABLE_COMPONENTS[]  (hardcoded 8)       └ section per category
+PropertyPanel                                <Inspector node=…>                loops widgetRegistry.get(type).propSchema
+  └ type==='heading' && (…text/level…)          └ {schema.map(f => <Field kind=f.kind/>)}
+  └ type==='text'    && (…)                          ├ TextField / SelectField / NumberField / …
+  └ type==='button'  && (…)                          ├ wrapped in <BindableField> when f.bindable
+  └ (table|form)     && (…dataView…)                  └ EventListField for kind:'event-list'
+```
+
+### 2.7 Sample node JSON after authoring (what `config.components` holds)
+
+```json
+[
+  { "id": "c1", "type": "heading", "props": { "text": { "$bind": "record.name", "mode": "expr" }, "level": "h1" } },
+  {
+    "id": "c2",
+    "type": "button",
+    "props": { "label": "Save", "variant": "primary" },
+    "events": {
+      "onClick": [
+        { "action": "runFlow", "flowId": "flow_abc", "input": {}, "awaitResult": true },
+        { "action": "showToast", "level": "success", "message": "Saved!" }
+      ]
+    }
+  },
+  { "id": "c3", "type": "table", "props": { "dataView": { "collection": "orders", "fields": ["id", "status"], "limit": 25 } } }
+]
+```
+
+`c1.props.text` is a `Binding` (round-trips untouched through the server; resolved in 2d). `c2.events.onClick`
+is a `PageAction[]` (executed in 2e). `c3.props.dataView` matches the existing table data-source shape exactly.
+
+---
+
+## 3. Data & API contracts
+
+All TS lives under `kelta-ui/app/src/pages/PageBuilderPage/`. **No backend/API change in 2b.** The only
+network reads are the **already-existing** collection/field metadata fetches (`useCollectionSchema`,
+`CollectionStoreContext`) and, for the flow picker, the existing `GET /api/flows` list.
+
+### 3.0 Types consumed from 2a (not redefined here)
+
+```ts
+// from '../model/pageModel' (2a)
+import type { PageComponent, PropValue, Binding, PageAction, EventHandlers } from '../model/pageModel'
+import { isBinding } from '../model/pageModel'
+// from '../widgets/types' (2a)
+import type { PropFieldSchema, PropFieldKind, WidgetCategory } from '../widgets/types'
+// from '../widgets/registry' (2a)
+import { widgetRegistry } from '../widgets/registry'
+```
+
+### 3.1 Common field-editor props (the shared contract)
+
+Every `inspector/fields/*` component implements the same base prop shape so `Inspector` can render them
+uniformly. The **value-write contract** is: a field receives the *current value at its key* and an
+`onChange(value)` that writes the **whole value** for that key — `Inspector` is responsible for splicing it
+into `props` at the (possibly dotted) `schema.key` via a `setByPath` helper.
+
+```ts
+// inspector/fields/types.ts
+import type { PropValue } from '../../model/pageModel'
+import type { PropFieldSchema } from '../../widgets/types'
+
+/** Base props handed to every field-editor component. */
+export interface FieldEditorProps<V = PropValue> {
+  schema: PropFieldSchema
+  /** Current value at schema.key (already read out of props via getByPath). May be undefined. */
+  value: V | undefined
+  /**
+   * Write the new value for this field. Inspector splices it back into props at schema.key.
+   * For literal editors this is a scalar; BindableField may pass a Binding.
+   */
+  onChange: (value: V) => void
+  /** The node being edited — needed by field-picker to read a sibling collection value. */
+  node: PageComponent
+  /** Stable id/testid base, e.g. `property-field-${schema.key}`. */
+  fieldId: string
+}
+```
+
+`Inspector` computes `value` with a `getByPath(node.props, schema.key)` and writes with
+`setByPath(node.props, schema.key, v)` (pure, immutable; lives in `inspector/propPath.ts`). These two
+helpers handle the `dataView.collection`-style dotted keys (a thin walker, **not** the binding resolver —
+binding resolution is 2d and operates on a live scope, this only walks the static `props` object).
+
+```ts
+// inspector/propPath.ts
+export function getByPath(obj: Record<string, unknown>, path: string): unknown
+export function setByPath(
+  obj: Record<string, PropValue>,
+  path: string,
+  value: PropValue,
+): Record<string, PropValue> // returns a new props object (immutable)
+export function deleteByPath(
+  obj: Record<string, PropValue>,
+  path: string,
+): Record<string, PropValue>
+```
+
+### 3.2 `inspector/fields/*` — per-kind components and value-write contracts
+
+Each maps one `PropFieldKind`. All use shared primitives from `@/components/ui/*`
+(`Input`, `Textarea`, `Select*`, `Label`, `Checkbox`) — **verified to exist** and exported from
+`kelta-ui/app/src/components/ui/`.
+
+```tsx
+// inspector/fields/TextField.tsx
+import { Input } from '@/components/ui/input'
+import type { FieldEditorProps } from './types'
+
+export function TextField({ value, onChange, fieldId }: FieldEditorProps): React.ReactElement {
+  return (
+    <Input
+      value={typeof value === 'string' ? value : ''}
+      onChange={(e) => onChange(e.target.value)}      // writes a raw string scalar
+      data-testid={fieldId}
+    />
+  )
+}
+```
+
+```tsx
+// inspector/fields/TextareaField.tsx  (kind:'textarea')
+import { Textarea } from '@/components/ui/textarea'
+// onChange(e.target.value) — raw string. (Replaces the old property-content <textarea>.)
+```
+
+```tsx
+// inspector/fields/NumberField.tsx  (kind:'number')
+import { Input } from '@/components/ui/input'
+// <Input type="number" .../>; onChange writes `e.target.value === '' ? undefined : Number(e.target.value)`
+// (matches the existing limit editor which stores `undefined` when blank, NOT 0).
+```
+
+```tsx
+// inspector/fields/BooleanField.tsx  (kind:'boolean')
+import { Checkbox } from '@/components/ui/checkbox'
+// onCheckedChange(checked => onChange(!!checked)) — writes a boolean.
+```
+
+```tsx
+// inspector/fields/SelectField.tsx  (kind:'select')
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import type { FieldEditorProps } from './types'
+
+export function SelectField({ schema, value, onChange, fieldId }: FieldEditorProps): React.ReactElement {
+  return (
+    <Select value={typeof value === 'string' ? value : ''} onValueChange={(v) => onChange(v)}>
+      <SelectTrigger data-testid={fieldId}><SelectValue /></SelectTrigger>
+      <SelectContent>
+        {(schema.options ?? []).map((o) => (
+          <SelectItem key={o.value} value={o.value}>{o.label}</SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  )
+}
+// onChange writes the selected option's `value` string. Reads schema.options from PropFieldSchema.
+```
+
+```tsx
+// inspector/fields/ColorField.tsx  (kind:'color')
+import { Input } from '@/components/ui/input'
+// Native <Input type="color"> + a paired text Input for hex entry; onChange writes the hex string.
+```
+
+```tsx
+// inspector/fields/CollectionPickerField.tsx  (kind:'collection-picker')
+import { useCollectionStore } from '@/context/CollectionStoreContext'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import type { FieldEditorProps } from './types'
+
+export function CollectionPickerField({ value, onChange, fieldId }: FieldEditorProps): React.ReactElement {
+  const { collections } = useCollectionStore()   // verified: CollectionStoreValue.collections: CollectionSchema[]
+  return (
+    <Select value={typeof value === 'string' ? value : ''} onValueChange={(v) => onChange(v)}>
+      <SelectTrigger data-testid={fieldId}><SelectValue placeholder="Select a collection" /></SelectTrigger>
+      <SelectContent>
+        {collections.map((c) => (
+          <SelectItem key={c.id} value={c.name}>{c.displayName}</SelectItem>   // stores the NAME (dataView.collection holds a name)
+        ))}
+      </SelectContent>
+    </Select>
+  )
+}
+// onChange writes the collection NAME string (parity with today's free-text property-collection input).
+```
+
+```tsx
+// inspector/fields/FieldPickerField.tsx  (kind:'field-picker', dependsOnCollection)
+import { useCollectionSchema } from '@/hooks/useCollectionSchema'
+import { Checkbox } from '@/components/ui/checkbox'
+import { getByPath } from '../propPath'
+import type { FieldEditorProps } from './types'
+
+export function FieldPickerField({ schema, value, onChange, node, fieldId }: FieldEditorProps): React.ReactElement {
+  // Sibling collection lives at the parent dot-path's `.collection` — for key 'dataView.fields'
+  // the collection is at 'dataView.collection'. Derive it generically:
+  const parent = schema.key.includes('.') ? schema.key.slice(0, schema.key.lastIndexOf('.')) : ''
+  const collectionKey = parent ? `${parent}.collection` : 'collection'
+  const collectionName = getByPath(node.props, collectionKey) as string | undefined
+  const { fields, isLoading } = useCollectionSchema(collectionName)   // verified hook: returns { fields, isLoading, ... }
+
+  const selected = Array.isArray(value) ? (value as string[]) : []
+  const toggle = (name: string) =>
+    onChange(selected.includes(name) ? selected.filter((f) => f !== name) : [...selected, name])
+
+  if (!collectionName) {
+    return <p className="text-xs text-muted-foreground" data-testid={`${fieldId}-empty`}>Select a collection first.</p>
+  }
+  if (isLoading) return <p className="text-xs text-muted-foreground">Loading…</p>
+  return (
+    <div data-testid={fieldId} className="flex flex-col gap-1">
+      {fields.map((f) => (
+        <label key={f.name} className="flex items-center gap-2 text-xs">
+          <Checkbox checked={selected.includes(f.name)} onCheckedChange={() => toggle(f.name)} />
+          {f.displayName ?? f.name}
+        </label>
+      ))}
+    </div>
+  )
+}
+// onChange writes a string[] of field names (parity with today's comma-split property-columns value).
+```
+
+```tsx
+// inspector/fields/ExpressionField.tsx  (kind:'expression')
+// A first-class expression editor (distinct from BindableField, which wraps a *literal* editor with an
+// fx toggle). It always edits a Binding and is the editor BindableField delegates to in expr mode.
+import { useState } from 'react'
+import { FieldExpressionPicker } from '@/components/FieldExpressionPicker'
+import { VariablePicker } from '@/components/VariablePicker'
+import { useCollectionStore } from '@/context/CollectionStoreContext'
+import { Button } from '@/components/ui/button'
+import type { Binding, PropValue } from '../../model/pageModel'
+import { isBinding } from '../../model/pageModel'
+import type { FieldEditorProps } from './types'
+
+export function ExpressionField({ value, onChange, fieldId }: FieldEditorProps): React.ReactElement {
+  const [open, setOpen] = useState(false)
+  const binding: Binding | null = isBinding(value) ? value : null
+  // NOTE: FieldExpressionPicker takes a rootCollectionId (a UUID), NOT a name, and its onInsert emits a
+  // BARE token (dot-path or fn stub) — the CALLER wraps {{…}}. The binding namespace (record/vars/page)
+  // for the page builder is provided as staticNamespaces here (2d swaps in the real page scope; in 2b we
+  // pass the page-builder namespace stubs so the picker is usable). rootCollectionId is null in 2b unless
+  // a page-level "record collection" is configured (that wiring is 2d's PageDataSource work).
+  return (
+    <div className="flex items-center gap-2" data-testid={fieldId}>
+      <code className="flex-1 rounded bg-muted px-2 py-1 font-mono text-xs">
+        {binding ? `{{${binding.$bind}}}` : '—'}
+      </code>
+      <VariablePicker
+        variables={PAGE_SCOPE_VARIABLES /* {record,vars,page} stubs; real list in 2d */}
+        onPick={(token) => onChange({ $bind: stripMergeTags(token), mode: 'expr' } as PropValue)}
+        raw
+      />
+      <Button size="sm" variant="outline" type="button" onClick={() => setOpen(true)}>fx</Button>
+      <FieldExpressionPicker
+        open={open}
+        onOpenChange={setOpen}
+        rootCollectionId={null}
+        staticNamespaces={PAGE_STATIC_NAMESPACES /* record/vars/page */}
+        mode="expression"
+        onInsert={(token) => onChange({ $bind: token, mode: 'expr' } as PropValue)}  // caller stores bare token
+      />
+    </div>
+  )
+}
+// onChange ALWAYS writes a Binding ({ $bind, mode:'expr' }). 2d makes PAGE_SCOPE_VARIABLES/PAGE_STATIC_NAMESPACES
+// reflect the page's variables + on-load data sources; in 2b they are the static record/vars/page roots.
+```
+
+> **Verified `FieldExpressionPicker` contract** (`components/FieldExpressionPicker/FieldExpressionPicker.tsx`):
+> props are `open`, `onOpenChange(open)`, `rootCollectionId: string | null`, `staticNamespaces?: StaticNamespace[]`,
+> `mode?: 'expression' | 'path-only'`, `allowedTypes?: FieldType[]`, `onInsert(token: string)`, `title?`, `testId?`.
+> **`onInsert` emits the bare assembled token** (a dot-path like `account_id.name`, or a function stub like
+> `IF(${condition}, ${then}, ${else})`) — the Javadoc states *"Callers wrap with `{{…}}` if they need merge-tag
+> syntax."* So `ExpressionField`/`BindableField` store the bare token as `binding.$bind` and render `{{…}}` only
+> for display. `StaticNamespace` = `{ name, label, fields: { name, displayName, type }[] }`.
+
+> **Verified `VariablePicker` contract** (`components/VariablePicker/VariablePicker.tsx`): props
+> `variables: VariableNode[]` (`{ path, label?, type? }`), `onPick(token)`, `trigger?`, `raw?`. With `raw`
+> it emits the bare path; otherwise it emits `${path}`. We pass `raw` and store the path as `$bind`.
+
+```tsx
+// inspector/fields/SpanField.tsx  (kind:'span')
+// Edits ResponsiveSpan { base, sm?, md?, lg? } as four 1..12 number inputs. onChange writes the ResponsiveSpan
+// object to node.span (NOT node.props — Inspector special-cases kind:'span' to target node.span). The CANVAS
+// resize handles that also set span are 2c; this is the inspector-side numeric editor only.
+```
+
+```tsx
+// inspector/fields/ChildrenField.tsx  (kind:'children')
+// A read-only summary of node.children (count + reorder is the canvas's job in 2c). In 2b it renders a small
+// "N child components — edit on canvas" hint so acceptsChildren widgets (card/container) show *something*
+// in the inspector. No write contract (children are edited on the canvas). data-testid="property-field-children".
+```
+
+### 3.3 `inspector/BindableField.tsx` — the `fx` toggle shell
+
+`BindableField` **wraps** a literal field editor. It owns the literal↔expression mode decision based on
+whether the current value `isBinding(value)`, renders the `fx` toggle, and delegates to either the literal
+editor (passed as `children` / a render-prop) or `ExpressionField`.
+
+```tsx
+// inspector/BindableField.tsx
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+import { ExpressionField } from './fields/ExpressionField'
+import type { Binding, PropValue } from '../model/pageModel'
+import { isBinding } from '../model/pageModel'
+import type { PropFieldSchema } from '../widgets/types'
+import type { PageComponent } from '../model/pageModel'
+
+export interface BindableFieldProps {
+  schema: PropFieldSchema
+  value: PropValue | undefined
+  onChange: (value: PropValue) => void
+  node: PageComponent
+  fieldId: string
+  /** The literal editor to show in literal mode (TextField/NumberField/etc.), already bound to value/onChange. */
+  renderLiteral: (args: { value: PropValue | undefined; onChange: (v: PropValue) => void }) => React.ReactNode
+  /** Fallback literal to write when switching expr → literal (descriptor defaultProps[key] ?? ''). */
+  literalDefault: PropValue
+}
+
+export function BindableField({
+  schema, value, onChange, node, fieldId, renderLiteral, literalDefault,
+}: BindableFieldProps): React.ReactElement {
+  const isExpr = isBinding(value)
+  const toggle = () => {
+    if (isExpr) {
+      onChange(literalDefault)                          // expr → literal: drop the binding
+    } else {
+      onChange({ $bind: '', mode: 'expr' } as Binding)  // literal → expr: start an empty binding
+    }
+  }
+  return (
+    <div className="flex flex-col gap-1">
+      <div className="flex items-center justify-between">
+        <span className="text-xs font-medium text-muted-foreground">{schema.label}</span>
+        <Button
+          type="button" size="sm" variant="ghost"
+          className={cn('h-5 px-1 text-[10px]', isExpr && 'bg-primary/10 text-primary')}
+          onClick={toggle}
+          data-testid={`bindable-fx-${schema.key}`}
+        >
+          fx
+        </Button>
+      </div>
+      {isExpr ? (
+        <ExpressionField schema={schema} value={value} onChange={onChange} node={node} fieldId={`property-field-${schema.key}`} />
+      ) : (
+        renderLiteral({ value, onChange })
+      )}
+    </div>
+  )
+}
+```
+
+**Write contract summary (the load-bearing part):**
+
+| Mode | Editor shown | `onChange` writes |
+|------|--------------|-------------------|
+| literal | `renderLiteral(...)` (e.g. `TextField`) | a scalar `PropValue` (string/number/boolean) |
+| expression | `ExpressionField` | a `Binding` `{ $bind, mode:'expr' }` |
+| toggle literal→expr | — | `{ $bind: '', mode:'expr' }` then picker fills `$bind` |
+| toggle expr→literal | — | `literalDefault` (= `descriptor.defaultProps[key] ?? ''`) |
+
+`Inspector` decides per field: if `schema.bindable`, render `<BindableField renderLiteral={…literal editor for kind…}>`;
+otherwise render the literal editor directly with no toggle. (Non-bindable kinds — `select`, `boolean`,
+`collection-picker`, `field-picker`, `event-list`, `span`, `children` — are never wrapped.)
+
+### 3.4 `inspector/fields/EventListField.tsx` — SHELL (authoring only; runtime in 2e)
+
+```tsx
+// inspector/fields/EventListField.tsx
+import type { PageAction, EventHandlers } from '../../model/pageModel'
+import type { PageComponent } from '../../model/pageModel'
+
+export interface EventListFieldProps {
+  /**
+   * The events this widget supports (descriptor.supportedEvents, declared on the descriptor in 2a),
+   * e.g. ['onClick']. Renders one tab per entry; the active tab edits that event's PageAction[].
+   */
+  supportedEvents: Array<keyof EventHandlers>
+  /** Current value of node.events (the whole EventHandlers map). May be undefined. */
+  value: EventHandlers | undefined
+  /** Writes the whole EventHandlers map back to node.events (NOT a single handler). */
+  onChange: (events: EventHandlers) => void
+  node: PageComponent
+  fieldId: string
+}
+```
+
+The field renders a tab strip over `supportedEvents`; the active tab's rows operate on
+`value?.[activeEvent] ?? []`. Operations (pure transforms over the active event's `PageAction[]`; the
+**runtime that executes** these actions is 2e). Each writes the **whole** `EventHandlers` map back via
+`onChange` — never a single handler. Let `next` be the transformed `PageAction[]` for the active event:
+
+| Op | Active event's `PageAction[]` (`actions = value?.[activeEvent] ?? []`) |
+|----|-------------------------------|
+| Add | `[...actions, defaultAction(selectedType)]` where `defaultAction('runFlow') = { action:'runFlow', flowId:'', input:{} }`, etc. |
+| Remove i | `actions.filter((_, idx) => idx !== i)` |
+| Reorder i→j | array move (immutable) |
+| Edit a param | `actions.map((a, idx) => idx === i ? { ...a, [field]: newValue } : a)` |
+
+Each op then writes `onChange({ ...value, [activeEvent]: next })`, **dropping the key** when `next` is
+empty (so empty events don't bloat the config). `Inspector` maps `kind:'event-list'` to `EventListField`,
+passing `supportedEvents = descriptor.supportedEvents ?? []` and `value = node.events`, and writing the
+returned map via `onChange({ events })` (deleting `node.events` entirely when the map is empty).
+
+> **Consumed-from 2e marker (in the file header):**
+> `// EventListField authors PageAction[] only. The action RUNTIME (dispatching runFlow → /api/flows/{id}/execute,`
+> `// navigate, createRecord, etc.) lands in slice 2e. Do not add execution here.`
+
+### 3.5 `inspector/Inspector.tsx` — the schema-driven panel
+
+```tsx
+// inspector/Inspector.tsx (signature)
+export interface InspectorProps {
+  /** The selected node, or null. */
+  node: PageComponent | null
+  /** Patch the node (props/events/span). Mirrors today's PropertyPanel onChange(updates: Partial<PageComponent>). */
+  onChange: (updates: Partial<PageComponent>) => void
+}
+```
+
+Render algorithm:
+
+1. `null` node → the existing "Select a component" empty state (`data-testid="property-panel"`).
+2. Read `descriptor = widgetRegistry.get(node.type)` (never undefined — plugin/default fallback from 2a).
+3. Render the read-only Component Type + ID rows (unchanged; `data-testid="property-type"`/`"property-id"`).
+4. Group `descriptor.propSchema` by `PropFieldSchema.group` (ungrouped fields go under a default section,
+   preserving array order). Render a group header per group.
+5. For each `PropFieldSchema`, pick the editor by `kind`:
+   - `span` → write target is `node.span`; call `onChange({ span })`.
+   - `event-list` → `EventListField`; **does not read `node.props`** — pass
+     `supportedEvents = descriptor.supportedEvents ?? []` and `value = node.events`; on change call
+     `onChange({ events })` with the whole returned `EventHandlers` map (the single `event-list` field has
+     `key:'events'`, but the value lives on `node.events`, not `node.props.events`).
+   - `children` → read-only summary; no write.
+   - everything else → write target is `node.props[key]`; compute `value = getByPath(node.props, key)` and
+     `onChange({ props: setByPath(node.props, key, v) })`. If `schema.bindable`, wrap the literal editor in
+     `<BindableField>`; else render the literal editor directly.
+
+This is the **single** place that knows the kind→editor mapping. Adding a new `PropFieldKind` = adding one
+`inspector/fields/*` component + one `case` in the `Inspector` switch (documented as a playbook recipe — §7).
+
+### 3.6 Versioning / back-compat
+
+- **No schema/config change.** Values authored here (`Binding` in `props`, `PageAction[]` in `events`,
+  `ResponsiveSpan` in `span`) all nest inside the existing `ui-pages.config` JSON and round-trip untouched
+  through the server (parent: "The server never parses `$bind`").
+- **Reading legacy props:** a literal-valued prop (string/number) renders in literal mode; a `Binding`-valued
+  prop renders in expr mode. `isBinding(value)` is the sole discriminator (defined in 2a).
+- **`PropertyPanel` removal** is internal; the inspector container keeps `data-testid="property-panel"` so
+  outer-shell selectors are stable. The per-field testids change from `property-<x>` to
+  `property-field-<key>` (see §5.6 for the migration of existing tests).
+
+### 3.7 i18n — all new chrome strings go through `useI18n`/`t()`
+
+Every user-visible string introduced by this slice is localized via `useI18n()` / `t('builder.…')` with
+`builder.*` keys — **never hardcode English**, matching the existing UI convention (parent §i18n). This
+covers, at minimum:
+
+- **Inspector group headers** — the `PropFieldSchema.group` value is a translation **key** (e.g.
+  `builder.inspector.group.content`), resolved via `t()` at render; the group strings in the §2 mockups
+  ("Content", "Data", "Events", "Layout") are the rendered English, not literals in code.
+- **Field labels** — `PropFieldSchema.label` is likewise a `builder.*` key resolved with `t()`.
+- **Palette category headers** — `t('builder.palette.category.<category>')` for `layout`/`content`/
+  `data`/`input`/`navigation`; the tile `aria-label` ("Add … component") uses a parameterized
+  `builder.palette.addAria` key.
+- **Empty-state / hint strings** — the inspector empty state ("Select a component"), the
+  "No editable properties" hint, the `field-picker` "Select a collection first." hint, and the
+  `children` "N child components — edit on canvas" summary all read from `builder.*` keys (the literal
+  English shown in the §3.2 code snippets is illustrative — wrap each in `t()` in the implementation).
+- **Event-list chrome** — the action-type select option labels, the "Add action" button, and the
+  per-event tab labels (`builder.events.<eventName>`, e.g. `builder.events.onClick`) go through `t()`.
+
+`data-testid`s remain the stable, untranslated English identifiers (`property-field-<key>`,
+`palette-category-<category>`, etc.) so tests are locale-independent; only the **displayed text** is
+localized.
+
+---
+
+## 4. DB migrations
+
+**None — stored in `ui-pages.config` JSON, no DDL.** Everything authored by this slice (`Binding` values,
+`PageAction[]`, `ResponsiveSpan`) nests inside the existing `config` column. No Flyway version consumed
+(head remains V146). No NATS subject or payload change.
+
+---
+
+## 5. File-by-file code changes
+
+All paths under `kelta-ui/app/src/pages/PageBuilderPage/` unless noted.
+
+### 5.1 New files — `inspector/`
+
+| File | Contents |
+|------|----------|
+| `inspector/Inspector.tsx` | §3.5 — the schema-driven panel. Loops `descriptor.propSchema`, groups by `group`, maps `kind`→editor, wraps `bindable` fields in `BindableField`. Keeps the `property-panel` / `property-type` / `property-id` testids and the empty-state. |
+| `inspector/BindableField.tsx` | §3.3 — the `fx` literal↔expr shell. |
+| `inspector/propPath.ts` | §3.1 — `getByPath` / `setByPath` / `deleteByPath` (immutable dotted-key walkers over `props`). |
+| `inspector/fields/types.ts` | §3.1 — `FieldEditorProps<V>`. |
+| `inspector/fields/index.ts` | Barrel: re-export all field components + a `FIELD_EDITORS: Record<PropFieldKind, …>` map (or the `Inspector` switch imports them directly). |
+| `inspector/fields/TextField.tsx` | §3.2 — `kind:'text'` → `Input`; writes string. |
+| `inspector/fields/TextareaField.tsx` | `kind:'textarea'` → `Textarea`; writes string. |
+| `inspector/fields/NumberField.tsx` | `kind:'number'` → `Input type=number`; writes `number \| undefined` (blank ⇒ `undefined`, matching today's limit editor). |
+| `inspector/fields/BooleanField.tsx` | `kind:'boolean'` → `Checkbox`; writes boolean. |
+| `inspector/fields/SelectField.tsx` | §3.2 — `kind:'select'` → `Select` over `schema.options`; writes the option value. |
+| `inspector/fields/ColorField.tsx` | `kind:'color'` → native color `Input` + hex text; writes hex string. |
+| `inspector/fields/CollectionPickerField.tsx` | §3.2 — `kind:'collection-picker'` → `Select` over `useCollectionStore().collections`; writes the collection **name**. |
+| `inspector/fields/FieldPickerField.tsx` | §3.2 — `kind:'field-picker'` → multi-`Checkbox` over `useCollectionSchema(siblingCollection).fields`; writes `string[]`; disabled hint when no collection. |
+| `inspector/fields/ExpressionField.tsx` | §3.2 — `kind:'expression'` → `FieldExpressionPicker` + `VariablePicker`; always writes a `Binding`. |
+| `inspector/fields/EventListField.tsx` | §3.4 — `kind:'event-list'` SHELL; one field (`key:'events'`) editing the whole `node.events` as tabs over `descriptor.supportedEvents`; writes the wholesale `EventHandlers` map. Runtime is 2e. |
+| `inspector/fields/SpanField.tsx` | `kind:'span'` → four 1..12 number inputs; writes `ResponsiveSpan` to `node.span`. Canvas resize is 2c. |
+| `inspector/fields/ChildrenField.tsx` | `kind:'children'` → read-only child-count summary; no write (children edited on canvas, 2c). |
+
+### 5.2 New file — `Palette.tsx` (replaces `ComponentPalette`)
+
+`pages/PageBuilderPage/Palette.tsx`:
+
+```tsx
+export interface PaletteProps {
+  onDragStart: (componentType: string) => void
+  onAddComponent: (componentType: string) => void
+}
+```
+
+- Reads `widgetRegistry.list()`, groups by `category` (declaration order: layout→content→data→input→navigation;
+  in the 8-widget set `input` is **non-empty** — it holds `form` per 2a §5.2 — and only `navigation` is empty),
+  renders a `palette-category-<category>` section per non-empty category, and the existing per-tile markup
+  (`palette-item-<type>`, `draggable`, `onDragStart`, `onClick`, `aria-label`). Icons/labels come from the
+  descriptor (`w.icon` / `w.label`).
+- Keeps the `component-palette` container testid + the `builder.pages.components` heading. Category
+  headers and tile `aria-label`s are localized via `t('builder.palette.*')` (§3.7), not hardcoded English.
+
+### 5.3 Refactor — `PageBuilderPage.tsx`
+
+**(a) Delete `AVAILABLE_COMPONENTS`** (~101–110) and the `ComponentPalette` component (~185–223). Replace the
+call site (~1604):
+
+```tsx
+// BEFORE: <ComponentPalette onDragStart={handleDragStart} onAddComponent={handleAddComponent} />
+// AFTER:
+<Palette onDragStart={handleDragStart} onAddComponent={handleAddComponent} />
+```
+
+**(b) Delete `PropertyPanel`** (~225–483, including the `heading`/`text`/`button`/`image`/`table`/`form`
+`&&` blocks and the `handleDataViewChange` helper). Replace the call site (~1613):
+
+```tsx
+// BEFORE: <PropertyPanel component={selectedComponent} onChange={handleComponentChange} />
+// AFTER:
+<Inspector node={selectedComponent} onChange={handleComponentChange} />
+```
+
+`handleComponentChange` is **unchanged** — it already accepts `Partial<PageComponent>` and merges via
+`{ ...comp, ...updates }`, so `Inspector`'s `onChange({ props })` / `onChange({ events })` / `onChange({ span })`
+all work without modification.
+
+**(c) Extend two built-in descriptors with the new prop kinds** (these descriptors live in
+`widgets/builtins/*` from 2a; 2b adds the schema entries that exercise `event-list` and `span`/`children`):
+
+- `widgets/builtins/button.tsx` — append **one** entry to `propSchema`:
+  `{ key: 'events', label: 'Events', kind: 'event-list', group: 'Events' }`, and ensure the descriptor
+  declares `supportedEvents: ['onClick']` (the 2a field that the `event-list` editor tabs over). The
+  single field edits the whole `node.events`; per-event tabs come from `supportedEvents`, not from
+  multiple `event-list` schema entries.
+- `widgets/builtins/card.tsx` & `container.tsx` — append
+  `{ key: 'children', label: 'Children', kind: 'children', group: 'Layout' }` (read-only summary in 2b;
+  full edit on the canvas in 2c). Optionally add a `span` field here too, but the **`span` editor wiring is
+  primarily 2c's** — gate it behind 2c if the canvas isn't present, or ship the inspector-side `SpanField`
+  now and let 2c add the canvas handles (recommended: ship `SpanField` now; it writes `node.span` which
+  round-trips harmlessly).
+
+> These are the **only** descriptor edits in 2b. The `text`/`level`/`content`/`label`/`variant`/`src`/`alt`/
+> `dataView.*` schema entries already exist from 2a (2a §2.1/§2.2 + §5.2). 2b consumes them; it does not
+> re-declare them.
+
+**(d)** Remove the now-unused `lucide-react` imports that only served `PropertyPanel`/`ComponentPalette`
+icon glyphs if they're no longer referenced (the `Preview`/`Canvas` icon usage was already removed in 2a).
+Run lint to catch dead imports.
+
+### 5.4 No change — `pages/app/CustomPage/PageTreeRenderer.tsx`
+
+Runtime rendering is unaffected by 2b (inspector/palette are builder-only). `PageTreeRenderer` already became
+a thin `<RenderTree mode="runtime">` wrapper in 2a. **No edits in this slice.** (Listed explicitly so reviewers
+don't expect a change.)
+
+### 5.5 No change — `pageConfig.ts`
+
+`PageConfig` (incl. `variables`/`dataSources`/`schemaVersion`) and `mergeConfig` were extended in 2a. 2b authors
+`events`/`span`/`Binding` values **inside** the component tree, which already round-trips via the existing
+`components` key. **No edits.** (Listed explicitly.)
+
+### 5.6 Test-selector migration (existing tests)
+
+The existing `PageBuilderPage.test.tsx` prop-edit assertions reference the old per-type testids
+(`property-text`, `property-level`, `property-content`, `property-label`, `property-variant`, `property-src`,
+`property-alt`, `property-collection`, `property-columns`, `property-limit`). The new scheme is
+`property-field-<key>`:
+
+| Old testid | New testid |
+|-----------|-----------|
+| `property-text` | `property-field-text` |
+| `property-level` | `property-field-level` |
+| `property-content` | `property-field-content` |
+| `property-label` | `property-field-label` |
+| `property-variant` | `property-field-variant` |
+| `property-src` | `property-field-src` |
+| `property-alt` | `property-field-alt` |
+| `property-collection` | `property-field-dataView.collection` |
+| `property-columns` | `property-field-dataView.fields` |
+| `property-limit` | `property-field-dataView.limit` |
+
+Update these in the same PR. `palette-item-<type>`, `property-panel`, `property-id`, `property-type` are
+**unchanged**.
+
+### 5.7 Registry bootstrap (no new work)
+
+`registerBuiltins()` already runs at module scope (2a §5.6). `Inspector`/`Palette` call
+`widgetRegistry.get`/`list` at render time, after bootstrap — no extra wiring. Tests call
+`widgetRegistry.clear()` + `registerBuiltins()` in `beforeEach` for isolation (2a §6 idiom).
+
+---
+
+## 6. Test plan
+
+Vitest + Testing Library + MSW, matching the existing idiom in `PageBuilderPage.test.tsx` (MSW `server` from
+`vitest.setup`, `createTestWrapper`) and `pageConfig.test.ts` (pure-function tests). Field components that
+read collection metadata mount inside the test wrapper that provides `CollectionStoreProvider` /
+`ApiContext` (MSW-backed `/api/collections`), as the existing `FieldExpressionPicker`/`FieldsTab` tests do.
+
+### 6.1 New — `inspector/propPath.test.ts`
+
+- `getByPath`/`setByPath`/`deleteByPath` on flat (`text`) and nested (`dataView.collection`) keys;
+  immutability (input object not mutated; returns a new object); creating intermediate objects when absent.
+
+### 6.2 New — `inspector/fields/fields.test.tsx` (one block per kind)
+
+For each `PropFieldKind`, mount the field with a `vi.fn()` `onChange` and assert the **value-write contract**:
+
+| Kind | Assertion |
+|------|-----------|
+| `text` | typing "Orders" → `onChange('Orders')` |
+| `textarea` | typing multiline → `onChange(<string>)` |
+| `number` | typing 25 → `onChange(25)`; clearing → `onChange(undefined)` |
+| `boolean` | checking → `onChange(true)`; unchecking → `onChange(false)` |
+| `select` | choosing 'h2' from `schema.options` → `onChange('h2')` |
+| `color` | entering `#ff0000` → `onChange('#ff0000')` |
+| `collection-picker` | with MSW collections, choosing "Orders" → `onChange('orders')` (the **name**) |
+| `field-picker` | with a selected sibling collection, toggling `status` → `onChange(['status'])`; with **no** collection → renders `…-empty` "Select a collection first." and does not crash |
+| `expression` | inserting via `FieldExpressionPicker` `onInsert('record.name')` → `onChange({ $bind:'record.name', mode:'expr' })` (assert the **bare token** is stored, `{{}}` only displayed) |
+| `span` | editing base→6 → `onChange({ base: 6 })` |
+| `children` | renders the child-count summary read-only; no `onChange` |
+
+### 6.3 New — `inspector/BindableField.test.tsx`
+
+- **literal → expr write:** render with a string value, click `bindable-fx-<key>` → `onChange({ $bind:'', mode:'expr' })`;
+  then drive the inner `ExpressionField` insert → `onChange({ $bind:'record.name', mode:'expr' })`.
+- **expr → literal write:** render with `{ $bind:'record.name', mode:'expr' }`, click `fx` →
+  `onChange(literalDefault)` (assert it equals `descriptor.defaultProps[key] ?? ''`).
+- **fx hidden for non-bindable:** a field with `bindable:false` renders no `bindable-fx-*` toggle.
+- **mode discrimination:** a `Binding` value mounts in expr mode (shows `bindable-expr-<key>` chip); a scalar
+  mounts in literal mode (shows the literal editor).
+
+### 6.4 New — `inspector/fields/EventListField.test.tsx`
+
+Mount with `supportedEvents={['onClick']}` and a `value` of the whole `EventHandlers` map. Every assertion
+checks that `onChange` receives the **wholesale `EventHandlers` map**, not a bare `PageAction[]`.
+
+- **tabs:** with `supportedEvents={['onClick','onChange']}`, two tabs render; switching tabs targets the
+  other event's actions.
+- **add:** click `event-add-onClick`, pick `runFlow` → `onChange({ onClick: [{ action:'runFlow', flowId:'', input:{} }] })`.
+- **remove:** with `value={{ onClick: [a0, a1] }}`, click `event-remove-onClick-0` → `onChange({ onClick: [a1] })`.
+- **reorder:** move row 0→1 → `onChange({ onClick: [a1, a0] })`.
+- **edit a param:** set `showToast` message → `onChange({ onClick: [{ ...a0, message: 'Done!' }] })` (action updates verbatim).
+- **drops empty event:** removing the last action of an event → `onChange({})` (the `onClick` key is dropped, not left as `[]`).
+- **runtime is NOT exercised here** (no flow execution) — that is asserted in 2e. A comment in the test names
+  the boundary.
+
+### 6.5 New — `inspector/Inspector.test.tsx`
+
+- Loops `propSchema`: a `heading` node renders `property-field-text` + `property-field-level`, grouped under
+  the "Content" header; a `table` node renders `dataView.collection`/`dataView.fields`/`dataView.limit` under "Data".
+- `bindable` field (`heading.text`) shows `bindable-fx-text`; non-bindable (`heading.level`) does not.
+- Editing `text` calls `onChange({ props: { ...prev, text: 'X' } })` (parity with old `PropertyPanel`).
+- Editing `dataView.collection` calls `onChange({ props: { dataView: { ...prev.dataView, collection: 'orders' } } })`.
+- `span`/`event-list` write to `onChange({ span })` / `onChange({ events })`, not `props`.
+- `null` node → empty state with `property-panel` testid.
+- Unknown/plugin type (no propSchema) → renders the read-only type/ID rows + an "No editable properties" hint,
+  no crash.
+
+### 6.6 New — `Palette.test.tsx`
+
+- Renders one `palette-category-<category>` per non-empty category and a `palette-item-<type>` per built-in
+  (all 8 present). Asserts the category grouping: `layout` (card, container), `content` (heading, text,
+  button, image), `data` (table), and `input` (**form** — proves the `input` section is non-empty and that
+  `palette-item-form` renders inside `palette-category-input`, not `palette-category-data`); `navigation` is
+  absent (empty category omitted).
+- Clicking `palette-item-heading` calls `onAddComponent('heading')`; `onDragStart` fires on drag start.
+- A plugin component registered via `componentRegistry.registerPageComponent` does **not** appear in the
+  palette (palette lists `widgetRegistry.list()` built-ins only — plugins are added to the canvas via the
+  existing add flow / 2a shim, not the palette; assert this to lock the behavior).
+
+### 6.7 Extend — `PageBuilderPage.test.tsx`
+
+- Update selectors per §5.6 (`property-field-*`).
+- Adding a component then editing it through the new `Inspector` produces the same `components` state shape
+  the save path persists (e.g. add `heading`, type "Orders" → saved `props.text === 'Orders'`).
+- Authoring a button `onClick` action persists `events.onClick` in the saved config.
+- The `table`/`form` collection+columns edits produce the same `props.dataView` shape as before (parity).
+
+### 6.8 e2e
+
+Playwright e2e is **post-deploy only** (project convention). The parent spec's builder e2e covers
+add-component → edit-property → save once deployed. No new e2e file in this slice; the inspector/palette are
+covered by the Vitest suites above.
+
+---
+
+## 7. Docs to update (same PR)
+
+| Doc | Change |
+|-----|--------|
+| `.claude/docs/status.md` (line ~48, "Page builder / screen builder" row) | Append: "slice 2b — **schema-driven inspector + palette**: the palette renders from `widgetRegistry.listByCategory()` (grouped by category) and the inspector (`inspector/Inspector.tsx`) loops over `descriptor.propSchema`, mapping each `PropFieldKind` to a field editor under `inspector/fields/*`; the hardcoded `AVAILABLE_COMPONENTS` array, `ComponentPalette`, and per-type `PropertyPanel` blocks are deleted. `bindable` props get an `fx` literal↔expression toggle (`BindableField`) that writes `{ $bind, mode:'expr' }` via `FieldExpressionPicker`; `EventListField` authors `PageAction[]` into `node.events` (add/remove/reorder) — **binding resolution lands in 2d, action runtime in 2e**." Keep the gap column unchanged ("typed/validated form fields", "per-page Cerbos authz" still move out in 2f/1h). |
+| `.claude/docs/playbooks.md` | **Add to the "Add a page component / widget" recipe** (created in 2a) a new sub-step: *"Add a new inspector field kind."* Steps: (1) add the kind to `PropFieldKind` in `widgets/types.ts`; (2) create `inspector/fields/<Kind>Field.tsx` implementing `FieldEditorProps` with its `onChange` write contract; (3) add a `case` in `inspector/Inspector.tsx`'s kind→editor switch; (4) if it should support `fx`, mark the schema field `bindable: true` (Inspector auto-wraps in `BindableField`); (5) add a Vitest block to `inspector/fields/fields.test.tsx`; (6) localize every visible string the editor renders via `t('builder.*')` — never hardcode English. Note that authoring an `event-list`/`expression` value only *writes* the model — the runtime that consumes it is 2e/2d. |
+| `.claude/docs/conventions.md` | If/when it documents page components: add the rule that **inspector property editors are schema-driven** — never add a per-type conditional to the inspector; add a `PropFieldSchema` entry to the widget descriptor and (if a new kind) a field editor. Cross-reference the `$bind` marker (`{ $bind, mode }`) as the single bound-value convention (full contract deferred to 2d). Note that all inspector/palette chrome strings (group/field labels, category headers, empty states) are localized via `useI18n`/`t()` with `builder.*` keys — never hardcoded English (§3.7). |
+| `.claude/docs/concerns.md` ("Large files" context) | Note that 2b further shrinks `PageBuilderPage.tsx` by deleting `PropertyPanel` (~250 lines) and `ComponentPalette` (~40 lines) and extracting them to `inspector/*` + `Palette.tsx`. If the file is still oversized after 2b, add a tracking note. |
+
+Per CLAUDE.md Rule 6 these doc edits ship **in the same PR** as the code.
+
+---
+
+## 8. Risks & open questions
+
+- **`FieldExpressionPicker` takes a collection UUID, the page builder has none (yet).** Verified:
+  `rootCollectionId: string | null` is a collection **id**, and the picker's cascading field discovery
+  (`FieldsTab`) resolves relationships against the `CollectionStore`. In 2b the page builder has no bound
+  "record collection" (that's a `PageDataSource`, authored in 2d), so `ExpressionField` passes
+  `rootCollectionId={null}` and exposes the `record`/`vars`/`page` roots via `staticNamespaces`. **Open
+  question:** the `record` namespace's leaf fields aren't known until 2d wires a page data source — in 2b the
+  expression editor can still author free-form `$bind` strings (the picker also lets the user type), but the
+  field-cascade is limited to declared namespaces. **Decision:** ship 2b with namespace-only expression
+  authoring; 2d feeds the real `rootCollectionId` (from the page's primary data source) + live variable list.
+  Flag in the PR so the user knows the expr picker gets richer in 2d.
+- **`onInsert` emits a bare token, not `{{…}}`.** Verified from the Javadoc ("Callers wrap with `{{…}}`"). We
+  store the bare token as `binding.$bind` and render `{{…}}` only for display. A test asserts the stored value
+  is bare — getting this wrong would double-wrap (`{{{{…}}}}`) once 2d's resolver prepends `{{`. Locked by §6.2.
+- **`EventListField` is a shell — do not build runtime here.** The temptation is to make the action rows
+  "work" (run the flow on click) while building the editor. That belongs in 2e. The file header comment and a
+  test-boundary note guard this. Authoring-only keeps 2b shippable and reviewable.
+- **`span`/`children` editors straddle 2b/2c.** `SpanField` (inspector numeric editor) ships here; the canvas
+  resize handles that *also* write `node.span` ship in 2c. `ChildrenField` is read-only here; child reorder is
+  2c's canvas. Both write/round-trip harmlessly via the existing `components` key, so shipping the inspector
+  side early carries no risk. **Decision:** ship both inspector-side now (recommended) — they're inert until
+  2c adds the canvas counterpart.
+- **Testid scheme change touches existing tests.** Moving from `property-<x>` to `property-field-<key>` (§5.6)
+  is a mechanical migration; the container testids (`property-panel`/`property-type`/`property-id`) and
+  `palette-item-<type>` are preserved to minimize churn and keep e2e selectors stable.
+- **`PageBuilderPage.tsx` size.** This slice net-shrinks it (deleting `PropertyPanel` ~250 lines +
+  `ComponentPalette` ~40 lines, extracting to `inspector/*`/`Palette.tsx`). It is **not** currently in
+  `concerns.md`'s "Large files" table. Do the extraction with the parity suite green; don't combine with the
+  2c canvas redesign.
+- **Sequencing.** 2b hard-depends on 2a (`widgetRegistry`, `propSchema`, `model/*`). 2b is a prerequisite for
+  a *usable* builder but not for 2c/2d/2e's other axes — those depend on `widgets/*` and `model/*` (2a), not on
+  the inspector. The `fx` toggle's *resolution* (2d) and the event *runtime* (2e) consume what 2b authors, so
+  land 2b before 2d/2e but it can land in parallel with 2c.

--- a/.claude/docs/specs/page-builder/2c-layout-engine.md
+++ b/.claude/docs/specs/page-builder/2c-layout-engine.md
@@ -1,0 +1,1176 @@
+# 2c — Layout engine + dnd-kit canvas
+
+> **Slice:** 2c (FE — the **Layout & grid** axis). **Parent:**
+> [`../page-builder-parity.md`](../page-builder-parity.md). This child spec **extends, never
+> contradicts** the parent's [The shared model](../page-builder-parity.md#the-shared-model),
+> [Inspector + canvas](../page-builder-parity.md#inspector--canvas), and the **Key architecture
+> decision: DnD = `@dnd-kit`** (parent §"Key architecture decisions"). It **consumes** the contracts
+> defined in [`2a-widget-registry.md`](./2a-widget-registry.md): `WidgetDescriptor` / `PropFieldSchema`
+> / `WidgetRenderProps` (`widgets/types.ts`), the `widgetRegistry` singleton + plugin shim, the shared
+> `RenderTree`/`renderNode` path, and the v2 `PageComponent` (`id`/`type`/`props`/`events?`/`span?`/
+> `children?`) defined in `model/pageModel.ts`. 2a left `treeOps.ts` with `insertNode`/`removeNode`/
+> `updateProps` implemented and `moveNode`/`setSpan` as `notImplemented` stubs — **2c finishes them**
+> and adds `model/migrate.ts`.
+>
+> Source-verified against the codebase on 2026-06-22 (Flyway head V146; this slice adds **no
+> migration**). If code and this doc disagree, trust the code and fix this doc.
+
+---
+
+## 1. Goal & scope
+
+### What this slice delivers
+
+Replaces the **vertical-stack-only** canvas with a real **layout engine**. Today the builder canvas
+(`Canvas` in `PageBuilderPage.tsx` ~698) is a flat `flex flex-col gap-2` list; drops **always append to
+root** (`handleAddComponent` ~1374 pushes onto the top-level array), there is no nesting beyond what a
+hand-edited tree provides, and the stored `position` (`ComponentPosition {row, column, width, height}`,
+~72) is **written but completely ignored** by both the canvas and the runtime renderer. Drag is native
+HTML5 (`onDragStart`/`onDragOver`/`onDrop` + `dataTransfer.getData('componentType')`).
+
+This slice ships:
+
+1. **Four new layout widgets** (descriptors registered in `widgets/builtins/`):
+   - `grid` — a 12-column CSS-grid container; children are placed by their per-child `span`.
+   - `row` — a horizontal flex/grid row; children flow left-to-right and carry `span`.
+   - `column` — a vertical container (a grid cell); holds a stack of children, itself spanning N of 12.
+   - `divider` — a leaf horizontal rule (no children, no span semantics of its own).
+2. **Per-child responsive `span`** — `ResponsiveSpan {base, sm?, md?, lg?}` (each `1..12`), already on the
+   v2 `PageComponent` from 2a. Mapped to Tailwind `col-span-{n}` + breakpoint prefixes
+   (`sm:col-span-{n}` …). Authored by dragging a resize handle that **snaps to the 12-col grid** (no pixel
+   coordinates are ever stored — `span` is the only layout state).
+3. **`@dnd-kit` canvas** — a single `DndContext` (PointerSensor + KeyboardSensor for a11y). Palette items
+   become **draggable sources**; **every container** (`grid`/`row`/`column`/`card`/`container` + the root)
+   is a **droppable** with its own per-container `SortableContext` (strategy: `rectSortingStrategy`,
+   collision: `closestCenter`) so children reorder within their parent and move **between** containers.
+4. **`SelectableNode`** wrapper — selection outline, a drag handle (`GripVertical`), and (for children of a
+   `grid`/`row`) **resize handles** on the right edge that drive `setSpan`.
+5. **`treeOps` completion** — `moveNode` + `setSpan` implemented (2a shipped `insertNode`/`removeNode`/
+   `updateProps`). Every drop/move/resize routes through `treeOps`, **fixing "drop only appends to root"**:
+   a drop targets a specific container + index.
+6. **`model/migrate.ts`** — converts a legacy tree (nodes carrying `position {row,column,width,height}`)
+   into a `grid`-rooted container/grid tree with `span` (`width` → `span.base`, grouped by `row`). Run once
+   on load when a page lacks `schemaVersion: 2`.
+7. **`PageBuilderPage.tsx` Canvas swap** — the native-DnD `Canvas` is replaced by the new
+   `canvas/Canvas.tsx`; `handleAddComponent` and the new move/resize handlers call `treeOps`.
+8. **The canonical `handleSavePage` / `mergeConfig` rewrite** — **2c OWNS this** (parent
+   §"Save & persistence (v2 round-trip)"). 2c is the first slice that must persist a page-level sibling
+   (`schemaVersion: 2`, stamped on migration), so it widens `mergeConfig` to overlay
+   `variables`/`dataSources`/`access`/`schemaVersion` **and** changes the save call site to pass the full
+   set. Widening `mergeConfig`'s accepted keys is **useless unless the call passes them** — this is the
+   exact silent-drop bug class the parent flags. See §5.5 + the new **§5.9 save-path before→after**.
+9. **The unsaved-changes guard** — 2c owns resolving the existing `handleBackToList` TODO
+   (`// Could show a confirmation dialog here`) and a `beforeunload` guard (parent §"Parity gaps NOT
+   covered" puts it in 2c scope). See §5.10.
+10. **Deprecating the create-form layout select** — the `layoutType` select (single/sidebar/grid →
+    `config.layout.type`) is orphaned by the widget-based layout; 2c documents `config.layout` as inert
+    legacy. See §5.11.
+11. **`@dnd-kit/core` + `@dnd-kit/sortable`** added to `kelta-ui/app` (the parent-mandated single new dep,
+    **scoped to the page canvas only**).
+
+### What this slice explicitly does NOT do
+
+| Out of scope | Lands in |
+|--------------|----------|
+| Schema-driven inspector / palette-from-registry (the palette stays the 2a registry-derived array; the inspector still edits props) | 2b |
+| Bindings, `resolveBindings`, `interpolate`, data sources, `field-value`/`list`/`repeater` | 2d |
+| Events/actions authoring + action runtime (`onClick` etc.) | 2e |
+| Typed form widgets (`dropdown`/`datepicker`/`lookup`/…) replacing text-only inputs | 2f |
+| `chart`/`tabs`/`nav`/`icon`/`link` widgets | 2g |
+| Migrating `PageLayoutsPage`/`MenuBuilderPage`/`FlowDesignerPage` off native DnD — **out of scope by parent decree** (they stay on native HTML5 DnD; only the *page canvas* adopts `@dnd-kit`) | — |
+| Any backend/render-contract change | 1g (already) |
+
+### Parent-doc sections this slice conforms to
+
+- **The shared model** — uses `PageComponent`/`ResponsiveSpan` as defined; `treeOps`
+  (`insertNode`/`moveNode`/`removeNode`/`updateProps`/`setSpan`) and `migrate` are the parent-named modules.
+- **Inspector + canvas** — `canvas/Canvas.tsx` + `canvas/dnd/*`, `DndContext` (PointerSensor +
+  KeyboardSensor), palette draggable sources, per-container `SortableContext` (`closestCenter`), drops/moves
+  → `treeOps`, grid-span resize snapping to the 12-col grid (no pixel coords), `SelectableNode` wrapper.
+- **Key architecture decision: DnD = `@dnd-kit/core` + `@dnd-kit/sortable`** (one new dep, canvas only);
+  `PageLayoutsPage` stays on native DnD.
+
+### Acceptance criteria
+
+- Dragging a palette item onto a **column/row/grid/card/container** inserts the new node **inside that
+  container at the drop index** — not at root. Dropping on empty canvas appends to root (back-compat).
+- Dragging an existing node **between** containers moves it (one `moveNode`); dragging within a container
+  reorders it (one `moveNode` with same parent, new index). No node is ever duplicated or lost.
+- A child of a `grid`/`row` shows a resize handle; dragging it changes the child's `span.base` in **integer
+  12-col steps** (snap), persisted as `span`. No `{row,column,width,height}` pixel/position data is written.
+- `span` renders as Tailwind `col-span-{base}` plus `sm:`/`md:`/`lg:` prefixes when those keys are set; a
+  `grid` is `grid grid-cols-12`.
+- A legacy page (nodes with `position`, no `schemaVersion`) loads via `migrate()` into a `grid > column >
+  widget` tree and renders identically-or-better; re-saving stamps `schemaVersion: 2` and drops `position`.
+- Keyboard DnD works: focus a node's drag handle, `Space` to lift, arrow keys to move between
+  positions/containers, `Space` to drop, `Esc` to cancel (dnd-kit `KeyboardSensor` defaults).
+- Editor preview (`RenderTree mode="editor"`) and runtime (`RenderTree mode="runtime"`) render the same
+  `grid`/`row`/`column`/`divider` + `span` identically (one descriptor `Render` each — the 2a de-dup
+  guarantee holds).
+- `/verify` green (lint + typecheck + `format:check` + `test:coverage` ≥ existing kelta-ui gate).
+
+---
+
+## 2. UI samples
+
+### 2.1 Canvas with the 12-col grid (after 2c)
+
+```
+┌─ Palette ───────┐ ┌─ Canvas (DndContext root droppable) ───────────────────────┐ ┌─ Inspector ─┐
+│ ▦ Grid   ▭ Row  │ │  grid · grid-cols-12                                        │ │  column     │
+│ ▯ Column ─ Divid│ │  ┌───────────────────────────────────────────────────────┐ │ │  span.base 6│
+│ H Heading T Text│ │  │ ░ column (span 6)        ⠿  │ ░ column (span 6)     ⠿  │ │ │  span.md  4 │
+│ B Button I Image│ │  │  ┌──────────────────────┐    │  ┌────────────────────┐  │ │ │  …          │
+│ F Form  ⊞ Table │ │  │  │ Heading "Orders"  ⠿  │    │  │ Table (orders)  ⠿  │◀▶│ │ │             │
+│ ▢ Card  ◻ Cont. │ │  │  └──────────────────────┘    │  └────────────────────┘  │ │ │             │
+│                 │ │  │  ┌──────────────────────┐    │       resize handle ──▲  │ │ │             │
+│  (drag a tile   │ │  │  │ Text "Recent…"    ⠿  │    │       (snaps 1..12)      │ │ │             │
+│   into a column)│ │  │  └──────────────────────┘    │                          │ │ │             │
+│                 │ │  └───────────────────────────────────────────────────────┘ │ │             │
+└─────────────────┘ └────────────────────────────────────────────────────────────┘ └─────────────┘
+   ⠿ = drag handle (GripVertical)   ◀▶ / ▲ = grid-span resize handle (right edge)
+   ░ = column drop-zone tint        selected node = primary outline + ring
+```
+
+### 2.2 Dragging a widget from the palette into a column
+
+```
+1. Pointer down on palette tile "Heading"        → useDraggable id="palette:heading"
+                                                    data = { source:'palette', widgetType:'heading' }
+2. Drag over the left column                      → that column's droppable id="container:col-1" lights
+                                                    (closestCenter picks the nearest sortable slot)
+   ┌ column (span 6) ──────────────┐
+   │ Heading "Orders"              │
+   │ ▒▒▒▒ insert here (index 1) ▒▒▒│ ← SortableContext shows the gap at the drop index
+   │ Text "Recent…"                │
+   └───────────────────────────────┘
+3. Drop                                           → onDragEnd:
+                                                    insertNode(tree, newNode('heading'),
+                                                               parentId='col-1', index=1)
+                                                    (NOT appended to root — the 2c fix)
+```
+
+`DragOverlay` renders a ghost of the dragged tile/node during the drag (dnd-kit `DragOverlay`), so the
+original stays in place until drop.
+
+### 2.3 Reorder within a row (between-container move too)
+
+```
+Before (row, 3 children):     drag "C" up over "A":      After onDragEnd:
+  ┌ row ───────────────┐        insertion line above A     ┌ row ───────────────┐
+  │ [A] [B] [C]        │   →    ┌ row ──────────────┐   →   │ [C] [A] [B]        │
+  └────────────────────┘        │ |[A] [B] [C]      │       └────────────────────┘
+                                └────────────────────┘    moveNode(tree, 'C', parentId='row-1', index=0)
+
+Between containers (column-1 → column-2):
+  moveNode(tree, 'C', toParentId='col-2', index=0)   (removeNode under col-1, insert under col-2)
+```
+
+`active.data.current = { source:'node', nodeId, parentId }`,
+`over.data.current = { container: <droppableId>, index: <slotIndex> }` — `onDragEnd` derives a single
+`moveNode` (or `insertNode` for palette sources). Same-parent + same-index is a **no-op** (guarded).
+
+### 2.4 Resize handle snapping spans
+
+```
+column (span.base = 6) — drag the right-edge handle leftward:
+
+  grid is 12 cols → each col ≈ canvasWidth/12 px.
+  delta_px accumulated → delta_cols = round(delta_px / colWidth)   ← SNAP to integer cols
+  newBase = clamp(6 + delta_cols, 1, 12)
+
+  drag left ~2 cols ─────────────►  span.base 6 → 4    setSpan(tree, 'col-1', { ...span, base: 4 })
+
+  ┌ col (6) ──────────┐ resize    ┌ col (4) ──┐
+  │                 ◀▶│  ───────► │         ◀▶│      grid auto-reflows; sibling reflows to fill.
+  └───────────────────┘           └───────────┘      Only `span` is stored — never px/row/column.
+```
+
+The handle reads the **container's measured width** (via the dnd `rect` or a `ResizeObserver` ref) only to
+compute the **column width for snapping** — the measured pixels are never persisted.
+
+### 2.5 Keyboard-drag a11y
+
+```
+Tab → focus a node's drag handle (button, aria-roledescription="draggable", tabIndex=0)
+Space/Enter  → "lift" (dnd-kit KeyboardSensor activates; announces "Picked up <type>")
+Arrow Up/Down → move within the SortableContext (reorder); announcer reads new index
+Arrow Left/Right (custom keyboardCoordinates) → hop to the sibling container at the same level
+Space/Enter  → drop (announces "Dropped over <container> position N")
+Esc → cancel (announces "Movement cancelled")
+```
+
+`DndContext` is given `accessibility={{ announcements, screenReaderInstructions }}` with Kelta-worded
+strings so screen-reader users get position feedback. The drag handle is a real `<button>` (focusable,
+`aria-label="Reorder <type>"`).
+
+### 2.6 Sample tree JSON — `grid > column(span) > widget`
+
+```json
+[
+  {
+    "id": "g1",
+    "type": "grid",
+    "props": {},
+    "children": [
+      {
+        "id": "col-1",
+        "type": "column",
+        "props": {},
+        "span": { "base": 12, "md": 6 },
+        "children": [
+          { "id": "h1", "type": "heading", "props": { "text": "Orders", "level": "h1" } },
+          { "id": "t1", "type": "text", "props": { "content": "Recent orders below." } }
+        ]
+      },
+      {
+        "id": "col-2",
+        "type": "column",
+        "props": {},
+        "span": { "base": 12, "md": 6 },
+        "children": [
+          { "id": "tb1", "type": "table",
+            "props": { "dataView": { "collection": "orders", "fields": ["id", "status", "total"], "limit": 25 } } }
+        ]
+      }
+    ]
+  },
+  { "id": "d1", "type": "divider", "props": {} }
+]
+```
+
+Stored at `config.components` with `config.schemaVersion: 2`. `span` is absent on `grid`/`divider` and
+on leaf children of a `column` (a `column` stacks its children full-width). Optional `events?` round-trips
+untouched (authored in 2e).
+
+### 2.7 Legacy → v2 migration (`migrate.ts`)
+
+```
+LEGACY (schemaVersion absent, every node has position {row,column,width,height}):
+[
+  { "id":"a", "type":"heading", "props":{...}, "position":{ "row":0, "column":0, "width":12, "height":1 } },
+  { "id":"b", "type":"text",    "props":{...}, "position":{ "row":1, "column":0, "width":6,  "height":1 } },
+  { "id":"c", "type":"image",   "props":{...}, "position":{ "row":1, "column":6, "width":6,  "height":1 } }
+]
+
+migrate(legacy) →  group by row, wrap each node in a column carrying span.base = width:
+[
+  { "id":"<gen>", "type":"grid", "props":{}, "children":[
+      { "id":"<gen>", "type":"column", "props":{}, "span":{ "base":12 }, "children":[ {a} ] },
+      { "id":"<gen>", "type":"column", "props":{}, "span":{ "base":6  }, "children":[ {b} ] },
+      { "id":"<gen>", "type":"column", "props":{}, "span":{ "base":6  }, "children":[ {c} ] }
+  ]}
+]
+```
+
+`position` is stripped from leaf nodes after wrapping. A node already lacking `position` (a 2a-created
+node) is wrapped in a single full-width `column` (`span.base = 12`). Idempotent: re-running on a v2 tree
+(`schemaVersion: 2`) returns it unchanged.
+
+---
+
+## 3. Data & API contracts
+
+All TS under `kelta-ui/app/src/pages/PageBuilderPage/`. **No backend/API/render-contract change** in 2c —
+`grid`/`row`/`column`/`divider`/`span` all nest inside the existing `config` JSON and round-trip through the
+pass-through render service untouched.
+
+### 3.1 `ResponsiveSpan` + Tailwind mapping
+
+`ResponsiveSpan` is already defined in `model/pageModel.ts` (2a, §3.1): `{ base:number; sm?:number;
+md?:number; lg?:number }`, each `1..12`. 2c adds the class mapping, in `canvas/spanClasses.ts`:
+
+```ts
+import type { ResponsiveSpan } from '../model/pageModel'
+
+/** Full literal class names so Tailwind's JIT scanner can see them (no dynamic string interpolation). */
+const COL_SPAN: Record<number, string> = {
+  1: 'col-span-1', 2: 'col-span-2', 3: 'col-span-3', 4: 'col-span-4',
+  5: 'col-span-5', 6: 'col-span-6', 7: 'col-span-7', 8: 'col-span-8',
+  9: 'col-span-9', 10: 'col-span-10', 11: 'col-span-11', 12: 'col-span-12',
+}
+const COL_SPAN_SM: Record<number, string> = {
+  1: 'sm:col-span-1', 2: 'sm:col-span-2', 3: 'sm:col-span-3', 4: 'sm:col-span-4',
+  5: 'sm:col-span-5', 6: 'sm:col-span-6', 7: 'sm:col-span-7', 8: 'sm:col-span-8',
+  9: 'sm:col-span-9', 10: 'sm:col-span-10', 11: 'sm:col-span-11', 12: 'sm:col-span-12',
+}
+const COL_SPAN_MD: Record<number, string> = { /* md:col-span-1 … md:col-span-12 */ }
+const COL_SPAN_LG: Record<number, string> = { /* lg:col-span-1 … lg:col-span-12 */ }
+
+export const GRID_CONTAINER_CLASS = 'grid grid-cols-12 gap-4'
+
+/** Clamp to the valid 1..12 grid range. */
+export function clampSpan(n: number): number {
+  return Math.min(12, Math.max(1, Math.round(n)))
+}
+
+/**
+ * Map a span to its Tailwind classes. `base` defaults to 12 (full width) when no span is set —
+ * matching a plain stacked child. Breakpoint keys are additive (base + any of sm/md/lg present).
+ */
+export function spanToClasses(span: ResponsiveSpan | undefined): string {
+  if (!span) return COL_SPAN[12]
+  const out = [COL_SPAN[clampSpan(span.base)]]
+  if (span.sm != null) out.push(COL_SPAN_SM[clampSpan(span.sm)])
+  if (span.md != null) out.push(COL_SPAN_MD[clampSpan(span.md)])
+  if (span.lg != null) out.push(COL_SPAN_LG[clampSpan(span.lg)])
+  return out.join(' ')
+}
+```
+
+> **Tailwind JIT caveat (load-bearing):** the maps use **full literal class strings** because Tailwind v4's
+> scanner cannot see `` `col-span-${n}` ``. The 48 literals (4 breakpoints × 12) are emitted exactly so the
+> classes survive the build. The two-breakpoint names (`sm`/`md`/`lg`) align with the `@kelta/components`
+> `ResponsiveBreakpoints` semantics (mobile 768 / tablet 1024 / desktop 1280) — `sm`≈tablet, `md`/`lg`≈
+> desktop tiers; the grid is mobile-first (`base` = all widths, prefixes override upward).
+
+### 3.2 `treeOps.ts` — full implementation (2a stubs finished)
+
+2a shipped `insertNode` / `removeNode` / `updateProps` (and `notImplemented` stubs for `moveNode` /
+`setSpan`). 2c implements the latter two and hardens the no-op guards. All functions are **pure** and
+return a **new immutable tree** (never mutate input). Signatures:
+
+```ts
+import type { PageComponent, ResponsiveSpan } from './pageModel'
+
+/** Insert `node` under `parentId` (or root when null) at `index` (or append when index omitted/out of range). */
+export function insertNode(
+  tree: PageComponent[],
+  node: PageComponent,
+  parentId: string | null,
+  index?: number,
+): PageComponent[]
+
+/** Remove the node with `id` anywhere in the tree. No-op (returns same-shaped new tree) if not found. */
+export function removeNode(tree: PageComponent[], id: string): PageComponent[]
+
+/** Shallow-merge `patch` into the target node's `props`. */
+export function updateProps(
+  tree: PageComponent[],
+  id: string,
+  patch: Record<string, unknown>,
+): PageComponent[]
+
+/**
+ * Move `id` to live under `toParentId` (or root when null) at `index`.
+ * Implemented as remove-then-insert with two guards:
+ *  - no-op if the move is to the SAME parent + SAME resulting index (returns the input tree reference),
+ *  - reject (throw) if `toParentId` is `id` or a DESCENDANT of `id` (would orphan the subtree).
+ * Index is interpreted AFTER removal when moving within the same parent (so dragging down by one is stable).
+ */
+export function moveNode(
+  tree: PageComponent[],
+  id: string,
+  toParentId: string | null,
+  index: number,
+): PageComponent[]
+
+/** Set (or clear) the responsive span on a node. `undefined` removes the key entirely. */
+export function setSpan(
+  tree: PageComponent[],
+  id: string,
+  span: ResponsiveSpan | undefined,
+): PageComponent[]
+```
+
+Internal helpers (not exported): `findNode(tree, id): { node; parentId } | null`,
+`isDescendant(tree, ancestorId, maybeChildId): boolean`, `mapTree(tree, fn)` recursive rebuilder.
+
+```ts
+export function moveNode(
+  tree: PageComponent[],
+  id: string,
+  toParentId: string | null,
+  index: number,
+): PageComponent[] {
+  const found = findNode(tree, id)
+  if (!found) return tree
+  if (toParentId === id || isDescendant(tree, id, toParentId)) {
+    throw new Error(`moveNode: cannot move ${id} into itself or a descendant`)
+  }
+  // No-op guard: same parent + index already equals the target slot.
+  if (found.parentId === toParentId) {
+    const siblings = childrenOf(tree, toParentId)
+    const currentIndex = siblings.findIndex((c) => c.id === id)
+    const target = Math.min(index, siblings.length - 1)
+    if (currentIndex === target) return tree
+  }
+  const node = found.node
+  const without = removeNode(tree, id)
+  return insertNode(without, node, toParentId, index)
+}
+
+export function setSpan(
+  tree: PageComponent[],
+  id: string,
+  span: ResponsiveSpan | undefined,
+): PageComponent[] {
+  return mapTree(tree, (n) =>
+    n.id === id ? (span === undefined ? omitSpan(n) : { ...n, span }) : n,
+  )
+}
+```
+
+### 3.3 DnD data payloads (`canvas/dnd/types.ts`)
+
+```ts
+import type { PageComponent } from '../../model/pageModel'
+
+/** Attached to useDraggable for a palette tile. */
+export interface PaletteDragData {
+  source: 'palette'
+  widgetType: string
+}
+
+/** Attached to useSortable for an existing node in the canvas. */
+export interface NodeDragData {
+  source: 'node'
+  nodeId: string
+  parentId: string | null
+}
+
+export type DragData = PaletteDragData | NodeDragData
+
+/** Attached to each droppable container + each sortable slot, read on drag-over/end. */
+export interface DropData {
+  /** The container node id this droppable belongs to (null = root canvas). */
+  container: string | null
+  /** Slot index within that container (for sortable items); containers expose their own length as fallback. */
+  index: number
+}
+
+/** Stable dnd id conventions (so onDragEnd can route without a registry lookup). */
+export const PALETTE_ID = (type: string) => `palette:${type}`        // draggable
+export const NODE_ID = (id: string) => `node:${id}`                  // sortable item
+export const CONTAINER_ID = (id: string | null) => `container:${id ?? 'root'}` // droppable
+```
+
+`onDragEnd(event)` logic (in `canvas/dnd/useCanvasDnd.ts`):
+
+```
+const a = event.active.data.current as DragData
+const o = event.over?.data.current as DropData | undefined
+if (!o) return                                   // dropped on nothing
+if (a.source === 'palette') {
+  insertNode(tree, makeNode(a.widgetType), o.container, o.index)   // descriptor.defaultProps applied
+} else {
+  moveNode(tree, a.nodeId, o.container, o.index)                   // no-op guard inside
+}
+```
+
+Sensors: `useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
+useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }))`. Collision:
+`closestCenter`. Each container wraps its children in
+`<SortableContext items={childIds} strategy={rectSortingStrategy}>`.
+
+### 3.4 Resize payload (`canvas/dnd/useSpanResize.ts`)
+
+Resize is **not** a dnd-kit drag (it would conflict with sort) — it's a lightweight pointer handler on the
+handle:
+
+```ts
+interface SpanResizeArgs {
+  nodeId: string
+  currentBase: number          // span.base (defaults 12)
+  gridWidthPx: number          // measured container width (NOT persisted)
+  breakpoint?: 'base' | 'sm' | 'md' | 'lg' // which key the inspector targets; canvas handle edits 'base'
+}
+// onPointerMove: deltaCols = Math.round(deltaPx / (gridWidthPx / 12))
+//                next = clampSpan(currentBase + deltaCols)
+// onPointerUp:   if (next !== currentBase) setSpan(tree, nodeId, { ...span, [breakpoint]: next })
+```
+
+Only the integer column delta is ever written; `gridWidthPx` is read transiently for snapping.
+
+### 3.5 Widget descriptors — the 4 layout builtins
+
+Each is a `WidgetDescriptor` (2a `widgets/types.ts`). `Render` is the single editor+runtime path
+(`mode` only affects empty-state placeholders, matching the 2a `card`/`container` convention).
+
+```tsx
+// widgets/builtins/grid.tsx
+import { GRID_CONTAINER_CLASS, spanToClasses } from '../../canvas/spanClasses'
+export const gridWidget: WidgetDescriptor = {
+  type: 'grid', label: 'Grid', icon: '▦', category: 'layout', acceptsChildren: true,
+  defaultProps: {},
+  propSchema: [], // 2c adds no editable props on the grid itself; children carry span (kind:'span' in 2b)
+  Render: ({ node, renderChild }) => (
+    <div className={GRID_CONTAINER_CLASS} data-testid="page-node-grid">
+      {(node.children ?? []).map((c) => (
+        <div key={c.id} className={spanToClasses(c.span)}>{renderChild(c)}</div>
+      ))}
+    </div>
+  ),
+}
+```
+
+```tsx
+// widgets/builtins/column.tsx — a vertical stack; itself spans N of 12 when inside a grid/row.
+export const columnWidget: WidgetDescriptor = {
+  type: 'column', label: 'Column', icon: '▯', category: 'layout', acceptsChildren: true,
+  defaultProps: {},
+  propSchema: [{ key: 'span', label: 'Width', kind: 'span', group: 'Layout' }], // editor uses span kind (2b)
+  Render: ({ node, renderChild, mode }) => {
+    const kids = node.children ?? []
+    if (kids.length === 0 && mode === 'editor') {
+      return <div className="min-h-[48px] rounded border border-dashed border-border"
+                  data-testid="page-node-column" />
+    }
+    return (
+      <div className="flex flex-col gap-4" data-testid="page-node-column">
+        {kids.map((c) => renderChild(c))}
+      </div>
+    )
+  },
+}
+```
+
+```tsx
+// widgets/builtins/row.tsx — horizontal grid; children placed by their span on a 12-col track.
+export const rowWidget: WidgetDescriptor = {
+  type: 'row', label: 'Row', icon: '▭', category: 'layout', acceptsChildren: true,
+  defaultProps: {},
+  propSchema: [],
+  Render: ({ node, renderChild }) => (
+    <div className={GRID_CONTAINER_CLASS} data-testid="page-node-row">
+      {(node.children ?? []).map((c) => (
+        <div key={c.id} className={spanToClasses(c.span)}>{renderChild(c)}</div>
+      ))}
+    </div>
+  ),
+}
+```
+
+```tsx
+// widgets/builtins/divider.tsx — leaf, no children, no span.
+export const dividerWidget: WidgetDescriptor = {
+  type: 'divider', label: 'Divider', icon: '─', category: 'layout', acceptsChildren: false,
+  defaultProps: {},
+  propSchema: [],
+  Render: () => <hr className="my-4 border-border" data-testid="page-node-divider" />,
+}
+```
+
+> `grid` and `row` share the `grid grid-cols-12` track (a `row` is a single-line conceptual grid; both
+> place children by `span`). The semantic distinction is authoring intent + palette label; rendering is the
+> same 12-col CSS grid. A `column` is the standard nesting cell that itself carries a `span`.
+
+### 3.6 `migrate.ts` contract
+
+```ts
+import type { PageComponent } from './pageModel'
+
+interface LegacyPosition { row: number; column: number; width: number; height: number }
+type LegacyNode = PageComponent & { position?: LegacyPosition }
+
+/**
+ * Convert a legacy component tree (nodes with `position`) into a v2 grid/column tree with `span`.
+ * - Top-level legacy nodes are grouped by `position.row`; each becomes a `column` (span.base = width,
+ *   clamped 1..12) inside a single root `grid`.
+ * - Nodes WITHOUT `position` (already v2-ish) are each wrapped in a full-width column (span.base = 12).
+ * - `position` is stripped from every node.
+ * - Children recurse (legacy nesting is rare but handled).
+ * Idempotent: a tree where `schemaVersion === 2` (caller-checked) is returned untouched.
+ */
+export function migrateTree(components: LegacyNode[]): PageComponent[]
+
+/** True if any node carries a legacy `position` (⇒ needs migration). */
+export function needsMigration(components: PageComponent[]): boolean
+```
+
+`PageBuilderPage` calls, on load: if `config.schemaVersion !== 2 && needsMigration(components)`, run
+`migrateTree` and set state; the migrated tree is persisted (with `schemaVersion: 2`) on the next save via
+the **2c-widened `mergeConfig` + widened `handleSavePage` call site (§5.9)** — note that `mergeConfig` and
+the save call are widened **here in 2c** (2a's `mergeConfig` only overlaid `components`/`layout`; the
+`PageConfig.schemaVersion?: 2` field is the marker 2c becomes the first to write).
+
+### 3.7 `PageComponent` / `ComponentPosition` — what changes
+
+No new model type is introduced. 2c **stops writing** `position`: `handleAddComponent` already dropped it in
+2a (§5.3 of 2a). `ComponentPosition` remains the deprecated legacy interface (exported from
+`model/pageModel.ts`, 2a §3.1) used **only** by `migrate.ts`'s `LegacyPosition`. The active model is the 2a
+v2 `PageComponent` with `span?`/`children?`.
+
+---
+
+## 4. DB migrations
+
+**None — stored in `ui-pages.config` JSON, no DDL.** `grid`/`row`/`column`/`divider` nodes, `span`, and
+`schemaVersion: 2` all nest inside the existing `config` JSON column; the render service is a pass-through
+(parent §"Backend changes"). No Flyway version consumed (head remains **V146**), no NATS subject or payload
+change.
+
+---
+
+## 5. File-by-file code changes
+
+All paths under `kelta-ui/app/src/` unless noted. New canvas code lives in
+`pages/PageBuilderPage/canvas/`.
+
+### 5.1 New — `pages/PageBuilderPage/canvas/`
+
+| File | Contents |
+|------|----------|
+| `canvas/Canvas.tsx` | The new canvas. Wraps the tree in one `<DndContext>` (PointerSensor + KeyboardSensor, `closestCenter`, Kelta `accessibility` announcements) + `<DragOverlay>`. Renders the tree through `renderNode` (2a) but wraps each node in `<SelectableNode>`; each container node also wraps its children in a `<SortableContext>` (via `<CanvasContainer>`). Owns selection state passthrough (`selectedId`/`onSelect`/`onDelete` props preserved from the old `Canvas` so `PageBuilderPage` wiring barely changes). Root is a droppable (`CONTAINER_ID(null)`). Empty-state copy unchanged (`builder.pages.canvasEmpty`/`canvasHint`). `data-testid="page-canvas"` preserved. |
+| `canvas/SelectableNode.tsx` | Wraps one node: `useSortable({ id: NODE_ID(node.id), data: NodeDragData })`. Renders the selection outline + ring (ports the existing `Canvas.renderComponent` chrome classes), a drag handle `<button>` (`GripVertical`, `aria-label="Reorder {type}"`, gets `listeners`/`attributes`), the delete `×` button (preserved `data-testid="delete-component-{id}"`), the "Custom" badge keyed on `componentRegistry.hasPageComponent(type)` (unchanged semantics), and — when the node is a child of a `grid`/`row` — the resize handle (`useSpanResize`). Body = `renderNode(node, { mode:'editor', tenantSlug, scope:{} })`. Preserves `data-testid="canvas-component-{id}"`. |
+| `canvas/CanvasContainer.tsx` | For a container node (`grid`/`row`/`column`/`card`/`container`): `useDroppable({ id: CONTAINER_ID(node.id), data: DropData })` + `<SortableContext items={childIds} strategy={rectSortingStrategy}>` wrapping the children (each a `<SelectableNode>`). Shows the drop-zone tint + insertion gap on `isOver`. The container's own visual shell comes from its descriptor `Render`; this component supplies the dnd plumbing around the children slot. |
+| `canvas/spanClasses.ts` | §3.1 — `spanToClasses`, `clampSpan`, `GRID_CONTAINER_CLASS`, the 48 literal class maps. |
+| `canvas/dnd/types.ts` | §3.3 — `PaletteDragData`/`NodeDragData`/`DragData`/`DropData` + id helpers (`PALETTE_ID`/`NODE_ID`/`CONTAINER_ID`). |
+| `canvas/dnd/useCanvasDnd.ts` | `useSensors` config, `onDragStart`/`onDragOver`/`onDragEnd` handlers, the palette-vs-node routing (§3.3) calling `insertNode`/`moveNode`, the active-drag state for `DragOverlay`, and the announcements object. Returns `{ sensors, onDragStart, onDragEnd, activeNode }`. |
+| `canvas/dnd/useSpanResize.ts` | §3.4 — pointer-based span resize hook returning `{ handleProps }`; computes integer col delta from measured grid width, calls `setSpan` on pointer-up. |
+| `canvas/dnd/announcements.ts` | Kelta-worded `Announcements` + `screenReaderInstructions` strings for the `DndContext accessibility` prop (a11y position feedback). |
+
+### 5.2 New — `pages/PageBuilderPage/widgets/builtins/`
+
+| File | Contents |
+|------|----------|
+| `widgets/builtins/grid.tsx` | §3.5 `gridWidget` (`grid grid-cols-12`, children by `span`). |
+| `widgets/builtins/row.tsx` | §3.5 `rowWidget`. |
+| `widgets/builtins/column.tsx` | §3.5 `columnWidget` (vertical stack, editable `span`, empty placeholder in editor). |
+| `widgets/builtins/divider.tsx` | §3.5 `dividerWidget` (leaf `<hr>`). |
+
+Register all four in `widgets/builtins/index.ts` `registerBuiltins()` (added to the 2a list of 8 → 12
+built-ins). They sort into the `layout` category, so 2b's `listByCategory('layout')` palette picks them up;
+in 2c the palette is still the registry-derived array (2a §5.3b), so they appear automatically once
+registered.
+
+### 5.3 Complete — `pages/PageBuilderPage/model/treeOps.ts`
+
+Replace the 2a `notImplemented('moveNode — 2c')` / `notImplemented('setSpan — 2c')` stub bodies with the
+§3.2 implementations + the internal helpers (`findNode`, `isDescendant`, `childrenOf`, `mapTree`,
+`omitSpan`). `insertNode`/`removeNode`/`updateProps` are unchanged (already implemented in 2a). The 2a
+`treeOps.test.ts` asserts the stubs throw — 2c flips those to behavioral assertions (§6.1).
+
+### 5.4 New — `pages/PageBuilderPage/model/migrate.ts`
+
+§3.6 — `migrateTree`, `needsMigration`, `LegacyPosition`/`LegacyNode` local types, and the row-grouping +
+column-wrapping logic. Pure, unit-tested.
+
+### 5.5 Refactor — `pages/PageBuilderPage/PageBuilderPage.tsx`
+
+**(a) Swap the canvas.** Delete the in-file native-DnD `Canvas` (`~688–872`: `handleDragOver`/
+`handleDragLeave`/`handleDrop`/`handleKeyDown`/`renderComponent` and the `onDragOver`/`onDrop` wiring) and
+the `CanvasProps.onDrop`/`getPageComponent` plumbing. Import the new canvas:
+
+```tsx
+// BEFORE: function Canvas({ components, selectedId, onSelect, onDrop, onDelete, getPageComponent }) {…native DnD…}
+// AFTER:
+import { Canvas } from './canvas/Canvas'
+```
+
+Call site (~1605):
+
+```tsx
+// BEFORE: <Canvas components={…} selectedId={…} onSelect={…} onDrop={handleCanvasDrop} onDelete={…} getPageComponent={getPageComponent} />
+// AFTER:
+<Canvas
+  components={components}
+  selectedId={selectedComponentId}
+  onSelect={handleSelectComponent}
+  onChange={handleTreeChange}   // tree mutations from dnd/resize flow back through one callback
+  onDelete={handleDeleteComponent}
+  tenantSlug={tenantSlug}
+/>
+```
+
+**(b) Palette becomes a draggable source.** `ComponentPalette` (~190) keeps its registry-derived
+`AVAILABLE_COMPONENTS` (2a) and its `onAddComponent` click (still valid — clicking appends to root via
+`handleAddComponent`). Replace the native `draggable`/`onDragStart` on each tile (~210) with a small
+`PaletteDraggable` wrapper using `useDraggable({ id: PALETTE_ID(type), data: { source:'palette',
+widgetType: type } })`. The palette is rendered **inside** the canvas's `DndContext` (lift the
+`ComponentPalette` into `Canvas`, or pass the palette as a child of the `DndContext` — see Canvas.tsx
+layout). Remove `handleDragStart`/`handleCanvasDrop`/`draggedComponentType` state (~1369–1396) — replaced
+by `useCanvasDnd`.
+
+**(c) Tree-mutation callback.** Add a single `handleTreeChange(next: PageComponent[])` that
+`setComponents(next)` + `setHasUnsavedChanges(true)`; the canvas computes `next` via `treeOps` and calls it
+on every drop/move/resize. `handleAddComponent` (~1374) stays (palette **click** path) but is rewritten to
+use `insertNode` so click-add and the descriptor defaults agree:
+
+```ts
+const handleAddComponent = useCallback((componentType: string) => {
+  const descriptor = widgetRegistry.get(componentType)
+  const node: PageComponent = { id: generateId(), type: componentType, props: { ...descriptor.defaultProps } }
+  setComponents((prev) => insertNode(prev, node, null)) // append to root
+  setSelectedComponentId(node.id)
+  setHasUnsavedChanges(true)
+}, [])
+```
+
+**(d) Migration on load.** Where the page's components are read into state (the `useEffect` that seeds
+`components` from `readComponents(currentPage)`), wrap:
+
+```ts
+const raw = readComponents(currentPage)
+const cfg = readConfig(currentPage)
+const seeded = cfg.schemaVersion !== 2 && needsMigration(raw) ? migrateTree(raw) : raw
+setComponents(seeded)
+```
+
+**(d.1) Persist the migration result on save — the canonical save-path rewrite (2c OWNS this).** See
+**§5.9** for the full before→after. In short: today `handleSavePage` (~1428) calls
+`mergeConfig(readConfig(currentPage), { components })` and `mergeConfig` (`pageConfig.ts`) only overlays
+the keys it is **passed**. So `schemaVersion` (and every future page-level sibling) is **silently dropped
+on save** unless the CALL passes it — widening `mergeConfig`'s accepted keys alone does nothing. 2c
+therefore changes **both**: (1) widen `mergeConfig` to overlay `variables`/`dataSources`/`access`/
+`schemaVersion`, **and** (2) change the one save call site to pass the full current set —
+`mergeConfig(readConfig(currentPage), { components, variables, dataSources, schemaVersion: 2 })`. 2c only
+*reads/writes* `components` + `schemaVersion` today; `variables`/`dataSources` are passed as their current
+(possibly `undefined`) state so the call shape is final and 2d/1h only extend the values, not re-touch the
+call site. The mutation **payload** (not just `mergeConfig`'s return) must be asserted to contain
+`schemaVersion` (§6.7).
+
+**(e) `tenantSlug`.** Thread it from the route (the builder runs under `/:tenantSlug/setup/...`) into
+`Canvas` (used by `renderNode` for plugin/data nodes). If unavailable, pass `''` (2a parity note).
+
+### 5.6 No change — runtime renderer
+
+`pages/app/CustomPage/PageTreeRenderer.tsx` is **already** the thin `<RenderTree mode="runtime">` wrapper
+(2a §5.4). The new `grid`/`row`/`column`/`divider` descriptors render through it automatically once
+registered — **no edit needed here**. Runtime `span` is honored because the `grid`/`row` descriptor `Render`
+applies `spanToClasses(child.span)` (the same code editor uses). This preserves the 2a de-dup guarantee.
+
+### 5.7 Dependency add — `kelta-ui/app/package.json`
+
+Add to `dependencies` (exact pins; current `@dnd-kit` majors as of 2026-06-22):
+
+```jsonc
+"@dnd-kit/core": "^6.3.1",
+"@dnd-kit/sortable": "^10.0.0",
+"@dnd-kit/utilities": "^3.2.2"   // peer of sortable, used for CSS.Transform on the drag handle
+```
+
+> Confirmed **no `@dnd-kit/*` present** today in `kelta-ui/app/package.json`, the `@kelta/*` packages, or
+> the lockfile. This is the parent-mandated single new dep, **scoped to the page canvas only** — no other
+> surface (`PageLayoutsPage`/`MenuBuilderPage`/`FlowDesignerPage`) is migrated. Run `npm install` in
+> `kelta-ui/app` to refresh the lockfile in the same PR. Verify the bundle-size budget (these three add
+> ~30–40 kB gz) is within the kelta-ui build gate.
+
+### 5.9 Rewrite — the save path (`PageBuilderPage.tsx` `handleSavePage` + `pageConfig.ts` `mergeConfig`) — **2c OWNS this (BLOCKER)**
+
+Parent §"Save & persistence (v2 round-trip)" names this the **#1 correctness risk**. 2c is the first slice
+that must persist a page-level sibling (`schemaVersion: 2`), so it lands the canonical rewrite. **Both
+sides must change** — widening `mergeConfig`'s accepted keys is **useless unless the save CALL passes
+them** (the exact silent-drop bug class the parent flags: a key not passed is never overlaid, so it never
+reaches the `config` JSON).
+
+**Canonical storage reminder (parent "Page-level config (v2) → Canonical storage"):** the tree lives at
+`config.components`; `schemaVersion: 2` is a **sibling of `components`** inside `config` (**NO `config.tree`
+wrapper**). `mergeConfig` overlays onto the flat `config` object — every key it writes is a direct child of
+`config`.
+
+**`pageConfig.ts` — `PageConfig` + `mergeConfig` widened:**
+
+```ts
+// BEFORE (verified ~lines 11–44):
+export interface PageConfig {
+  layout?: PageLayout
+  components?: PageComponent[]
+}
+export function mergeConfig(
+  existing: PageConfig,
+  changes: { components?: PageComponent[]; layout?: PageLayout }
+): PageConfig {
+  const merged: PageConfig = { ...existing }
+  if (changes.layout !== undefined) merged.layout = changes.layout
+  if (changes.components !== undefined) merged.components = changes.components
+  return merged
+}
+
+// AFTER (2c widens both the type and the overlay set — schemaVersion + the page-level siblings):
+export interface PageConfig {
+  layout?: PageLayout            // inert legacy (see §5.11) — kept for back-compat, not authored
+  components?: PageComponent[]
+  variables?: PageVariable[]     // sibling of components (2d populates; 2c passes through)
+  dataSources?: PageDataSource[] // sibling of components (2d populates; 2c passes through)
+  access?: { requiredPermission?: string } // sibling (1h populates; 2c passes through)
+  schemaVersion?: 2              // sibling marker — 2c is the first writer
+}
+export function mergeConfig(
+  existing: PageConfig,
+  changes: {
+    components?: PageComponent[]
+    layout?: PageLayout
+    variables?: PageVariable[]
+    dataSources?: PageDataSource[]
+    access?: { requiredPermission?: string }
+    schemaVersion?: 2
+  }
+): PageConfig {
+  const merged: PageConfig = { ...existing }
+  if (changes.layout !== undefined) merged.layout = changes.layout
+  if (changes.components !== undefined) merged.components = changes.components
+  if (changes.variables !== undefined) merged.variables = changes.variables
+  if (changes.dataSources !== undefined) merged.dataSources = changes.dataSources
+  if (changes.access !== undefined) merged.access = changes.access
+  if (changes.schemaVersion !== undefined) merged.schemaVersion = changes.schemaVersion
+  return merged
+}
+```
+
+> `PageVariable`/`PageDataSource` are the parent §"Page-level config (v2)" types; 2c imports/forward-declares
+> them (2d gives them their authored shape). 2c only *writes* values for `components` + `schemaVersion`; the
+> rest are overlaid only when their (2d/1h-owned) state is defined — but the call site passes them now so the
+> shape is final.
+
+**`PageBuilderPage.tsx` — `handleSavePage` (~1428) call site widened:**
+
+```ts
+// BEFORE (verified ~1428–1438):
+const handleSavePage = useCallback(() => {
+  if (!editingPageId) return
+  updateMutation.mutate({
+    id: editingPageId,
+    data: {
+      config: mergeConfig(readConfig(currentPage), { components }),  // ← drops schemaVersion/siblings
+    } as unknown as Partial<UIPage>,
+  })
+}, [editingPageId, components, currentPage, updateMutation])
+
+// AFTER (2c passes the full current set — schemaVersion:2 is now persisted; 2d fills variables/dataSources,
+// 1h fills access — they only widen the VALUES, never re-touch this call site):
+const handleSavePage = useCallback(() => {
+  if (!editingPageId) return
+  updateMutation.mutate({
+    id: editingPageId,
+    data: {
+      config: mergeConfig(readConfig(currentPage), {
+        components,
+        variables,        // current page-variable state (undefined until 2d) — passed so it round-trips
+        dataSources,      // current data-source state (undefined until 2d)
+        schemaVersion: 2, // 2c stamps v2 on every save (migration is now persisted)
+      }),
+    } as unknown as Partial<UIPage>,
+  })
+}, [editingPageId, components, variables, dataSources, currentPage, updateMutation])
+```
+
+**Why both edits are load-bearing:** widening `mergeConfig` without widening the call leaves the new keys
+unreachable (the call still passes only `{ components }`, so `mergeConfig` overlays nothing new) — the page
+saves, `schemaVersion` is dropped, and the legacy page **re-migrates on every reload** (the migration is
+never persisted). The test (§6.7) asserts the `updateMutation.mutate` **payload** contains `schemaVersion:
+2`, not merely that `mergeConfig` *can* return it — 2d/1h extend that same payload assertion for their keys.
+
+### 5.10 Resolve — the unsaved-changes guard (`handleBackToList` + `beforeunload`) — **2c OWNS this**
+
+Parent §"Parity gaps NOT covered" places the unsaved-changes guard **in 2c scope** ("today a
+`// Could show a confirmation dialog here` TODO"). dnd-kit makes more canvas state losable (reorders, span
+resizes, drop-into-container moves are all `setHasUnsavedChanges(true)` mutations), so 2c finishes it rather
+than deferring.
+
+```ts
+// BEFORE (verified ~1357–1366):
+const handleBackToList = useCallback(() => {
+  if (hasUnsavedChanges) {
+    // Could show a confirmation dialog here   ← empty TODO
+  }
+  setViewMode('list')
+  setEditingPageId(null)
+  setComponents([])
+  setSelectedComponentId(null)
+  setHasUnsavedChanges(false)
+}, [hasUnsavedChanges])
+
+// AFTER: confirm before discarding in-builder; bail if the author cancels.
+const handleBackToList = useCallback(() => {
+  if (hasUnsavedChanges && !window.confirm(t('builder.pages.unsavedConfirm'))) {
+    return // stay in the builder; nothing is reset
+  }
+  setViewMode('list')
+  setEditingPageId(null)
+  setComponents([])
+  setSelectedComponentId(null)
+  setHasUnsavedChanges(false)
+}, [hasUnsavedChanges, t])
+```
+
+Plus a native tab-close / refresh guard while editing with unsaved changes:
+
+```ts
+useEffect(() => {
+  if (!hasUnsavedChanges) return
+  const onBeforeUnload = (e: BeforeUnloadEvent) => {
+    e.preventDefault()
+    e.returnValue = '' // browsers show their own native prompt; the string is ignored
+  }
+  window.addEventListener('beforeunload', onBeforeUnload)
+  return () => window.removeEventListener('beforeunload', onBeforeUnload)
+}, [hasUnsavedChanges])
+```
+
+> `window.confirm`/`beforeunload` is the minimal in-scope guard (a styled modal is a later polish — not
+> required for 2c). The confirm copy is i18n'd (`builder.pages.unsavedConfirm`, §5.8/§7). Test: with
+> `hasUnsavedChanges` true, a mocked `window.confirm → false` keeps `viewMode === 'edit'` (no reset);
+> `→ true` resets to the list (§6.7).
+
+### 5.11 Deprecate — the create-form `layoutType` select (`config.layout` → inert legacy) — **2c OWNS the decision**
+
+The create/edit form's `layoutType` `<select>` (single/sidebar/grid, `data-testid="page-layout-select"`,
+~1082–1093) writes `config.layout = { type }` via `handleSubmit`/`mergeConfig`. The new **widget-based**
+layout (`grid`/`row`/`column` + per-child `span`) makes `config.layout.type` **orphaned** — nothing in the
+canvas, the descriptors, or the runtime renderer reads it. 2c must pick one and spec it; **decision: keep
+the field but document `config.layout` as inert legacy** (do **not** rip the select out in 2c):
+
+- **Why not remove now:** the select is also the page's create-time form field; deleting it touches the
+  create flow + its tests, which is out of the canvas axis. Removal is a clean follow-up once no page reads
+  `config.layout`.
+- **What 2c does:** (a) `mergeConfig` still overlays `layout` (preserved on round-trip — never dropped),
+  so existing pages keep their stored `layout` untouched; (b) the canvas/runtime **ignore** `config.layout`
+  entirely (layout is expressed by the widget tree + `span`); (c) the `PageConfig.layout` field carries a
+  `// inert legacy` comment (§5.9) alongside `schemaVersion: 2`; (d) `conventions.md` + `concerns.md` record
+  `config.layout` as deprecated/inert (a future slice may remove the select). No runtime behavior depends on
+  `layoutType` after 2c.
+
+This is the explicit answer to "deprecate/remove the select **or** document `config.layout` as inert legacy"
+— 2c documents it inert (lowest-risk), and flags removal as deferred.
+
+### 5.8 Docs (same PR) — see §7.
+
+---
+
+## 6. Test plan
+
+Vitest + Testing Library + (where fetch is involved) MSW, matching the existing idiom in
+`PageBuilderPage.test.tsx` and `pageConfig.test.ts`. **Playwright e2e is post-deploy only** (project
+convention) — the canvas drag/reorder/resize e2e runs once deployed; no new e2e file in this slice.
+
+### 6.1 `model/treeOps.test.ts` (extend the 2a file)
+
+- `insertNode`: append to root (no index), insert at a specific root index, nested insert by `parentId`,
+  index out-of-range → append; input tree not mutated (immutability assertion via deep-freeze).
+- `removeNode`: remove at root, remove deeply nested, remove non-existent → returns an equivalent tree
+  (no-op), originals unmutated.
+- `updateProps`: shallow-merge patch, no-op on missing id.
+- `setSpan`: set span on a node, overwrite, clear with `undefined` (key removed), no-op on missing id.
+- `moveNode`:
+  - reorder within the same parent (down-by-one is stable — index interpreted after removal),
+  - move **into another container** at index 0 / middle / end,
+  - move to root,
+  - **no-op guard**: same parent + same index returns the **input reference** (assert `===`),
+  - **cycle guard**: moving a node into itself or a descendant **throws** (assert the error).
+- Flip the 2a "stub throws `notImplemented`" assertions for `moveNode`/`setSpan` to behavioral tests.
+
+### 6.2 `model/migrate.test.ts` (new)
+
+- `needsMigration`: true when any node has `position`, false otherwise (and false for a v2 tree).
+- `migrateTree`: legacy nodes grouped by `row` → one `grid` of `column`s with `span.base = width`
+  (clamped); `position` stripped from leaves; a node without `position` → full-width column; nested legacy
+  children recurse.
+- `width` clamping: `width:0`/`width:99` → `span.base` clamped to `1`/`12`.
+- **Real legacy `config` fixture (not only synthetic `position` nodes).** Build the fixture from an actual
+  page `config` shape as the worker stores it — `{ layout: { type:'single' }, components: [...legacy nodes
+  with position...] }` (no `schemaVersion`) — and run `readComponents(page)` → `migrateTree(...)` so the
+  test exercises the same read path `PageBuilderPage` uses on load (catches a wrapper/shape mismatch a
+  hand-rolled `position[]` array would miss). Assert the migrated tree is a `grid > column > widget`
+  structure and `config.layout` is left untouched by the migration (it is inert legacy, §5.11 — `migrate`
+  only rewrites `components`).
+- **Idempotency = fixpoint (assert deep-equal, both directions).** `migrateTree(migrateTree(legacy))`
+  **deep-equals** `migrateTree(legacy)` (running twice changes nothing). Separately, a tree already at
+  `schemaVersion: 2` is returned by the caller-guard untouched: assert `needsMigration(v2Tree) === false`
+  and that the load path (`cfg.schemaVersion === 2`) skips `migrateTree` entirely (no re-wrap, no extra
+  `grid` layer — the classic double-migration bug).
+- **migrate → save → reload round-trip (deep-equal).** Simulate the full persistence cycle with the §5.9
+  save path: `migrateTree(legacyComponents)` → `mergeConfig(readConfig(page), { components: migrated,
+  schemaVersion: 2 })` → read the resulting `config` back via `readComponents` / `readConfig`. Assert the
+  reloaded `components` **deep-equals** the migrated tree (no node dropped, no `position` resurrected, no
+  `span` lost during the `mergeConfig` overlay) **and** `config.schemaVersion === 2`. This is the regression
+  guard for "a node silently dropped during the `mergeConfig` save" — the exact failure the parent's
+  save-round-trip mandate targets.
+
+### 6.3 `canvas/spanClasses.test.ts` (new)
+
+- `spanToClasses(undefined)` → `'col-span-12'`.
+- `{ base:6 }` → `'col-span-6'`; `{ base:12, md:6 }` → `'col-span-12 md:col-span-6'`; all four breakpoints
+  present → 4 space-joined classes in `base sm md lg` order.
+- `clampSpan` clamps + rounds (`0→1`, `13→12`, `5.6→6`).
+- Sanity: every emitted class is one of the 48 literals (guards against accidental template interpolation).
+
+### 6.4 `canvas/Canvas.interaction.test.tsx` (new — dnd-kit interaction)
+
+Uses `@testing-library/user-event` + dnd-kit's `KeyboardSensor` for deterministic drags (pointer DnD is
+flaky in jsdom; the standard pattern is to drive dnd-kit via **keyboard**: focus handle → `Space` → arrows →
+`Space`). Per the dnd-kit testing guidance, assert the **resulting tree** (via the `onChange` spy), not pixel
+positions.
+
+- **Drop from palette into a column:** render a tree with one empty `column`; keyboard-drag the palette
+  `heading` draggable over the column; assert `onChange` fired with a tree where the column has a `heading`
+  child at the expected index (not at root) — proves the "no longer appends to root" fix.
+- **Reorder within a row:** 3 children `[A,B,C]`; keyboard-drag `C` to index 0; assert `onChange` tree =
+  `[C,A,B]` (one `moveNode`).
+- **Move between containers:** drag a child from `col-1` to `col-2`; assert it left col-1 and entered col-2
+  (no duplication — node count constant).
+- **No-op guard:** drag a node and drop it back in place; assert `onChange` is **not** called (or called
+  with the identical reference).
+- **Selection + delete chrome preserved:** clicking a node fires `onSelect`; the `×` button fires
+  `onDelete`; `canvas-component-{id}` / `delete-component-{id}` testids still present.
+- **a11y:** the drag handle is a `<button>` with `aria-label`; the `DndContext` exposes the announcer
+  region (assert `role="status"`/`aria-live` region exists).
+
+### 6.4b `canvas/dnd/useCanvasDnd.test.ts` (new — routing unit, not interaction)
+
+Unit-test the `onDragEnd` **routing branches** directly (no DOM drag — call the handler with synthetic
+`DragEndEvent`-shaped `active`/`over` payloads), complementing the keyboard interaction test in §6.4
+(which exercises the real dnd-kit pipeline). This pins the palette-vs-node decision logic in isolation:
+
+- **Palette-source branch:** `active.data.current = { source:'palette', widgetType:'heading' }`, `over` a
+  container → asserts `insertNode` is called with the dropped container id + slot index and a node built
+  from `widgetRegistry.get('heading').defaultProps` (NOT `moveNode`, NOT root).
+- **Node-source branch:** `active.data.current = { source:'node', nodeId, parentId }`, `over` a different
+  container → asserts `moveNode(tree, nodeId, over.container, over.index)` (NOT `insertNode`).
+- **Dropped on nothing:** `over == null` → handler returns early; neither `insertNode` nor `moveNode` runs;
+  `onChange` not called.
+- **No-op guard surfaced:** node dropped back in place (`moveNode` returns the input reference) → `onChange`
+  is not invoked (or invoked with the identical reference) — proves the §3.2 guard is honored at the hook
+  boundary, not just inside `treeOps`.
+- **`onChange` payload:** on a real move/insert, `onChange` receives the new tree from `treeOps` (spy the
+  `insertNode`/`moveNode` result).
+
+### 6.5 `canvas/useSpanResize.test.ts` (new)
+
+Drive the resize hook with synthetic pointer deltas + a fixed `gridWidthPx` (e.g. 1200 → colWidth 100);
+assert: `+250px` → `+3` cols → `setSpan` base `6→9` (snapped); `-700px` → clamp at `1`; sub-half-column
+delta (`+40px`) → **no** `setSpan` (rounds to 0). Persists only `span` (no px).
+
+### 6.6 `widgets/builtins/layout.parity.test.tsx` (new)
+
+- `grid`/`row` render `grid grid-cols-12` and wrap each child in `spanToClasses(child.span)`.
+- `column` stacks children (`flex flex-col gap-4`), shows the dashed placeholder when empty **in editor
+  mode** only.
+- `divider` renders `<hr data-testid="page-node-divider">`.
+- **Editor vs runtime identical:** render a `grid > column(span) > heading` tree via `RenderTree
+  mode="editor"` and `mode="runtime"`; assert identical DOM/classes for the layout nodes (extends the 2a
+  `renderTree.test.tsx` cross-mode assertion).
+
+### 6.7 Extend `PageBuilderPage.test.tsx`
+
+- Palette now lists 12 items including `palette-item-grid`/`row`/`column`/`divider`.
+- Click-adding a `grid` applies its `defaultProps` and appends to root via `insertNode`.
+- **Save-payload assertion (the §5.9 BLOCKER fix):** after any edit, assert the `updateMutation.mutate`
+  **payload** (intercepted via the MSW handler or a `mutate` spy — NOT just `mergeConfig`'s return value)
+  has `data.config.schemaVersion === 2`. This is the direct guard for the silent-drop bug: a widened
+  `mergeConfig` that isn't passed `schemaVersion` would still produce a payload **without** it, and this
+  test would fail. (2d extends this same payload assertion to `variables`/`dataSources`; 1h to `access`.)
+- **Migration on load + persisted on save (round-trip):** seed `currentPage` with a legacy
+  `position`-bearing `config` (no `schemaVersion`); assert the canvas renders a migrated `grid`/`column`
+  structure (testids present), that saving sends `config.schemaVersion: 2` **and** the migrated
+  `config.components` (no node dropped), and that a subsequent reload does **not** re-migrate
+  (`needsMigration` false on the saved tree).
+- **Unsaved-changes guard (§5.10):** with `hasUnsavedChanges` true, mock `window.confirm`:
+  `→ false` keeps `viewMode === 'edit'` (no state reset, `data-testid="page-canvas"` still present);
+  `→ true` returns to the list view. Assert the confirm message uses the i18n key (not a hardcoded string).
+- **Layout select inert (§5.11):** the `page-layout-select` still renders in the create/edit form and its
+  value round-trips through `mergeConfig` (preserved, never dropped), but changing it does **not** alter the
+  rendered canvas layout (the widget tree owns layout) — a light assertion that `config.layout` is inert.
+- Existing preview/selection tests stay green (same testids; the canvas swap preserves
+  `page-canvas`/`canvas-component-*`/`delete-component-*`).
+
+### 6.8 Extend `pageConfig.test.ts`
+
+2c widens `mergeConfig` (§5.9), so its test grows with the new overlay keys:
+
+- `mergeConfig` overlays `schemaVersion: 2` while **preserving** existing untouched keys
+  (`components`/`layout` — the 2a-covered keys stay green).
+- `mergeConfig` overlays `variables`/`dataSources`/`access` when passed, and **leaves them untouched** when
+  a change object omits them (the silent-drop guard at the helper level: omitted key ⇒ existing value
+  preserved, never wiped).
+- A change object passing only `{ components }` (the legacy 2a shape) still does **not** invent
+  `schemaVersion`/siblings — proving the helper is additive and the *call site* (§5.9) is what introduces
+  `schemaVersion: 2`. (Pairs with the §6.7 payload assertion that the call site now does pass it.)
+
+### 6.9 kelta-test-harness
+
+**N/A — FE-only, no DB write path.** No new server constraint is exercised (the tree round-trips through the
+existing `config` JSON pass-through unchanged), so the DB-constraint integration guard
+(`feedback_db-constraint-test-gap`) does not apply here.
+
+---
+
+## 6b. i18n — new canvas/layout strings
+
+Per parent §i18n ("each FE slice owns its strings") and CLAUDE.md: **no hardcoded English** — all new
+user-facing strings go through `useI18n`/`t()` with `builder.*` keys, added to the locale catalog(s) in the
+**same PR**. The current builder is fully `useI18n`-driven; 2c keeps it so. Strings 2c introduces:
+
+| Key | Surface | Example copy |
+|-----|---------|--------------|
+| `builder.pages.layoutWidgets.grid` | Palette tile label (`grid`) | "Grid" |
+| `builder.pages.layoutWidgets.row` | Palette tile label (`row`) | "Row" |
+| `builder.pages.layoutWidgets.column` | Palette tile label (`column`) | "Column" |
+| `builder.pages.layoutWidgets.divider` | Palette tile label (`divider`) | "Divider" |
+| `builder.pages.layoutCategory` | Palette `layout` category header | "Layout" |
+| `builder.pages.columnEmpty` | Empty-column placeholder (editor) | "Drop a widget here" |
+| `builder.pages.spanLabel` | Inspector/handle `span` (Width) label | "Width" |
+| `builder.pages.resizeAria` | Resize-handle `aria-label` | "Resize column width" |
+| `builder.pages.reorderAria` | Drag-handle `aria-label` (`{type}` interpolated) | "Reorder {type}" |
+| `builder.pages.unsavedConfirm` | §5.10 unsaved-changes confirm dialog | "You have unsaved changes. Discard them?" |
+| `builder.pages.dnd.*` (picked/dropped/cancelled/over) | `DndContext` `accessibility.announcements` (`canvas/dnd/announcements.ts`) | "Picked up {type}", "Dropped over {container}, position {n}", "Movement cancelled" |
+
+> The descriptor `label`s shown in §3.5 ("Grid"/"Row"/"Column"/"Divider") are **display strings**: the
+> palette renders them via `t(builder.pages.layoutWidgets.<type>)`, not the raw `descriptor.label` literal
+> (descriptor labels stay English fallbacks). The a11y announcement strings in
+> `canvas/dnd/announcements.ts` (§5.1) are i18n'd too — they are not exempt because they are
+> screen-reader-only. A test asserts the unsaved-confirm and at least one announcement read from `t()` (not
+> a literal), matching the existing builder i18n test idiom.
+
+---
+
+## 7. Docs to update (same PR)
+
+Per CLAUDE.md Rule 6, these ship **in the same PR** as the code.
+
+| Doc | Change |
+|-----|--------|
+| `.claude/docs/status.md` (Page builder / screen builder row) | Add: "slice 2c — **layout engine + `@dnd-kit` canvas**: new `grid`/`row`/`column`/`divider` layout widgets; per-child responsive `span {base,sm,md,lg}` (Tailwind `col-span-*` + breakpoints); the native-HTML5 stack-only canvas is replaced by a `DndContext` (Pointer + Keyboard sensors) with per-container `SortableContext` reorder, **drop-into-container** (no longer appends to root), and **grid-span resize** snapping to the 12-col grid; `model/treeOps` (`moveNode`/`setSpan`) completed and `model/migrate.ts` converts legacy `position` trees to `grid`/`column`+`span`. The ignored `ComponentPosition {row,column,width,height}` is now migrated away and no longer written." Move "responsive grid / drop-into-container / reorder / resize" **out of the gap column**. |
+| `.claude/docs/conventions.md` | In the page-config v2 contract section (stubbed in 2a, fleshed in 2d): document `span: {base,sm,md,lg}` (1..12, mobile-first), the `grid`/`row`/`column`/`divider` layout vocabulary, the `schemaVersion: 2` marker + the v1(`position`)→v2(`grid`/`span`) `migrate` back-compat rule, and the **DnD convention**: the page canvas uses `@dnd-kit` (scoped) — `PageLayoutsPage`/`MenuBuilderPage` remain native HTML5 DnD (do not migrate them). State that the only persisted layout state is `span` (no pixel/row/column coords). **Document the save-path rule (§5.9):** page-level siblings (`schemaVersion`/`variables`/`dataSources`/`access`) persist **only** if the `handleSavePage` call passes them to `mergeConfig` — widening `mergeConfig`'s keys alone silently drops them. **Document `config.layout` as inert legacy (§5.11):** the create-form `layoutType` select is orphaned by the widget tree; `config.layout` is preserved on round-trip but read by nothing (removal deferred). |
+| `.claude/docs/playbooks.md` ("Add a page component / widget" recipe, added in 2a) | Add a note: a **layout** (container) widget sets `acceptsChildren: true`, renders `node.children` via `renderChild`, and (for grid-track containers) wraps each child in `spanToClasses(child.span)`; the canvas auto-makes any `acceptsChildren` node a droppable + `SortableContext`. |
+| `.claude/docs/concerns.md` (Large files table) | `PageBuilderPage.tsx`: note 2c **net-shrinks** it again by extracting the canvas (`~688–872` native-DnD `Canvas` + drag handlers) into `canvas/*`. Record the **new `@dnd-kit` dependency** as a watch item (bundle size; pointer-DnD jsdom-test flakiness mitigated by keyboard-driven interaction tests). Record **`config.layout` as inert/deprecated** (the `layoutType` select is orphaned; removal deferred — §5.11) so a future slice can safely delete the select. Note the **save-path silent-drop class** (§5.9) is now closed for `schemaVersion` but the `mergeConfig`-must-be-passed-the-key invariant must hold for every future page-level sibling. |
+| `CLAUDE.md` Stack table (Frontend build / deps) | No version-table row needed for a feature dep, but if the table tracks notable FE libs, add `@dnd-kit` (page-canvas DnD). Otherwise leave; the dep is recorded in `package.json` + this spec. |
+| i18n locale catalog(s) (the `builder.*` message source the builder's `useI18n` reads) | Add every new `builder.pages.*` key from §6b (layout widget labels, `layoutCategory`, `columnEmpty`, `spanLabel`, `resizeAria`, `reorderAria`, `unsavedConfirm`, `builder.pages.dnd.*` announcements) to each maintained locale. No hardcoded English in components — strings flow through `t()`. |
+| `project_outsystems_roadmap.md` (memory) | Record slice 2c shipped under Rec 1 (page-builder parity, Layout & grid axis). |
+
+---
+
+## 8. Risks & open questions
+
+- **`@dnd-kit` is a new runtime dependency.** Mitigation: scoped to the page canvas only (parent decree);
+  three small packages (~30–40 kB gz); pin exact majors (`core ^6`, `sortable ^10`, `utilities ^3`). Verify
+  the kelta-ui build/bundle gate still passes. Do **not** migrate `PageLayoutsPage`/`MenuBuilderPage`/
+  `FlowDesignerPage` — they stay native HTML5 DnD; mixing the two libs in one tree is the trap to avoid.
+- **Pointer DnD is flaky in jsdom.** Mitigation: interaction tests drive dnd-kit via the **KeyboardSensor**
+  (focus handle → Space → arrows → Space) and assert the **resulting tree** through the `onChange` spy, not
+  pixels — the standard dnd-kit testing approach. Pointer-drag fidelity is covered post-deploy by Playwright.
+- **Tailwind JIT cannot see dynamic `col-span-${n}`.** Mitigation: `spanClasses.ts` emits the **48 full
+  literal class names**; `spanClasses.test.ts` asserts every produced class is one of those literals so an
+  accidental template-string regression fails CI rather than silently dropping the class at build time.
+- **Resize must store only `span`, never pixels.** The historical bug was the ignored
+  `ComponentPosition {row,column,width,height}`. `useSpanResize` reads the measured grid width transiently
+  to compute an **integer column delta** and persists only `span`. A test asserts no px value is written.
+  Open question for the user: should the canvas resize handle edit `span.base` only (current design — the
+  inspector edits `sm`/`md`/`lg` per breakpoint in 2b), or expose a breakpoint toggle on the handle itself?
+  **Recommended:** handle edits `base`; breakpoint overrides via the inspector (keeps the canvas gesture
+  simple).
+- **`grid` vs `row` render the same 12-col CSS grid.** They differ only in palette label/authoring intent.
+  Open question: is a distinct `row` widget worth shipping, or should `row` be dropped and `grid` + per-child
+  `span` cover all cases? **Recommended:** keep both for OutSystems-parity familiarity (named `row`/`column`
+  vocabulary), but flag for the user — collapsing to `grid`-only is a cheap simplification if preferred.
+- **Migration determinism for already-published legacy pages.** `migrateTree` groups by `position.row`;
+  pages authored before `position` was meaningfully set (all `row:0`) collapse to a single full-width
+  column-per-node grid — acceptable (renders as today's stack). Idempotency + the `schemaVersion: 2` stamp
+  prevent re-migration. Migration runs **in the builder on load** (not server-side) so a page is only
+  rewritten when an author opens + saves it — no mass backfill, no migration job.
+- **Save-path is the #1 correctness risk (parent decree) — closed in 2c.** Widening `mergeConfig` without
+  widening the `handleSavePage` call would silently drop `schemaVersion`, re-migrating the page on every
+  reload. 2c changes **both** (§5.9) and asserts the **mutation payload** (§6.7), not just `mergeConfig`'s
+  return. The invariant — *every page-level sibling must be passed at the call site* — is documented for
+  2d/1h to extend (`variables`/`dataSources`/`access`).
+- **Create-form `layoutType` select is orphaned (decided: deprecate-in-place, removal deferred).** The
+  widget tree + `span` now own layout, so `config.layout.type` is read by nothing. 2c keeps the select and
+  marks `config.layout` inert legacy (§5.11) rather than ripping it out (the select is also the create-time
+  form field; removal touches the create flow + tests — out of the canvas axis). **Open question for the
+  user:** remove the select entirely in a follow-up, or keep it as a no-op page hint? **Recommended:** keep
+  it inert now, schedule removal once no page reads `config.layout`.
+- **Sequencing.** 2c hard-depends on **2a** (`widgets/*`, `model/*`, `RenderTree`, `treeOps` stubs) being
+  merged. It is independent of 2b (inspector) — the 2c `column` `span` `propSchema` field uses the `kind:'span'`
+  control that **2b** builds; in 2c the inspector still edits props via the legacy `PropertyPanel`, so canvas
+  resize (not the inspector) is the `span` authoring path until 2b lands. Land order: 2a → (2b ∥ 2c). 2d/2e
+  build on the same canvas but don't block 2c.

--- a/.claude/docs/specs/page-builder/2d-binding-expressions.md
+++ b/.claude/docs/specs/page-builder/2d-binding-expressions.md
@@ -1,0 +1,1044 @@
+# Slice 2d — Data binding & expressions
+
+> Child spec of [page-builder-parity.md](../page-builder-parity.md). **Extends, never contradicts**
+> the parent's [The shared model](../page-builder-parity.md#the-shared-model) (bindings/scope),
+> [Page-level config (v2)](../page-builder-parity.md#page-level-config-v2), and
+> [Widget registry](../page-builder-parity.md#widget-registry). Consumes the types defined once in
+> [2a — Widget registry](./2a-widget-registry.md) (`WidgetDescriptor`, `WidgetRenderProps`,
+> `PageComponent`, `Binding`, `PropValue`, `RenderTree`/`renderNode`) and the render-contract siblings
+> surfaced by [1g — Render contract v2](./1g-render-contract-v2.md) (`variables` / `dataSources`).
+>
+> Source-verified against the codebase on 2026-06-22 (Flyway head **V146**, next **V147**; this slice
+> adds **no** migration). If code and this doc disagree, **trust the code and fix this doc.**
+
+**Axis:** Data binding. **Depends on:** 2a (model + registry + `RenderTree`), and benefits from 1g
+(contract siblings) but tolerates its absence (`scope.data` / `vars` simply stay empty). **Blocks:** none
+hard, but 2e (events) reuses the same scope + `interpolate` for action params.
+
+---
+
+## 1. Goal & scope
+
+### What this slice delivers
+
+The **binding/expression layer** that turns the static-props builder into one where *any* prop can be
+bound to a record field, a page variable, or an on-load data-source result, and evaluated **client-side**
+through the existing `@kelta/formula` engine and the `FieldExpressionPicker`.
+
+Concretely:
+
+1. **`model/bindingScope.ts`** — the `BindingScope` type `{ record, vars, page, item, data }` and a
+   `getPath(scope, "record.name")` dot-walker (because the formula parser is **flat-key only** — see
+   §3.1, verified).
+2. **`model/resolveBindings.ts`** — `resolveBindings(props, scope)` that recursively replaces every
+   `Binding` (`{ $bind, mode }`) in a props object:
+   - `mode:'path'` → `getPath(scope, expr)` walker (dotted access like `record.name`,
+     `data.accounts[0].name`).
+   - `mode:'expr'` → **flatten** the leaves the expression references (`evaluator.extractFieldRefs(expr)`
+     → `getPath` each) into a flat `Record<string, unknown>`, then `evaluator.evaluate(expr, flat)`.
+     This is the **flat-scope bridge** to `@kelta/formula`.
+3. **`model/interpolate.ts`** — `interpolate("Hi {{record.name}}", scope)` for `{{…}}`-templated strings
+   (the same `{{…}}` merge-tag convention `FieldExpressionPicker` already emits).
+4. **`BindableField` finalization** (the `fx` literal↔expr toggle stubbed in 2b) — stores
+   `{ $bind, mode }` and opens `FieldExpressionPicker` with `record` / `vars` / `page` / `data` namespace
+   roots. The render path resolves it via `RenderTree`'s `resolveBindings(props, scope)`.
+5. **Page `variables`** — a `usePageVariables(contract.variables)` state hook (read/seed defaults/`setVar`)
+   feeding `scope.vars`.
+6. **Page `dataSources`** — a `usePageDataSources(contract.dataSources, scope)` hook that fans out
+   `apiClient.getList` / `apiClient.getOne` per source on page load (the **same authorized JSON:API path**
+   `DataTableNode` uses today), populating `scope.data.<name>`.
+7. **New data widgets:**
+   - **`field-value`** — renders a single bound value through `FieldRenderer` (read-only, 21 field types,
+     FLS-stripped server-side).
+   - **`list` / `repeater`** — binds an **array** source and renders its children once per row under a
+     per-row `item` scope (capped at `MAX_REPEATER_ROWS`, §3.9).
+8. **Page-settings drawer (NEW host surface — 2d owns it).** The current builder has only a flat
+   create/edit page form, so 2d **builds the page-settings drawer shell** plus the **Variables** section
+   and the **Data sources** section inside it (§2.3, §5.7). 1h later adds its Access field into this same
+   drawer. The Data-sources section enforces `MAX_PAGE_DATA_SOURCES` (§3.9).
+
+The runtime `table` / `form` widgets (migrated in 2a) **keep** their own JSON:API fetch — `dataSources`
+**generalize** that fetch so *arbitrary* props can be bound, they do not replace it.
+
+### What this slice explicitly does NOT do
+
+| Out of scope | Lands in |
+|--------------|----------|
+| `EventListField` UI + the action runtime (`runFlow`/`navigate`/`setVar`/…) | 2e |
+| dnd-kit canvas, `treeOps.moveNode`/`setSpan`, responsive `span` resize, `migrate.ts` | 2c |
+| Typed/validated form inputs (`dropdown`/`datepicker`/`lookup`/…) replacing text-only `FormNode` | 2f |
+| `chart` / `tabs` / `nav` / `icon` widgets | 2g |
+| Per-page Cerbos authz gate | 1h |
+| **Any server-side binding/dataSource resolution** | **never — see §3.7 (CRITICAL)** |
+
+> **Inspector dependency.** `BindableField` and the schema-driven `Inspector` (looping over
+> `descriptor.propSchema`, wrapping `bindable` fields) are introduced in **2b** as a literal-only
+> toggle stub. 2d **finalizes** `BindableField` to (a) store the `{ $bind, mode }` shape and (b) open
+> `FieldExpressionPicker`. If 2b's `Inspector` has not landed, 2d ships `ExpressionField` + `BindableField`
+> standalone and the existing hardcoded `PropertyPanel` keeps editing non-bindable props.
+
+### Conforms to (parent-doc sections)
+
+- §"The shared model" — `Binding = { $bind; mode?: 'path' | 'expr' }`, the scope `{ record, vars, page,
+  item, data }`, `resolveBindings` / `interpolate`, the flat-scope formula bridge.
+- §"Page-level config (v2) → Canonical storage" — the component tree lives at **`config.components`**;
+  `variables`/`dataSources` are **siblings** in `config` (**no `config.tree` wrapper**); the binding
+  namespace authority (`record` / `vars` / `data.<name>` / `page` / `item`); `$bind` is the **single**
+  expression marker and **the server never parses it**. `PageVariable` / `PageDataSource` shapes.
+- §"Widget registry → resolved-node invariant" — `node.props` handed to `Render` is **already fully
+  resolved**; descriptors do **not** re-resolve (only `list`/`repeater` re-resolves the per-row `item`
+  scope for its children via `renderChild(child, scope?)` — the 2a-defined signature). `field-value` and
+  `list`/`repeater` descriptors.
+- §"Security" — `getPath` skips `__proto__`/`constructor`/`prototype`; client-side-only resolution keeps
+  Cerbos/FLS the only data gate.
+- §"DoS / fan-out caps (2d)" — `MAX_PAGE_DATA_SOURCES` (12) + repeater render cap (200) + per-page-view
+  governor-quota note.
+- §"Slice plan → 2d" — 2d owns creating the page-settings drawer + Variables + Data-sources sections,
+  extends 2c's save call with `variables`/`dataSources`, and re-runs 2a's parity suite unchanged.
+
+### Acceptance criteria
+
+- A `heading` whose `text` prop is `{ $bind: "record.name", mode: "path" }` renders the record's `name`
+  at runtime; the inspector shows the `fx` toggle in expr state and re-opening the picker round-trips the
+  path.
+- `{ $bind: "IF(vars.count > 0, 'Has rows', 'Empty')", mode: "expr" }` evaluates through `@kelta/formula`
+  via the flat-scope bridge and renders the right branch.
+- An interpolated string prop `"Showing {{data.accounts[0].name}}"` renders the resolved value inline.
+- A page with a `dataSources` entry `{ name:'accounts', collection:'accounts', mode:'list', limit:25 }`
+  fetches via `apiClient.getList('/api/accounts?page[size]=25')` on load and a bound `table`/`list`
+  reads `scope.data.accounts`.
+- A `repeater` bound to `data.accounts` renders its child subtree once per row, each row resolving
+  `item.<field>`.
+- A `field-value` bound to `record.email` renders through `FieldRenderer type="email"`.
+- Missing path (`record.nope`) resolves to `null` (not a throw); a malformed expr resolves to `null`
+  and logs once (does not crash the tree).
+- **No server call resolves a binding** — every record read is a JSON:API request from the client, so
+  Cerbos/FLS stay enforced server-side (proven by the §6 tests asserting fetch URLs, not server resolution).
+- **Caps enforced (§3.9):** a page cannot declare more than `MAX_PAGE_DATA_SOURCES` (12) sources in the
+  builder; a `repeater`/`list` renders at most `MAX_REPEATER_ROWS` (200) rows with a "showing N of M" note.
+- **Parity guard:** re-running **2a's builtin parity / golden-snapshot suite UNCHANGED** after 2d lands
+  produces byte-identical snapshots for all 8 built-ins — proving the now-real `resolveBindings` is an
+  **identity on literal (non-bound) props** (see §6.10c).
+- `/verify` green (lint + typecheck + `test:coverage` ≥ the kelta-ui gate).
+
+---
+
+## 2. UI samples
+
+### 2.1 The `fx` toggle on a heading's `text` prop (inspector)
+
+`BindableField` wraps any `propSchema` entry with `bindable: true`. The little `fx` button toggles between
+**literal** (a plain input) and **expression** (a read-only chip + "Edit" that opens the
+`FieldExpressionPicker`). Verified behavior of the picker: `onInsert(token)` gives the **dot-path** (e.g.
+`account_id.name`) or a **function stub** (e.g. `IF(${cond}, ${then}, ${else})`); the caller wraps with
+`{{…}}` for templates or stores the raw token as `$bind`.
+
+```
+Literal mode (default):                  Expression mode (fx active):
+┌─ Text ───────────────── [fx] ┐         ┌─ Text ───────────────── [fx●]┐
+│ ┌──────────────────────────┐ │         │ ┌──────────────────────┐ ✎    │
+│ │ Orders                   │ │   ──►   │ │ {{record.name}}      │ Edit │
+│ └──────────────────────────┘ │         │ └──────────────────────┘      │
+└──────────────────────────────┘         │ mode: path                    │
+                                          └───────────────────────────────┘
+   stores: props.text = "Orders"             stores:
+                                             props.text = { $bind: "record.name", mode: "path" }
+```
+
+Clicking **Edit** opens the picker:
+
+```
+┌─ Insert field or expression ───────────────────────────────────────────┐
+│ Selected:  {{record.name}}                          [Cancel] [Insert]   │
+├──────────┬──────────────────┬──────────────────┬───────────────────────┤
+│ Fields   │ Available        │ Account          │  (cascades on          │
+│ Funcs    │ variables        │ • name   string  │   relationship rows)   │
+│          │ • record ▸       │ • email  string  │                        │
+│          │ • vars   ▸       │ • owner_id ▸     │                        │
+│          │ • page   ▸       │ • created_at ... │                        │
+│          │ • data   ▸       │                  │                        │
+└──────────┴──────────────────┴──────────────────┴───────────────────────┘
+```
+
+The four roots (`record` / `vars` / `page` / `data`) are passed as `staticNamespaces`; `record` *also*
+cascades into the current collection's real schema via `rootCollectionId` (so `record.account_id.name`
+deep paths work through the existing cascading column picker). Picking a function switches to expr `mode`.
+
+### 2.2 Expression picker bound to `record` / `vars` / `data`
+
+`ExpressionField` constructs the `staticNamespaces` for the picker:
+
+```
+record  → cascades into the page's bound collection schema (rootCollectionId)
+vars    → StaticNamespace { name:'vars',  label:'Page variables', fields: [ {name:'count', type:'number'}, … ] }
+page    → StaticNamespace { name:'page',  label:'Route / page',    fields: [ {name:'slug', type:'string'}, {name:'params', type:'json'} ] }
+data    → StaticNamespace { name:'data',  label:'Data sources',    fields: [ {name:'accounts', type:'json'}, … ] }   // from contract.dataSources names
+item    → only inside a list/repeater subtree (the inspector adds it when editing a descendant of a repeater)
+```
+
+`vars` leaf list is derived from `contract.variables` (name + type); `data` leaf list from
+`contract.dataSources` (name, type `json`). Both are zero-config for the author — they reflect what the
+page already declares.
+
+### 2.3 Page-settings drawer (NEW in 2d) — Variables + Data sources sections
+
+> **Host-surface ownership (MAJOR — 2d creates this).** The current builder has **only a flat
+> create/edit page form** (title/slug/layout fields) — there is **no page-settings drawer** and no
+> Variables or Data-sources UI, and **no earlier slice creates them** (2a is registry/render, 2b is the
+> per-node inspector, 2c is canvas/layout + the save rewrite). So 2d **owns building the page-settings
+> drawer shell** and **both** the **Variables** section and the **Data sources** section inside it. 1h
+> later adds its single Access field into this same drawer — it does not create the drawer.
+
+The drawer is opened from a **"Page settings"** button in the builder toolbar and holds three stacked
+sections (Access added by 1h):
+
+```
+┌─ Page settings ───────────────────────────────────────────────── [ × ] ┐
+│                                                                          │
+│  ▸ Variables                                            [+ Add variable] │
+│    ┌──────────────────────────────────────────────────────────────────┐ │
+│    │ Name [ count ]   Type ( number ▾ )   Default [ 0 ]      [ Remove ] │ │
+│    └──────────────────────────────────────────────────────────────────┘ │
+│                                                                          │
+│  ▸ Data sources                                          [+ Add source]  │
+│    (the Data-sources editor below)                                       │
+│                                                                          │
+│  ▸ Access            (added by slice 1h — not in 2d)                     │
+└──────────────────────────────────────────────────────────────────────────┘
+```
+
+Both sections are **pure config**, persisted into `config.variables` / `config.dataSources` (siblings of
+`config.components`; round-trip through 1g untouched). The **Data sources** section:
+
+```
+┌─ Data sources ──────────────────────────────────────── [+ Add source] ┐
+│ ┌────────────────────────────────────────────────────────────────────┐ │
+│ │ Name        [ accounts        ]   Mode  ( ● List  ○ Single )        │ │
+│ │ Collection  [ accounts      ▾ ]   Limit [ 25 ]                       │ │
+│ │ Fields      [ name × ] [ email × ] [ + ]                            │ │
+│ │ Filter      { status: { $bind: "vars.statusFilter", mode:"path" } } │ │
+│ │                                                          [ Remove ]  │ │
+│ └────────────────────────────────────────────────────────────────────┘ │
+│ Single-mode adds:  Record id  [fx] { $bind: "page.params.id", path }    │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+On load the page fetches each source (list → `getList`, single → `getOne`) and exposes the result at
+`scope.data.<name>`. Bound props/widgets read it; `refreshData` (2e) re-runs one source.
+
+### 2.4 A `repeater` rendering children per row (runtime)
+
+```
+Tree:                                         Runtime output (data.accounts = [{name:'Acme'},{name:'Globex'}]):
+repeater (source = {{data.accounts}})          ┌─ card ─────────────┐   ┌─ card ─────────────┐
+  └ card                                        │ Acme               │   │ Globex             │
+      └ heading (text = {{item.name}})          │ View ▸             │   │ View ▸             │
+      └ button  (label = "View")                └────────────────────┘   └────────────────────┘
+```
+
+Each iteration renders the **child subtree** with `scope.item = row` (and `scope.record = row` aliased,
+so child bindings can use either `item.name` or `record.name` inside a row — `record` is the natural
+"current row" inside a repeat, per parent §"Page-level config (v2)").
+
+### 2.5 Sample component-tree JSON (what `config.components` holds)
+
+```json
+[
+  { "id": "h1", "type": "heading",
+    "props": { "text": { "$bind": "data.accounts[0].name", "mode": "path" }, "level": "h1" } },
+
+  { "id": "fv1", "type": "field-value",
+    "props": { "source": { "$bind": "record.email", "mode": "path" }, "fieldType": "email" } },
+
+  { "id": "rep1", "type": "repeater",
+    "props": { "source": { "$bind": "data.accounts", "mode": "path" } },
+    "children": [
+      { "id": "rc1", "type": "card", "props": {}, "children": [
+        { "id": "rh1", "type": "heading",
+          "props": { "text": { "$bind": "item.name", "mode": "path" }, "level": "h3" } },
+        { "id": "rt1", "type": "text",
+          "props": { "content": "Status: {{item.status}}" } }
+      ]}
+    ]
+  },
+
+  { "id": "txt1", "type": "text",
+    "props": { "content": { "$bind": "IF(vars.count > 0, 'Has accounts', 'No accounts')", "mode": "expr" } } }
+]
+```
+
+Stored `config` JSON (canonical storage — `components`, `variables`, `dataSources` are all
+**siblings** inside `config`; there is **no `config.tree` wrapper**, per parent §"Page-level config (v2)
+→ Canonical storage"):
+
+```json
+{
+  "schemaVersion": 2,
+  "variables": [ { "name": "count", "type": "number", "default": 0 } ],
+  "dataSources": [
+    { "name": "accounts", "collection": "accounts", "mode": "list",
+      "fields": ["name", "email", "status"], "limit": 25 }
+  ],
+  "components": [ /* the array above */ ]
+}
+```
+
+> **Storage vs. render contract.** The component tree is persisted at **`config.components`** — the
+> location the existing builder already writes and `CustomPage` already reads. The 1g render contract
+> carries the *whole* `config` map verbatim in its `tree` field, so at the contract layer
+> `contract.tree.components` resolves to this same array; `variables`/`dataSources` are *also* surfaced as
+> separate contract fields read from `config.*` top-level. 2d reads/writes `config.components` /
+> `config.variables` / `config.dataSources` — never a `config.tree.*` path.
+
+All `$bind` markers round-trip through the server **verbatim** — the server resolves nothing (1g §3.4).
+
+---
+
+## 3. Data & API contracts
+
+All TS lives under `kelta-ui/app/src/pages/PageBuilderPage/`. **No backend/API change in 2d** (data flows
+through the existing JSON:API; the render contract was finalized in 1g).
+
+### 3.1 The `@kelta/formula` public API (verified — quoted) and the flat-key limitation
+
+From `kelta-web/packages/formula/src/index.ts` and `FormulaEvaluator.ts` (real, unmodified):
+
+```ts
+// FormulaEvaluator.ts — the methods 2d uses:
+evaluate(expression: string, fieldValues: Record<string, unknown>): unknown
+extractFieldRefs(expression: string): string[]
+validate(expression: string): void               // throws FormulaException on parse error
+// constructor(opts?: { cacheMaxSize?: number; functions?: FormulaFunction[] })
+```
+
+> **The flat-key limitation (load-bearing, verified in `parser.ts`).** `FormulaParser.parseIdentifierOrFunction`
+> (parser.ts:179–213) consumes only `isLetterOrDigit(c) || c === '_'` and **stops at `.`**. So an
+> identifier is a single flat segment producing `{ kind: 'fieldRef', fieldName: <segment> }`. Consequences:
+> - `record.name` does **not** evaluate natively — the parser reads `record` as a `fieldRef`, then hits `.`
+>   and throws `Unexpected character at position N: '.'`.
+> - `evaluateAst` for a `fieldRef` does a **flat** lookup `context.fieldValues[node.fieldName]` and returns
+>   `null` when the key is `undefined` (ast.ts:33–36) — i.e. **missing leaf → null**, never a throw.
+>
+> This is precisely why 2d splits resolution into two modes:
+> - **`mode:'path'`** — dotted/indexed access (`record.name`, `data.accounts[0].name`) is handled by a
+>   hand-written `getPath` **walker** in `bindingScope.ts`, never by the formula parser.
+> - **`mode:'expr'`** — we **flatten** the leaves the expression references into a flat map keyed by the
+>   *exact identifier the parser sees*, then call `evaluate`. Because the parser can't read `record.name`
+>   as one identifier, expr authors reference **flat** identifiers (e.g. `count`, or function calls over
+>   them); `ExpressionField` maps a picked dotted path to a flat alias when inserting into an expr (see
+>   §3.4). For the common case the picker emits flat leaf names directly into expressions.
+
+### 3.2 `model/bindingScope.ts` — scope + `getPath` walker
+
+```ts
+import type { PropValue } from './pageModel'
+
+/**
+ * The binding scope (parent §"The shared model"). All five roots are optional; absent roots resolve
+ * to undefined → null. `record` is the current record OR the current repeat row (aliased to `item`).
+ */
+export interface BindingScope {
+  /** Current record / current repeat row. */
+  record?: Record<string, unknown>
+  /** Page variables (usePageVariables). */
+  vars?: Record<string, unknown>
+  /** Route params + page meta: { slug, path, params }. */
+  page?: { slug?: string; path?: string; params?: Record<string, string> }
+  /** Per-row scope inside list/repeater (also aliased into `record`). */
+  item?: Record<string, unknown>
+  /** On-load data-source results keyed by source name (usePageDataSources). */
+  data?: Record<string, unknown>
+}
+
+export const EMPTY_SCOPE: BindingScope = {}
+
+/** Tokens that could traverse the prototype chain — refused (return null) per parent §"Security". */
+const UNSAFE_KEYS = new Set(['__proto__', 'constructor', 'prototype'])
+
+/**
+ * Walk a dotted/indexed path against the scope. Supports `a.b`, `a[0]`, `a.b[2].c`.
+ * Returns `null` for any missing segment (never throws) — matches the formula engine's
+ * missing-leaf semantics so `mode:'path'` and `mode:'expr'` agree on absent values.
+ * Prototype-pollution guard (parent §"Security"): any `__proto__`/`constructor`/`prototype` token
+ * short-circuits to null so a bound path can never reach the prototype chain.
+ */
+export function getPath(scope: BindingScope, path: string): unknown {
+  if (!path) return null
+  // Tokenize "a.b[0].c" → ['a','b','0','c']
+  const tokens = path
+    .replace(/\[(\d+)\]/g, '.$1')
+    .split('.')
+    .filter((t) => t.length > 0)
+  let cur: unknown = scope
+  for (const tok of tokens) {
+    if (UNSAFE_KEYS.has(tok)) return null   // refuse prototype-chain traversal
+    if (cur == null) return null
+    if (typeof cur !== 'object') return null
+    cur = (cur as Record<string, unknown>)[tok]
+  }
+  return cur === undefined ? null : cur
+}
+
+/** The set of valid root identifiers — used to build picker namespaces and validate `$bind`. */
+export const SCOPE_ROOTS = ['record', 'vars', 'page', 'item', 'data'] as const
+export type ScopeRoot = (typeof SCOPE_ROOTS)[number]
+```
+
+### 3.3 `model/resolveBindings.ts` — recursive prop resolution + the flat-scope bridge
+
+```ts
+import { FormulaEvaluator } from '@kelta/formula'
+import { isBinding, type Binding, type PropValue } from './pageModel'
+import { getPath, type BindingScope } from './bindingScope'
+
+/** One shared evaluator (caches parsed ASTs; cheap to reuse). */
+const evaluator = new FormulaEvaluator()
+
+/** Resolve a single binding against the scope. Never throws — falls back to null + a single warn. */
+export function resolveBinding(binding: Binding, scope: BindingScope): unknown {
+  const expr = binding.$bind
+  const mode = binding.mode ?? 'path'
+  try {
+    if (mode === 'path') {
+      return getPath(scope, expr)
+    }
+    // mode === 'expr': flatten referenced leaves → call FormulaEvaluator.evaluate.
+    return evaluator.evaluate(expr, flattenScopeForExpr(expr, scope))
+  } catch (err) {
+    if (import.meta.env?.DEV) {
+      // eslint-disable-next-line no-console
+      console.warn(`[resolveBinding] "${expr}" (${mode}) failed:`, err)
+    }
+    return null
+  }
+}
+
+/**
+ * The flat-scope bridge to @kelta/formula. The parser is flat-key only (it cannot read `record.name`
+ * as one identifier — see §3.1), so for `mode:'expr'` we:
+ *   1. ask the evaluator which identifiers the expression references (extractFieldRefs),
+ *   2. resolve each via getPath against the scope (so even a flat `count` or a pre-aliased leaf works),
+ *   3. hand back a flat Record<string, unknown> keyed by those exact identifiers.
+ * Identifiers that are not present resolve to null (engine treats undefined as null anyway).
+ */
+export function flattenScopeForExpr(expr: string, scope: BindingScope): Record<string, unknown> {
+  const flat: Record<string, unknown> = {}
+  let refs: string[]
+  try {
+    refs = evaluator.extractFieldRefs(expr)
+  } catch {
+    refs = []
+  }
+  for (const ref of refs) {
+    flat[ref] = getPath(scope, ref)
+  }
+  return flat
+}
+
+/**
+ * Deep-resolve every Binding in a props object. Leaves literals untouched; recurses into arrays and
+ * plain objects. Returns a NEW object (does not mutate). Used by renderNode before calling descriptor.Render.
+ */
+export function resolveBindings(
+  props: Record<string, PropValue>,
+  scope: BindingScope,
+): Record<string, unknown> {
+  return resolveValue(props, scope) as Record<string, unknown>
+}
+
+function resolveValue(value: PropValue, scope: BindingScope): unknown {
+  if (isBinding(value)) return resolveBinding(value, scope)
+  if (Array.isArray(value)) return value.map((v) => resolveValue(v, scope))
+  if (value !== null && typeof value === 'object') {
+    const out: Record<string, unknown> = {}
+    for (const [k, v] of Object.entries(value)) out[k] = resolveValue(v as PropValue, scope)
+    return out
+  }
+  return value // string | number | boolean | null
+}
+```
+
+> **Note on flat identifiers in expr mode.** Because the parser can't tokenize `record.name`, an expr
+> like `IF(record.name = "x", …)` would *throw at parse* (caught → null). Two supported expr authoring
+> shapes: (a) flat scope leaves the page declares directly — `vars` and `data` source names are flat
+> single-segment identifiers (`count`, `accounts`), so `IF(count > 0, …)` works natively; (b) when a
+> dotted record path is needed inside an expression, `ExpressionField` inserts a **flat alias** token and
+> records the alias→path mapping (see §3.4) so the flatten step resolves it. The common authored case is
+> flat. `mode:'path'` is the right tool for raw dotted access — keep expr for IF/logic over leaves.
+
+### 3.4 `model/interpolate.ts` — `{{…}}` templated strings
+
+```ts
+import { resolveBinding } from './resolveBindings'
+import type { BindingScope } from './bindingScope'
+import type { Binding } from './pageModel'
+
+const TEMPLATE_RE = /\{\{\s*([^}]+?)\s*\}\}/g
+
+/**
+ * Replace every {{ expr }} occurrence in a template string with its resolved value.
+ * A token defaults to mode:'path'; a token prefixed `=` (e.g. {{= IF(count>0,'a','b') }}) is mode:'expr'.
+ * Non-string resolved values are stringified (null/undefined → ''). Plain strings pass through unchanged.
+ */
+export function interpolate(template: string, scope: BindingScope): string {
+  if (!template.includes('{{')) return template
+  return template.replace(TEMPLATE_RE, (_match, raw: string) => {
+    const isExpr = raw.startsWith('=')
+    const binding: Binding = { $bind: isExpr ? raw.slice(1).trim() : raw.trim(), mode: isExpr ? 'expr' : 'path' }
+    const value = resolveBinding(binding, scope)
+    return value == null ? '' : String(value)
+  })
+}
+
+/** True when a string contains at least one {{…}} token (used by widgets to decide whether to interpolate). */
+export function isTemplate(value: unknown): value is string {
+  return typeof value === 'string' && value.includes('{{')
+}
+```
+
+> Widgets that render free text (`heading.text`, `text.content`, `button.label`) call `interpolate(value,
+> scope)` on the **resolved** prop so authors can mix literals + tags (`"Showing {{data.accounts[0].name}}"`)
+> without flipping to full expr mode. `resolveBindings` handles the structured `$bind` form;
+> `interpolate` handles inline tags in literal strings. Both share `resolveBinding`.
+
+### 3.5 `BindableField` / `ExpressionField` contract (inspector)
+
+```ts
+// inspector/fields/ExpressionField.tsx
+import type { Binding, PropValue } from '../../model/pageModel'
+import type { StaticNamespace } from '@/components/FieldExpressionPicker'
+
+export interface ExpressionFieldProps {
+  value: PropValue                      // literal OR { $bind, mode }
+  onChange: (next: PropValue) => void
+  /** Collection the page's `record` is bound to, for the picker's cascading columns. null ⇒ namespaces only. */
+  rootCollectionId: string | null
+  /** vars/page/data (and item inside a repeat) as static namespaces. */
+  namespaces: StaticNamespace[]
+  label: string
+  testId?: string
+}
+```
+
+`BindableField` (the 2b wrapper) renders the literal input by default and, when the `fx` toggle is on,
+delegates to `ExpressionField`. Storage shape (matches parent §"The shared model"):
+
+- **Field-path token** picked → `{ $bind: "<dot.path>", mode: "path" }`.
+- **Function/expression** picked (or the user types one) → `{ $bind: "<expr>", mode: "expr" }`.
+- Toggling `fx` **off** converts back to a literal (`""` or the descriptor default).
+
+The picker is the existing `FieldExpressionPicker` (`onInsert(token)` → wrap into `$bind`); `namespaces`
+are built by `buildScopeNamespaces(contract)` (a small helper in `hooks/usePageBindingContext.ts`) from
+`contract.variables` + `contract.dataSources` + the static `page` set.
+
+### 3.6 `PageVariable` / `PageDataSource` (re-affirm parent shapes; defined in 2a's `pageConfig.ts`)
+
+These are **already defined** in `pageConfig.ts` per 2a §3.5 / parent §"Page-level config (v2)". 2d
+**consumes** them (does not redefine). Quoted for reference:
+
+```ts
+export interface PageVariable {
+  name: string
+  type: 'string' | 'number' | 'boolean' | 'json'
+  default?: PropValue
+}
+
+export interface PageDataSource {
+  name: string
+  collection: string
+  fields?: string[]
+  filter?: Record<string, unknown>      // values MAY be Bindings ({ $bind, mode }) — resolved client-side
+  sort?: string[]
+  limit?: number
+  mode: 'list' | 'single'
+  recordId?: PropValue                  // single-mode: a Binding or literal id
+}
+```
+
+### 3.7 On-load fetch contract (CRITICAL — client-side, authorized JSON:API only)
+
+`usePageDataSources` resolves each source's dynamic config against the **current scope** (so `filter` /
+`recordId` bindings work), then fetches through `apiClient` — the **same authorized path**
+`DataTableNode` uses, so Cerbos/FLS strip denied fields **server-side**.
+
+```ts
+// hooks/usePageDataSources.ts (contract sketch)
+//
+// For each PageDataSource:
+//   mode 'list'   → apiClient.getList<Record<string,unknown>>(buildListUrl(src, scope))
+//   mode 'single' → apiClient.getOne<Record<string,unknown>>(`/api/${src.collection}/${resolvedId}`)
+//
+// buildListUrl composes the authorized JSON:API query string:
+//   /api/{collection}?page[size]={limit ?? 25}
+//     [&fields[{collection}]={fields.join(',')}]
+//     [&filter[{k}][EQ]={resolvedValue} ...]      // filter values run through resolveBindings(scope)
+//     [&sort={sort.join(',')}]
+//
+// Result is exposed at scope.data[src.name]:
+//   list   → the T[] array
+//   single → the single object (or null on 404)
+//
+// Fetch via @tanstack/react-query (queryKey ['page-data', slug, src.name, resolvedConfigHash]); list
+// page size is clamped to the server's MAX_HTTP_PAGE_SIZE (200) defensively. No new endpoint.
+```
+
+**Hard rules (verified against parent §"Backend changes" + 1g §8):**
+
+- **The server never resolves `$bind` and never fetches a dataSource.** Resolution + fetch are **100%
+  client-side**. The render contract round-trips `variables`/`dataSources`/`tree` opaquely (1g).
+- Every record read is an `apiClient` call to `/api/{collection}…` → gateway → worker → Cerbos route
+  authz + `CerbosFieldSecurityAdvice` FLS. There is **no** alternate read path. This is the security
+  invariant the whole effort preserves.
+- `filter` / `recordId` bindings are resolved **client-side** and sent as **query params** — the worker
+  still applies tenant RLS + Cerbos on top, so a malicious bound filter cannot widen access.
+
+### 3.8 New widget descriptors (parent §"Widget registry")
+
+```ts
+// widgets/builtins/field-value.tsx — read-only single bound value via FieldRenderer
+export const fieldValueWidget: WidgetDescriptor = {
+  type: 'field-value',
+  label: 'Field value', icon: '◇', category: 'data', acceptsChildren: false,
+  defaultProps: { source: '', fieldType: 'string' },
+  propSchema: [
+    { key: 'source',    label: 'Value',      kind: 'expression', bindable: true, group: 'Data' },
+    { key: 'fieldType', label: 'Render as',  kind: 'select', options: FIELD_TYPE_OPTIONS, group: 'Data' },
+  ],
+  Render: ({ node }) => {
+    // node.props is ALREADY fully resolved by renderNode (parent §"Widget registry → resolved-node
+    // invariant"). Descriptors must NOT re-resolve — just read the resolved values.
+    return <FieldRenderer type={(node.props.fieldType as FieldType) ?? 'string'} value={node.props.source} />
+  },
+}
+
+// widgets/builtins/list.tsx — registered for BOTH 'list' and 'repeater' (aliases)
+export const repeaterWidget: WidgetDescriptor = {
+  type: 'repeater',
+  label: 'Repeater', icon: '▦', category: 'data', acceptsChildren: true,
+  defaultProps: { source: { $bind: '', mode: 'path' } },
+  propSchema: [
+    { key: 'source', label: 'Items (array)', kind: 'expression', bindable: true, group: 'Data' },
+  ],
+  Render: ({ node, scope, renderChild }) => {
+    // node.props.source is ALREADY resolved (at the repeater's own scope) by renderNode — the resolved-node
+    // invariant means the repeater does NOT call resolveBindings on its own props (parent §"Widget registry
+    // → resolved-node invariant"). It is the ONE descriptor allowed to re-resolve, and ONLY for the per-row
+    // `item` scope it builds for its children — which it does via renderChild(child, rowScope), NOT by
+    // calling resolveBindings here.
+    const source = node.props.source
+    const rows = Array.isArray(source) ? source : []
+    const visible = rows.slice(0, MAX_REPEATER_ROWS)          // DoS cap — §3.9
+    return (
+      <div data-testid="page-node-repeater" className="flex flex-col gap-4">
+        {visible.map((row, i) => {
+          // Per-row scope: item = row, and record aliased to the row (parent §"binding namespace").
+          // renderChild(child, rowScope) re-runs renderNode under rowScope, so each child's props are
+          // resolved against the row — the ONLY re-resolution the repeater triggers.
+          const rowScope: BindingScope = { ...scope, item: row as Record<string, unknown>, record: row as Record<string, unknown> }
+          return (
+            <RepeatRow key={(row as { id?: string })?.id ?? i} node={node} scope={rowScope} renderChild={renderChild} />
+          )
+        })}
+        {rows.length > MAX_REPEATER_ROWS && (
+          <div data-testid="page-node-repeater-truncated" className="text-sm text-muted-foreground">
+            {t('builder.repeater.truncated', { shown: MAX_REPEATER_ROWS, total: rows.length })}
+          </div>
+        )}
+      </div>
+    )
+  },
+}
+```
+
+> **Per-row scope propagation.** `renderChild` from 2a's `WidgetRenderProps` **already** has the signature
+> `(child: PageComponent, scope?: BindingScope) => ReactNode` — the optional `scope` override is defined in
+> 2a (parent §"Widget registry → resolved-node invariant"), **not** widened here. The repeater renders each
+> child under `rowScope` by calling `renderChild(child, rowScope)`, which re-runs `renderNode` under that
+> scope so the child's props resolve against the row. 2d does **not** change the `renderChild` signature;
+> it only makes the resolver inside `renderNode` real (§5.4). `list` is registered as an alias of `repeater`
+> (same descriptor, `type:'list'`).
+
+### 3.9 DoS / fan-out caps (parent §"DoS / fan-out caps (2d)")
+
+Two hard caps owned by this slice, plus the governor-quota note:
+
+```ts
+// model/limits.ts (new — small constants module, imported by the data-source panel + repeater)
+/** A page may declare at most this many on-load data sources; each fires its own fetch. */
+export const MAX_PAGE_DATA_SOURCES = 12
+/** A repeater/list renders at most this many rows; the rest are truncated with a "showing N of M" note. */
+export const MAX_REPEATER_ROWS = 200
+```
+
+- **`MAX_PAGE_DATA_SOURCES` (12)** — enforced **in the builder** Data-sources panel (§5.7): the
+  `[+ Add source]` button disables once 12 sources exist, with an inline `t('builder.data.maxSources', …)`
+  message. The on-load hook (`usePageDataSources`) also slices defensively to the cap so a hand-edited
+  `config` with more sources cannot fan out unbounded fetches.
+- **Repeater render cap (`MAX_REPEATER_ROWS`, 200)** — the `repeater`/`list` descriptor (§3.8) renders at
+  most 200 rows and shows a `data-testid="page-node-repeater-truncated"` "showing N of M" line for the
+  remainder. This is the repeater's own cap; the bound `table` widget keeps its independent
+  `MAX_TABLE_ROWS=100` / `MAX_HTTP_PAGE_SIZE=200` clamps (parent).
+- **Governor-quota note.** Each page view consumes per-tenant API governor quota **proportional to its
+  declared data sources** (one authorized JSON:API GET per source on load, plus any `refreshData` from
+  2e). This is expected and documented in §8 — a page with N sources costs ≥N reads per view.
+
+---
+
+## 4. DB migrations
+
+**None — stored in `ui-pages.config` JSON, no DDL.**
+
+Everything new (`variables` / `dataSources` / `$bind` markers) nests inside the existing `ui-pages.config`
+JSON column (declared `FieldDefinition.json("config")`,
+`runtime-core/.../model/system/SystemCollectionDefinitions.java`). No new column, no Flyway version
+consumed; head remains **V146** (next available V147, **unused** by this slice). No NATS subject/payload
+change — this is a client-side render concern, and the write path (`UIPageConfigEventPublisher` /
+`UIPageSlugHook`) already broadcasts `config` changes wholesale.
+
+---
+
+## 5. File-by-file code changes
+
+All paths under `kelta-ui/app/src/`.
+
+### 5.1 New — `pages/PageBuilderPage/model/`
+
+| File | Contents |
+|------|----------|
+| `model/bindingScope.ts` | §3.2 — `BindingScope`, `EMPTY_SCOPE`, `getPath` walker (dot + `[n]` indexing, missing → null), `SCOPE_ROOTS` / `ScopeRoot`. |
+| `model/resolveBindings.ts` | §3.3 — `resolveBinding`, `flattenScopeForExpr` (the flat-scope bridge to `@kelta/formula`), `resolveBindings` (deep, immutable), private `resolveValue`. Owns the single `new FormulaEvaluator()`. |
+| `model/interpolate.ts` | §3.4 — `interpolate(template, scope)` (`{{…}}`, `{{= expr }}` for expr mode), `isTemplate`. |
+
+> `model/pageModel.ts` (`Binding`, `PropValue`, `isBinding`) already exists from 2a — **imported**, not
+> modified. `resolveBindings.ts` is the module 2a's `renderTree.tsx` referenced as a "no-op shim" (2a §3.4);
+> 2d provides the real implementation.
+
+### 5.2 New — `pages/PageBuilderPage/hooks/`
+
+| File | Contents |
+|------|----------|
+| `hooks/usePageVariables.ts` | `usePageVariables(variables: PageVariable[]): { vars: Record<string,unknown>; setVar(name, value): void; reset(): void }`. Seeds state from each `PageVariable.default` (coerced by `type`); `setVar` updates one (used by 2e's `setVar` action); memoized. Feeds `scope.vars`. |
+| `hooks/usePageDataSources.ts` | §3.7 — `usePageDataSources(dataSources: PageDataSource[], scope: BindingScope): { data: Record<string,unknown>; refresh(name): void; isLoading: boolean }`. One `useQuery` per source via a stable `useQueries`; `buildListUrl`/single-id resolved through `resolveBindings(src.filter/recordId, scope)`. Uses `apiClient.getList`/`getOne`. Feeds `scope.data`. Exposes `refresh(name)` (invalidates that source's query — wired to 2e `refreshData`). |
+| `hooks/usePageBindingContext.ts` | Assembles the live `BindingScope` for a page render: merges `record` (if the page is record-bound), `vars` (from `usePageVariables`), `data` (from `usePageDataSources`), `page` (route params from `useParams`). Also exports `buildScopeNamespaces(contract): StaticNamespace[]` for the inspector picker (§3.5). |
+
+### 5.3 New — `pages/PageBuilderPage/widgets/builtins/`
+
+| File | Contents |
+|------|----------|
+| `widgets/builtins/field-value.tsx` | §3.8 — `fieldValueWidget` (→ `FieldRenderer`). `FieldRendererProps` verified: `{ type, value, fieldName?, displayName?, tenantSlug?, targetCollection?, displayLabel?, className?, truncate? }`. `data-testid="page-node-field-value"`. |
+| `widgets/builtins/list.tsx` | §3.8 — `repeaterWidget` + `RepeatRow` (renders the node's children under `rowScope` via `renderChild`). Register under **both** `repeater` and `list` in `registerBuiltins()`. `data-testid="page-node-repeater"`. |
+
+`widgets/builtins/index.ts` (`registerBuiltins()` from 2a) gains:
+`widgetRegistry.register(fieldValueWidget)`, `widgetRegistry.register(repeaterWidget)`, and a `list` alias
+(`widgetRegistry.register({ ...repeaterWidget, type: 'list', label: 'List' })`).
+
+### 5.4 Modify — `pages/PageBuilderPage/widgets/renderTree.tsx` (make the resolver real)
+
+**One** surgical change to the 2a module: turn 2a's identity-no-op resolver into the real
+`resolveBindings`. The `renderChild` signature and the `RenderTree` `scope` prop are **already defined in
+2a** (`(child, scope?) => ReactNode`, `scope` defaulted `{}`) — 2d does **not** widen them.
+
+**Resolve bindings before `Render`.** Replace the 2a no-op call with the real one:
+
+```tsx
+// BEFORE (2a): resolveBindings is an identity no-op shim; props pass through untouched.
+// AFTER (2d): the same call site, now backed by the real implementation from model/resolveBindings.
+import { resolveBindings } from '../model/resolveBindings'
+// …inside renderNode, build a resolved node so descriptors read plain (already-resolved) values:
+const resolvedProps = resolveBindings(node.props, ctx.scope)
+const resolvedNode = { ...node, props: resolvedProps }
+return <descriptor.Render key={node.id} node={resolvedNode} scope={ctx.scope} mode={ctx.mode}
+                          tenantSlug={ctx.tenantSlug} renderChild={renderChild} />
+```
+
+> **Resolved-node invariant (align with 2a / parent §"Widget registry → resolved-node invariant").**
+> `node.props` handed to every descriptor's `Render` is **already fully resolved** against the current
+> scope. Descriptors **must not** call `resolveBindings` again — `field-value` reads `node.props.source`
+> directly, and the **only** exception is the `list`/`repeater` descriptor, which re-resolves **solely the
+> per-row `item` scope for its children** by calling `renderChild(child, rowScope)` (which re-runs
+> `renderNode` under `rowScope`). The repeater reads its own array from the already-resolved
+> `node.props.source`; it never re-runs `resolveBindings` on its own props. `scope` is still passed to
+> `Render` so the repeater can build `rowScope`.
+
+The 2a-defined `renderChild` — `(child: PageComponent, childScope: BindingScope = ctx.scope) =>
+renderNode(child, { ...ctx, scope: childScope })` — already carries the optional per-row scope override;
+2d relies on it unchanged. `RenderTree`'s `scope` prop (accepted in 2a, defaulted `{}`) is now wired from
+`CustomPage`/preview with the live scope.
+
+### 5.5 Finalize — `inspector/fields/ExpressionField.tsx` + `BindableField`
+
+- **`inspector/fields/ExpressionField.tsx`** (new) — §3.5. Renders the chip + Edit button; opens
+  `FieldExpressionPicker` (`open`, `rootCollectionId`, `staticNamespaces`, `mode`, `onInsert`). On
+  `onInsert(token)`: if the active tab produced a function stub (or the user is in expr mode) →
+  `{ $bind: token, mode: 'expr' }`; else `{ $bind: token, mode: 'path' }`. Shows the current `$bind`
+  in a `code` chip; a "Clear" reverts to literal.
+- **`inspector/fields/BindableField.tsx`** (finalize the 2b stub) — keep the `fx` toggle; in expr state
+  delegate to `ExpressionField` (was a literal-only placeholder in 2b). Wire `rootCollectionId` +
+  `namespaces` from `usePageBindingContext` via inspector context. The 2b literal branch is unchanged.
+
+> If 2b has not yet landed `BindableField`, ship both files here; the schema-driven `Inspector` consuming
+> `propSchema.bindable` is still 2b's responsibility — 2d only guarantees `BindableField` is binding-aware.
+
+### 5.6 Modify — `pages/app/CustomPage/CustomPage.tsx` (wire scope at runtime)
+
+- Read the 1g contract siblings: `contract.variables`, `contract.dataSources` (already typed by 1g).
+- Build the scope:
+  ```tsx
+  const { vars, setVar } = usePageVariables(contract.variables ?? [])
+  const { data } = usePageDataSources(contract.dataSources ?? [], { vars, page })   // dataSources may read vars/page
+  const scope: BindingScope = { vars, data, page: { slug: pageSlug, params } }
+  ```
+- Pass `scope` to the renderer: `<PageTreeRenderer components={contract.tree?.components ?? []}
+  tenantSlug={tenantSlug ?? ''} scope={scope} />`. `PageTreeRenderer` (the thin 2a wrapper) forwards
+  `scope` to `<RenderTree scope={scope} … />`.
+- **No binding resolution or data fetch happens server-side** — all of the above is client React.
+
+### 5.7 Modify — `pages/PageBuilderPage/PageBuilderPage.tsx` + new `inspector/pageSettings/` (drawer + panels)
+
+2d **creates the page-settings drawer host surface** — it does not exist today (the builder has only the
+flat create/edit page form; no earlier slice adds a drawer — see §2.3). New components under
+`inspector/pageSettings/`:
+
+| File | Contents |
+|------|----------|
+| `inspector/pageSettings/PageSettingsDrawer.tsx` | The drawer **shell** opened from a new **"Page settings"** toolbar button. Stacks the Variables + Data-sources sections; reserves a slot 1h fills with its Access field. Reads/writes `config.variables` / `config.dataSources` via the page-config state. |
+| `inspector/pageSettings/VariablesSection.tsx` | Editor for `config.variables` (`PageVariable[]`): add/remove rows, name + `type` select + `default`. (§2.3 wireframe.) |
+| `inspector/pageSettings/DataSourcesSection.tsx` | Editor for `config.dataSources` (`PageDataSource[]`) (§2.3): name, mode (List/Single), collection, fields, limit, bound filter, single-mode record id. **Enforces `MAX_PAGE_DATA_SOURCES` (§3.9):** `[+ Add source]` disables at 12 with an inline `t('builder.data.maxSources')` message. |
+
+`PageBuilderPage.tsx` wires the **"Page settings"** button → `PageSettingsDrawer`, and passes the editor
+preview a **design-time scope**: `vars` seeded from variable defaults, `data` empty arrays by default;
+an opt-in "Preview with live data" toggle may call `usePageDataSources` — default **off** to keep parity
+with 2a's no-live-fetch-in-editor decision.
+
+> Extract these into `inspector/pageSettings/` rather than inlining — `PageBuilderPage.tsx` is already
+> large (§8). The drawer is the single host for page-level config so 1h can drop in Access cleanly.
+
+#### Save call — extend 2c's `handleSavePage` (correction owned with 2c)
+
+2c **owns** the canonical `handleSavePage`/`mergeConfig` rewrite (parent §"Save & persistence") that
+widens `mergeConfig` to overlay page-level siblings and passes the full set:
+`mergeConfig(readConfig(currentPage), { components, variables, dataSources, schemaVersion: 2 })`. **2d
+extends that same call to include its keys (`variables`/`dataSources`)** — it does not re-do the rewrite,
+it only ensures `variables`/`dataSources` are in the passed set so the drawer's edits persist (otherwise
+`mergeConfig` silently drops them — the exact bug class the parent calls out). A **mutation-payload test**
+(§6.10b) asserts the `updateMutation.mutate` body carries `variables` and `dataSources`, not just that
+`mergeConfig` returns them.
+
+### 5.8 No backend changes
+
+Confirmed: data flows through the existing JSON:API (`apiClient.getList`/`getOne`/`postResource`), the
+1g render contract already surfaces `variables`/`dataSources`, and there is no new endpoint, gateway
+route, NATS subject, or migration.
+
+### 5.9 i18n — new strings (parent §"i18n": all via `useI18n`/`t()`, `builder.*` keys)
+
+Every new user-facing string in 2d's UI (the page-settings drawer, Variables/Data-sources sections, the
+binding `fx` field, and the repeater truncation note) goes through `useI18n`/`t()` — **no hardcoded
+English** (the builder is already fully `useI18n`-driven). 2d owns these keys (illustrative set):
+
+| Key | Use |
+|-----|-----|
+| `builder.pageSettings.title` / `.open` | Drawer title + "Page settings" toolbar button |
+| `builder.variables.title` / `.add` / `.remove` / `.name` / `.type` / `.default` | Variables section |
+| `builder.data.title` / `.add` / `.remove` / `.mode.list` / `.mode.single` / `.collection` / `.limit` / `.fields` / `.filter` / `.recordId` | Data-sources section |
+| `builder.data.maxSources` | `MAX_PAGE_DATA_SOURCES` cap message (§3.9) |
+| `builder.binding.fx` / `.edit` / `.clear` / `.expression` / `.literal` / `.mode.path` / `.mode.expr` | `BindableField`/`ExpressionField` chrome |
+| `builder.repeater.truncated` | Repeater "showing N of M" note (§3.8/§3.9) |
+
+---
+
+## 6. Test plan
+
+Vitest + Testing Library + MSW, matching the existing idiom (`pageConfig.test.ts` for pure functions;
+`PageBuilderPage.test.tsx` / `PageTreeRenderer` tests for render with MSW `server`). Pure model tests need
+no DOM.
+
+### 6.1 New — `model/resolveBindings.test.ts`
+
+- **Literal passthrough:** `resolveBindings({ a: 'x', b: 3, c: true, d: null }, scope)` returns the same
+  values (no `$bind`).
+- **Path mode — flat:** `{ $bind: 'record.name', mode: 'path' }` against `{ record: { name: 'Acme' } }`
+  → `'Acme'`.
+- **Path mode — nested + index:** `{ $bind: 'data.accounts[0].name', mode: 'path' }` against
+  `{ data: { accounts: [{ name: 'Acme' }] } }` → `'Acme'`.
+- **Missing path → null:** `{ $bind: 'record.nope', mode: 'path' }` → `null`; `record.a.b.c` where `a` is
+  undefined → `null` (no throw).
+- **Expr mode via formula (flat-scope bridge):** `{ $bind: 'IF(count > 0, "yes", "no")', mode: 'expr' }`
+  against `{ vars: { count: 2 } }` — assert `flattenScopeForExpr` produces `{ count: 2 }` (since
+  `extractFieldRefs('IF(count > 0, …)')` → `['count']` and `getPath(scope,'count')` walks `scope.count`…
+  **note** the bridge resolves the *bare* ref against the scope root) → result `'yes'`. Also test the
+  explicit-vars form the picker emits.
+- **Expr mode — referenced leaf missing → null inside formula:** `{ $bind: 'count + 1', mode: 'expr' }`
+  with empty scope → `extractFieldRefs` `['count']`, `getPath` → null, engine `toDouble(null)=0` → `1`
+  (proves missing-leaf = null = 0-in-arithmetic, matching `ast.toDouble`).
+- **Malformed expr → null + warn (dev):** `{ $bind: 'IF(', mode: 'expr' }` → `null`, no throw.
+- **Deep recursion:** a props object with a `Binding` nested inside an array and an object resolves each.
+- **Default mode is path:** `{ $bind: 'vars.x' }` (no `mode`) behaves as path.
+
+### 6.2 New — `model/interpolate.test.ts`
+
+- **Plain string passthrough:** `interpolate('hello', scope)` → `'hello'` (no `{{`).
+- **Single tag (path):** `interpolate('Hi {{record.name}}', { record: { name: 'Ada' } })` → `'Hi Ada'`.
+- **Indexed tag:** `interpolate('{{data.accounts[0].name}}', { data: { accounts: [{ name: 'Acme' }] } })`
+  → `'Acme'`.
+- **Expr tag (`{{= …}}`):** `interpolate('{{= IF(count > 0, "a", "b") }}', { vars: { count: 1 } })` → `'a'`.
+- **Missing → empty string:** `interpolate('x {{record.nope}} y', scope)` → `'x  y'`.
+- **Multiple tags + literal mix** in one string.
+
+### 6.3 New — `model/bindingScope.test.ts`
+
+- `getPath` dot, `[n]`, mixed, missing-root, null-midway, empty-path → null; non-object midway → null.
+- **Prototype-pollution guard:** `getPath(scope, '__proto__')`, `'constructor'`, `'a.constructor.prototype'`
+  all return `null` (never reach the prototype chain) — parent §"Security".
+
+### 6.4 New — `widgets/builtins/field-value.test.tsx`
+
+- Renders `FieldRenderer` with `type` from `fieldType` and `value` from the resolved `source` binding
+  (`record.email` path) — assert the email is shown via `data-testid="page-node-field-value"` wrapping a
+  `FieldRenderer` output; defaults to `type='string'` when `fieldType` absent.
+
+### 6.5 New — `widgets/builtins/list.test.tsx` (repeater)
+
+- Bound to `data.accounts` (2 rows) → renders the child subtree **twice**; each row's `{{item.name}}` and
+  `{{item.status}}` resolve to that row's values (assert two `page-node-repeater` children with distinct
+  text). `record.name` inside a row also resolves (record-aliased-to-row).
+- Empty/absent array → renders zero rows (no crash).
+- `list` alias renders identically to `repeater`.
+- **Render cap (§3.9):** an array of >200 rows renders exactly `MAX_REPEATER_ROWS` (200) child subtrees and
+  shows the `page-node-repeater-truncated` "showing 200 of N" line; ≤200 renders no truncation note.
+
+### 6.6 New — `widgets/renderTree.binding.test.tsx`
+
+- A `heading` with `text = { $bind: 'record.name', mode: 'path' }` rendered via `RenderTree mode="runtime"`
+  with `scope.record` shows the name. The **same tree** in `mode="editor"` with a design-time scope shows
+  the same value (de-dup guarantee from 2a preserved under binding).
+- A `text` with `content = "Showing {{data.x}}"` interpolates.
+
+### 6.7 New — `hooks/usePageDataSources.test.tsx`
+
+- **Authorized JSON:API path (security-critical):** a `list` source mocks MSW `/api/accounts` and asserts
+  the **request URL** is `/api/accounts?page[size]=25` (the same authorized path `DataTableNode` uses) and
+  that `data.accounts` is populated. **Assert no server-side binding resolution** — the test proves the
+  fetch is a normal `apiClient.getList`, i.e. Cerbos/FLS apply server-side (denied fields would be absent).
+- **Single mode:** `mode:'single'` with `recordId = { $bind: 'page.params.id', mode:'path' }` resolves the
+  id client-side and fetches `/api/accounts/{id}` via `getOne`; 404 → `data.x = null`.
+- **Bound filter resolved client-side:** `filter: { status: { $bind:'vars.s', mode:'path' } }` with
+  `vars.s='open'` → request includes `filter[status][EQ]=open` (resolved on the client, sent as a query
+  param; worker still enforces RLS/Cerbos).
+- **`refresh(name)`** invalidates and refetches one source.
+
+### 6.8 New — `hooks/usePageVariables.test.tsx`
+
+- Seeds `vars` from `default` per `type` (number/string/boolean/json); `setVar` updates one; `reset`
+  restores defaults.
+
+### 6.9 New — `inspector/fields/ExpressionField.test.tsx`
+
+- `fx` on → opens `FieldExpressionPicker`; `onInsert('account_id.name')` → `onChange({ $bind:
+  'account_id.name', mode: 'path' })`; a function stub → `mode: 'expr'`; "Clear" → literal.
+- Re-opening with an existing `{ $bind }` shows the chip and round-trips.
+
+### 6.10 New — `inspector/pageSettings/PageSettingsDrawer.test.tsx`
+
+- Opening the **"Page settings"** drawer shows the **Variables** and **Data sources** sections (the drawer
+  is created in 2d — assert both render).
+- Variables section: add/remove a variable, edit name/type/default → reflected in `config.variables`.
+- Data sources section: add/remove a source; **`MAX_PAGE_DATA_SOURCES` cap** — with 12 sources the
+  `[+ Add source]` button is disabled and the `builder.data.maxSources` message shows.
+
+### 6.10b New — `PageBuilderPage.save.test.tsx` (mutation payload)
+
+- **Save round-trip (correction owned with 2c):** after editing variables + data sources in the drawer,
+  trigger save and assert the **`updateMutation.mutate` body** (not just `mergeConfig`'s return) contains
+  both `variables` and `dataSources` (plus `components`/`schemaVersion` from 2c) — proving 2d's keys are in
+  the passed set so they are not silently dropped on save.
+
+### 6.10c — Parity guard (re-run 2a's suite UNCHANGED)
+
+- **Builtin parity / golden-snapshot identity (correction 7):** re-run **2a's** builtin parity /
+  golden-snapshot suite **UNCHANGED** after 2d lands. Because every literal (non-`$bind`) prop is unchanged
+  by the now-real `resolveBindings` (literals pass through `resolveValue` untouched), all 8 built-ins must
+  produce byte-identical snapshots — proving the real resolver is an **identity on literal props**. Any
+  diff is a regression in the resolver, not an intended change. (No new snapshot file; this re-runs the
+  existing 2a suite as-is.)
+
+### 6.11 e2e (post-deploy, Playwright — project convention)
+
+A bound page (heading `{{record.name}}` or a `repeater` over a `dataSource`) renders the live value after
+deploy; a denied field bound via `field-value` shows empty (server stripped it) — proving FLS holds end to
+end. No new e2e file authored in this slice (e2e is post-deploy per convention); covered by the Vitest
+suite above pre-merge.
+
+> **DB-constraint test-gap guard:** N/A — this slice adds no write path, DDL, or constraint. It is a
+> read/render concern; the on-load fetch is a plain authorized GET. The
+> [guard](../../../projects/-Users-craigklinker-GitHub-emf/memory/feedback_db-constraint-test-gap.md)
+> applies to constraint-bearing writes, which this is not.
+
+---
+
+## 7. Docs to update (same PR)
+
+| Doc | Change |
+|-----|--------|
+| `.claude/docs/conventions.md` | Document the **page config v2 binding contract** (the parent owns the high-level shape; this slice makes it real): `$bind` is the single expression marker; `mode:'path'` walks scope dot/`[n]` paths via `getPath` (because `@kelta/formula`'s parser is flat-key only — cite the limitation), `mode:'expr'` flattens referenced leaves then calls `FormulaEvaluator.evaluate`; `{{…}}` interpolation in literal strings (`{{= expr }}` for expr mode); the namespace authority `record`/`vars`/`page`/`item`/`data`. State the **client-side-only** resolution rule and that the server round-trips `$bind` untouched (preserves Cerbos/FLS). |
+| `.claude/docs/status.md` | Page-builder row: move **data binding & on-load data sources** out of the gap column → "slice 2d: any prop bindable to `record`/`vars`/`data` via `$bind` (`path`/`expr`), page `variables` + on-load `dataSources` (client-side authorized JSON:API fetch), `field-value` + `list`/`repeater` widgets. Binding resolution is client-side only — server resolves nothing (FLS preserved)." Keep events/typed-forms/per-page-authz in the gap (2e/2f/1h). |
+| `.claude/docs/architecture.md` | `PageRenderService` / custom-page data-flow row: note that bindings + dataSources resolve **client-side** against the authorized JSON:API path; the render contract stays a pure pass-through (no server-side `$bind`/dataSource evaluation) so Cerbos route authz + `CerbosFieldSecurityAdvice` FLS remain the only data gate. |
+| `.claude/docs/playbooks.md` | Extend the "Add a page component / widget" recipe (added in 2a) with the **bindable prop** step: mark a `PropFieldSchema` `bindable: true` and `kind:'expression'`; read **already-resolved** props in `Render` (`node.props` is resolved by `renderNode` — the resolved-node invariant; descriptors do **not** call `resolveBindings`); the **only** per-row exception is `list`/`repeater`, which renders children under a row scope via `renderChild(child, rowScope)`. Note `dataSources` for on-load data and the `usePageBindingContext` scope assembly. |
+
+Per CLAUDE.md Rule 6 these doc edits ship **in the same PR** as the code.
+
+---
+
+## 8. Risks & open questions
+
+- **Expr-mode dotted access is intentionally limited (verified constraint).** `@kelta/formula`'s parser is
+  flat-key only (`parser.ts` `parseIdentifierOrFunction` stops at `.`), so `IF(record.name = "x", …)`
+  throws at parse and resolves to `null`. The design routes **all dotted access through `mode:'path'`**
+  and keeps `mode:'expr'` for logic over **flat** leaves (`vars.*`/`data.*` names are single segments;
+  raw record leaves can be aliased by `ExpressionField`). **Open question for the user:** is flat-leaf
+  expr sufficient for v1, or should we add a pre-pass that rewrites dotted refs in expressions to flat
+  aliases (a small transform over `extractFieldRefs` + source substitution) so authors can write
+  `record.name` inside `IF(...)` directly? **Recommendation:** ship flat-leaf expr + `path` for dotted now;
+  add the alias pre-pass only if authors hit it. (Do **not** extend the formula parser — it's shared with
+  the backend formula-field engine and must stay parity-locked.)
+- **Client-side resolution is the security boundary — do not regress it.** The single most important
+  invariant: **no `$bind` or dataSource is resolved/fetched server-side.** Every record read is an
+  `apiClient` GET to `/api/{collection}…` so the gateway+worker enforce Cerbos route authz and FLS. A
+  reviewer must reject any change that resolves a binding in `PageRenderService` or fetches a dataSource
+  server-side (1g §8 says the same). `usePageDataSources.test` asserts the fetch URL is the authorized
+  path; keep that test load-bearing.
+- **`renderChild`'s scope override is 2a's, not a 2d widening.** The optional `scope` arg on
+  `WidgetRenderProps.renderChild` (`(child, scope?) => ReactNode`) is **defined in 2a** (parent §"Widget
+  registry → resolved-node invariant"); 2d uses it unchanged and does **not** alter the interface. The
+  repeater **requires** it; containers/cards omit it (back-compat). Land 2d's `renderTree.tsx` change (the
+  identity-resolver → real-resolver flip) with the **2a parity tests re-run unchanged** (§6.10c) to prove
+  containers/cards and all literal props are unaffected. **Sequencing:** 2d depends on 2a's
+  `renderTree`/registry/model and benefits from 2b's `BindableField`; if 2b is not merged, ship
+  `BindableField`+`ExpressionField` here.
+- **Page-settings drawer is a new host surface 2d owns.** No earlier slice creates a page-settings
+  drawer, Variables UI, or Data-sources UI — the builder has only the flat create/edit page form. 2d
+  builds the drawer shell + both sections (§2.3, §5.7); 1h later drops its Access field into the same
+  drawer. Keep them in `inspector/pageSettings/` so `PageBuilderPage.tsx` (already large) does not bloat.
+- **Governor-quota consumption per page view.** Each declared on-load data source costs one authorized
+  JSON:API GET per page view (plus 2e `refreshData` re-fetches), so a page with N sources consumes ≥N
+  reads of per-tenant API governor quota per view. `MAX_PAGE_DATA_SOURCES` (12) bounds the fan-out;
+  editor live-data preview stays **off by default** to avoid surprise authoring-time consumption. Noted in
+  `concerns.md` per the parent §"Security → Abuse/governor".
+- **`flattenScopeForExpr` semantics for non-flat refs.** `extractFieldRefs` returns the flat identifiers
+  the parser saw; `getPath(scope, ref)` resolves a *single-segment* ref against the scope root (e.g.
+  `count` → `scope.count`, which is **undefined** unless the author aliased a var to a bare name). The
+  natural authored shape is `vars` flattened into the eval scope: `ExpressionField` should, for expr mode,
+  flatten `vars`/`data`/`item`/`record` **leaves** into the eval map (so `count` means `vars.count`). The
+  spec's `flattenScopeForExpr` uses `getPath` for parity with `path` mode; **open decision:** also spread
+  `scope.vars`/`scope.item`/`scope.record` top-level into the flat map so bare leaf names resolve without
+  a `vars.` prefix (matches how formula-field expressions reference plain field names). **Recommendation:**
+  spread `record`+`item`+`vars` leaves (then overlay `extractFieldRefs` getPath results) so authored
+  expressions read like field formulas. Pin this in `resolveBindings.test.ts`.
+- **Editor live-data preview is off by default.** Per 2a's decision, the editor does not fetch live data
+  (parity). 2d adds an opt-in "Preview with live data" toggle; default off avoids surprise reads and
+  governor-limit consumption while authoring. Confirm with the user whether on-by-default is desired.
+- **`PageBuilderPage.tsx` size.** Adding the Data/Variables config panels grows the (already large) file;
+  prefer extracting them into `inspector/pageSettings/` components. Not currently flagged in
+  `concerns.md`, but keep the additions modular so 2b/2c extractions stay clean.
+- **No JPA / records rule (Rule 2) and NATS rule (Rule 1) untouched** — this slice is FE-only; it adds no
+  backend model, repository, or system-collection hook, so neither rule is engaged.

--- a/.claude/docs/specs/page-builder/2e-events-actions.md
+++ b/.claude/docs/specs/page-builder/2e-events-actions.md
@@ -1,0 +1,660 @@
+# 2e — Events & actions
+
+> **Slice:** 2e (FE). **Axis:** Logic & events.
+> **Parent:** [`../page-builder-parity.md`](../page-builder-parity.md). This child spec **extends, never
+> contradicts** the parent's [The shared model](../page-builder-parity.md#the-shared-model) (the
+> `PageAction` union + `EventHandlers`) and [Reuse Map](../page-builder-parity.md#reuse-map) (flow
+> execute/poll endpoints, JSON:API create/update). It consumes the types defined once in
+> [`2a-widget-registry.md`](./2a-widget-registry.md#31-modelpagemodelts--v2-model-matches-parent-the-shared-model)
+> (`PageAction`, `EventHandlers`, `Binding`, `PropValue`, `PageComponent`) — **2e does not redefine them**;
+> it only adds the runtime executor and finalizes the editor.
+> Source-verified against the codebase on 2026-06-22 (Flyway head V146; **this slice adds no migration**).
+> If code and this doc disagree, trust the code and fix this doc.
+
+---
+
+## 1. Goal & scope
+
+### What this slice delivers
+
+Wire page **events** to **actions**. Today a `button` node can only carry a `props.href` and the runtime
+renders it as an `<a>` (verified: `PageTreeRenderer.tsx` `PageNodeRenderer` `case 'button'`). There is **no
+event model and no action runtime** — clicking a button does nothing beyond following an href. 2e closes the
+"Logic & events/actions" axis:
+
+1. **Finalize the inspector `EventListField`** (`inspector/fields/EventListField.tsx`). 2b ships its editor
+   **shell** as the canonical model: **ONE** `kind:'event-list'` prop with **`key:'events'`** whose value is
+   the whole `node.events` (`EventHandlers`), tabbed over **`descriptor.supportedEvents`** (declared on
+   `WidgetDescriptor` in 2a) — **not** a `key:'onClick'` field and **not** a separate ad-hoc `supportedEvents`
+   field introduced here. 2e fills the shell in: per-event tabs (filtered to `descriptor.supportedEvents`,
+   e.g. `onClick`/`onChange`/`onSubmit`/`onLoad`), an **ordered** `PageAction[]` list per event with **add /
+   remove / reorder**, and a **per-action sub-form** keyed on `action`:
+   - `runFlow` → flow picker (`GET /api/flows`) + input-mapping rows (`key` → literal-or-`{$bind}` value)
+     + `awaitResult` toggle.
+   - `navigate` → `to` (route path) + `params` rows + `newTab` toggle.
+   - `openUrl` → `url` (bindable) + `newTab` toggle.
+   - `createRecord` / `updateRecord` → collection picker + `attributes` rows (+ `recordId` for update).
+   - `refreshData` → `dataSource` picker (names from `config.dataSources`).
+   - `setVar` → `name` picker (from `config.variables`) + `value`.
+   - `showToast` → `level` select (`info`/`success`/`error`) + `message`.
+
+2. **The client-side action runtime** (`runtime/executeAction.ts` + `runtime/useActionRunner.ts`). One
+   `executeActions(actions, ctx)` entry point runs an ordered `PageAction[]` **sequentially**, resolving each
+   action's bindable values (`input`/`attributes`/`params`/`message`/`url`/`recordId`/`value`) through the
+   **2d** `resolveBindings`/`getPath` against the event scope, then dispatching:
+   - `runFlow` → `POST /api/flows/{flowId}/execute` with `{ input: <resolved> }`; if `awaitResult`, poll
+     `GET /api/flows/executions/{id}` until terminal.
+   - `navigate` → react-router `navigate(...)`; `openUrl` → `window.open` / `location.assign`.
+   - `createRecord` → `apiClient.postResource('/api/{collection}', attrs)`; `updateRecord` →
+     `apiClient.patchResource('/api/{collection}/{id}', attrs)` (Cerbos + write-FLS enforced **server-side** —
+     the runtime never bypasses the authorized JSON:API path).
+   - `refreshData` → invalidate the React Query key for the named data source (re-runs the 2d on-load fetch).
+   - `setVar` → update page-variable state (the 2d `usePageVariables` store).
+   - `showToast` → `useToast().showToast(message, level)` (sonner-backed).
+
+3. **Wire the `button` and `form` widget descriptors to fire events.** `button`'s `onClick` runs
+   `events.onClick`; `form`'s `onSubmit` runs `events.onSubmit` (in addition to its existing create path);
+   `onLoad` runs once on page mount; `onChange` is wired on input widgets (delivered fully in 2f, stubbed
+   here). Firing happens **only in `mode:'runtime'`** — the editor preview never executes actions.
+
+4. **Own the full-flow post-deploy e2e** (`e2e-tests/tests/page-builder-v2.spec.ts`). As the terminal
+   behavior slice (parent §"End-to-end e2e ownership"/"Slice plan → 2e"), 2e authors the one owned spec — a
+   real mutation, not just render — as a **named deliverable** done post-deploy before the feature is declared
+   complete. See §6.5; **1h** adds the negative authz case.
+
+### What this slice explicitly does NOT do
+
+| Out of scope | Lands in |
+|--------------|----------|
+| `BindableField` / `fx` toggle / `resolveBindings` / `getPath` / `interpolate` / binding scope | **2d** (2e *consumes* them) |
+| Page variables store + on-load data-source fetch hooks (`usePageVariables`, `usePageDataSources`) | **2d** (2e *reads/writes* them) |
+| `EventListField` editor **shell** + the `kind:'event-list'` prop wiring into the inspector loop | **2b** (2e *finalizes* the body) |
+| Typed inputs that emit `onChange` (`text-input`/`dropdown`/`datepicker`/…) | **2f** (2e leaves `onChange` plumbed but unfired by built-ins) |
+| Any backend change to the flow / JSON:API endpoints | N/A — actions ride existing endpoints |
+| Server-side action execution | N/A — all actions are client-side; server stays a pass-through (parent §"Backend changes") |
+
+### Parent-doc sections this conforms to
+
+- [The shared model → `PageAction` / `EventHandlers`](../page-builder-parity.md#the-shared-model) — the union
+  is reproduced **verbatim** in §3.1; 2e adds no new action kinds.
+- [Reuse Map](../page-builder-parity.md#reuse-map) rows: *Run a flow from an event*
+  (`POST /api/flows/{flowId}/execute` → poll `GET /api/flows/executions/{id}`), *Create/update record from an
+  event* (JSON:API `POST`/`PATCH`), *Variable insertion* / *Expression picker* (input-mapping value editor).
+- [`2d` binding resolution](./2a-widget-registry.md) — action values may be `{$bind}` and resolve against the
+  event scope `{ record, vars, data, page, item }`.
+
+### Acceptance criteria
+
+- A `button` node with `events.onClick = [{action:'showToast', level:'success', message:'Hi'}]` shows a
+  success toast on click in the runtime (`CustomPage`), and **does nothing** in the editor preview.
+- `runFlow` posts `{ input: <resolved> }` to `/api/flows/{flowId}/execute`; with `awaitResult:true` it polls
+  `/api/flows/executions/{id}` every 1.5 s until status is terminal (`COMPLETED`/`FAILED`/`CANCELLED`), then
+  resolves; without it, it fires-and-forgets after the 202-style RUNNING response.
+- `createRecord`/`updateRecord` call `apiClient.postResource`/`patchResource` against `/api/{collection}` —
+  the authorized JSON:API path (a Cerbos/write-FLS denial surfaces as an error toast, not a bypass).
+- Bindable action values (`{$bind:'record.id', mode:'path'}` etc.) resolve against the click scope before the
+  request fires (verified by a unit test with a stubbed scope).
+- Actions in a list run **in order**; an awaited action that rejects **stops the chain** and surfaces an error
+  toast (subsequent actions do not run).
+- The `EventListField` round-trips `EventHandlers` through the existing builder save path (into the `config`
+  JSON column) with no schema/migration change; reorder/add/remove mutate `node.events` immutably.
+- `/verify` green (lint + typecheck + `test:coverage` ≥ the existing kelta-ui gate).
+
+---
+
+## 2. UI samples
+
+### 2.1 Inspector — `EventListField` for a `button`'s `onClick`
+
+The inspector (2b) loops over `descriptor.propSchema`; the `button` descriptor declares an `{ key:'events',
+kind:'event-list' }` field, which renders the `EventListField` below. Event tabs are filtered to the events a
+widget supports (`button` → `onClick`; `form` → `onSubmit`; any → `onLoad`).
+
+```
+┌─ Inspector ─ button ───────────────────────────────┐
+│ Content                                             │
+│   Label      [ Place order            ]             │
+│   Variant    [ primary    ▾]                        │
+│ ─────────────────────────────────────────────────  │
+│ Events                                              │
+│   ┌ onClick ┬ onLoad ┐                              │  ← event tabs (widget-supported only)
+│   │ ▣ Actions (run in order)                        │
+│   │ ┌───────────────────────────────────────────┐  │
+│   │ │ ⠿ 1. Create record · orders          ✎  ✕ │  │  ← ⠿ drag handle (reorder), ✎ edit, ✕ remove
+│   │ │ ⠿ 2. Run flow · Notify Ops           ✎  ✕ │  │
+│   │ │ ⠿ 3. Show toast · success            ✎  ✕ │  │
+│   │ └───────────────────────────────────────────┘  │
+│   │ [ + Add action ▾ ]                              │  ← menu: runFlow / navigate / openUrl /
+│   └───────────────────────────────────────────────┘  │     createRecord / updateRecord / refreshData /
+│                                                     │     setVar / showToast
+└─────────────────────────────────────────────────────┘
+```
+
+### 2.2 Per-action sub-form — `runFlow` with input mapping
+
+Clicking ✎ on a `runFlow` action expands its sub-form. The flow picker is a `select` populated from
+`GET /api/flows` (id → name). Each input-mapping row's **value** cell is a `BindableField` (2d): the `fx`
+toggle flips a literal to `{$bind, mode:'expr'}` via `FieldExpressionPicker`.
+
+```
+┌─ Edit action · Run flow ───────────────────────────┐
+│ Flow        [ Notify Ops (flow-7c2…)   ▾]          │  ← options from GET /api/flows
+│ Await result  [✓]   (poll until the flow finishes)  │  ← awaitResult
+│ Inputs (→ $.input.<key>)                            │
+│   ┌ key ──────────┬ value ───────────────┬──┐      │
+│   │ orderId       │ fx {{record.id}}      │ ✕│      │  ← value is BindableField; fx = expr binding
+│   │ priority      │ "high"                │ ✕│      │  ← literal
+│   └───────────────┴───────────────────────┴──┘      │
+│   [ + Add input ]                                   │
+│                                            [ Done ] │
+└─────────────────────────────────────────────────────┘
+```
+
+> **Double-wrap is handled by the runtime, not the editor.** The editor stores the **inner** map
+> (`{ orderId: {$bind…}, priority:'high' }`) as `action.input`. `executeAction` sends
+> `{ input: <resolved action.input> }` as the HTTP body — i.e. it adds the outer wrap. So the flow reads
+> `$.input.orderId` exactly as documented in `integrations.md` → "the double-wrap rule". The editor never asks
+> the author to wrap twice.
+
+### 2.3 Per-action sub-forms — the other action kinds (abbreviated)
+
+```
+navigate     to [ /app/p/orders   ]   newTab [ ]   params: key→value rows (bindable)
+openUrl      url [ fx {{record.link}} ]   newTab [✓]
+createRecord collection [ orders ▾ ]   attributes: key→value rows (bindable)
+updateRecord collection [ orders ▾ ]   recordId [ fx {{record.id}} ]   attributes: key→value rows
+refreshData  dataSource [ ordersList ▾ ]            ← names from config.dataSources
+setVar       name [ selectedId ▾ ]   value [ fx {{record.id}} ]   ← name from config.variables
+showToast    level [ success ▾ ]   message [ Saved! ]   (message bindable)
+```
+
+### 2.4 Sample tree JSON with `events.onClick`
+
+What `config.components` holds for a button that creates a record, runs a flow, then toasts. The optional v2
+`events` key round-trips untouched through the server (parent §"Backend stays a pass-through").
+
+```json
+{
+  "id": "b1",
+  "type": "button",
+  "props": { "label": "Place order", "variant": "primary" },
+  "events": {
+    "onClick": [
+      {
+        "action": "createRecord",
+        "collection": "orders",
+        "attributes": {
+          "customer": { "$bind": "vars.customerId", "mode": "path" },
+          "status": "NEW"
+        }
+      },
+      {
+        "action": "runFlow",
+        "flowId": "flow-7c2a",
+        "awaitResult": true,
+        "input": { "orderId": { "$bind": "record.id", "mode": "path" } }
+      },
+      { "action": "showToast", "level": "success", "message": "Order placed" }
+    ]
+  }
+}
+```
+
+### 2.5 Runtime sequence — click → resolve → execute → toast
+
+```
+USER clicks <button data-testid="page-node-button"> in CustomPage (mode:'runtime')
+        │
+        ▼
+button descriptor onClick → useActionRunner().run(node.events.onClick, scope)
+        │
+        ▼  executeActions([...], ctx) — sequential
+   ┌────────────────────────────────────────────────────────────────────┐
+   │ 1. createRecord                                                     │
+   │    resolveBindings(action.attributes, scope) → { customer:'u-9',…}  │  (2d)
+   │    apiClient.postResource('/api/orders', {customer:'u-9',status…})  │  → JSON:API (Cerbos/FLS)
+   │    ↳ on reject: showToast(err.message,'error'); STOP chain          │
+   │                                                                     │
+   │ 2. runFlow (awaitResult:true)                                       │
+   │    resolveBindings(action.input, scope) → { orderId:'ord-42' }      │
+   │    apiClient.fetch('/api/flows/flow-7c2a/execute', POST,            │
+   │        body { input:{ orderId:'ord-42' } })                         │  → { data:{ id, attrs:{status:RUNNING}}}
+   │    id = unwrapResource(json).id                                     │
+   │    poll GET /api/flows/executions/{id} @1.5s until status terminal  │  → COMPLETED/FAILED/CANCELLED
+   │    ↳ FAILED ⇒ reject ⇒ error toast; STOP chain                      │
+   │                                                                     │
+   │ 3. showToast('Order placed','success')  → useToast().showToast(…)   │  → sonner
+   └────────────────────────────────────────────────────────────────────┘
+```
+
+### 2.6 Before / after (the `button` widget)
+
+```
+BEFORE 2e: button renders <a href> or <button> with NO onClick behavior
+           (PageTreeRenderer case 'button' — href only). events is unmodelled.
+
+AFTER 2e:  button descriptor reads node.events.onClick; in runtime mode attaches
+           onClick={() => run(events.onClick, scope)}. href still works (an href
+           button with no onClick is unchanged). Editor preview: inert (no fire).
+```
+
+---
+
+## 3. Data & API contracts
+
+All TS lives under `kelta-ui/app/src/pages/PageBuilderPage/`. **No backend/API change in 2e** — every action
+rides an endpoint that already exists.
+
+### 3.1 `PageAction` union + `EventHandlers` (defined in 2a; reproduced here — authoritative match to parent)
+
+These types are **declared in `model/pageModel.ts` by 2a**; 2e imports them. Reproduced verbatim so this spec
+is self-contained — **if this drifts from `pageModel.ts`, the code wins.**
+
+```ts
+export type PageAction =
+  | { action: 'runFlow'; flowId: string; input?: Record<string, PropValue>; awaitResult?: boolean }
+  | { action: 'navigate'; to: string; params?: Record<string, PropValue>; newTab?: boolean }
+  | { action: 'openUrl'; url: PropValue; newTab?: boolean }
+  | { action: 'createRecord' | 'updateRecord'; collection: string; attributes: Record<string, PropValue>; recordId?: PropValue }
+  | { action: 'refreshData'; dataSource: string }
+  | { action: 'setVar'; name: string; value: PropValue }
+  | { action: 'showToast'; level: 'info' | 'success' | 'error'; message: PropValue }
+
+export type EventHandlers = Partial<
+  Record<'onClick' | 'onChange' | 'onSubmit' | 'onLoad', PageAction[]>
+>
+```
+
+`PropValue` includes `Binding` (`{ $bind: string; mode?: 'path' | 'expr' }`) — any value cell in an action may
+hold a literal or a binding (resolved in 2d).
+
+### 3.2 `runtime/executeAction.ts` — the action runtime
+
+```ts
+import type { NavigateFunction } from 'react-router-dom'
+import type { QueryClient } from '@tanstack/react-query'
+import type { ApiClient } from '@/services/apiClient'
+import type { ToastType } from '@/components/Toast/Toast'
+import type { PageAction, PropValue } from '../model/pageModel'
+import { resolveBindings } from '../model/resolveBindings' // 2d
+import { unwrapResource } from '@/utils/jsonapi'
+
+/** Everything the runtime needs to dispatch actions. Built once by useActionRunner (§3.3). */
+export interface ActionRuntimeContext {
+  apiClient: ApiClient
+  navigate: NavigateFunction
+  queryClient: QueryClient
+  /** sonner-backed toast — exactly useToast().showToast. */
+  showToast: (message: string, type: ToastType) => void
+  /** Update a page variable (2d store). */
+  setVar: (name: string, value: PropValue) => void
+  /** React Query key prefix for a named data source (2d). refreshData invalidates it. */
+  dataSourceQueryKey: (name: string) => unknown[]
+  /** Binding scope captured at fire time: { record, vars, data, page, item }. */
+  scope: Record<string, unknown>
+  tenantSlug: string
+}
+
+/** Run one action. Resolves its bindable values against ctx.scope, then dispatches. */
+export async function executeAction(action: PageAction, ctx: ActionRuntimeContext): Promise<void>
+
+/**
+ * Run an ordered action list sequentially. The first action that throws stops the chain and the
+ * error is surfaced (an error toast) by the caller. Returns when all actions complete.
+ */
+export async function executeActions(actions: PageAction[], ctx: ActionRuntimeContext): Promise<void>
+
+/** Poll a flow execution to terminal. Exported for direct unit testing. */
+export async function pollFlowExecution(
+  apiClient: ApiClient,
+  executionId: string,
+  opts?: { intervalMs?: number; timeoutMs?: number },
+): Promise<{ status: string }>
+```
+
+**Per-action dispatch contracts (exact):**
+
+| `action` | Resolved values | Dispatch |
+|----------|-----------------|----------|
+| `runFlow` | `input` → `resolveBindings(action.input ?? {}, scope)` | `apiClient.fetch('/api/flows/${flowId}/execute', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ input }) })`; read id via `unwrapResource(await resp.json()).id`; if `awaitResult` → `pollFlowExecution(apiClient, id)` |
+| `navigate` | `params` → resolved, appended as query string | **`assertSafeUrl(toWithParams)` first** (see below); `newTab` → `window.open(toWithParams, '_blank')` else `navigate(toWithParams)` |
+| `openUrl` | `url` → resolved string | **`assertSafeUrl(url)` first** (see below); `newTab` → `window.open(url, '_blank', 'noopener')` else `window.location.assign(url)` |
+| `createRecord` | `attributes` → resolved | `apiClient.postResource('/api/${collection}', attrs)` |
+| `updateRecord` | `attributes` + `recordId` → resolved | `apiClient.patchResource('/api/${collection}/${recordId}', attrs)` |
+| `refreshData` | — | `queryClient.invalidateQueries({ queryKey: ctx.dataSourceQueryKey(action.dataSource) })` |
+| `setVar` | `value` → resolved | `ctx.setVar(action.name, value)` |
+| `showToast` | `message` → resolved string | `ctx.showToast(message, action.level)` |
+
+> **URL scheme allow-list (SECURITY — parent §"Security — binding & action output safety").** `navigate.to`
+> and `openUrl.url` are author- **and** data-controlled: a `{$bind}` can resolve at fire time to a
+> `javascript:` or `data:` URL, which would execute as XSS the moment it reaches `window.location.assign` /
+> `window.open` / the router. Before any of those calls, `executeAction` runs `assertSafeUrl(resolved)`, which
+> parses the (already-resolved) target and **rejects any scheme not in `{ http, https, mailto, tel, relative }`**
+> (relative = no scheme, i.e. an in-app path like `/app/p/orders`). A rejected URL throws → the chain stops and
+> an error toast surfaces (the action does **not** navigate/open). `assertSafeUrl` lives in
+> `runtime/executeAction.ts` (a small pure helper, exported for unit testing). Because resolution happens
+> first, the check sees the **final** string a `{$bind}` produced — not the literal `{$bind}` marker. (This is
+> the 2e half of the shared allow-list; 2g applies the same list to `link.href`/`image.src`.)
+>
+> **Binding resolution boundary (two distinct resolutions — do not conflate).** There are two `{$bind}`
+> resolutions, owned by different layers:
+> 1. **Widget props** (`node.props`) are resolved **before** they reach the descriptor's `Render` — this is the
+>    parent's **resolved-node invariant** (parent §"Widget registry"): `WidgetRenderProps.node.props` is
+>    **always** fully binding-resolved by `RenderTree`/`renderNode` (identity no-op in 2a, real in 2d).
+>    Descriptors (including `button`/`form` here) **must not** call `resolveBindings` on their own props — so
+>    the `scope` 2e captures at fire time is read from already-resolved props/state, not re-resolved.
+> 2. **Action values** (`input`/`attributes`/`params`/`message`/`url`/`recordId`/`value`) are resolved by the
+>    **2e action runtime, client-side, at fire time**, against the **event scope** — *not* by `RenderTree`,
+>    because an action's bindings (e.g. `{$bind:'record.id'}`) must resolve against the scope live at click,
+>    which a static prop pass can't capture. `resolveBindings` (2d) walks the value tree and replaces every
+>    `{$bind}` leaf with its scope value (`mode:'path'` → `getPath`, `mode:'expr'` → `FormulaEvaluator`).
+>    `executeAction` calls it on the action's value object **once** before dispatch; literals pass through
+>    untouched. If 2d has not merged, `executeAction` imports a no-op `resolveBindings` shim (identity) so 2e is
+>    independently testable — swapping in the real resolver is a single import change.
+>
+> So: props arrive resolved (2a invariant, server never resolves — pass-through only); action `{$bind}` values
+> are resolved client-side by 2e against the event scope.
+
+### 3.3 `runtime/useActionRunner.ts` — the React binding
+
+```ts
+import { useNavigate } from 'react-router-dom'
+import { useQueryClient } from '@tanstack/react-query'
+import { useApi } from '@/context/ApiContext'
+import { useToast } from '@/components/Toast/Toast'
+import type { PageAction } from '../model/pageModel'
+
+/** Returns a stable `run(actions, scope)` that builds an ActionRuntimeContext and executes the list. */
+export function useActionRunner(opts: {
+  tenantSlug: string
+  setVar: (name: string, value: unknown) => void
+  dataSourceQueryKey: (name: string) => unknown[]
+}): { run: (actions: PageAction[] | undefined, scope: Record<string, unknown>) => Promise<void> }
+```
+
+`run` is a no-op when `actions` is empty/undefined. It wraps `executeActions` in a try/catch that calls
+`showToast(err.message, 'error')` on rejection (the single error surface for the whole chain).
+
+### 3.4 Verified flow endpoint — request / response / poll (quoted from real code)
+
+**Execute** — `FlowExecutionController.executeFlow` (`@PostMapping("/{flowId}/execute")`):
+
+Request body (the runtime sends the `input` form — the double-wrap outer layer):
+```jsonc
+{ "input": { "orderId": "ord-42" } }   // controller reads body.input → state.input → flow reads $.input.orderId
+```
+
+Response (`JsonApiResponseBuilder.single("flow-executions", resultExecutionId, attrs)` where
+`attrs = { flowId, status: "RUNNING" }`):
+```jsonc
+{ "data": { "type": "flow-executions", "id": "<executionId>", "attributes": { "flowId": "…", "status": "RUNNING" } } }
+```
+> The async response is **always `200 OK` with `status:"RUNNING"`** (the controller starts the execution via
+> `flowEngine.startExecution(...)` and returns immediately — it does not wait). The execution id is
+> `data.id` — `unwrapResource(json).id`.
+
+**Poll** — `getExecution` (`@GetMapping("/executions/{executionId}")`): returns
+`JsonApiResponseBuilder.single("flow-executions", id, execMap)` where `execMap` includes
+`status`, `stateData`, `errorMessage`, `completedAt`, … :
+```jsonc
+{ "data": { "type": "flow-executions", "id": "<executionId>",
+            "attributes": { "status": "COMPLETED", "stateData": {…}, "errorMessage": null, … } } }
+```
+Terminal statuses (from `DebugTab` / `FlowExecutionData.isTerminal()`): **`COMPLETED` / `FAILED` /
+`CANCELLED`**; in-flight: `RUNNING` / `WAITING`. `pollFlowExecution` reads
+`unwrapResource(await resp.json()).status` and resolves when terminal, rejects on `FAILED`/`CANCELLED` (so the
+chain stops), or rejects on `timeoutMs` (default 60 s, interval 1.5 s).
+
+> **Bug to fix while here (low-risk, in-scope-adjacent):** the existing admin pages (`FlowsPage.tsx` line ~119,
+> `FlowDesignerPage.tsx` line ~159) read `(await resp.json()).executionId` from the execute response — but the
+> controller returns JSON:API `data.id`, **not** a top-level `executionId`. The new runtime reads it correctly
+> via `unwrapResource(json).id`. We do **not** rewrite the admin pages in this slice (out of scope), but a
+> follow-up chip is flagged so they stop relying on a field that isn't there.
+
+**Gateway / authz:** `/api/flows/**` is a **static route** registered in
+`RouteConfigService.registerStaticRoutes()` (`{"flows", "/api/flows/**", "flows"}`), so it gets only the blanket
+`API_ACCESS` check at the gateway (not per-resource Cerbos) — the same path the existing FlowsPage execute uses.
+No new route or authz change is needed.
+
+### 3.5 JSON:API create / update (verified FE methods)
+
+- **Create:** `apiClient.postResource('/api/${collection}', attrs)` — auto-wraps the plain attrs object into
+  `{ data: { type, attributes } }` and unwraps the response (`apiClient.ts` `postResource`). This is exactly
+  the path `PageTreeRenderer`'s `FormNode` already uses for create.
+- **Update:** `apiClient.patchResource('/api/${collection}/${recordId}', attrs)` — auto-wraps with the id
+  extracted from the URL (`apiClient.ts` `patchResource`). (No existing page-builder caller today; this is the
+  update equivalent of the create path.)
+- Both go through the gateway → worker JSON:API, so **Cerbos route authz + write-side FLS
+  (`CerbosFieldWriteSecurityAdvice`) are enforced server-side** — a write-denied field or record surfaces as a
+  4xx that the runtime turns into an error toast. The runtime never constructs raw SQL or bypasses the filter.
+
+### 3.6 Config / contract delta
+
+**None.** `events` is an **optional** key on `PageComponent` (defined in 2a), nested inside the existing
+`ui-pages.config` JSON column. The render contract (1g) already round-trips the whole tree; `events`
+round-trips with it. No new `PageConfig` top-level field, no NATS subject, no render-contract field. v1 pages
+(no `events`) are unaffected — a node without `events` simply has no handlers.
+
+---
+
+## 4. DB migrations
+
+**None — stored in `ui-pages.config` JSON, no DDL.** Confirmed per this slice: every action dispatches to an
+**already-existing** endpoint (`POST /api/flows/{id}/execute`, `GET /api/flows/executions/{id}`, JSON:API
+`POST`/`PATCH /api/{collection}`); `events` nests in the existing `config` column. Flyway head remains **V146**;
+no version consumed. No NATS subject or payload change.
+
+---
+
+## 5. File-by-file code changes
+
+All paths under `kelta-ui/app/src/pages/PageBuilderPage/` unless noted.
+
+### 5.1 New — runtime executor
+
+| File | Contents |
+|------|----------|
+| `runtime/executeAction.ts` | §3.2 — `ActionRuntimeContext`, `executeAction`, `executeActions` (sequential; first reject stops the chain), `pollFlowExecution`, and **`assertSafeUrl(url)`** (URL scheme allow-list — throws on a scheme not in `{http,https,mailto,tel,relative}`; called before every `navigate`/`openUrl` dispatch). Imports `resolveBindings` (2d), `unwrapResource` (`@/utils/jsonapi`). No React here — pure async/sync functions for direct unit testing. |
+| `runtime/useActionRunner.ts` | §3.3 — `useActionRunner({ tenantSlug, setVar, dataSourceQueryKey })` → `{ run }`. Pulls `apiClient` from `useApi()`, `navigate` from `useNavigate()`, `queryClient` from `useQueryClient()`, `showToast` from `useToast()`; assembles `ActionRuntimeContext` per `run(actions, scope)` call; wraps `executeActions` in try/catch → error toast. |
+
+### 5.2 Finalize — inspector `EventListField`
+
+| File | Contents |
+|------|----------|
+| `inspector/fields/EventListField.tsx` | **2b ships the shell; 2e fills the body.** This is the **single** `kind:'event-list'` field with **`key:'events'`** — its `value` is the whole `node.events`. Props (matching the shell 2b wired): `{ value: EventHandlers \| undefined; onChange: (next: EventHandlers) => void; supportedEvents: Array<keyof EventHandlers>; collections: …; flows: …; dataSources: string[]; variables: string[] }`, where `supportedEvents` is the descriptor's `descriptor.supportedEvents` (declared in 2a) that the inspector loop passes through — **not** a field re-declared in 2e. Renders event tabs (filtered to `descriptor.supportedEvents`), a sortable `PageAction[]` list per event (add via "+ Add action" menu, remove, **reorder**), and the per-action sub-form (§5.3). All mutations are immutable (`treeOps`-style local helpers `addAction`/`removeAction`/`moveAction`/`updateAction`). Emits the whole `EventHandlers` up via `onChange` → the inspector writes it to `node.events` through the existing `updateProps`-equivalent save path. |
+| `inspector/fields/actions/ActionEditor.tsx` | Dispatches on `action.action` to the right sub-form; renders the add-action menu (the 8 kinds). |
+| `inspector/fields/actions/RunFlowForm.tsx` | Flow picker (`select` from `GET /api/flows` via a `useFlows()` query — id→name), `awaitResult` toggle, input-mapping rows (key text + value `BindableField`). |
+| `inspector/fields/actions/NavigateForm.tsx` | `to` text, `params` rows (bindable), `newTab` toggle. |
+| `inspector/fields/actions/OpenUrlForm.tsx` | `url` `BindableField`, `newTab` toggle. |
+| `inspector/fields/actions/RecordForm.tsx` | Used for `createRecord`/`updateRecord`: collection picker (reuse `useCollectionSchema` collection list), `attributes` rows (bindable), `recordId` `BindableField` (update only). |
+| `inspector/fields/actions/RefreshDataForm.tsx` | `dataSource` `select` from `dataSources` (config.dataSources names). |
+| `inspector/fields/actions/SetVarForm.tsx` | `name` `select` from `variables`, `value` `BindableField`. |
+| `inspector/fields/actions/ShowToastForm.tsx` | `level` `select` (info/success/error), `message` `BindableField`. |
+| `inspector/hooks/useFlows.ts` | `useQuery(['flows'], () => apiClient.getList('/api/flows'))` → `{ id, name }[]` for the flow picker. (Reuses `apiClient.getList`; `/api/flows` is the existing static route.) |
+
+> **Reuse, don't reinvent, the value editor.** Every "value" cell (input-mapping value, attribute value,
+> `message`, `url`, `recordId`, `setVar` value) is a **`BindableField`** (2d) — the `fx` toggle + literal text
+> input. The `EventListField` does not implement its own expression UI; it composes `BindableField`. (Per the
+> Reuse Map / Pitfall "❌ Fork a new shared form component".)
+>
+> **i18n (mandatory — parent §"i18n").** Every new user-facing string in 2e goes through `useI18n`/`t()` with
+> `builder.*` keys — **no hardcoded English** (the builder is fully `useI18n`-driven). 2e owns these strings:
+> - **The 8 action-type labels** (in the "+ Add action" menu and each action row title):
+>   `builder.actions.runFlow` / `navigate` / `openUrl` / `createRecord` / `updateRecord` / `refreshData` /
+>   `setVar` / `showToast`.
+> - **Per-sub-form labels** (one `builder.actions.<kind>.<field>` namespace), e.g. `RunFlowForm` "Flow",
+>   "Await result", "Inputs", "Add input"; `NavigateForm` "To", "Params", "New tab"; `OpenUrlForm` "URL",
+>   "New tab"; `RecordForm` "Collection", "Attributes", "Record ID"; `RefreshDataForm` "Data source";
+>   `SetVarForm` "Name", "Value"; `ShowToastForm` "Level", "Message" — plus the shared "Events" tab/section
+>   label, "Actions (run in order)", "Add action", "Edit action", "Done", and the toast-level option labels
+>   (`info`/`success`/`error`). Each sub-form file pulls `t()` from `useI18n`; the EventListField test asserts
+>   no raw English literal leaks (consistent with the existing builder i18n tests).
+
+### 5.3 Wire widget descriptors to fire events (built-ins from 2a)
+
+| File | Change |
+|------|--------|
+| `widgets/builtins/button.tsx` | Ensure the descriptor carries a `propSchema` entry `{ key:'events', label:'Events', kind:'event-list' }` and `supportedEvents:['onClick']` on the **descriptor** (the `WidgetDescriptor.supportedEvents` field declared in 2a — the inspector reads it to filter the `event-list` tabs). In `Render`, when `mode==='runtime'` and `node.events?.onClick`, attach `onClick={(e)=>{ if(!href) e.preventDefault(); void run(node.events!.onClick!, scope) }}`. `run` comes from `useActionRunner` (the descriptor's `Render` is a component, so it may call the hook). `mode==='editor'` → no handler (inert). href-only buttons unchanged. |
+| `widgets/builtins/form.tsx` | `supportedEvents:['onSubmit']`. In `Render` (runtime), after the existing create mutation succeeds (or instead, if `events.onSubmit` is set), run `events.onSubmit`. Decision: if `onSubmit` actions exist, they run **after** the built-in create resolves (so `record` in scope reflects the created row); a form with no `onSubmit` behaves exactly as today. |
+| `widgets/builtins/index.ts` | No registration change — descriptors already registered in 2a; only their internals change. |
+
+> **`supportedEvents` lives on the descriptor** (`WidgetDescriptor.supportedEvents?: Array<keyof
+> EventHandlers>`, **already declared in 2a** — see parent §"Widget registry"), read by the inspector's
+> single `event-list` field to filter tabs. 2e does **not** re-add it to `widgets/types.ts`; it only sets the
+> value on the built-in descriptors it wires (`button` → `['onClick']`, `form` → `['onSubmit']`). The default
+> when a descriptor omits it is `['onClick','onLoad']` (applied in the registry/inspector, per 2a). **No
+> `types.ts` change in 2e.**
+
+### 5.4 Page mount — `onLoad`
+
+| File | Change |
+|------|--------|
+| `pages/app/CustomPage/CustomPage.tsx` (or the `RenderTree` runtime host) | After the tree mounts and the 2d data sources resolve, run any root-level `onLoad` actions once (page-level `events.onLoad`, if the page config carries it) via `useActionRunner`. Guard with a `useRef` so it fires once per mount. (If page-level events aren't modelled yet, this is a no-op hook call — `events.onLoad` on individual nodes fires from their descriptor's mount effect; v1 scope: node-level `onLoad` on `container`/`form` only, page-level deferred to whoever adds a page-events panel.) |
+
+### 5.5 Type touch
+
+**None.** `WidgetDescriptor.supportedEvents?: Array<keyof EventHandlers>` is **already declared in 2a** (parent
+§"Widget registry") and the `kind:'event-list'`/`key:'events'` `PropFieldSchema` is wired by 2b. 2e adds no
+field to `widgets/types.ts`; it only consumes these. (Previously this section claimed 2e adds `supportedEvents`
+to `WidgetDescriptor` — corrected: 2a owns it.)
+
+---
+
+## 6. Test plan
+
+Vitest + Testing Library + MSW, matching the existing idiom (`PageBuilderPage.test.tsx` uses the MSW `server`
+from `vitest.setup` + `createTestWrapper`; `apiClient.test.ts` mocks the axios instance). React Query in tests
+uses a `QueryClient` with `retry:false`.
+
+### 6.1 New — `runtime/executeAction.test.ts` (per action type; mock `apiClient`/router/toast)
+
+A fake `ActionRuntimeContext` with `vi.fn()` for `apiClient.fetch`/`postResource`/`patchResource`, `navigate`,
+`queryClient.invalidateQueries`, `showToast`, `setVar`, and a fixed `scope`.
+
+- **`showToast`** → calls `ctx.showToast('Saved', 'success')` (and resolves a `{$bind}` message against scope).
+- **`setVar`** → calls `ctx.setVar('selectedId', <resolved value>)`.
+- **`navigate`** → `navigate('/app/p/orders?status=NEW')` when `params` resolve; `newTab` → `window.open` spy.
+- **`openUrl`** → `window.open(url,'_blank','noopener')` / `location.assign` per `newTab`.
+- **URL scheme allow-list (SECURITY)** → an `openUrl`/`navigate` whose resolved target is
+  `javascript:alert(1)` (and `data:text/html,…`) **throws/rejects** (`assertSafeUrl` blocks it): assert
+  `window.open`/`location.assign`/`navigate` were **never** called and the action rejected. A `{$bind}` that
+  resolves to a `javascript:` URL is likewise blocked (resolution runs first, so the check sees the final
+  string). Allowed schemes (`https://…`, `mailto:…`, `tel:…`, relative `/app/p/orders`) pass through and
+  dispatch normally.
+- **`createRecord`** → `apiClient.postResource('/api/orders', {customer:'u-9', status:'NEW'})` with bindings
+  resolved against scope; assert the exact resolved body.
+- **`updateRecord`** → `apiClient.patchResource('/api/orders/ord-42', {...})` with `recordId` resolved.
+- **`refreshData`** → `queryClient.invalidateQueries({ queryKey: dataSourceQueryKey('ordersList') })`.
+- **`runFlow` (fire-and-forget)** → `apiClient.fetch('/api/flows/flow-7c2a/execute', POST)` with
+  body `{ input: { orderId:'ord-42' } }` (assert the **outer wrap is added** and bindings resolved); resolves
+  without polling when `awaitResult` is falsy.
+- **`runFlow` async + poll** → execute returns `{data:{id:'ex-1',attributes:{status:'RUNNING'}}}`; first poll
+  `GET /api/flows/executions/ex-1` → `RUNNING`, second → `COMPLETED`; assert `pollFlowExecution` resolves after
+  the second poll. Use fake timers (`vi.useFakeTimers()` + `advanceTimersByTimeAsync`) for the 1.5 s interval.
+  A `FAILED`/`CANCELLED` poll → `executeAction` rejects.
+- **`executeActions` ordering** → three `vi.fn` actions run in order; a rejecting awaited action **stops the
+  chain** (subsequent action not called) and the rejection propagates to the caller.
+
+### 6.2 New — `inspector/fields/EventListField.test.tsx` (editing)
+
+- Renders only `supportedEvents` tabs (`button` → `onClick` + `onLoad`; not `onSubmit`).
+- "+ Add action" → pick `showToast` → `onChange` emits `{ onClick:[{action:'showToast',level:'info',message:''}] }`.
+- Edit a `runFlow` action: flow picker lists `GET /api/flows` (MSW), selecting one sets `flowId`; adding an
+  input row + typing a key/value emits the updated `input` map; toggling `awaitResult` sets the flag.
+- **Reorder** (drag or up/down control) swaps two actions' order in the emitted array.
+- **Remove** drops the action; emitting `{ onClick: [] }` (or removing the event key) is asserted.
+- A bindable value cell flips to a `{$bind, mode:'expr'}` via the `fx` toggle (BindableField integration —
+  stub `FieldExpressionPicker` if 2d not present; assert the emitted `{$bind}` shape).
+
+### 6.3 New — `runtime/useActionRunner.test.tsx`
+
+- `run([])` / `run(undefined)` is a no-op (no fetch, no toast).
+- `run([{action:'showToast',...}], scope)` mounted in a test component with `ApiContext`/`ToastProvider`/Router
+  wrappers fires the toast.
+- A rejecting action surfaces **one** error toast with `err.message` and does not throw out of `run`.
+
+### 6.4 Extend — widget parity / behavior tests
+
+- `widgets/builtins/button.test.tsx`: in `mode:'runtime'`, clicking the button runs `events.onClick`
+  (`run` spy called with the action list + scope); in `mode:'editor'`, clicking is inert (`run` not called).
+  An href button with no `onClick` still renders `<a>` and navigates normally (parity).
+- `widgets/builtins/form.test.tsx`: submitting runs the create mutation, then `events.onSubmit` (order
+  asserted via a spy sequence); a form with no `onSubmit` behaves as before (parity with 2a/1f).
+
+### 6.5 e2e (post-deploy, Playwright) — **2e owns `page-builder-v2.spec.ts` (named deliverable)**
+
+Per the parent §"End-to-end e2e ownership" and §"Slice plan → 2e", **2e is the terminal behavior slice and
+OWNS the one full-flow e2e spec** — it is **not** "covered by the parent." Because the admin route is absent
+until deployed, e2e is **post-deploy**, but the spec is a **named deliverable authored post-deploy, before the
+feature is declared done** (not optional, not deferrable).
+
+**Deliverable:** `e2e-tests/tests/page-builder-v2.spec.ts` — the complete authored-page flow:
+**palette → drop a widget into a grid column → bind a prop → wire a button `onClick` event → save → publish →
+open the runtime page → assert a record is created via the button event and persists.** The assertion is a
+**real mutation** (the row created by the `onClick` `createRecord` action is queried back via the JSON:API and
+confirmed to persist), **not merely that the page renders**. (A `showToast` may accompany it, but the
+load-bearing assertion is the persisted record.)
+
+This is the same `page-builder-v2.spec.ts` the parent names; earlier FE slices (2a–2d) leave it to this slice.
+**1h** later adds a **negative authz case** to the same suite (a denied user → 404). Runs against the deployed
+env, not in this PR's CI.
+
+---
+
+## 7. Docs to update (same PR)
+
+| Doc | Change |
+|-----|--------|
+| `.claude/docs/status.md` (Page builder / screen builder row, line ~48) | Add slice 2e: "**events & actions**: page widgets fire ordered `PageAction[]` per event (`onClick`/`onSubmit`/`onLoad`/`onChange`) via the client-side action runtime (`runtime/executeAction.ts`) — `runFlow` (`POST /api/flows/{id}/execute` `{input}` → optional poll `GET /api/flows/executions/{id}` to terminal), `navigate`/`openUrl` (router/window), `createRecord`/`updateRecord` (JSON:API `POST`/`PATCH`, Cerbos+write-FLS enforced), `refreshData` (invalidate the named data-source query), `setVar`, `showToast` (sonner); `inspector/fields/EventListField` authors them (add/remove/reorder + per-action sub-forms); action values may be `{$bind}` resolved (2d). Move 'buttons only do href' out of the gap column." Leave 'typed/validated form fields' (2f) and 'per-page Cerbos authz' (1h) in the gap column. |
+| `.claude/docs/integrations.md` (Flows section, ~line 104) | Add a short subsection **"Page-event → flow framing"**: page-builder events that run a flow use the **same** `POST /api/flows/{flowId}/execute` double-wrap rule — the editor stores the **inner** input map on `action.input`, and `executeAction` sends `{ input: <resolved action.input> }`, so the flow reads `$.input.<key>` (cross-reference the existing "double-wrap rule"). Note the async response is `status:"RUNNING"` and `awaitResult` polls `GET /api/flows/executions/{id}` to a terminal status (`COMPLETED`/`FAILED`/`CANCELLED`). This is the **only** new integration framing 2e introduces (no new endpoint/subject). |
+| `.claude/docs/conventions.md` | If/when it documents page config v2 (deferred to 2d): add that `events` is an optional `EventHandlers` key on a node, `$bind` values inside action inputs/attributes follow the same binding contract, and the runtime never executes actions in `mode:'editor'`. |
+| `.claude/docs/concerns.md` | Note (test-gap row): action runtime correctness (esp. `runFlow` poll + chain-stop-on-reject, and the `assertSafeUrl` scheme allow-list) is covered only by Vitest with mocked `apiClient`/timers; the 2e-owned post-deploy Playwright spec `e2e-tests/tests/page-builder-v2.spec.ts` (§6.5) is the real-path guard — it asserts a **persisted record** from a button event, not just render — mirroring the "DB-constraint test gap" memory (mocks can hide endpoint-shape drift, e.g. the existing `executionId` vs `data.id` read). |
+
+Per CLAUDE.md Rule 6 these doc edits ship **in the same PR** as the code.
+
+---
+
+## 8. Risks & open questions
+
+- **Sequencing — 2e depends on 2a, 2b, and 2d.** It consumes the model (`PageAction`/`EventHandlers` from 2a),
+  the inspector shell + `kind:'event-list'` wiring (2b), and binding resolution + the page-variable / data-source
+  stores (2d: `resolveBindings`, `BindableField`, `usePageVariables`, `usePageDataSources`). **Mitigation:**
+  `executeAction` imports an identity `resolveBindings` shim if 2d hasn't merged (swap is one import), and the
+  `EventListField` value cells fall back to a plain text input if `BindableField` is absent — so 2e is buildable
+  and unit-testable ahead of full 2d, but should land **after** 2d for the bindable value editors to work.
+- **Existing admin pages read a field the controller doesn't return.** `FlowsPage.tsx`/`FlowDesignerPage.tsx`
+  read `(await resp.json()).executionId` from the execute response, but the worker returns JSON:API `data.id`
+  (verified in `FlowExecutionController.executeFlow`). The **new** runtime reads it correctly via
+  `unwrapResource(json).id`. Out of scope to fix the admin pages here, but flagged as a follow-up (a stale read
+  that "works" only because those pages don't strictly depend on the navigation that uses it). **Open question:**
+  fold the admin-page fix into this PR or a separate chore? (Recommend separate — keeps 2e a pure FE-feature PR.)
+- **Action chain semantics — stop vs continue on error.** Decision in this spec: an **awaited** action that
+  rejects **stops the chain** and shows one error toast. A fire-and-forget `runFlow` (`awaitResult:false`) that
+  fails server-side won't stop the chain (we never await it). **Open question for the user:** is "stop on first
+  error" the right default, or should each action be independently best-effort? (Recommend stop-on-error — least
+  surprising for create-then-flow sequences.)
+- **`runFlow` poll cost.** `awaitResult` polls every 1.5 s up to 60 s. A long-running flow will time out the
+  await (reject → error toast) even though the flow keeps running server-side. **Mitigation:** document that
+  `awaitResult` is for short flows; default to fire-and-forget. The poll interval/timeout are constants in
+  `executeAction.ts` (not yet configurable per action) — a future `timeoutMs` on the `runFlow` action is a clean
+  extension. **Open question:** expose a per-action timeout in the editor now, or defer? (Recommend defer.)
+- **URL scheme allow-list (SECURITY — MAJOR).** `navigate.to` and `openUrl.url` are author- **and**
+  data-controlled (a `{$bind}` can resolve to `javascript:`/`data:`, i.e. stored XSS that fires on click). 2e
+  guards both with `assertSafeUrl` (§3.2): before `window.location.assign`/`window.open`/the router runs, the
+  resolved target's scheme must be in `{http, https, mailto, tel, relative}`; anything else throws → the chain
+  stops and an error toast surfaces. The check runs **after** binding resolution, so it sees the final string a
+  `{$bind}` produced. A Vitest case asserts a `javascript:` URL is blocked (§6.1). This is the 2e half of the
+  shared allow-list (parent §"Security — binding & action output safety"); 2g applies the same list to
+  `link.href`/`image.src`. Without it, a published end-user page could execute attacker-controlled script.
+- **`navigate` target validation (functional).** Beyond the scheme allow-list, `navigate.to` is authored
+  free-text; a bad in-app path renders the router's not-found. No allow-list of page slugs in 2e (the editor
+  could populate a slug picker from `GET /api/pages` later). **Mitigation:** treat `to` as a literal-or-binding
+  string; document that it's the in-app route path (e.g. `/:tenant/app/p/<slug>`), not an absolute URL —
+  absolute/external URLs use `openUrl`.
+- **Editor must never fire actions.** The single biggest correctness risk: the descriptor `Render` is shared by
+  editor preview and runtime (2a). Guard is the `mode` flag — handlers attach **only** when `mode==='runtime'`.
+  A button-descriptor test asserts the editor click is inert. (Same discipline as the `table`/`form`
+  placeholder-vs-fetch split in 2a.)
+- **File size.** 2e adds `runtime/*` and `inspector/fields/actions/*` as **new small files** rather than growing
+  `PageBuilderPage.tsx` — net-neutral on the oversized-file concern (the inspector itself already moved out in
+  2b). No file is pushed past the `concerns.md` threshold.

--- a/.claude/docs/specs/page-builder/2f-typed-forms.md
+++ b/.claude/docs/specs/page-builder/2f-typed-forms.md
@@ -1,0 +1,808 @@
+# 2f — Typed form widgets
+
+> **Slice:** 2f (FE). **Axis:** Widgets / typed forms.
+> **Parent:** [`../page-builder-parity.md`](../page-builder-parity.md). This child spec **extends, never
+> contradicts** the parent's [Reuse Map](../page-builder-parity.md#reuse-map) (ResourceForm / typed inputs /
+> FieldType rows) and [Widget registry](../page-builder-parity.md#widget-registry) (Input widgets row).
+> **Depends on:** **2a** (the `WidgetDescriptor`/`PropFieldSchema`/`PageComponent` v2 contract, the
+> `widgetRegistry`, the shared `RenderTree`, and the `form`/`table` builtins that moved out of
+> `PageTreeRenderer`) and, for default values, **2d** (`{ $bind }` → `resolveBindings`/`bindingScope`).
+> Source-verified against the codebase on 2026-06-22 (Flyway head V146; this slice adds no migration).
+> If code and this doc disagree, trust the code and fix this doc.
+
+---
+
+## 1. Goal & scope
+
+### What this slice delivers
+
+Makes page-builder forms **typed and validated** instead of the text-only inputs shipped in slice 1f.
+
+After 2a, the `form` builtin (`widgets/builtins/form.tsx`) wraps the **verbatim-moved** `FormNode` — a flat
+list of `<input type="text">` that POSTs raw strings via `apiClient.postResource('/api/{collection}', values)`.
+This slice **replaces that body** so the `form` widget renders through the `@kelta/components`
+**`ResourceForm`** — schema-driven create/edit, Zod validation, one typed input per `FieldType`, field-level
+authz, and a pluggable field-renderer registry — bound to a collection.
+
+It also adds the parent's **Input-category standalone widgets**, each mapping a `FieldType` → the correct
+control and sourcing its options from `useCollectionSchema` + the picklist endpoint:
+
+| Widget | Control reused | FieldType(s) it targets |
+|--------|----------------|-------------------------|
+| `text-input` | shadcn `Input` (`@/components/ui/input`) | `string`, `phone`, `email`, `url`, `external_id`, `auto_number` |
+| `number-input` | shadcn `Input type="number"` | `number`, `currency`, `percent` |
+| `checkbox` | shadcn `Checkbox` (`@/components/ui/checkbox`) | `boolean` |
+| `dropdown` | native `<select>` (picklist via schema) | `picklist` |
+| `datepicker` | `Input type="date"` / `type="datetime-local"` | `date`, `datetime` |
+| `lookup` | `LookupSelect` (`@/components/LookupSelect`) | `reference`, `lookup`, `master_detail` |
+| `multi-picklist` | `MultiPicklistSelect` (`@/components/MultiPicklistSelect`) | `multi_picklist` |
+| `rich-text` | `RichTextEditor` (`@/components/RichTextEditor`) | `rich_text` |
+
+Each standalone input:
+
+- binds to a `{ collection, field }` pair, reads the field's `FieldType` from `useCollectionSchema`, and
+  renders the matching control (the same control the existing `ObjectFormPage` renders for that type);
+- sources `dropdown`/`multi-picklist` options from `enumValues` (resolved via the picklist endpoint, FIELD or
+  GLOBAL source, exactly as `ObjectFormPage` does today), and `lookup` options via `useCollectionSchema`'s
+  reference resolution;
+- accepts a `{ $bind }` **default value** (resolved by 2d's `resolveBindings` against the page scope —
+  `record`/`vars`/`data.<src>`/`page`/`item`);
+- writes its value into page state (a `vars`-backed binding target) so 2e events / the `form` submit can read
+  it; the standalone inputs are **uncontrolled-by-default** local-state inputs that mirror into the binding
+  target, matching how `ObjectFormPage` lifts `onChange(field.name, value)`.
+
+Submission stays on the **authorized JSON:API path**: `ResourceForm` POSTs/PATCHes through the
+`@kelta/sdk` client (`client.resource(name).create/update`), and standalone-input + `form` flows go through
+`apiClient.postResource`/`patchResource`. The gateway + worker enforce Cerbos and write-FLS, and the **worker
+validates required/type/unique on write** — client (Zod) validation is **advisory UX only** and never the
+source of truth.
+
+All new widgets register in `widgets/builtins/` and are resolved through the single `widgetRegistry` +
+`RenderTree` introduced in 2a.
+
+**Category — `input`.** The `form` widget (→ `ResourceForm`) **and** all eight standalone inputs are
+`WidgetDescriptor.category: 'input'`, consistent with 2a (where `form`'s category was **fixed to `input` and
+not moved later**) and the parent [Widget registry](../page-builder-parity.md#widget-registry) Input row. The
+`input` category is therefore already **non-empty from 2a** (the placeholder `form` builtin shipped under it);
+2f only populates it with the typed controls. `widgetRegistry.listByCategory('input')` returns `form` + the
+eight inputs (§6.4).
+
+### What this slice explicitly does NOT do
+
+| Out of scope | Lands in |
+|--------------|----------|
+| Bindings **UI** (`BindableField`/`fx` toggle), `resolveBindings`/`bindingScope`/`interpolate` impl | 2d (consumed here for default values) |
+| Events/actions authoring + action runtime (`onSubmit` → run flow, `onChange` → setVar) | 2e (the `form`/inputs expose the event hooks; wiring is 2e) |
+| The schema-driven `Inspector` shell + palette-from-registry | 2b (this slice only adds `propSchema` arrays + a few new `PropFieldKind`s) |
+| Non-input widget breadth (`chart`, `tabs`, `nav`, `icon`, `link`, `image` polish) | 2g |
+| Server-side validation changes | N/A — the worker already validates required/type/unique on write; unchanged |
+
+### Parent-doc sections this conforms to
+
+- **Reuse Map** — `ResourceForm` (schema-driven, Zod, typed inputs, field authz), `LookupSelect` /
+  `MultiPicklistSelect` / `RichTextEditor` typed inputs, `useCollectionSchema` → `fetchCollectionSchema`,
+  `FieldType` enum, `GET /api/fields…` / `GET /api/picklist-values?…`, and the JSON:API create/update path.
+- **Widget registry → Input widgets** — `form` (→ `ResourceForm`), `text-input`, `number-input`, `checkbox`,
+  `dropdown`, `datepicker`, `lookup` (→ `LookupSelect`), `multi-picklist` (→ `MultiPicklistSelect`),
+  `rich-text` (→ `RichTextEditor`).
+- **2a contract** — `WidgetDescriptor` / `PropFieldSchema` / `WidgetRenderProps` / `PageComponent` v2.
+- **2d contract** — `{ $bind }` default values resolved through `resolveBindings(props, scope)`.
+
+### Acceptance criteria
+
+- The `form` widget, in `mode:'runtime'`, renders via `ResourceForm` bound to `props.dataView.collection`:
+  typed inputs per `FieldType`, Zod validation messages, field-level authz (denied fields not shown), create
+  (`recordId` absent) and edit (`recordId` bound) modes. The old text-only `FormNode` is **deleted**.
+- Each standalone input widget maps its bound field's `FieldType` → the correct control (per the §3.1 table),
+  matching what `ObjectFormPage` renders for that type today.
+- `dropdown` and `multi-picklist` populate options from the picklist endpoint (FIELD when the field owns the
+  values, GLOBAL when `fieldTypeConfig.globalPicklistId` is set), exactly as `ObjectFormPage` resolves them.
+- `lookup` resolves reference options from the target collection.
+- Every input accepts a `{ $bind }` default that resolves through 2d's scope.
+- **Rich-text / HTML output is sanitized** through the same sanitizer `FieldRenderer`'s `rich_text` path uses;
+  no `dangerouslySetInnerHTML` on unsanitized bound HTML (a `<script>`/`onerror` payload is stripped before
+  render — §6.2a).
+- All widgets are registered in `widgets/builtins/index.ts` `registerBuiltins()` and resolve through
+  `widgetRegistry` + `RenderTree` (no new switch site).
+- All new user-facing strings (empty/unconfigured, advisory required, "Select…" placeholder, submit toast,
+  widget/prop labels) go through `useI18n` — no hardcoded literals (§3.6).
+- Vitest: per-input (type→control, picklist options, validation) + form-submit (mock `apiClient`/SDK client).
+- `status.md`: "typed/validated form fields" moves **out** of the page-builder gap column.
+- `/verify` green (lint + typecheck + `test:coverage` ≥ existing kelta-ui gate).
+
+---
+
+## 2. UI samples
+
+### 2.1 A `form` widget bound to a collection (runtime) — typed inputs
+
+`form` node bound to `orders` (fields: `status` picklist, `dueDate` date, `customer` lookup, `total`
+currency, `notes` rich_text):
+
+```
+┌─ form (orders) ───────────────────────────────────────────────┐
+│  Status *           [ Open                       ▼ ]   ← dropdown (picklist enumValues)
+│  Due date           [ 2026-06-22            📅 ]        ← datepicker (type="date")
+│  Customer *         [ Acme Corp                  ▼ ]   ← LookupSelect (searchable)
+│  Total              [ 1250.00                     ]    ← number-input (currency)
+│  Notes              ┌───────────────────────────────┐ ← RichTextEditor
+│                     │ B  I  U  • 1.  🔗  </>        │
+│                     │ Ship by end of week.          │
+│                     └───────────────────────────────┘
+│                                                                │
+│         [ Cancel ]                       [ Create ]            │
+└────────────────────────────────────────────────────────────────┘
+```
+
+- Validation is live: clearing `Status` (required) shows `kelta-resource-form__error-message` "Required";
+  submit is still attempted server-side (worker is the source of truth).
+- A read-denied field (e.g. `internalScore`) is **absent** — `ResourceForm.accessibleFields` filters it via
+  `schema.authz.fieldLevel` before render (and the worker would strip it regardless).
+
+Before → after (the `form` widget body):
+
+```
+BEFORE 2f (the verbatim-moved FormNode from 1f/2a):
+  fields.map(f => <input type="text" value={values[f]} onChange=… />)
+  → every field is a bare text box; numbers, dates, picklists, lookups all typed as free text;
+    no validation; POST { status:"Open", total:"1250.00", dueDate:"2026-06-22" } as strings.
+
+AFTER 2f:
+  <ResourceForm resourceName={collection} recordId={resolvedRecordId} onSave=… onCancel=… />
+  → typed control per FieldType (dropdown / datepicker / LookupSelect / number / RichText), Zod
+    validation, field authz; ResourceForm.transformFormData coerces number/boolean/json before the
+    SDK create/update call.
+```
+
+### 2.2 Inspector data-source config (form widget)
+
+The 2b inspector loops over the descriptor's `propSchema`; the `form` descriptor exposes:
+
+```
+┌─ Inspector · form ───────────────────────────┐
+│ Data                                          │
+│   Collection      [ orders            ▼ ]     │  collection-picker → props.dataView.collection
+│   Mode            ( ) Create  (•) Edit        │  select → props.mode  ('create' | 'edit')
+│   Record id        fx [ {{record.id}}    ]    │  expression (bindable) → props.recordId  (edit mode)
+│   Read-only       [ ] off                     │  boolean → props.readOnly
+│ Behaviour                                     │
+│   On submit       [ + Add action ]            │  event-list → events.onSubmit  (authored in 2e)
+└───────────────────────────────────────────────┘
+```
+
+A standalone input's inspector:
+
+```
+┌─ Inspector · dropdown ───────────────────────┐
+│ Data                                          │
+│   Collection      [ orders            ▼ ]     │  collection-picker → props.collection
+│   Field           [ status            ▼ ]     │  field-picker (dependsOnCollection) → props.field
+│   Default value    fx [ {{vars.status}}  ]    │  expression (bindable) → props.defaultValue
+│   Required        [x] on                      │  boolean → props.required (advisory; worker enforces)
+└───────────────────────────────────────────────┘
+```
+
+> The `field-picker` for a `dropdown` filters the collection's fields to `picklist` type; `multi-picklist`
+> to `multi_picklist`; `lookup` to the reference types; `datepicker` to `date`/`datetime`; etc. (filter hint
+> carried on `PropFieldSchema.fieldTypeFilter`, §3.3). In 2f the existing 2b inspector is reused; this slice
+> only supplies the schemas.
+
+### 2.3 Sample component tree JSON
+
+```json
+[
+  {
+    "id": "f1",
+    "type": "form",
+    "props": {
+      "dataView": { "collection": "orders" },
+      "mode": "edit",
+      "recordId": { "$bind": "record.id", "mode": "path" },
+      "readOnly": false
+    },
+    "events": { "onSubmit": [{ "action": "showToast", "level": "success", "message": "Saved" }] }
+  },
+  {
+    "id": "d1",
+    "type": "dropdown",
+    "props": {
+      "collection": "orders",
+      "field": "status",
+      "defaultValue": { "$bind": "vars.defaultStatus", "mode": "path" },
+      "required": true
+    }
+  },
+  {
+    "id": "dt1",
+    "type": "datepicker",
+    "props": { "collection": "orders", "field": "dueDate" }
+  },
+  {
+    "id": "lk1",
+    "type": "lookup",
+    "props": { "collection": "orders", "field": "customer", "required": true }
+  }
+]
+```
+
+The `events.onSubmit` array round-trips untouched in 2f (authored/run in 2e). `recordId`/`defaultValue` are
+`{ $bind }` values resolved by 2d's `resolveBindings(props, scope)` inside `renderNode` **before** the
+descriptor's `Render` runs — so per the 2a resolved-node invariant the descriptor receives **already-resolved**
+plain values and 2f never calls `resolveBindings` itself (§3.5).
+
+### 2.4 Before / after render path
+
+```
+TODAY (after 2a, before 2f):
+  form  builtin → mode:'runtime' → <FormNode dataView=…/>   (text-only <input>, POST raw strings)
+  inputs: none (no standalone input widgets exist)
+
+AFTER 2f:
+  form  builtin → mode:'runtime' → <ResourceFormWidget collection=… recordId=… />
+                                     └─ <ResourceForm/> (@kelta/components: typed inputs, Zod, authz)
+  dropdown/datepicker/checkbox/number-input/text-input/lookup/multi-picklist/rich-text builtins
+     → each <…InputWidget collection field defaultValue/> → useCollectionSchema → typed control
+```
+
+No change to the editor-mode placeholder behaviour established in 2a: `mode:'editor'` still renders a static
+placeholder box for `form` (and for each input, a disabled preview of the control) so the canvas needs no live
+data. Live data fetch happens only at `mode:'runtime'`.
+
+---
+
+## 3. Data & API contracts
+
+All TS lives under `kelta-ui/app/src/pages/PageBuilderPage/`. **No backend/API change in 2f** — every field's
+type/picklist/reference metadata is already served by existing endpoints (see §4).
+
+### 3.1 `FieldType` → input-widget → control mapping (authoritative)
+
+The UI normalizes backend `FieldType` (uppercase) to lowercase via `useCollectionSchema`'s
+`normalizeFieldType` (`DOUBLE/INTEGER/LONG→number`, `REFERENCE/LOOKUP→master_detail`, etc.). The mapping below
+is over the **UI `FieldType`** union from `useCollectionSchema.ts` and mirrors the controls `ObjectFormPage`
+renders today (verified at `ObjectFormPage.tsx` ~191–308).
+
+| Backend `FieldType` (enum) | UI type (`useCollectionSchema`) | `form` (ResourceForm) control | Standalone widget | Standalone control |
+|----------------------------|----------------------------------|-------------------------------|-------------------|--------------------|
+| `STRING`, `TEXT` | `string` | `<input type="text">` | `text-input` | `Input` |
+| `PHONE` | `phone` | `<input type="tel">` | `text-input` | `Input` |
+| `EMAIL` | `email` | `<input type="email">` | `text-input` | `Input type="email"` |
+| `URL` | `url` | `<input type="url">` | `text-input` | `Input type="url"` |
+| `EXTERNAL_ID` | `external_id` | `<input type="text">` | `text-input` | `Input` |
+| `AUTO_NUMBER` | `auto_number` | `<input type="text">` | `text-input` (read-only) | `Input disabled` |
+| `INTEGER`/`LONG`/`DOUBLE` | `number` | `<input type="number">` | `number-input` | `Input type="number"` |
+| `CURRENCY` | `currency` | `<input type="number">` | `number-input` | `Input type="number" step="0.01"` |
+| `PERCENT` | `percent` | `<input type="number">` | `number-input` | `Input type="number"` |
+| `BOOLEAN` | `boolean` | `<input type="checkbox">` | `checkbox` | `Checkbox` |
+| `DATE` | `date` | `<input type="date">` | `datepicker` | `Input type="date"` |
+| `DATETIME` | `datetime` | `<input type="datetime-local">` | `datepicker` | `Input type="datetime-local"` |
+| `PICKLIST` | `picklist` | `<select>` (`enumValues`) | `dropdown` | native `<select>` |
+| `MULTI_PICKLIST` | `multi_picklist` | (custom renderer) | `multi-picklist` | `MultiPicklistSelect` |
+| `REFERENCE`/`LOOKUP`/`MASTER_DETAIL` | `master_detail` (+ `reference`/`lookup`) | text (default) → custom renderer | `lookup` | `LookupSelect` |
+| `RICH_TEXT` | `rich_text` | `<textarea>` | `rich-text` | `RichTextEditor` |
+| `JSON`/`ARRAY`/`GEOLOCATION` | `json` | `<textarea>` (JSON) | *(use `form`; no standalone in v1)* | — |
+| `ENCRYPTED` | `encrypted` | `<input type="password">` | *(use `form`)* | — |
+| `FORMULA`/`ROLLUP_SUMMARY`/`VECTOR` | `formula`/`rollup_summary`/— | **not editable** (computed) | excluded from `field-picker` | — |
+
+> **Closing the ResourceForm gap via the field-renderer registry.** `ResourceForm`'s built-in
+> `renderDefaultFieldInput` (verified at `ResourceForm.tsx` ~556–626) is **plain HTML**: `picklist` falls
+> through to `<input type="text">`, `multi_picklist` has no case, and `reference`/`lookup`/`master_detail`
+> render a text box with a placeholder. To make the **`form` widget** as rich as the standalone inputs, 2f
+> registers app-side field renderers via `ResourceForm.setComponentRegistry(...)` (the exported
+> `ComponentRegistryInterface` with `getFieldRenderer(fieldType)`/`hasFieldRenderer(fieldType)`), wiring the
+> same `LookupSelect` / `MultiPicklistSelect` / native `<select>` / `RichTextEditor` controls in for
+> `picklist`/`multi_picklist`/`reference`/`lookup`/`master_detail`/`rich_text`. `setComponentRegistry` is
+> called once at page-builder bootstrap (see §5.6). This reuses the **existing pluggable field-renderer
+> registry** rather than forking `ResourceForm`.
+
+> **SECURITY — sanitize rich-text / HTML output (parent §"Security — binding & action output safety").** The
+> `rich-text` widget — and **any** path that displays HTML-bearing field output (e.g. a `field-value`/registry
+> renderer for a `rich_text` field, or a `{ $bind }` that resolves to HTML) — MUST pass that HTML through the
+> **existing sanitizer** before it reaches the DOM: the **same** sanitizer `FieldRenderer`'s `rich_text` path
+> uses today (reuse it; do not introduce a second sanitizer or relax its allow-list). **Never**
+> `dangerouslySetInnerHTML` on unsanitized bound/authored HTML. Plain text bindings are auto-escaped by React
+> and need no sanitizer; this rule is specifically for HTML-bearing output. The `RichTextEditor` *edit* control
+> emits HTML on `onChange`; the worker remains the source of truth on write, but any **render** of that HTML
+> (preview, read-only, bound display) goes through the sanitizer. A test asserts a `<script>`/`onerror`
+> payload bound into a `rich_text` field is stripped before render (§6.2a).
+
+### 3.2 Schema + picklist fetch contracts (already served — reused verbatim)
+
+- **Collection schema** — `useCollectionSchema(collectionName)` → `fetchCollectionSchema` →
+  `GET /api/collections/{name}?include=fields`. Returns `CollectionSchema { id, name, displayName,
+  displayFieldName?, fields: FieldDefinition[] }`. Each `FieldDefinition` carries `type` (normalized),
+  `required`, `referenceTarget`/`referenceCollectionId`, `fieldTypeConfig` (JSONB; object **or** JSON string),
+  and `enumValues?`/`lookupOptions?` (populated at runtime by form pages — and by these widgets).
+- **Picklist values** — `GET /api/picklist-values?filter[picklistSourceId][eq]=<id>&filter[picklistSourceType][eq]=<FIELD|GLOBAL>`.
+  Source resolution (verified at `ObjectFormPage.tsx` ~838–865): parse `field.fieldTypeConfig` (handling both
+  object and string); if `config.globalPicklistId` is present use `sourceId = globalPicklistId`,
+  `sourceType = 'GLOBAL'`; else `sourceId = field.id`, `sourceType = 'FIELD'`. Response rows are
+  `PicklistValueDto { value, label, isDefault, isActive, sortOrder }`; keep `isActive`, sort by `sortOrder`,
+  map to `value`. **This logic is extracted into a shared hook** (§5.4 `usePicklistOptions`) so the `dropdown`,
+  `multi-picklist`, and the `form` widget's field-renderer registry all share one implementation (no
+  duplication of the resolution code across three sites).
+- **Lookup options** — reference fields resolve their option list from the target collection
+  (`referenceCollectionId`/`referenceTarget`) via the existing `useLookupDisplayMap` hook
+  (`@/hooks/useLookupDisplayMap`, verified used by `ObjectFormPage`), producing `LookupOption { id, label }[]`.
+
+> No new endpoint, query param, or response shape. The `?filter[…][eq]` casing (`[eq]`, lowercase) matches the
+> existing call sites — keep it.
+
+### 3.3 New widget contracts — descriptors + `propSchema`
+
+The standalone inputs share a common props shape:
+
+```ts
+// widgets/builtins/inputs/types.ts
+import type { PropValue } from '../../../model/pageModel'
+
+/** Shared props for every standalone typed input widget. */
+export interface InputWidgetProps {
+  /** Collection whose schema supplies the field's FieldType + options. */
+  collection: string
+  /** Field name on that collection. */
+  field: string
+  /** {{$bind}} default value (resolved by 2d before Render); literal otherwise. */
+  defaultValue?: PropValue
+  /** Advisory client-side required flag; the worker is the source of truth on write. */
+  required?: boolean
+  /** Render disabled. */
+  readOnly?: boolean
+  /** Placeholder for text-like controls. */
+  placeholder?: string
+}
+```
+
+`propSchema` for the standalone inputs (consumed by the 2b inspector). One new `PropFieldKind` is needed and
+one optional hint added to `PropFieldSchema` — both **additive** to the 2a `types.ts`:
+
+```ts
+// widgets/types.ts — additive deltas (do not break 2a)
+export type PropFieldKind =
+  | 'text' | 'textarea' | 'number' | 'boolean' | 'select' | 'color'
+  | 'collection-picker' | 'field-picker' | 'expression' | 'event-list' | 'span' | 'children'
+  // (no new kind required — field-picker + collection-picker already exist from 2a)
+
+export interface PropFieldSchema {
+  key: string
+  label: string
+  kind: PropFieldKind
+  options?: Array<{ value: string; label: string }>
+  bindable?: boolean
+  group?: string
+  dependsOnCollection?: boolean
+  /** NEW (2f): when kind:'field-picker', restrict the field list to these UI FieldTypes. */
+  fieldTypeFilter?: import('../hooks/useCollectionSchema').FieldType[]
+}
+```
+
+`dropdown` descriptor (representative):
+
+```tsx
+// widgets/builtins/inputs/dropdown.tsx
+import type { WidgetDescriptor } from '../../types'
+import { DropdownInput } from './DropdownInput'
+
+export const dropdownWidget: WidgetDescriptor = {
+  type: 'dropdown',
+  label: 'Dropdown',
+  icon: '▾',
+  category: 'input',
+  acceptsChildren: false,
+  defaultProps: { collection: '', field: '', required: false },
+  propSchema: [
+    { key: 'collection', label: 'Collection', kind: 'collection-picker', group: 'Data' },
+    { key: 'field', label: 'Field', kind: 'field-picker', dependsOnCollection: true,
+      fieldTypeFilter: ['picklist'], group: 'Data' },
+    { key: 'defaultValue', label: 'Default value', kind: 'expression', bindable: true, group: 'Data' },
+    { key: 'required', label: 'Required', kind: 'boolean', group: 'Data' },
+  ],
+  Render: ({ node }) => <DropdownInput {...(node.props as never)} />,
+}
+```
+
+The other input descriptors are identical in shape, differing only in `type`/`label`/`icon`, the
+`fieldTypeFilter`, and the inner control component:
+
+| Widget `type` | `fieldTypeFilter` | inner component |
+|---------------|-------------------|-----------------|
+| `text-input` | `['string','phone','email','url','external_id','auto_number']` | `TextInput` |
+| `number-input` | `['number','currency','percent']` | `NumberInput` |
+| `checkbox` | `['boolean']` | `CheckboxInput` |
+| `dropdown` | `['picklist']` | `DropdownInput` |
+| `datepicker` | `['date','datetime']` | `DatePickerInput` |
+| `lookup` | `['master_detail','lookup','reference']` | `LookupInput` (→ `LookupSelect`) |
+| `multi-picklist` | `['multi_picklist']` | `MultiPicklistInput` (→ `MultiPicklistSelect`) |
+| `rich-text` | `['rich_text']` | `RichTextInput` (→ `RichTextEditor`) |
+
+`form` descriptor (replaces the 2a placeholder/`FormNode` body):
+
+```tsx
+// widgets/builtins/form.tsx (2f rewrite of the runtime branch)
+export const formWidget: WidgetDescriptor = {
+  type: 'form',
+  label: 'Form',
+  icon: '▤',
+  category: 'input',
+  acceptsChildren: false,
+  defaultProps: { dataView: { collection: '' }, mode: 'create', readOnly: false },
+  propSchema: [
+    { key: 'dataView.collection', label: 'Collection', kind: 'collection-picker', group: 'Data' },
+    { key: 'mode', label: 'Mode', kind: 'select',
+      options: [{ value: 'create', label: 'Create' }, { value: 'edit', label: 'Edit' }], group: 'Data' },
+    { key: 'recordId', label: 'Record id', kind: 'expression', bindable: true, group: 'Data' },
+    { key: 'readOnly', label: 'Read-only', kind: 'boolean', group: 'Data' },
+  ],
+  Render: ({ node, mode }) =>
+    mode === 'editor'
+      ? <FormPlaceholder collection={readDataView(node.props).collection} />
+      : <ResourceFormWidget node={node} />,
+}
+```
+
+### 3.4 `ResourceForm` props used (verified — `ResourceForm.tsx` ~210 / `types.ts`)
+
+```ts
+interface ResourceFormProps {
+  resourceName: string                       // ← props.dataView.collection
+  recordId?: string                          // ← resolved props.recordId (edit mode); absent ⇒ create
+  onSave: (data: unknown) => void            // ← fire events.onSubmit (2e) / showToast; invalidate
+  onCancel: () => void                       // ← no-op / clear in builder runtime
+  initialValues?: Record<string, unknown>    // ← from resolved defaults / data source (2d)
+  readOnly?: boolean                         // ← props.readOnly
+  className?: string                         // ← 'kelta-page-form'
+}
+```
+
+`ResourceForm` internally: fetches schema via `client.discover()`, builds the Zod schema with `buildZodSchema`
+(verified `ResourceForm.tsx` ~41–146 — `boolean`→`z.boolean`, `number/currency/percent`→preprocessed
+`z.number`, `date/datetime`→date-parse refine, `email`/`url`/`json` refines, `reference/lookup/master_detail`
+→`z.string`), filters fields by `schema.authz.fieldLevel` (`hasFieldAccess`), and on submit runs
+`transformFormData` (number/boolean/json coercion) then `client.resource(name).create/update`. **We pass props
+only — no fork.** The richer controls (picklist/lookup/multi/rich-text) come from the field-renderer registry
+wired in §3.1/§5.6.
+
+> **`ResourceForm` needs a `KeltaProvider` (`useKeltaClient`).** `@kelta/components` is already mounted under
+> a `KeltaProvider` in kelta-ui (verified: `main.tsx`, `ObjectFormPage`, `ObjectDetailPage`,
+> `CollectionsPage`, … all consume it). The page-builder runtime (`CustomPage`) and editor render inside the
+> app shell that already provides it, so `ResourceFormWidget` mounts `<ResourceForm/>` directly. If a render
+> surface is found to be outside the provider, wrap that subtree in `KeltaProvider` (see Risks §8).
+
+### 3.5 Default-value resolution (depends on 2d) — resolved-node invariant
+
+**2f descriptors honor the 2a [resolved-node invariant](../page-builder-parity.md#widget-registry) and do NOT
+call `resolveBindings` themselves.** Per that invariant, `WidgetRenderProps.node.props` handed to a
+descriptor's `Render` is **always fully binding-resolved** by `renderNode` (`widgets/renderTree.tsx`) before
+`Render` runs — in 2a via the identity no-op, in 2d via the real `resolveBindings(node.props, scope)`. So
+every `{ $bind }` value a 2f widget cares about — a standalone input's `defaultValue`, and the `form`'s
+`recordId` and any bound props (`mode`/`readOnly`) — **arrives already resolved to a plain literal** at
+`Render`. A 2f descriptor only:
+
+- declares those props `bindable` in its `propSchema` (so 2b's inspector offers the `fx` toggle), and
+- **reads the resolved literal** (`props.defaultValue`, `props.recordId`) — never the `{ $bind }` marker.
+
+2f adds **no** call to `resolveBindings`/`interpolate`/`bindingScope`; that is the resolver's job in
+`renderNode`, not the widget's (the *only* descriptor the parent permits to re-resolve is `list`/`repeater`
+under a per-row `item` scope — not a 2f widget). If 2d has not yet shipped on a branch, `resolveBindings` is
+the 2a no-op pass-through and a `{ $bind }` props value is treated as a literal — the input shows no default
+(and `form` no `recordId`) rather than crashing. The standalone control's local-state **seed** is therefore
+read directly from the already-resolved `props.defaultValue`.
+
+### 3.6 i18n — all new user-facing strings via `useI18n`
+
+Per the parent slice plan (2b: "All new strings via `useI18n`"), **every** user-facing string 2f introduces is
+added through the existing `useI18n` hook with a key — **no hardcoded English literals** in the new widgets,
+controls, or descriptors. This covers:
+
+- **Empty / unconfigured states** — the standalone-input "no field configured" box and the `FormPlaceholder`
+  text (`pageBuilder.input.noFieldConfigured`, `pageBuilder.form.placeholder`).
+- **Control affordances** — the `dropdown`/`form`-select "Select…" empty option
+  (`pageBuilder.input.selectPlaceholder`); reuse the existing key if `ObjectFormPage` already has one rather
+  than minting a duplicate.
+- **Error / validation state** — the advisory required label surfaced on a standalone input
+  (`pageBuilder.input.required`). The `form` widget's validation messages come from `ResourceForm`'s own
+  (already-localized) Zod copy — **not** re-implemented here.
+- **Feedback** — the default submit toast (`pageBuilder.form.saved`) fired by `onSave` (placeholder until 2e
+  wires `events.onSubmit`).
+- **Descriptor `label`s / palette** — widget labels (`Dropdown`, `Date picker`, …) and `propSchema` field
+  `label`s shown by the 2b inspector are resolved through `useI18n` at the inspector/palette render site (the
+  2b mechanism), so the descriptor `label`/propSchema `label` strings are i18n **keys/source** consumed by 2b,
+  not raw display literals baked into the runtime.
+
+New keys land in the existing kelta-ui locale catalog alongside the page-builder keys 2a/2b added. A test
+asserts the empty/required/placeholder strings render via `useI18n` (no raw literal in the DOM-under-mock).
+
+### 3.7 `config` JSON schema delta
+
+**None.** All new props (`collection`, `field`, `defaultValue`, `mode`, `recordId`, `readOnly`, `required`,
+`placeholder`) nest inside each component's existing `props` object in `config.components`. `events`/`span`
+are the 2a optional fields, untouched. No `PageConfig` top-level change.
+
+---
+
+## 4. DB migrations
+
+**None.** Field metadata (type, `required`, `enumValues`/picklists, `referenceTarget`,
+`referenceCollectionId`, `fieldTypeConfig`) is **already served by existing endpoints** —
+`GET /api/collections/{name}?include=fields` and `GET /api/picklist-values?filter[…]` — and consumed today by
+`ObjectFormPage`/`ResourceFormPage`. This slice is **front-end only**: the widget props nest in the existing
+`ui-pages.config` JSON column (no DDL, no Flyway version consumed; head remains **V146**). No NATS subject or
+payload change. Confirmed explicitly: there is nothing new to migrate.
+
+---
+
+## 5. File-by-file code changes
+
+All paths under `kelta-ui/app/src/pages/PageBuilderPage/` unless noted.
+
+### 5.1 New — standalone input widgets
+
+| File | Contents |
+|------|----------|
+| `widgets/builtins/inputs/types.ts` | `InputWidgetProps` (§3.3). |
+| `widgets/builtins/inputs/useFieldDef.ts` | Hook: `useFieldDef(collection, field) → { fieldDef?, isLoading }` — wraps `useCollectionSchema(collection)` and finds the field by `name`. Single place that maps a `{collection,field}` pair → its `FieldDefinition` (type + config). |
+| `widgets/builtins/inputs/usePicklistOptions.ts` | Hook extracting the `ObjectFormPage` picklist-source resolution (FIELD vs GLOBAL via `fieldTypeConfig.globalPicklistId`) + the `/api/picklist-values?filter[…]` fetch → sorted active `value[]`. Used by `DropdownInput`, `MultiPicklistInput`, and the `form` field-renderer registry. |
+| `widgets/builtins/inputs/useLookupOptions.ts` | Thin wrapper over the existing `useLookupDisplayMap` (`@/hooks/useLookupDisplayMap`) → `LookupOption[]` for one reference field. |
+| `widgets/builtins/inputs/TextInput.tsx` | `Input` (`@/components/ui/input`); `type` chosen from `fieldDef.type` (`email`/`url`/`tel`/`text`); `auto_number` → disabled. Local state seeded from resolved `defaultValue`; mirrors to binding target. `data-testid="page-input-text"`. |
+| `widgets/builtins/inputs/NumberInput.tsx` | `Input type="number"`; `currency` → `step="0.01"`. `data-testid="page-input-number"`. |
+| `widgets/builtins/inputs/CheckboxInput.tsx` | `Checkbox` (`@/components/ui/checkbox`) + label. `data-testid="page-input-checkbox"`. |
+| `widgets/builtins/inputs/DropdownInput.tsx` | Native `<select>` populated from `usePicklistOptions`; "Select…" empty option; matches `ObjectFormPage` ~232–253 markup. `data-testid="page-input-dropdown"`. |
+| `widgets/builtins/inputs/DatePickerInput.tsx` | `Input type="date"` (or `datetime-local` when `fieldDef.type==='datetime'`). `data-testid="page-input-date"`. |
+| `widgets/builtins/inputs/LookupInput.tsx` | `LookupSelect` (`@/components/LookupSelect`) fed by `useLookupOptions`. `data-testid="page-input-lookup"`. |
+| `widgets/builtins/inputs/MultiPicklistInput.tsx` | `MultiPicklistSelect` (`@/components/MultiPicklistSelect`) fed by `usePicklistOptions`; value normalized via the exported `normalizeMultiPicklistValue`. `data-testid="page-input-multipicklist"`. |
+| `widgets/builtins/inputs/RichTextInput.tsx` | `RichTextEditor` (`@/components/RichTextEditor`); `value`/`onChange(html)`. `data-testid="page-input-richtext"`. |
+| `widgets/builtins/inputs/{textInput,numberInput,checkbox,dropdown,datepicker,lookup,multiPicklist,richText}.tsx` | One `WidgetDescriptor` per widget (§3.3 shape), each importing its `*Input` control. |
+| `widgets/builtins/inputs/index.ts` | `registerInputBuiltins()` — `widgetRegistry.register(...)` for all 8 input descriptors. |
+
+Each `*Input` control:
+- calls `useFieldDef(props.collection, props.field)`; while loading shows a disabled skeleton control;
+- on missing collection/field shows a dashed "no field configured" box (matching the `FormNode`/`DataTableNode`
+  empty-state idiom), its label via `useI18n` (`pageBuilder.input.noFieldConfigured`) — no hardcoded literal
+  (§3.6);
+- seeds local state from the **already-resolved** `props.defaultValue` (literal post-2d);
+- in `mode:'editor'` renders **disabled** (preview-only); in `mode:'runtime'` is interactive and mirrors its
+  value into the page binding target (`vars.<id>` convention from 2d) so 2e events / a sibling `form` can read
+  it.
+
+### 5.2 Rewrite — `widgets/builtins/form.tsx` (the primary reuse)
+
+Replace the 2a runtime branch (`<FormNode/>`) with `<ResourceFormWidget/>`:
+
+```tsx
+// widgets/builtins/form.tsx
+import { ResourceForm } from '@kelta/components'
+import { readDataView } from './dataTableNode' // shared reader moved in 2a
+import { useApi } from '@/context/ApiContext'
+import { toast } from 'sonner'
+import type { WidgetRenderProps } from '../types'
+
+function ResourceFormWidget({ node }: { node: WidgetRenderProps['node'] }) {
+  const collection = readDataView(node.props).collection
+  const recordId = typeof node.props.recordId === 'string' ? node.props.recordId : undefined // resolved by 2d
+  const readOnly = node.props.readOnly === true
+  const queryClient = useQueryClient()
+  if (!collection) return <FormPlaceholder collection={undefined} />
+  return (
+    <ResourceForm
+      className="kelta-page-form"
+      resourceName={collection}
+      recordId={recordId}
+      readOnly={readOnly}
+      onSave={() => {
+        void queryClient.invalidateQueries({ queryKey: ['page-table', collection] })
+        // events.onSubmit runtime is wired in 2e; 2f fires a default success toast.
+        toast.success(t('pageBuilder.form.saved')) // i18n via useI18n (§3.6) — no raw literal
+      }}
+      onCancel={() => { /* builder runtime: no-op */ }}
+      data-testid="page-node-form"
+    />
+  )
+}
+```
+
+- `FormNode` (the verbatim-moved text-only form from 2a, in `widgets/builtins/formNode.tsx`) is **deleted**,
+  along with its file. Its `data-testid`s (`page-node-form`, `form-submit`, `form-success`, `form-error`) are
+  superseded by `ResourceForm`'s markup (`kelta-resource-form__*` + the `[data-field]`/submit button); the
+  parity tests are updated to the `ResourceForm` selectors (§6).
+- `readDataView` stays (shared with `table`); `FormPlaceholder` (editor-mode static box) is added in
+  `form.tsx`.
+
+### 5.3 Removal of old text-only `FormNode` logic
+
+- Delete `widgets/builtins/formNode.tsx` (created in 2a as the verbatim move).
+- Remove its export from `widgets/builtins/index.ts` and its import in `form.tsx`.
+- Grep-verify no other importer references `FormNode` (it only existed inside `PageTreeRenderer` pre-2a, moved
+  to a builtin in 2a, removed here). The runtime now has **zero** bespoke form markup — all forms go through
+  `ResourceForm`.
+
+### 5.4 Shared hooks (extraction, not duplication)
+
+`usePicklistOptions` and `useLookupOptions` (§5.1) extract logic that **already exists** inline in
+`ObjectFormPage.tsx` and `ResourceFormPage.tsx`. Per the component-reuse rule (do not fork), 2f:
+- creates the hooks under `widgets/builtins/inputs/`;
+- has the new input widgets + the `form` field-renderer registry consume them;
+- leaves `ObjectFormPage`/`ResourceFormPage` untouched in this slice (a follow-up may migrate them to the
+  shared hooks — flagged, not done here, to keep the slice scoped).
+
+### 5.5 `widgets/builtins/index.ts` — registration
+
+```ts
+// AFTER (2f): register the new input widgets alongside the 2a builtins
+import { registerInputBuiltins } from './inputs'
+export function registerBuiltins(): void {
+  if (done) return
+  done = true
+  // …2a built-ins (heading/text/button/image/card/container/table/form)…
+  registerInputBuiltins() // text-input, number-input, checkbox, dropdown, datepicker, lookup, multi-picklist, rich-text
+}
+```
+
+`registerBuiltins` stays idempotent (the 2a `done` guard). Because both render surfaces already call
+`registerBuiltins()` (2a §5.6), the input widgets light up in the builder palette, editor preview, and runtime
+with no extra wiring.
+
+### 5.6 `ResourceForm` field-renderer registry bootstrap
+
+Add `widgets/builtins/registerFormFieldRenderers.ts`:
+
+```ts
+import { setComponentRegistry } from '@kelta/components'
+import { DropdownInput, MultiPicklistInput, LookupInput, RichTextInput } from './inputs'
+// Wrap each input control to the @kelta/components FieldRendererProps signature
+// ({ value, field, onChange, readOnly }) and expose them by FieldType.
+setComponentRegistry({
+  hasFieldRenderer: (t) => ['picklist','multi_picklist','reference','lookup','master_detail','rich_text'].includes(t),
+  getFieldRenderer: (t) => FIELD_RENDERERS[t],
+})
+```
+
+Called once at page-builder bootstrap (same module-scope spot as `registerBuiltins()` in `PageBuilderPage.tsx`
+and `PageTreeRenderer.tsx`, guarded for idempotency). This upgrades the **`form` widget's** picklist / lookup /
+multi-picklist / rich-text inputs to the rich controls — reusing the existing pluggable registry rather than
+modifying `ResourceForm`.
+
+> **Coexistence check:** if the app has *already* called `setComponentRegistry` elsewhere for plugin field
+> renderers, do not clobber it — the bootstrap merges (delegates unknown types to the prior registry). Verified
+> the kelta-ui app does not currently call `@kelta/components`' `setComponentRegistry` (it wires its own
+> `componentRegistry` for page/plugin components, a different object), so 2f is the first caller; the merge
+> guard is defensive.
+
+### 5.7 No-touch files
+
+`registry.ts`, `renderTree.tsx`, `types.ts` (except the additive `fieldTypeFilter`), `model/*`,
+`PageRenderService.java`/`PageRenderContract.java`, `componentRegistry.ts`, and the picklist/field endpoints are
+**unchanged**. `ResourceForm.tsx` is **not forked** — only consumed + extended via its public
+`setComponentRegistry` seam.
+
+---
+
+## 6. Test plan
+
+Vitest + Testing Library + MSW, matching the existing idiom (`PageBuilderPage.test.tsx` MSW `server`,
+`LookupSelect.test.tsx`/`MultiPicklistSelect.test.tsx` interaction tests, `ResourceForm.test.tsx`).
+
+### 6.1 New — `widgets/builtins/inputs/inputWidgets.test.tsx` (per-input)
+
+For each of the 8 input widgets, with `useCollectionSchema` mocked (MSW
+`/api/collections/orders?include=fields`):
+
+- **type → control:** mounting the widget bound to a field of the matching `FieldType` renders the expected
+  control (assert by `data-testid`): `dropdown`→native `<select>`, `datepicker`→`input[type=date]`
+  (and `datetime`→`datetime-local`), `checkbox`→`Checkbox`, `number-input`→`input[type=number]`,
+  `text-input`→`input[type=email|url|tel|text]` per field type, `lookup`→`LookupSelect` trigger
+  (`*-trigger`), `multi-picklist`→`MultiPicklistSelect`, `rich-text`→`RichTextEditor`.
+- **picklist options:** mock `/api/picklist-values?filter[picklistSourceId][eq]=…&filter[picklistSourceType][eq]=FIELD`
+  → `dropdown` renders one `<option>` per active value in `sortOrder` order; a field whose
+  `fieldTypeConfig.globalPicklistId` is set fetches with `…[picklistSourceType][eq]=GLOBAL` and `sourceId` =
+  the global id (assert the request URL). `multi-picklist` lists the same options as checkboxes.
+- **validation (advisory):** a `required` `dropdown`/`text-input` left empty shows the advisory required state
+  but the test asserts the value still POSTs (server is the source of truth) — i.e. client validation does
+  **not** block submission silently.
+- **default value:** `props.defaultValue` (literal, post-2d) seeds the control's initial value.
+- **editor vs runtime:** `mode:'editor'` renders the control **disabled** and performs **no** picklist/lookup
+  fetch; `mode:'runtime'` is interactive and fetches.
+- **i18n (§3.6):** the empty "no field configured" state, the advisory required label, and the "Select…"
+  placeholder render via `useI18n` keys (no raw English literal in the mocked DOM).
+
+### 6.2 New — `widgets/builtins/form.test.tsx` (form submit)
+
+- Renders `form` bound to `orders` in `mode:'runtime'` → mounts `ResourceForm`; with the schema mocked, assert
+  typed controls appear (a `<select>` for the `status` picklist via the registry renderer, a `date` input for
+  `dueDate`, a `LookupSelect` for `customer`).
+- **submit (mock apiClient/SDK client):** fill required fields, submit → assert the `@kelta/sdk` client
+  `resource('orders').create(...)` (or `apiClient.postResource`) is called with **coerced** values
+  (`total` as number, not string), then `onSave` fires the success toast.
+- **edit mode:** with `recordId` resolved, `ResourceForm` fetches the record and submits via `update`.
+- **field authz:** a field present in `schema.authz.fieldLevel` the user lacks is **not** rendered.
+- **empty/placeholder:** `mode:'editor'` (or no `collection`) renders `FormPlaceholder`, no fetch.
+
+### 6.2a New — rich-text output sanitization (SECURITY)
+
+In `widgets/builtins/inputs/inputWidgets.test.tsx` (or a focused `richTextSanitize.test.tsx`):
+
+- **sanitizer runs on HTML render:** bind a `rich_text` field whose value contains a hostile payload
+  (`<img src=x onerror="alert(1)">` and `<script>alert(1)</script>`) and render the read-only / bound display
+  path → assert the `onerror`/`<script>` is **stripped** (not present in the DOM) and benign markup
+  (`<b>`/`<a href>`) survives — i.e. the **same** sanitizer `FieldRenderer`'s `rich_text` path uses was
+  applied.
+- **no raw `dangerouslySetInnerHTML`:** assert the rendered subtree never injects the unsanitized string
+  verbatim (a `javascript:`-href / inline handler from the bound HTML does not reach the DOM).
+
+### 6.3 New — `widgets/builtins/inputs/usePicklistOptions.test.ts`
+
+Pure-ish hook test (renderHook + MSW): FIELD vs GLOBAL source resolution from `fieldTypeConfig` (object **and**
+JSON-string forms), `isActive` filtering, `sortOrder` ordering, empty-on-error fallback (matches
+`ObjectFormPage` behaviour).
+
+### 6.4 Extend — `widgets/registry.test.ts` / `renderTree.test.tsx`
+
+- `widgetRegistry.listByCategory('input')` returns all 8 new widgets (+ `form`).
+- `RenderTree` renders an input node end-to-end through the shared path (descriptor lookup → control).
+
+### 6.5 e2e (post-deploy only — project convention)
+
+Playwright, run after deploy (not in this PR): on a published page with a `form` bound to a collection, fill a
+picklist + date + lookup, submit, and assert the record is created (and a denied field is absent). Covered by
+the parent spec's positive page-render e2e; no new e2e file lands in this slice.
+
+---
+
+## 7. Docs to update (same PR)
+
+| Doc | Change |
+|-----|--------|
+| `.claude/docs/status.md` (page-builder row, line ~48) | **Move "typed/validated form fields (text-only inputs today)" OUT of the gap column.** Add to the built list: "slice 2f — **typed form widgets**: the `form` widget renders via `@kelta/components` `ResourceForm` (typed input per `FieldType`, Zod validation, field-level authz, pluggable field-renderer registry wired to `LookupSelect`/`MultiPicklistSelect`/native `<select>`/`RichTextEditor`); standalone Input-category widgets `text-input`/`number-input`/`checkbox`/`dropdown`/`datepicker`/`lookup`/`multi-picklist`/`rich-text` map a `FieldType`→control, sourcing picklist options from `GET /api/picklist-values?filter[…]` (FIELD/GLOBAL) and reference options from the target collection; the text-only `FormNode` is removed; submit stays on the authorized JSON:API path (Cerbos/write-FLS server-side, worker validates required/type/unique)." Leave "per-page Cerbos authz" in the gap column (1h). |
+| `.claude/docs/playbooks.md` | Extend the 2a "Add a page component / widget" recipe with the **typed-input sub-pattern**: a standalone input widget is a `WidgetDescriptor` (category `input`) whose `Render` reads `{collection,field}` via `useCollectionSchema`/`useFieldDef`, maps the `FieldType` to a control, and (for picklist/lookup) sources options from `usePicklistOptions`/`useLookupOptions`. For the `form` widget, prefer extending `ResourceForm` via `setComponentRegistry` over forking it. |
+| `.claude/docs/conventions.md` | If/where it documents page widgets: add the rule that typed inputs **reuse** `LookupSelect`/`MultiPicklistSelect`/`RichTextEditor`/`ResourceForm` (never re-implement), the picklist source-resolution convention (`fieldTypeConfig.globalPicklistId` → GLOBAL else FIELD), that **client validation is advisory** — the worker validates required/type/unique on write, that **HTML-bearing output (`rich_text`) is sanitized via the same sanitizer `FieldRenderer` uses** (never `dangerouslySetInnerHTML` on unsanitized bound HTML — §3.1/§8), and that **all new user-facing widget strings go through `useI18n`** (§3.6). |
+| `.claude/docs/integrations.md` | Confirm/cross-link the picklist + collection-schema fetch contracts as the canonical source for form field metadata (no new integration; reference existing endpoints). |
+
+Per CLAUDE.md Rule 6 these doc edits ship **in the same PR** as the code.
+
+---
+
+## 8. Risks & open questions
+
+- **`ResourceForm` runs on `@kelta/sdk`'s `client`, not the kelta-ui `apiClient`.** `ResourceForm` fetches its
+  schema via `client.discover()` and submits via `client.resource(name).create/update` (verified
+  `ResourceForm.tsx` ~232/296/323) — a **different** client than the input widgets' `useApi().apiClient`. Both
+  ultimately hit the same authorized JSON:API through the gateway (Cerbos/FLS enforced), so security is
+  preserved, but tests must mock the **SDK client** for the `form` path and `apiClient` for the standalone
+  inputs. **Mitigation:** the `form.test.tsx` mocks `useKeltaClient`/the SDK client; input tests mock
+  `apiClient`. Confirm the `KeltaProvider`'s client and `ApiContext`'s `apiClient` are pointed at the same
+  base/auth (they are in the app shell).
+- **`KeltaProvider` must wrap the render surface.** `ResourceForm` calls `useKeltaClient()`/`useCurrentUser()`;
+  both throw outside a `KeltaProvider`. The app shell already provides it (verified `main.tsx` and sibling
+  pages), and both the editor and `CustomPage` render inside the shell. **Open question:** does the page-builder
+  **editor preview** (`PageBuilderPage` `Preview`, `mode:'editor'`) sit inside the provider? It renders only the
+  `FormPlaceholder` in editor mode (no `ResourceForm` mount), so it does **not** need the provider — but verify
+  before relying on it; if a live editor preview is ever added, wrap that subtree.
+- **`ResourceForm` default controls are weaker than the standalone inputs.** Its built-in
+  `renderDefaultFieldInput` renders `picklist`/`reference`/`multi_picklist` as plain text/`<input>` (verified
+  ~556–626). Without the §5.6 field-renderer registry, the `form` widget would be *less* typed than the
+  standalone `dropdown`/`lookup`. **Mitigation:** the registry wiring is **required**, not optional — it's part
+  of acceptance. A `form.test.tsx` case asserts the picklist field renders a `<select>` (registry-backed), not
+  a text box.
+- **Picklist source-resolution logic is duplicated in `ObjectFormPage`/`ResourceFormPage`.** 2f extracts it
+  into `usePicklistOptions` and uses the hook in the new widgets, but does **not** refactor the two existing
+  pages in this slice (scope control). **Flagged** as a follow-up so the inline copies don't drift from the
+  shared hook.
+- **Computed/uneditable fields.** `formula`/`rollup_summary`/`vector`/`auto_number` must be excluded from a
+  form's editable set and from the `field-picker` for inputs. `ResourceForm` does not special-case these; the
+  `form` widget relies on the worker rejecting writes to computed fields, and the `field-picker` `fieldTypeFilter`
+  keeps them out of standalone-input binding. **Decision:** exclude computed types client-side via
+  `fieldTypeFilter`; `auto_number` is bindable but rendered disabled.
+- **Rich-text / HTML output is XSS-sensitive (SECURITY).** `rich_text` field values are author/data-controlled
+  HTML and a `{ $bind }` can resolve to a hostile string. Any **render** of HTML-bearing output (the
+  `rich-text` widget's read-only/bound display, the `form`'s `rich_text` registry renderer, a bound
+  `field-value`) MUST pass through the **same sanitizer** `FieldRenderer`'s `rich_text` path uses today — never
+  `dangerouslySetInnerHTML` on unsanitized HTML (parent §"Security — binding & action output safety", §3.1
+  note here). **Mitigation:** reuse the existing sanitizer (one allow-list, no fork); §6.2a asserts a
+  `<script>`/`onerror` payload is stripped before render. Plain-text bindings are React-escaped and exempt.
+
+- **`fieldTypeConfig` polymorphism.** It arrives as a parsed object **or** a JSON string (JSONB serialization
+  path); `usePicklistOptions` must handle both (the `ObjectFormPage` code does — copy that handling exactly).
+- **Sequencing.** 2f hard-depends on **2a** (registry/RenderTree/`form` builtin/`readDataView`) and
+  soft-depends on **2d** (`{ $bind }` default-value resolution — degrades to literal if absent). It should land
+  after 2a and ideally after 2d. 2b (inspector) is independent: 2f only **supplies** `propSchema` arrays; the
+  inspector that renders them is 2b's. Events (`onSubmit`/`onChange` runtime) are 2e — 2f fires a default
+  success toast as a placeholder until 2e wires real `events.onSubmit` actions.

--- a/.claude/docs/specs/page-builder/2g-widget-breadth.md
+++ b/.claude/docs/specs/page-builder/2g-widget-breadth.md
@@ -1,0 +1,1196 @@
+# 2g — Widget breadth
+
+> **Slice:** 2g (FE). **Axis:** Widgets.
+> **Parent:** [`../page-builder-parity.md`](../page-builder-parity.md). This child spec **extends, never
+> contradicts** the parent's [Widget registry](../page-builder-parity.md#widget-registry) (the v1 widget
+> set) and [Reuse Map](../page-builder-parity.md#reuse-map). The `WidgetDescriptor` / `PropFieldSchema` /
+> `WidgetRenderProps` / `PageComponent` v2 / `Binding` / `PropValue` types are **defined once in 2a**
+> ([`./2a-widget-registry.md`](./2a-widget-registry.md) §3.2) — this slice consumes them and adds new
+> built-in descriptors only.
+> Source-verified against the codebase on 2026-06-22 (Flyway head V146; **this slice adds no migration**).
+> If code and this doc disagree, trust the code and fix this doc.
+
+---
+
+## 1. Goal & scope
+
+### What this slice delivers
+
+The remaining **breadth** of the v1 widget set from the parent registry — the presentational and
+structural widgets that are not data-binding (2d), event (2e), or typed-form (2f) work. Each is a
+**first-class `WidgetDescriptor`** under `widgets/builtins/` (one file per widget), with `type`,
+`label`, `icon`, `category`, `defaultProps`, `propSchema`, and a **single `Render`** used by both the
+editor preview (`mode:'editor'`) and the runtime (`mode:'runtime'`) through the shared `RenderTree`
+from 2a. No widget here is a plugin shim — they are built-ins registered in `registerBuiltins()`.
+
+Widgets added in this slice:
+
+| Widget | `type` | Category | Wraps / built on | New in 2g |
+|--------|--------|----------|------------------|-----------|
+| Chart | `chart` | `data` | `recharts` (`^3.7.0`, already a dep) — `BarChart`/`LineChart`/`PieChart` | descriptor + Render |
+| Tabs | `tabs` | `navigation` | local `@/components/ui/tabs` (radix `Tabs` wrapper) | descriptor + Render |
+| Nav | `nav` | `navigation` | `@kelta/components` `Navigation` (exported) | descriptor + Render |
+| Icon | `icon` | `content` | `lucide-react` (`^0.563.0`) `icons` map (name → component) | descriptor + Render |
+| Link | `link` | `content` | `react-router-dom` `Link` / `<a>` | descriptor + Render |
+| Image (polish) | `image` | `content` | native `<img>` | **upgrades** the 2a `image` built-in |
+
+`chart` binds to a **page data source array** (the `data.<sourceName>` namespace introduced in
+parent §"Page-level config (v2)" and authored in 2d); `tabs` introduces a **per-tab children-container
+model** so each tab hosts a sub-tree rendered through `renderChild`; `nav` renders a menu (static items,
+or items from a bound array); `icon`/`link`/`image` are leaf presentational widgets with **bindable**
+props where it makes sense (icon name, link label/target, image src/alt).
+
+### What this slice explicitly does NOT do
+
+| Out of scope | Lands in / owned by |
+|--------------|---------------------|
+| The `BindableField` `fx` toggle UI + `resolveBindings`/`interpolate`/scope machinery | 2d (this slice **declares** `bindable: true` on prop schemas; the actual resolution is 2d's `RenderTree` change — see §3.7) |
+| Page `dataSources` authoring + on-load fetch hook (`usePageDataSources`) that fills `data.<name>` | 2d (chart **consumes** a resolved array from scope; it does not fetch) |
+| Events/actions on `link`/`nav`/`button` (click → navigate/runFlow) authoring + runtime | 2e (`link` uses a plain href/router target here; `PageAction` wiring is 2e) |
+| Typed form inputs (`dropdown`/`datepicker`/`lookup`/`multi-picklist`/`number-input`/`checkbox`) and `form` → `ResourceForm` | 2f |
+| Schema-driven `Inspector` looping over `propSchema` (incl. a chart series editor, nav-items editor, icon picker) | 2b (this slice **populates** `propSchema`; 2b renders it. Until 2b ships, the legacy `PropertyPanel` edits these via raw JSON/dataView fields — see §8) |
+| dnd-kit canvas drop-into-container / reorder / `span` for tab children | 2c (`tabs` children use the same `PageComponent[]` tree `treeOps` already mutate) |
+| Any backend / API / Flyway / NATS change | **None** — all widgets are presentational; tree round-trips inside `ui-pages.config` |
+
+### Parent-doc sections this conforms to
+
+- **Widget registry** — adds exactly the breadth members named in the parent's built-in list:
+  Content `icon`, `link`, `image`; Data `chart`; Navigation `nav` (→ `Navigation`), `tabs` (→ radix).
+- **Reuse Map** — `chart` uses the already-present `recharts`; `nav` uses `@kelta/components`
+  `Navigation`; `tabs` uses the in-repo radix `Tabs` wrapper (`@/components/ui/tabs`).
+- **The shared model** — `tabs` children are `PageComponent[]`; chart binds to `data.<source>` via the
+  `Binding` (`$bind`) convention. No new model types.
+
+### Acceptance criteria
+
+- `widgetRegistry.list()` includes `chart`, `tabs`, `nav`, `icon`, `link`, and the upgraded `image`,
+  each in its declared category; palette (2b) and `RenderTree` resolve them with **no switch**.
+- A `chart` node with `props.dataView` bound to a resolved `data.<name>` array renders a recharts
+  bar/line/pie per `props.chartType`, mapping `props.xKey` / `props.series[]` to axes/series.
+- A `tabs` node renders a radix tab list from `props.tabs[]` and, per active tab, renders that tab's
+  `children` sub-tree through `renderChild` — switching tabs swaps the rendered sub-tree.
+- A `nav` node renders `Navigation` from `props.items[]` (static) or a bound array.
+- An `icon` node renders the named lucide icon (`props.name`), size/color from props; unknown name →
+  graceful fallback (no crash).
+- A `link` node renders an in-app `react-router-dom` `Link` for an internal `to`, or an `<a>` for an
+  external `href`, with a bindable label.
+- `image` honors bindable `src`/`alt` and an `objectFit` prop (`cover`/`contain`/`fill`/`none`).
+- A `link.href` / `image.src` resolving to a non-allow-listed scheme (`javascript:`, `data:`) is
+  **neutralized** before render via the shared `safeUrl` allow-list (`{http,https,mailto,tel,relative}`,
+  same as 2e); proven by a blocked-`javascript:` test (§3.9, §6.5–6.7).
+- All new user-facing strings + empty states ("No data", "No menu items", "No tabs configured.",
+  "No image source") go through `useI18n`/`t()` with `builder.widget.*` keys — no hardcoded English (§3.10).
+- Editor preview and runtime render each widget through the **same descriptor `Render`** (one path),
+  reading **already-resolved** props (the 2a resolved-node invariant — 2g never calls `resolveBindings`);
+  proven by Vitest rendering the same JSON in both modes.
+- `/verify` green (lint + typecheck + `test:coverage` ≥ existing kelta-ui gate).
+
+---
+
+## 2. UI samples
+
+### 2.1 Palette (after 2b registry-driven palette; categories from `listByCategory`)
+
+```
+┌─ Widgets ─────────────────────────────────────────────┐
+│  CONTENT                                               │
+│   [H] Heading   [¶] Text   [▭] Button                  │
+│   [★] Icon      [↗] Link   [▦] Image                   │   ← Icon / Link new; Image polished
+│  DATA                                                  │
+│   [⊞] Table     [∿] Chart  [≣] List   [{}] Field       │   ← Chart new
+│  NAVIGATION                                            │
+│   [☰] Nav       [⊓] Tabs                               │   ← Nav / Tabs new
+│  LAYOUT                                                │
+│   [▤] Grid  [▭] Row  [▯] Column  [▢] Container  …      │
+└───────────────────────────────────────────────────────┘
+```
+
+Icons are kept as the single-char glyphs the 2a palette already uses (the palette renders
+`descriptor.icon` as text). The lucide *icon library by name* is used only **inside** the `icon`
+widget's `Render`, not for the palette glyph.
+
+### 2.2 Chart bound to a data source — inspector + runtime
+
+Inspector (schema-driven, rendered by 2b from `chart`'s `propSchema`):
+
+```
+┌─ Inspector · Chart ───────────────────────────────────┐
+│ DATA                                                   │
+│  Data source        [ data.orders ▾ ]   (fx)           │  ← bindable: { $bind:'data.orders' }
+│  Chart type         ( ) Bar  (•) Line  ( ) Pie         │
+│  X axis key         [ month        ]                    │
+│  Series                                                 │
+│   ┌───────────────────────────────────────────────┐    │
+│   │ key: total    label: Revenue   color: ████  ✕  │    │   ← series[] editor (2b)
+│   │ key: count    label: Orders    color: ████  ✕  │    │
+│   │ [ + Add series ]                               │    │
+│   └───────────────────────────────────────────────┘    │
+│ APPEARANCE                                             │
+│  Height (px)        [ 300 ]                             │
+│  Show legend        [✓]   Show grid [✓]                 │
+└────────────────────────────────────────────────────────┘
+```
+
+Runtime output (a `line` chart over the resolved `data.orders` array):
+
+```
+ Revenue / Orders                                  ── Revenue  ── Orders
+ 1200 ┤                               ╭───────●
+  900 ┤                     ╭────────╯
+  600 ┤        ╭───────────╯
+  300 ┤●──────╯
+    0 ┼──────┬──────┬──────┬──────┬──────┬──────
+       Jan    Feb    Mar    Apr    May    Jun
+```
+
+The array comes from scope (`data.orders`), resolved by 2d's `usePageDataSources` → `resolveBindings`.
+In **editor** mode with no live data, the chart renders a small sample/placeholder series so the
+designer sees a shape (see §3.1 `EDITOR_SAMPLE`). No fetch happens inside the widget.
+
+### 2.3 Tabs with child containers — canvas + tree
+
+Canvas (editor): selecting the active tab shows that tab's drop-zone sub-tree.
+
+```
+┌─ Tabs ────────────────────────────────────────────────┐
+│ [ Overview ]  Details    Activity         (+ add tab)  │   ← radix tab list (props.tabs[])
+├────────────────────────────────────────────────────────┤
+│  ┌── drop zone: tab "Overview".children ───────────┐   │
+│  │  [Heading]  Orders                              │   │   ← renderChild over children sub-tree
+│  │  [Table]    orders                              │   │
+│  └─────────────────────────────────────────────────┘   │
+└────────────────────────────────────────────────────────┘
+```
+
+### 2.4 Nav — runtime
+
+```
+┌──────────────────────────────────────────────┐
+│ Home    Orders    Customers ▾    Settings     │   ← Navigation, orientation:'horizontal'
+│                    ├ All customers             │
+│                    └ Segments                  │
+└──────────────────────────────────────────────┘
+```
+
+### 2.5 Sample component-tree JSON (what `config.components` holds)
+
+**Chart** (bound to a data source named `orders`):
+
+```json
+{
+  "id": "ch1",
+  "type": "chart",
+  "props": {
+    "dataView": { "$bind": "data.orders", "mode": "path" },
+    "chartType": "line",
+    "xKey": "month",
+    "series": [
+      { "key": "total", "label": "Revenue", "color": "#3B82F6" },
+      { "key": "count", "label": "Orders", "color": "#06B6D4" }
+    ],
+    "height": 300,
+    "showLegend": true,
+    "showGrid": true
+  }
+}
+```
+
+**Tabs** (per-tab `children` sub-trees):
+
+```json
+{
+  "id": "tb1",
+  "type": "tabs",
+  "props": {
+    "tabs": [
+      { "value": "overview", "label": "Overview" },
+      { "value": "details", "label": "Details" }
+    ],
+    "defaultTab": "overview"
+  },
+  "children": [
+    {
+      "id": "tab-overview",
+      "type": "tab-panel",
+      "props": { "value": "overview" },
+      "children": [
+        { "id": "h1", "type": "heading", "props": { "text": "Orders", "level": "h2" } },
+        { "id": "t1", "type": "table", "props": { "dataView": { "collection": "orders", "fields": ["id", "status", "total"], "limit": 25 } } }
+      ]
+    },
+    {
+      "id": "tab-details",
+      "type": "tab-panel",
+      "props": { "value": "details" },
+      "children": [
+        { "id": "txt1", "type": "text", "props": { "content": "Detail content." } }
+      ]
+    }
+  ]
+}
+```
+
+> **Tabs children model (authoritative).** A `tabs` node owns N **`tab-panel`** child nodes, one per
+> entry in `props.tabs[]`, matched by `value`. Each `tab-panel` is a normal container node (its own
+> `children` are an ordinary sub-tree, drop-target in 2c). `tab-panel` is registered as an internal
+> built-in (`category:'layout'`, **not** shown in the palette — see §3.2) so `widgetRegistry.get` never
+> falls through to the unknown descriptor for it. This keeps the whole structure inside the standard
+> `PageComponent[]` tree that `treeOps` already mutate; no special "tabs only" tree shape.
+
+**Nav** (static items):
+
+```json
+{
+  "id": "nv1",
+  "type": "nav",
+  "props": {
+    "orientation": "horizontal",
+    "items": [
+      { "id": "home", "label": "Home", "path": "/app/p/home" },
+      { "id": "orders", "label": "Orders", "path": "/app/p/orders" }
+    ]
+  }
+}
+```
+
+**Icon / Link / Image:**
+
+```json
+[
+  { "id": "ic1", "type": "icon", "props": { "name": "shopping-cart", "size": 20, "color": "#3B82F6" } },
+  { "id": "lk1", "type": "link", "props": { "label": "View orders", "to": "/app/p/orders" } },
+  { "id": "lk2", "type": "link", "props": { "label": "Docs", "href": "https://kelta.io/docs", "newTab": true } },
+  { "id": "im1", "type": "image", "props": { "src": { "$bind": "record.logoUrl", "mode": "path" }, "alt": "Logo", "objectFit": "contain" } }
+]
+```
+
+### 2.6 Before / after
+
+```
+BEFORE 2g (after 2f): registry has heading/text/button/image/card/container/grid/row/column/divider/
+                      table/list/repeater/field-value/form + typed inputs + nav?/tabs? absent or
+                      stubbed; no chart; image is the bare 2a built-in (src/alt only).
+
+AFTER 2g: + chart (recharts, bound array) + tabs (radix, per-tab children) + nav (@kelta/components
+          Navigation) + icon (lucide by name) + link (router/href, bindable) + image polish
+          (bindable src/alt + object-fit). All first-class descriptors; one Render per widget;
+          editor and runtime share it.
+```
+
+---
+
+## 3. Data & API contracts
+
+All TS lives under `kelta-ui/app/src/pages/PageBuilderPage/`. **No backend / API / `config`-schema
+change in 2g** beyond using `props` shapes already permitted by the v2 `PageComponent` (`props:
+Record<string, PropValue>`, `children?: PageComponent[]`). The new prop shapes below are plain
+`PropValue` data inside `props` and round-trip untouched (the server never parses them).
+
+### 3.1 `chart` descriptor (concrete TS)
+
+```tsx
+// widgets/builtins/chart.tsx
+import {
+  ResponsiveContainer,
+  BarChart,
+  Bar,
+  LineChart,
+  Line,
+  PieChart,
+  Pie,
+  Cell,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+} from 'recharts'
+import type { WidgetDescriptor } from '../types'
+
+/** One plotted series, mapped to a numeric key in each row of the bound array. */
+interface ChartSeries {
+  key: string
+  label?: string
+  color?: string
+}
+
+const DEFAULT_COLORS = ['#3B82F6', '#06B6D4', '#8B5CF6', '#10B981', '#F59E0B', '#EF4444']
+
+/** Editor placeholder so the designer sees a shape with no live data source. */
+const EDITOR_SAMPLE = [
+  { __x: 'A', total: 12, count: 4 },
+  { __x: 'B', total: 19, count: 7 },
+  { __x: 'C', total: 9, count: 3 },
+  { __x: 'D', total: 22, count: 9 },
+]
+
+function asArray(v: unknown): Array<Record<string, unknown>> {
+  return Array.isArray(v) ? (v as Array<Record<string, unknown>>) : []
+}
+
+export const chartWidget: WidgetDescriptor = {
+  type: 'chart',
+  label: 'Chart',
+  icon: '∿',
+  category: 'data',
+  acceptsChildren: false,
+  defaultProps: {
+    chartType: 'bar',
+    xKey: '',
+    series: [],
+    height: 300,
+    showLegend: true,
+    showGrid: true,
+  },
+  propSchema: [
+    // `dataView` is bindable to a page data source array, e.g. { $bind:'data.orders', mode:'path' }.
+    { key: 'dataView', label: 'Data source', kind: 'expression', bindable: true, group: 'Data' },
+    {
+      key: 'chartType',
+      label: 'Chart type',
+      kind: 'select',
+      options: [
+        { value: 'bar', label: 'Bar' },
+        { value: 'line', label: 'Line' },
+        { value: 'pie', label: 'Pie' },
+      ],
+      group: 'Data',
+    },
+    { key: 'xKey', label: 'X axis key', kind: 'text', group: 'Data' },
+    // `series` is edited by a dedicated array editor the 2b inspector renders for kind:'series'.
+    { key: 'series', label: 'Series', kind: 'expression', group: 'Data' },
+    { key: 'height', label: 'Height (px)', kind: 'number', group: 'Appearance' },
+    { key: 'showLegend', label: 'Show legend', kind: 'boolean', group: 'Appearance' },
+    { key: 'showGrid', label: 'Show grid', kind: 'boolean', group: 'Appearance' },
+  ],
+  Render: ({ node, mode }) => {
+    const props = node.props as Record<string, unknown>
+    const chartType = (props.chartType as string) || 'bar'
+    const xKey = (props.xKey as string) || (mode === 'editor' ? '__x' : '')
+    const series = Array.isArray(props.series) ? (props.series as unknown as ChartSeries[]) : []
+    const height = typeof props.height === 'number' ? props.height : 300
+    const showLegend = props.showLegend !== false
+    const showGrid = props.showGrid !== false
+
+    // In 2d, `dataView` ({$bind:'data.orders'}) is resolved to an array before Render is called.
+    // 2g consumes the resolved value. With none (or in editor), fall back to EDITOR_SAMPLE.
+    const resolved = asArray(props.dataView)
+    const data = resolved.length > 0 ? resolved : mode === 'editor' ? EDITOR_SAMPLE : []
+    const effectiveSeries: ChartSeries[] =
+      series.length > 0
+        ? series
+        : mode === 'editor'
+          ? [
+              { key: 'total', label: 'Total', color: DEFAULT_COLORS[0] },
+              { key: 'count', label: 'Count', color: DEFAULT_COLORS[1] },
+            ]
+          : []
+
+    if (data.length === 0) {
+      return (
+        <div
+          className="flex h-[var(--chart-h)] w-full items-center justify-center rounded-lg border border-dashed border-border text-sm text-muted-foreground"
+          style={{ ['--chart-h' as string]: `${height}px` }}
+          data-testid="page-node-chart-empty"
+        >
+          No data
+        </div>
+      )
+    }
+
+    return (
+      <div className="w-full" data-testid="page-node-chart" data-chart-type={chartType}>
+        <ResponsiveContainer width="100%" height={height}>
+          {chartType === 'pie' ? (
+            <PieChart>
+              {showLegend && <Legend />}
+              <Tooltip />
+              <Pie
+                data={data}
+                dataKey={effectiveSeries[0]?.key ?? 'value'}
+                nameKey={xKey}
+                cx="50%"
+                cy="50%"
+                outerRadius="80%"
+              >
+                {data.map((_, i) => (
+                  <Cell key={i} fill={DEFAULT_COLORS[i % DEFAULT_COLORS.length]} />
+                ))}
+              </Pie>
+            </PieChart>
+          ) : chartType === 'line' ? (
+            <LineChart data={data}>
+              {showGrid && <CartesianGrid strokeDasharray="3 3" className="stroke-border" />}
+              <XAxis dataKey={xKey} className="text-xs" />
+              <YAxis className="text-xs" />
+              <Tooltip />
+              {showLegend && <Legend />}
+              {effectiveSeries.map((s, i) => (
+                <Line
+                  key={s.key}
+                  type="monotone"
+                  dataKey={s.key}
+                  name={s.label ?? s.key}
+                  stroke={s.color ?? DEFAULT_COLORS[i % DEFAULT_COLORS.length]}
+                  dot={false}
+                />
+              ))}
+            </LineChart>
+          ) : (
+            <BarChart data={data}>
+              {showGrid && <CartesianGrid strokeDasharray="3 3" className="stroke-border" />}
+              <XAxis dataKey={xKey} className="text-xs" />
+              <YAxis className="text-xs" />
+              <Tooltip />
+              {showLegend && <Legend />}
+              {effectiveSeries.map((s, i) => (
+                <Bar
+                  key={s.key}
+                  dataKey={s.key}
+                  name={s.label ?? s.key}
+                  fill={s.color ?? DEFAULT_COLORS[i % DEFAULT_COLORS.length]}
+                />
+              ))}
+            </BarChart>
+          )}
+        </ResponsiveContainer>
+      </div>
+    )
+  },
+}
+```
+
+> **Chart data-binding contract.** The chart is **pure**: it never fetches. Its `dataView` prop is a
+> binding (`{ $bind:'data.<sourceName>', mode:'path' }`) that 2d's `resolveBindings(props, scope)`
+> replaces — **before `Render` runs** — with the array result of the page data source (filled by
+> `usePageDataSources` in `CustomPage` / preview). Each array element is one row (a flat record); `xKey`
+> names the category/x field, and each `series[].key` names a numeric field on the row. This matches the
+> recharts contract used in `MonitoringOverviewPage.tsx` (`<LineChart data={data}><XAxis dataKey=… />
+> <Line dataKey=… />`). Until 2d resolves bindings, `props.dataView` is the literal `Binding` object →
+> `asArray` returns `[]` → editor shows the sample, runtime shows "No data". This degrades safely and
+> needs no change when 2d lands.
+
+### 3.2 `tabs` + `tab-panel` descriptors (concrete TS)
+
+```tsx
+// widgets/builtins/tabs.tsx
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
+import type { WidgetDescriptor } from '../types'
+import type { PageComponent } from '../../model/pageModel'
+
+interface TabDef {
+  value: string
+  label: string
+}
+
+function readTabs(props: Record<string, unknown>): TabDef[] {
+  return Array.isArray(props.tabs)
+    ? (props.tabs as unknown as TabDef[]).filter((t) => t && typeof t.value === 'string')
+    : []
+}
+
+/** Find the tab-panel child whose props.value matches a tab. */
+function panelFor(children: PageComponent[] | undefined, value: string): PageComponent | undefined {
+  return (children ?? []).find(
+    (c) => c.type === 'tab-panel' && (c.props as Record<string, unknown>).value === value,
+  )
+}
+
+export const tabsWidget: WidgetDescriptor = {
+  type: 'tabs',
+  label: 'Tabs',
+  icon: '⊓',
+  category: 'navigation',
+  acceptsChildren: true, // children are tab-panel nodes
+  defaultProps: {
+    tabs: [
+      { value: 'tab-1', label: 'Tab one' },
+      { value: 'tab-2', label: 'Tab two' },
+    ],
+    defaultTab: 'tab-1',
+  },
+  propSchema: [
+    // 2b renders a tab-list editor for kind:'expression' here (add/remove/rename/reorder tabs,
+    // keeping a matching tab-panel child in sync via treeOps).
+    { key: 'tabs', label: 'Tabs', kind: 'expression', group: 'Tabs' },
+    { key: 'defaultTab', label: 'Default tab', kind: 'text', group: 'Tabs' },
+  ],
+  Render: ({ node, renderChild }) => {
+    const props = node.props as Record<string, unknown>
+    const tabs = readTabs(props)
+    if (tabs.length === 0) {
+      return (
+        <div className="text-xs text-muted-foreground" data-testid="page-node-tabs-empty">
+          No tabs configured.
+        </div>
+      )
+    }
+    const defaultTab = (props.defaultTab as string) || tabs[0].value
+    return (
+      <Tabs defaultValue={defaultTab} className="w-full" data-testid="page-node-tabs">
+        <TabsList>
+          {tabs.map((t) => (
+            <TabsTrigger key={t.value} value={t.value} data-testid={`tab-trigger-${t.value}`}>
+              {t.label}
+            </TabsTrigger>
+          ))}
+        </TabsList>
+        {tabs.map((t) => {
+          const panel = panelFor(node.children, t.value)
+          return (
+            <TabsContent key={t.value} value={t.value} data-testid={`tab-content-${t.value}`}>
+              {panel
+                ? (panel.children ?? []).map((child) => renderChild(child))
+                : null}
+            </TabsContent>
+          )
+        })}
+      </Tabs>
+    )
+  },
+}
+
+/**
+ * Internal container node, one per tab. NOT shown in the palette (see registerBuiltins).
+ * It only renders its children when rendered standalone (e.g. via treeOps moves in the canvas);
+ * the tabs Render reaches into panel.children directly. Registered so widgetRegistry.get never
+ * falls through to the unknown descriptor for 'tab-panel'.
+ */
+export const tabPanelWidget: WidgetDescriptor = {
+  type: 'tab-panel',
+  label: 'Tab panel',
+  icon: '▢',
+  category: 'layout',
+  acceptsChildren: true,
+  defaultProps: { value: '' },
+  propSchema: [{ key: 'value', label: 'Tab value', kind: 'text', group: 'Tab' }],
+  Render: ({ node, renderChild }) => (
+    <div data-testid="page-node-tab-panel">
+      {(node.children ?? []).map((child) => renderChild(child))}
+    </div>
+  ),
+}
+```
+
+> **Tabs children model.** `tabs.children` is an array of `tab-panel` nodes keyed by `value`; each
+> `tab-panel.children` is the per-tab sub-tree. The `tabs` `Render` renders the radix list from
+> `props.tabs[]` and, per tab, looks up the matching `tab-panel` and maps its `children` through the
+> shared `renderChild`. This keeps everything in the standard `PageComponent[]` tree (2c's `treeOps`
+> insert/move/remove operate on `tab-panel.children` like any container). When a tab is added/removed in
+> the inspector (2b), the editor keeps `props.tabs[]` and the `tab-panel` children in sync.
+
+### 3.3 `nav` descriptor (concrete TS, wraps `@kelta/components` `Navigation`)
+
+```tsx
+// widgets/builtins/nav.tsx
+import { Navigation, type MenuItem } from '@kelta/components'
+import type { WidgetDescriptor } from '../types'
+
+function readItems(props: Record<string, unknown>): MenuItem[] {
+  // items may be a literal array (authored) or a 2d-resolved bound array.
+  return Array.isArray(props.items) ? (props.items as unknown as MenuItem[]) : []
+}
+
+export const navWidget: WidgetDescriptor = {
+  type: 'nav',
+  label: 'Nav',
+  icon: '☰',
+  category: 'navigation',
+  acceptsChildren: false,
+  defaultProps: {
+    orientation: 'horizontal',
+    items: [],
+  },
+  propSchema: [
+    {
+      key: 'orientation',
+      label: 'Orientation',
+      kind: 'select',
+      options: [
+        { value: 'horizontal', label: 'Horizontal' },
+        { value: 'vertical', label: 'Vertical' },
+      ],
+      group: 'Nav',
+    },
+    // 2b renders a menu-items editor for kind:'expression' (add/remove items with id/label/path).
+    { key: 'items', label: 'Menu items', kind: 'expression', bindable: true, group: 'Nav' },
+  ],
+  Render: ({ node }) => {
+    const props = node.props as Record<string, unknown>
+    const items = readItems(props)
+    const orientation = props.orientation === 'vertical' ? 'vertical' : 'horizontal'
+    if (items.length === 0) {
+      return (
+        <div className="text-xs text-muted-foreground" data-testid="page-node-nav-empty">
+          No menu items.
+        </div>
+      )
+    }
+    return (
+      <Navigation
+        items={items}
+        orientation={orientation}
+        testId="page-node-nav"
+      />
+    )
+  },
+}
+```
+
+> `Navigation` (verified export from `@kelta/components` `index.ts`) integrates with `react-router-dom`
+> (`useNavigate`/`useLocation`) and filters by `currentUser.roles`. 2g passes static `items` and
+> `orientation`; `currentUser` is left default (`null` → no role filtering) since page-builder nav is
+> public-page chrome. `MenuItem` (`{ id, label, path?, icon?, children?, roles?, onClick? }`) is the
+> authored shape. `Navigation` renders its own `data-testid` from `testId` — we pass `page-node-nav`.
+
+### 3.4 `icon` descriptor (concrete TS, lucide by name)
+
+```tsx
+// widgets/builtins/icon.tsx
+import { icons, HelpCircle } from 'lucide-react'
+import type { WidgetDescriptor } from '../types'
+
+/** lucide exports an `icons` map keyed by PascalCase name; convert kebab/snake input. */
+function toPascal(name: string): string {
+  return name
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map((p) => p.charAt(0).toUpperCase() + p.slice(1))
+    .join('')
+}
+
+export const iconWidget: WidgetDescriptor = {
+  type: 'icon',
+  label: 'Icon',
+  icon: '★',
+  category: 'content',
+  acceptsChildren: false,
+  defaultProps: { name: 'star', size: 20, color: '' },
+  propSchema: [
+    { key: 'name', label: 'Icon name', kind: 'text', bindable: true, group: 'Icon' },
+    { key: 'size', label: 'Size (px)', kind: 'number', group: 'Icon' },
+    { key: 'color', label: 'Color', kind: 'color', group: 'Icon' },
+  ],
+  Render: ({ node }) => {
+    const props = node.props as Record<string, unknown>
+    const rawName = (props.name as string) || 'star'
+    const size = typeof props.size === 'number' ? props.size : 20
+    const color = (props.color as string) || undefined
+    // icons is keyed by PascalCase; fall back to HelpCircle for an unknown name (no crash).
+    const LucideIcon = icons[toPascal(rawName) as keyof typeof icons] ?? HelpCircle
+    return (
+      <LucideIcon
+        size={size}
+        color={color}
+        className={color ? undefined : 'text-foreground'}
+        data-testid="page-node-icon"
+        aria-hidden="true"
+      />
+    )
+  },
+}
+```
+
+> Verified: `lucide-react@^0.563.0` exports an `icons` object (`name → component`) and named PascalCase
+> components (e.g. `HelpCircle`). `dynamicIconImports` is **not** exported in this version, so the static
+> `icons` map is the correct by-name lookup (no async/dynamic-import path). Unknown names degrade to
+> `HelpCircle` rather than throwing.
+
+### 3.5 `link` descriptor (concrete TS, router/href, bindable)
+
+```tsx
+// widgets/builtins/link.tsx
+import { Link } from 'react-router-dom'
+import type { WidgetDescriptor } from '../types'
+import { safeUrl } from '../urlSafety'
+
+export const linkWidget: WidgetDescriptor = {
+  type: 'link',
+  label: 'Link',
+  icon: '↗',
+  category: 'content',
+  acceptsChildren: false,
+  defaultProps: { label: 'Link', to: '', href: '', newTab: false },
+  propSchema: [
+    { key: 'label', label: 'Label', kind: 'text', bindable: true, group: 'Link' },
+    { key: 'to', label: 'Internal route', kind: 'text', bindable: true, group: 'Link' },
+    { key: 'href', label: 'External URL', kind: 'text', bindable: true, group: 'Link' },
+    { key: 'newTab', label: 'Open in new tab', kind: 'boolean', group: 'Link' },
+  ],
+  Render: ({ node, mode }) => {
+    const props = node.props as Record<string, unknown>
+    const label = (props.label as string) || 'Link'
+    const to = (props.to as string) || ''
+    // `href` is author/data-controlled (a {$bind} can resolve to `javascript:`/`data:`); scheme-validate
+    // against the shared allow-list ({http, https, mailto, tel, relative}) before rendering <a href>.
+    // safeUrl returns '' for a rejected scheme, which neutralizes the link (renders inert, no navigation).
+    const href = safeUrl((props.href as string) || '')
+    const newTab = props.newTab === true
+    const className =
+      'text-primary underline-offset-2 hover:underline focus-visible:outline-ring'
+
+    // External href wins when set (and passed the scheme check); else an internal router link.
+    if (href) {
+      return (
+        <a
+          href={href}
+          target={newTab ? '_blank' : undefined}
+          rel={newTab ? 'noopener noreferrer' : undefined}
+          className={className}
+          data-testid="page-node-link"
+        >
+          {label}
+        </a>
+      )
+    }
+    // In editor mode, never navigate — render a non-navigating anchor so canvas clicks select.
+    if (mode === 'editor' || !to) {
+      return (
+        <a href={to || '#'} className={className} data-testid="page-node-link" onClick={(e) => e.preventDefault()}>
+          {label}
+        </a>
+      )
+    }
+    return (
+      <Link to={to} target={newTab ? '_blank' : undefined} className={className} data-testid="page-node-link">
+        {label}
+      </Link>
+    )
+  },
+}
+```
+
+> `link` here is **navigation-by-target only** (router `to` / external `href`). Wiring a `link`/`button`
+> click to a `PageAction` (`runFlow`/`createRecord`/…) is **2e** — out of scope. In `editor` mode the
+> link never navigates (prevents the canvas from leaving the builder). `to`/`href`/`label` are bindable
+> so 2d can drive e.g. `to: {{ '/app/p/' & record.slug }}`. **Security:** because `href` is
+> author/data-controlled, it is passed through `safeUrl` (§3.9) which rejects any scheme outside
+> `{http, https, mailto, tel, relative}` — a bound `javascript:` / `data:` href is neutralized to `''`
+> (inert link), reusing the same allow-list as 2e's `navigate`/`openUrl`.
+
+### 3.6 `image` polish (upgrades the 2a built-in)
+
+```tsx
+// widgets/builtins/image.tsx  (REPLACES the bare 2a image built-in)
+import type { WidgetDescriptor } from '../types'
+import { safeUrl } from '../urlSafety'
+
+const OBJECT_FIT = ['cover', 'contain', 'fill', 'none'] as const
+type ObjectFit = (typeof OBJECT_FIT)[number]
+
+export const imageWidget: WidgetDescriptor = {
+  type: 'image',
+  label: 'Image',
+  icon: '▦',
+  category: 'content',
+  acceptsChildren: false,
+  defaultProps: { src: '', alt: 'Image', objectFit: 'cover' },
+  propSchema: [
+    { key: 'src', label: 'Source URL', kind: 'text', bindable: true, group: 'Image' },
+    { key: 'alt', label: 'Alt text', kind: 'text', bindable: true, group: 'Image' },
+    {
+      key: 'objectFit',
+      label: 'Fit',
+      kind: 'select',
+      options: OBJECT_FIT.map((v) => ({ value: v, label: v })),
+      group: 'Image',
+    },
+  ],
+  Render: ({ node, mode }) => {
+    const props = node.props as Record<string, unknown>
+    // `src` is author/data-controlled (bindable); scheme-validate before rendering <img src> so a bound
+    // `javascript:`/`data:` URL is neutralized to '' (→ placeholder/empty), per §3.9. Same allow-list as link.
+    const src = safeUrl((props.src as string) || '')
+    const alt = (props.alt as string) || 'Image'
+    const fit = (OBJECT_FIT as readonly string[]).includes(props.objectFit as string)
+      ? (props.objectFit as ObjectFit)
+      : 'cover'
+    // No src: placeholder in editor (matches 2a), empty in runtime.
+    if (!src) {
+      if (mode === 'editor') {
+        return (
+          <div
+            className="flex h-32 w-full items-center justify-center rounded-lg border border-dashed border-border text-xs text-muted-foreground"
+            data-testid="page-node-image-placeholder"
+          >
+            No image source
+          </div>
+        )
+      }
+      return null
+    }
+    return (
+      <img
+        src={src}
+        alt={alt}
+        className="max-w-full rounded-lg"
+        style={{ objectFit: fit }}
+        data-testid="page-node-image"
+      />
+    )
+  },
+}
+```
+
+> Polish over the 2a `image` built-in (which had `src`/`alt` only and a fixed placeholder): `src`/`alt`
+> are now declared **`bindable`** (so 2d can drive `src: {{record.logoUrl}}`), and an `objectFit` select
+> controls CSS `object-fit`. `data-testid` unchanged (`page-node-image` / `page-node-image-placeholder`)
+> so 2a parity tests stay green. **Security:** `src` is scheme-validated via `safeUrl` (§3.9) before it
+> reaches `<img>`; a bound `javascript:`/`data:` URL is rejected to `''` → the no-src branch (placeholder
+> in editor, `null` in runtime), so it can never become a live `<img src>` attribute.
+
+### 3.7 Binding & scope dependency (note, not a blocker)
+
+These widgets declare `bindable: true` on the relevant `propSchema` entries (chart `dataView`, nav
+`items`, icon `name`, link `label`/`to`/`href`, image `src`/`alt`).
+
+> **Resolved-node invariant (per 2a).** Every 2g descriptor `Render` receives props that are **already
+> resolved** by the time it runs — `chart`'s `dataView`/bound `series`, and `nav`/`tabs`' bound props all
+> arrive as their final array/string values, never as live `Binding` objects, exactly per the parent's
+> authoritative [resolved-node invariant](../page-builder-parity.md#widget-registry) (`renderTree.tsx`)
+> and 2a §3.4's `renderNode`. The parent states descriptors **must not** call `resolveBindings`
+> themselves (the sole exception is `list`/`repeater` re-resolving children under each per-row `item`
+> scope — **none of the 2g widgets are that exception**). **So 2g descriptors do NOT call
+> `resolveBindings` themselves** — resolution is the single reserved call point in 2d's `renderNode`
+> (`resolveBindings(node.props, scope)` *before* `descriptor.Render`). The 2g `Render` bodies only read
+> `node.props`; they contain no scope plumbing, no `resolveBindings` import, and no binding-aware
+> branching beyond the degrade-safe type guards below.
+
+In 2a/2g (pre-2d) the resolver is the identity no-op shim, so a literal `Binding` object can still be
+present in `node.props`; once 2d makes the resolver real, the same `Render` reads the resolved value with
+**no edit**. With an unresolved `Binding` object present (pre-2d), every widget degrades gracefully:
+
+| Widget | Unresolved-binding behavior |
+|--------|-----------------------------|
+| `chart` | `asArray(Binding)` → `[]` → editor sample / runtime "No data" |
+| `nav` | `readItems(Binding)` → `[]` → "No menu items" |
+| `icon` | non-string name → falls back to `star`/`HelpCircle` |
+| `link` | non-string label/to → `'Link'` / `''`; rejected/`javascript:` href (§3.9) → `''` (renders inert) |
+| `image` | non-string src, or rejected/`javascript:` src (§3.9) → placeholder (editor) / `null` (runtime) |
+
+No `renderTree`/registry/types signature changes are needed in 2g (the resolved-node invariant is owned
+by 2a's `renderNode`; 2g consumes it).
+
+### 3.8 No new model / config / endpoint types
+
+- `WidgetDescriptor` / `PropFieldSchema` / `PropFieldKind` / `WidgetRenderProps` — **unchanged** from
+  2a §3.2. The chart series, tab list, and nav items are stored as ordinary `PropValue` arrays inside
+  `props`; the 2b inspector renders bespoke editors for them by keying on `kind` + `key` (an inspector
+  concern, not a registry-type change). If 2b needs distinct prop-field kinds (e.g. `'series'`,
+  `'tab-list'`, `'menu-items'`), those are added to `PropFieldKind` **in 2b**, not here — 2g uses the
+  existing `'expression'` kind as the schema placeholder so the descriptors compile against the 2a types.
+- `PageComponent`, `PageConfig` — **unchanged**. `tabs.children`/`tab-panel.children` use the existing
+  `children?: PageComponent[]`.
+- Render contract / `PageRenderService` — **unchanged** (pure pass-through; tree round-trips in `config`).
+
+### 3.9 URL scheme allow-list — `link.href` / `image.src` (security)
+
+`link.href` and `image.src` accept author- and **data-controlled** URLs: both props are `bindable: true`,
+so a `{ $bind }` (resolved by 2d before `Render`) can evaluate to a hostile `javascript:` or `data:` URL.
+Rendering such a value straight into an `<a href>` / `<img src>` is an XSS / data-exfiltration vector.
+Per the parent's [Security — binding & action output safety](../page-builder-parity.md#security--binding--action-output-safety),
+both props are passed through a shared **scheme allow-list** — `{ http, https, mailto, tel, relative }` —
+**before render**, rejecting everything else (notably `javascript:` and `data:`). This is the **same
+allow-list 2e applies** to its `navigate`/`openUrl` action targets; 2g and 2e share one `safeUrl` helper
+so the rule has a single source of truth.
+
+```tsx
+// widgets/urlSafety.ts  (shared by link/image here and by 2e's navigate/openUrl)
+const ALLOWED_SCHEMES = new Set(['http:', 'https:', 'mailto:', 'tel:'])
+
+/**
+ * Returns `url` if it is safe to place in an `href`/`src`, else `''`.
+ * Allows the {http, https, mailto, tel} schemes plus scheme-relative/relative URLs
+ * (no scheme — in-app paths like `/app/p/orders`, `#anchor`, `./img.png`). Rejects
+ * `javascript:`, `data:`, `vbscript:`, `file:`, and any other absolute scheme.
+ */
+export function safeUrl(url: string): string {
+  const trimmed = url.trim()
+  if (trimmed === '') return ''
+  // A relative/anchor/path URL has no scheme prefix → allowed (the `relative` member of the allow-list).
+  // Match an explicit scheme: leading `<scheme>:` per RFC 3986 (letter, then letters/digits/+/-/.).
+  const schemeMatch = /^([a-zA-Z][a-zA-Z0-9+.-]*):/.exec(trimmed)
+  if (!schemeMatch) return trimmed // relative — no scheme to reject
+  const scheme = schemeMatch[1].toLowerCase() + ':'
+  return ALLOWED_SCHEMES.has(scheme) ? trimmed : ''
+}
+```
+
+> **Why a shared helper, not per-widget inline checks.** 2e's `navigate`/`openUrl` must apply the identical
+> rule; duplicating the scheme list invites drift (a scheme allowed in one path but blocked in another).
+> `widgets/urlSafety.ts` is the single allow-list both slices import. `link` and `image` call `safeUrl`
+> at the top of `Render`; a rejected URL collapses to `''`, which routes through each widget's existing
+> empty-`href`/empty-`src` branch (inert link / placeholder-or-`null` image) — **no crash, no live hostile
+> attribute, no new error surface**. The check runs *after* 2d resolves a binding, so it catches both
+> literal author input and `{$bind}`-derived URLs.
+
+### 3.10 i18n (new widget strings + empty states)
+
+Per the parent's [i18n](../page-builder-parity.md#i18n) rule, **every new user-facing string this slice
+introduces goes through `useI18n`/`t()` with `builder.*` keys** — the builder is fully `useI18n`-driven;
+do not hardcode the English literals shown in the §3 code (they are illustrative). The 2g surface strings
+are the widget **empty states**, plus the new inspector labels (rendered by 2b from `propSchema.label`,
+which 2b funnels through `t()` — 2g supplies stable keys via the schema). The code samples above inline
+the English for readability; the shipped `Render`/`propSchema` resolve these keys instead:
+
+| Key | English (default) | Used by |
+|-----|-------------------|---------|
+| `builder.widget.chart.empty` | "No data" | `chart` runtime empty state (`page-node-chart-empty`) |
+| `builder.widget.nav.empty` | "No menu items." | `nav` empty state (`page-node-nav-empty`) |
+| `builder.widget.tabs.empty` | "No tabs configured." | `tabs` empty state (`page-node-tabs-empty`) |
+| `builder.widget.image.empty` | "No image source" | `image` editor placeholder (`page-node-image-placeholder`) |
+| `builder.widget.{chart,tabs,nav,icon,link,image}.label` | "Chart" / "Tabs" / "Nav" / "Icon" / "Link" / "Image" | palette + inspector titles (`descriptor.label`) |
+| `builder.widget.*.field.*` | the `propSchema[].label` strings (e.g. "Data source", "Chart type", "Menu items", "Icon name", "External URL", "Fit") | 2b inspector field labels |
+
+> **Pattern.** Each widget `Render` calls `useI18n()` (or receives `t` via `WidgetRenderProps`, consistent
+> with how 2a's builtins localize) and emits `t('builder.widget.<type>.empty')` for its empty state rather
+> than a literal. `descriptor.label` and `propSchema[].label` stay as the **default key fallbacks** the 2b
+> inspector localizes (2b owns funneling schema labels through `t()`; 2g owns adding the keys + defaults to
+> the `builder.*` catalog). New keys are added to the same `useI18n` message catalog the existing builder
+> strings live in, in this PR. No string this slice adds is hardcoded English in shipped code.
+
+---
+
+## 4. DB migrations
+
+**None — FE only.** Every widget's data nests inside the existing `ui-pages.config` JSON column
+(component `props` / `children`); there is no DDL, no Flyway version consumed (head remains **V146**,
+next new migration **V147**), and no NATS subject or payload change. The render contract is untouched.
+
+---
+
+## 5. File-by-file code changes
+
+All paths under `kelta-ui/app/src/pages/PageBuilderPage/`. **One file per widget** under
+`widgets/builtins/`, the registration edit, plus one shared `widgets/urlSafety.ts` helper (§3.9). No
+edits to `renderTree.tsx`, `registry.ts`, or `types.ts` (the 2a contracts already support these
+descriptors; the resolved-node invariant lives in 2a's `renderNode` and 2g consumes it unchanged).
+
+### 5.1 New files — `widgets/builtins/` (+ shared `widgets/urlSafety.ts`)
+
+| File | Contents |
+|------|----------|
+| `widgets/builtins/chart.tsx` | §3.1 — `chartWidget` descriptor. `recharts` `Bar`/`Line`/`Pie` keyed on `props.chartType`; `props.dataView` (resolved array, 2d) → `data`; `props.xKey` → axis; `props.series[]` → series. Editor sample fallback. `data-testid="page-node-chart"` / `page-node-chart-empty`. |
+| `widgets/builtins/tabs.tsx` | §3.2 — `tabsWidget` **and** `tabPanelWidget`. Radix `Tabs`/`TabsList`/`TabsTrigger`/`TabsContent` from `@/components/ui/tabs`; per-tab `renderChild` over the matching `tab-panel.children`. `data-testid="page-node-tabs"` / `tab-trigger-<v>` / `tab-content-<v>` / `page-node-tab-panel`. |
+| `widgets/builtins/nav.tsx` | §3.3 — `navWidget`. Wraps `@kelta/components` `Navigation` with `items`/`orientation`. `testId="page-node-nav"`. |
+| `widgets/builtins/icon.tsx` | §3.4 — `iconWidget`. `lucide-react` `icons[PascalName]` with `HelpCircle` fallback; `size`/`color`. `data-testid="page-node-icon"`. |
+| `widgets/builtins/link.tsx` | §3.5 — `linkWidget`. `react-router-dom` `Link` for `to`, `<a>` for external `href`; editor mode inert. `data-testid="page-node-link"`. |
+| `widgets/builtins/image.tsx` | §3.6 — `imageWidget`, **replacing** the 2a bare image built-in. Adds `objectFit`; `src`/`alt` bindable; `src` passed through `safeUrl`. `data-testid="page-node-image"` / `page-node-image-placeholder`. |
+| `widgets/urlSafety.ts` | §3.9 — shared `safeUrl(url)` scheme allow-list (`{http, https, mailto, tel, relative}`; rejects `javascript:`/`data:` → `''`). Imported by `link`/`image` here and by 2e's `navigate`/`openUrl`. (If 2e ships first and already created it, 2g imports the existing module — single source of truth; do not fork.) |
+
+> If 2a already created `widgets/builtins/image.tsx`, this slice **edits** it to the §3.6 version (adds
+> `objectFit`, marks `src`/`alt` bindable, routes `src` through `safeUrl`, keeps the existing
+> `data-testid`s). The 2a image parity test stays green; new tests assert `objectFit` and that a
+> `javascript:` `src` is neutralized.
+
+### 5.2 Registration — `widgets/builtins/index.ts`
+
+Extend `registerBuiltins()` (from 2a §5.6) to register the new descriptors. Keep idempotency (the 2a
+`let done = false` guard). `tab-panel` is registered so `widgetRegistry.get('tab-panel')` resolves, but
+is **excluded from the palette** by 2b (the palette in 2b sources from `listByCategory`; add a
+`paletteHidden?: boolean` only if 2b needs it — otherwise 2b filters `type==='tab-panel'`). 2g’s job is
+registration; the palette filter is a 2b concern. Image is replaced (same `type:'image'` overwrites the
+2a registration — `register()` is overwrite-by-`type`).
+
+```ts
+// widgets/builtins/index.ts  (additions)
+import { chartWidget } from './chart'
+import { tabsWidget, tabPanelWidget } from './tabs'
+import { navWidget } from './nav'
+import { iconWidget } from './icon'
+import { linkWidget } from './link'
+import { imageWidget } from './image' // upgraded (replaces 2a image)
+
+let done = false
+export function registerBuiltins(): void {
+  if (done) return
+  done = true
+  // …2a built-ins (heading/text/button/card/container/table/form)…
+  widgetRegistry.register(imageWidget) // upgraded image
+  // 2c layout (grid/row/column/divider), 2d (list/repeater/field-value), 2f (typed inputs)…
+  widgetRegistry.register(chartWidget)
+  widgetRegistry.register(tabsWidget)
+  widgetRegistry.register(tabPanelWidget)
+  widgetRegistry.register(navWidget)
+  widgetRegistry.register(iconWidget)
+  widgetRegistry.register(linkWidget)
+}
+```
+
+### 5.3 No edits to shared infra
+
+- `widgets/renderTree.tsx` — **no change** (the `renderChild` plumbing the tabs/container widgets use is
+  already provided by 2a `WidgetRenderProps.renderChild`).
+- `widgets/registry.ts`, `widgets/types.ts` — **no change** (descriptors fit the 2a contracts; new prop
+  arrays are plain `PropValue`).
+- `PageBuilderPage.tsx` / `PageTreeRenderer.tsx` — **no change** (both already render via `RenderTree`
+  after 2a; new types resolve through the registry).
+- `componentRegistry.ts` — **no change** (these are built-ins, not plugin shims — explicitly first-class
+  descriptors per the slice scope).
+
+### 5.4 Registration sequencing note
+
+This slice **depends on 2a** (`widgets/{types,registry,renderTree}.tsx` + `registerBuiltins()`). It is
+independent of 2b/2c/2d/2e/2f at the descriptor level: the widgets render literal `props` today and
+resolved `props` once 2d/2e land, with **no edits** required in those slices. The series/tab/nav inline
+editors are 2b inspector work; until then the legacy `PropertyPanel` (still present per 2a §5.3(f)) edits
+these via its raw `dataView`/JSON fields, which is enough to demo each widget.
+
+---
+
+## 6. Test plan
+
+Vitest + Testing Library, matching the existing kelta-ui idiom (`PageBuilderPage.test.tsx`,
+`pageConfig.test.ts`) and the 2a `widgets/*.test` suites. Each test calls `widgetRegistry.clear()` +
+`registerBuiltins()` in `beforeEach` for isolation (per 2a §8). **One spec per widget**, each rendering
+**from the descriptor** through `renderNode`/`<RenderTree>` (not the component directly) so the
+single-render-path guarantee is exercised. Tests render within the builder's i18n provider (as 2a's
+suites do) so the localized empty states (§3.10) resolve; assert empty states by `data-testid`, not by
+the English literal, so the i18n indirection stays test-stable.
+
+### 6.1 `widgets/builtins/chart.test.tsx`
+
+- Renders from descriptor: `chart` node with `chartType:'bar'`, `xKey:'month'`,
+  `series:[{key:'total'}]`, and `props.dataView` set to a literal array → asserts
+  `data-testid="page-node-chart"`, `data-chart-type="bar"`, and that recharts mounts (mock
+  `ResponsiveContainer` to a fixed size in jsdom, as `MonitoringOverviewPage` tests do, since
+  `ResponsiveContainer` needs a measured box).
+- **Binds data:** passing a resolved 3-row array renders the series; `chartType:'line'` →
+  `data-chart-type="line"`; `chartType:'pie'` → `PieChart` path.
+- **Editor sample fallback:** `mode="editor"` with no `dataView` renders the sample (non-empty), not
+  "No data". `mode="runtime"` with no data → `page-node-chart-empty` "No data".
+- Unresolved `Binding` object as `dataView` → treated as empty (degrade-safe).
+
+### 6.2 `widgets/builtins/tabs.test.tsx`
+
+- Renders the tab list from `props.tabs[]` (`tab-trigger-overview`, `tab-trigger-details`).
+- **Tab switching:** default tab's `tab-content-overview` is visible; clicking `tab-trigger-details`
+  shows `tab-content-details` and hides overview (radix `data-[state=inactive]:hidden`).
+- **Per-tab children:** the active tab renders its `tab-panel.children` sub-tree via `renderChild`
+  (assert a child `heading`/`text` `data-testid` appears under the active `tab-content`).
+- Empty `tabs` → `page-node-tabs-empty`.
+
+### 6.3 `widgets/builtins/nav.test.tsx`
+
+- Renders `Navigation` from `props.items[]` with `data-testid="page-node-nav"`; item labels present.
+- `orientation:'vertical'` passes through (assert `Navigation` receives it — class/aria).
+- Empty items → `page-node-nav-empty`. Wrap in `MemoryRouter` (Navigation uses `react-router-dom`).
+
+### 6.4 `widgets/builtins/icon.test.tsx`
+
+- Known name (`'star'` / `'shopping-cart'`) renders an svg (`page-node-icon`), `size`/`color` applied.
+- Kebab/snake → PascalCase conversion works (`'shopping-cart'` resolves).
+- **Unknown name** (`'not-a-real-icon'`) renders the `HelpCircle` fallback, no throw.
+
+### 6.5 `widgets/builtins/link.test.tsx`
+
+- External `href` → `<a target/rel>`; internal `to` (runtime) → router `Link` (assert `href` attr).
+- `newTab:true` → `target="_blank"` + `rel="noopener noreferrer"`.
+- **Editor mode** internal `to` → inert anchor (click `preventDefault`, no navigation). Wrap in
+  `MemoryRouter`.
+- **Security — scheme allow-list:** `href:'javascript:alert(1)'` is **neutralized** — `safeUrl` rejects
+  it to `''`, so no `<a>` carries a `javascript:` href (the node falls through to the inert internal
+  branch). Same for `href:'data:text/html,...'`. A `mailto:`/`tel:` href is **allowed**.
+
+### 6.6 `widgets/builtins/image.test.tsx`
+
+- `src` set → `<img src alt>` with `style.objectFit` from `props.objectFit`; invalid fit → `cover`.
+- No `src`, `mode="editor"` → `page-node-image-placeholder`; `mode="runtime"` → renders nothing.
+- Parity: `data-testid`s unchanged from 2a.
+- **Security — scheme allow-list:** `src:'javascript:...'` / `src:'data:image/svg+xml,...'` is rejected by
+  `safeUrl` → no `<img src>` renders; the node falls through to the no-src branch (placeholder in editor,
+  `null` in runtime). An `https:` `src` renders normally.
+
+### 6.7 `widgets/urlSafety.test.ts` (scheme allow-list)
+
+- Allows `http:`/`https:`/`mailto:`/`tel:` and relative URLs (`/app/p/x`, `#a`, `./img.png`, ``) → returned
+  unchanged.
+- **Rejects** `javascript:`, `data:`, `vbscript:`, `file:` (and mixed-case `JavaScript:`) → returns `''`.
+- Whitespace-padded `  javascript:…  ` still rejected (trim-then-check).
+
+### 6.8 `widgets/builtins/index.test.ts` (registration)
+
+- After `registerBuiltins()`, `widgetRegistry.get('chart'|'tabs'|'tab-panel'|'nav'|'icon'|'link'|'image')`
+  each returns a real descriptor (not the unknown default); `listByCategory('navigation')` includes
+  `nav` + `tabs`; `listByCategory('data')` includes `chart`; `image` is the upgraded descriptor
+  (has an `objectFit` prop-schema entry).
+
+### 6.9 Shared render-path test (extend `widgets/renderTree.test.tsx` from 2a)
+
+- Render a tree containing `chart`/`tabs`/`nav`/`icon`/`link`/`image` in both `mode:'editor'` and
+  `mode:'runtime'`; assert each resolves through the **same descriptor `Render`** (no unknown
+  fallback), confirming the editor-preview/runtime de-dup holds for the breadth widgets.
+
+### 6.10 e2e
+
+Playwright e2e is **post-deploy only** (project convention). Once deployed, the parent spec's
+page-render e2e is extended with: author a page with a `chart` bound to a data source, a `tabs` widget
+with child containers, and a `nav`; publish; load `/:tenant/app/p/<slug>`; assert the chart svg renders,
+clicking a tab swaps content, and nav links navigate. No new e2e file ships in this slice; the breadth is
+covered by the Vitest suites above.
+
+---
+
+## 7. Docs to update (same PR)
+
+| Doc | Change |
+|-----|--------|
+| `.claude/docs/status.md` (line ~48, "Page builder / screen builder" row) | Add: "slice 2g — **widget breadth**: `chart` (recharts bar/line/pie bound to a page data-source array via `props.dataView` `$bind`), `tabs` (radix `@/components/ui/tabs`, per-tab `tab-panel` child containers rendered through the shared `renderChild`), `nav` (`@kelta/components` `Navigation`), `icon` (lucide-react `icons` map by name, `HelpCircle` fallback), `link` (router `Link` / external `<a>`, bindable label/target), and `image` polish (bindable `src`/`alt` + `object-fit`) — all first-class `WidgetDescriptor`s in `widgets/builtins/`, one `Render` shared by editor preview and runtime; no backend change." |
+| `.claude/docs/playbooks.md` | Extend the 2a "Add a page component / widget" recipe with the **breadth widget** examples: a widget that wraps a reused component (`nav` → `Navigation`, `tabs` → `@/components/ui/tabs`), a widget that consumes a bound data-source array (`chart`), and the **internal-container pattern** (`tab-panel` registered but palette-hidden, children rendered via `renderChild`). |
+| `.claude/docs/conventions.md` | If/when it documents page widgets: note (a) breadth widgets are **first-class descriptors**, never plugin shims; (b) the **chart data-binding contract** (pure widget; `dataView` is a `{$bind:'data.<source>'}` resolved to an array by 2d before `Render`; `xKey` + `series[].key` map rows to axes/series — widgets never fetch); (c) the **tabs children model** (`tab-panel` child per tab, sub-tree via `renderChild`); (d) the **URL scheme allow-list** (`link.href`/`image.src` pass through the shared `widgets/urlSafety.ts` `safeUrl`, same `{http,https,mailto,tel,relative}` list as 2e's `navigate`/`openUrl` — `javascript:`/`data:` rejected); (e) new widget strings + empty states go through `useI18n`/`t()` with `builder.widget.*` keys (no hardcoded English). |
+
+Per CLAUDE.md Rule 6 these doc edits ship **in the same PR** as the code. No `architecture.md` /
+`integrations.md` change (no backend, API, NATS, or external-integration surface touched — state
+"N/A — FE-only, no backend/integration change" in the PR description). The new `builder.widget.*` i18n
+keys (§3.10) are added to the builder's `useI18n` message catalog in this PR.
+
+---
+
+## 8. Risks & open questions
+
+- **URL injection via bound `href`/`src` (security).** `link.href`/`image.src` are bindable, so a
+  `{$bind}` can resolve to `javascript:`/`data:` — rendering it into `<a href>`/`<img src>` is XSS.
+  **Mitigation (§3.9):** both props pass through the shared `widgets/urlSafety.ts` `safeUrl` allow-list
+  (`{http,https,mailto,tel,relative}`, identical to 2e's `navigate`/`openUrl`) before render; a rejected
+  scheme collapses to `''` (inert link / placeholder image). A **blocked-`javascript:` test** is required
+  (link 6.5 + image 6.6 + the `urlSafety` unit spec 6.7). **Sequencing note:** if 2e ships `urlSafety.ts`
+  first, 2g imports it — do not fork the scheme list (drift risk).
+- **`recharts` `ResponsiveContainer` in jsdom.** It needs a measured parent box; in tests (per
+  `MonitoringOverviewPage` precedent) mock `ResponsiveContainer` to a fixed width/height so the chart
+  mounts. **Mitigation:** a shared test helper that stubs `ResponsiveContainer` to render children at a
+  fixed size; assert on the inner chart’s `data-testid`/series, not pixel geometry.
+- **Chart binding ordering vs 2d.** `chart` reads an **already-resolved** array from `props.dataView`.
+  If 2g ships **before** 2d, the binding object is never resolved → chart always shows the editor sample
+  / runtime "No data". This is degrade-safe and visible, but the *useful* chart (live data) only works
+  once 2d's `resolveBindings` call point is live. **Open question for sequencing:** ship 2g after 2d so
+  charts are immediately bindable, or before (presentational-only, live binding arrives with 2d)? Either
+  compiles and tests pass; **recommend after 2d** for a complete demo.
+- **`tab-panel` palette visibility.** `tab-panel` must be registered (so `widgetRegistry.get` resolves
+  it) but **not** offered in the palette as a standalone widget. 2g registers it; the palette filter is a
+  **2b** concern (`listByCategory` filter / optional `paletteHidden`). If 2b has not yet landed, the
+  legacy palette array (2a §5.3(b)) does not include `tab-panel` (it derives from a curated list), so no
+  leak today. **Track:** ensure 2b's registry-driven palette excludes `type==='tab-panel'`.
+- **Series / tab-list / nav-items editors are 2b.** 2g declares these as `kind:'expression'` schema
+  entries so the descriptors compile against the 2a `PropFieldKind` union. The **rich editors** (add/remove
+  series, add/rename/reorder tabs keeping `tab-panel` children in sync, menu-item editor) are inspector
+  work in 2b — which may add dedicated `PropFieldKind`s (`'series'`/`'tab-list'`/`'menu-items'`). Until
+  then, editing happens via raw JSON in the legacy `PropertyPanel`. **Open question:** add those
+  `PropFieldKind`s now (in 2g `types.ts`) or in 2b? **Recommend 2b** (keep 2g additive-only, no shared
+  contract change) — noted so 2b owns it.
+- **`Navigation` is router- and role-aware.** It calls `useNavigate`/`useLocation`, so `nav` only
+  renders inside a router (always true on `CustomPage` runtime and the builder; tests wrap in
+  `MemoryRouter`). Role filtering uses `currentUser.roles`; 2g passes no `currentUser` (→ no filtering),
+  which is correct for public-page nav. Authoring role-gated nav items is a later enhancement, not 2g.
+- **`lucide-react` `icons` map size.** Importing the full `icons` object pulls the icon registry; this is
+  already how named lucide imports work across the app and tree-shakes per-named-component, but the
+  `icons` map is a barrel. **Mitigation:** acceptable for a builder widget (the page already imports many
+  lucide icons); if bundle size regresses materially, switch the `icon` widget to a curated allow-list
+  map of the ~50 most-used icons (a follow-up, not a blocker). `dynamicIconImports` is **not** available
+  in `^0.563.0`, so async lazy-loading is not an option here.
+- **`PageBuilderPage.tsx` size.** 2g adds **no** code to `PageBuilderPage.tsx` (all new code is in
+  `widgets/builtins/*`), so it does not regress the file-size concern (`concerns.md`); if anything it
+  reinforces the descriptor-per-file pattern that shrank it in 2a.
+- **Sequencing.** Hard prerequisite: **2a** (registry + `RenderTree` + `registerBuiltins`). Soft: **2d**
+  (chart live data), **2b** (rich inline editors for series/tabs/nav). Independent of 2c/2e/2f. Ship 2g
+  after 2a (and ideally 2d/2b for full UX); it is additive and independently shippable behind the
+  registry.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -315,6 +315,7 @@ are bugs. When in doubt, trust the code and correct the doc to match.
 | `concerns.md` | Known risks, fragile files (don't bloat), tech debt, test gaps, Postgres connection sizing |
 | `ci-cd.md` | GitHub Actions pipeline, Harbor/ArgoCD deploy, smoke/rollback, container builds |
 | `status.md` | **Capability map: what's Complete vs UI-only-stub vs Planned** — check before touching a subsystem |
+| `specs/` | **Forward-looking feature specs** (multi-slice efforts). `specs/page-builder-parity.md` is the parent for the page-builder→OutSystems-parity work; per-slice specs (contracts, UI samples, migrations, file-by-file changes) live in `specs/page-builder/`. Read the relevant slice spec before implementing it. |
 
 Module-level: `kelta-{ai,auth,gateway,mcp,worker}/CLAUDE.md`, `kelta-ui/DESIGN.md`.
 Human-facing: `README.md` (local dev, ports, Makefile), `CONTRIBUTING.md`, `SECURITY.md`.


### PR DESCRIPTION
## Summary
- Adds the planning spec tree for closing the page-builder gap with OutSystems across four axes: **layout & responsive grid**, **data binding & expressions**, **logic & events/actions**, and **widget library + typed forms**.
- Documentation only — no source code changed. Parent spec defines the shared contract; 9 slice specs each carry UI samples, exact contracts, DB-migration notes (all "none — config-JSON only"), and file-by-file code changes.

## Changes
- `.claude/docs/specs/page-builder-parity.md` — parent spec (shared model, widget descriptor registry, config-JSON v2 schema, reuse map, security/rollout/e2e/save-persistence, slice plan).
- `.claude/docs/specs/page-builder/{1g,2a,2b,2c,2d,2e,2f,2g,1h}-*.md` — per-slice feature specs.
- `CLAUDE.md` — reference-doc table row pointing at `specs/`.

## Key design decisions (source-verified)
- Backend stays a pass-through; entire tree nests in `ui-pages.config` JSON → **zero migrations**. Render contract `1.0`→`2.0`; tree canonical at `config.components` (no `config.tree` wrapper).
- Central FE move: one widget descriptor registry replaces 5 hardcoded switch sites; one shared `RenderTree` for editor preview + runtime.
- Bindings resolved **client-side only** (`{{record.name}}`, `$bind`) so Cerbos/FLS stay server-enforced. Events ride existing endpoints (flow execute, JSON:API create/update) — no new backend.
- DnD via `@dnd-kit` (canvas-scoped). Per-page authz via config `requiredPermission` (404-not-403).
- Cross-spec review pass corrected: save-path persistence of v2 keys, real-DB round-trip/authz harness tests, feature-flagged renderer rollout, URL/XSS allow-lists, DoS caps, unified event-field + resolved-node contracts.

## Testing
- N/A — documentation only. Specs define the per-slice test plans (Vitest, worker unit, kelta-test-harness integration, post-deploy Playwright) to be executed when each slice is implemented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)