### PR TITLE
fix(flows): read flow-execute id from JSON:API data.id

### DIFF
--- a/kelta-ui/app/src/pages/FlowDesignerPage/FlowDesignerPage.tsx
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/FlowDesignerPage.tsx
@@ -6,6 +6,7 @@ import type { Node, Edge } from '@xyflow/react'
 
 import { useApi } from '../../context/ApiContext'
 import type { CreateFlowRequest } from '@kelta/sdk'
+import { unwrapResource } from '../../utils/jsonapi'
 import { useToast, LoadingSpinner, ErrorMessage } from '../../components'
 import { cn } from '@/lib/utils'
 import { FlowToolbar } from './components/FlowToolbar'
@@ -156,13 +157,14 @@ export function FlowDesignerPage() {
         body: JSON.stringify({ state, test: true }),
       })
       if (!resp.ok) throw new Error('Failed to start test execution')
-      return (await resp.json()) as { executionId: string }
+      // JSON:API envelope ({ data: { type: 'flow-executions', id, attributes } }) — id is `data.id`.
+      return unwrapResource<{ id: string }>(await resp.json())
     },
     onSuccess: (data) => {
-      if (data?.executionId) {
+      if (data?.id) {
         showToast('Test execution started', 'success')
         setTestDialogOpen(false)
-        handleViewExecution(data.executionId)
+        handleViewExecution(data.id)
       }
     },
     onError: (err: Error) => {

--- a/kelta-ui/app/src/pages/FlowsPage/FlowsPage.tsx
+++ b/kelta-ui/app/src/pages/FlowsPage/FlowsPage.tsx
@@ -4,7 +4,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useI18n } from '../../context/I18nContext'
 import { useApi } from '../../context/ApiContext'
 import { getTenantSlug } from '../../context/TenantContext'
-import { unwrapCollection } from '../../utils/jsonapi'
+import { unwrapCollection, unwrapResource } from '../../utils/jsonapi'
 import {
   useToast,
   ConfirmDialog,
@@ -116,7 +116,9 @@ export function FlowsPage({ testId = 'flows-page' }: FlowsPageProps): React.Reac
           (errBody as Record<string, string>).message || `Execute failed: ${resp.statusText}`
         )
       }
-      return (await resp.json()) as { executionId: string }
+      // The execute endpoint returns a JSON:API envelope
+      // ({ data: { type: 'flow-executions', id, attributes } }); the execution id is `data.id`.
+      return unwrapResource<{ id: string }>(await resp.json())
     },
     onSuccess: (data) => {
       showToast(t('flows.executionStarted'), 'success')
@@ -125,10 +127,8 @@ export function FlowsPage({ testId = 'flows-page' }: FlowsPageProps): React.Reac
         queryClient.invalidateQueries({ queryKey: ['flow-executions', execItemId] })
       }
       // Navigate to the debug view in the flow designer
-      if (runFlowTarget && data?.executionId) {
-        navigate(
-          `/${getTenantSlug()}/flows/${runFlowTarget.id}/design?executionId=${data.executionId}`
-        )
+      if (runFlowTarget && data?.id) {
+        navigate(`/${getTenantSlug()}/flows/${runFlowTarget.id}/design?executionId=${data.id}`)
       }
     },
     onError: (err: Error) => showToast(err.message, 'error'),

--- a/kelta-ui/app/src/pages/FlowsPage/flowExecuteResponse.test.ts
+++ b/kelta-ui/app/src/pages/FlowsPage/flowExecuteResponse.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Flow-execute response-shape contract.
+ *
+ * `POST /api/flows/{flowId}/execute` (FlowExecutionController) returns a JSON:API
+ * envelope — `{ data: { type: 'flow-executions', id, attributes: { flowId, status } } }`
+ * — NOT a flat `{ executionId }`. Both `FlowsPage` (run → navigate to the debug view) and
+ * `FlowDesignerPage` (test → open the debug tab) parse the execution id via
+ * `unwrapResource(json).id`. Reading a top-level `response.executionId` (the prior bug)
+ * resolves to `undefined`, so the post-execute navigation/poll silently no-ops.
+ *
+ * This pins the contract those two call sites depend on.
+ */
+import { describe, it, expect } from 'vitest'
+import { unwrapResource } from '../../utils/jsonapi'
+
+const executeResponse = {
+  data: {
+    type: 'flow-executions',
+    id: 'exec-123',
+    attributes: { flowId: 'flow-1', status: 'RUNNING' },
+  },
+}
+
+describe('flow-execute response parsing', () => {
+  it('extracts the execution id from data.id via unwrapResource', () => {
+    const result = unwrapResource<{ id: string; flowId: string; status: string }>(executeResponse)
+
+    expect(result.id).toBe('exec-123')
+    expect(result.flowId).toBe('flow-1')
+    expect(result.status).toBe('RUNNING')
+  })
+
+  it('has no top-level executionId — guards the prior silent no-op regression', () => {
+    expect((executeResponse as Record<string, unknown>).executionId).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary
- `FlowsPage` (run → navigate to debug view) and `FlowDesignerPage` (test → open debug tab) read a non-existent top-level `executionId` from the `POST /api/flows/{flowId}/execute` response.
- The endpoint (`FlowExecutionController`) returns a JSON:API envelope — `{ data: { type: "flow-executions", id, attributes: { flowId, status: "RUNNING" } } }` — so `response.executionId` was always `undefined` and the post-execute navigation/poll **silently no-op'd**.
- Both call sites now parse the id via `unwrapResource(json).id`, matching how every other resource is unwrapped.

## Changes
- `kelta-ui/app/src/pages/FlowsPage/FlowsPage.tsx` — `executeMutation` returns `unwrapResource<{ id }>(…)`; navigation uses `data.id`.
- `kelta-ui/app/src/pages/FlowDesignerPage/FlowDesignerPage.tsx` — `testMutation` likewise; `handleViewExecution(data.id)`.
- `kelta-ui/app/src/pages/FlowsPage/flowExecuteResponse.test.ts` — new contract test pinning the envelope→`data.id` shape and guarding the prior `executionId` regression.

## Testing
- `vitest run` (FlowsPage + FlowDesignerPage + jsonapi): 32 passed.
- `eslint` clean on changed files; `prettier --check` clean; `tsc` reports no errors in the changed files (pre-existing repo-wide tsc errors are unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)