### PR TITLE
fix(ui): persist collection displayName and reflect saved displayField

### DIFF
--- a/kelta-ui/app/src/i18n/translations/en.json
+++ b/kelta-ui/app/src/i18n/translations/en.json
@@ -105,6 +105,7 @@
     "deleteCollection": "Delete Collection",
     "collectionName": "Collection Name",
     "displayName": "Display Name",
+    "displayField": "Display Field",
     "description": "Description",
     "status": "Status",
     "active": "Active",
@@ -1438,6 +1439,8 @@
     "descriptionPlaceholder": "Enter a description for this collection...",
     "nameHint": "Lowercase letters, numbers, and underscores only. Must start with a letter.",
     "activeHint": "Inactive collections are hidden from the resource browser but data is preserved.",
+    "displayFieldNone": "Auto-detect",
+    "displayFieldHint": "The field shown when records appear in lookup dropdowns. If not set, defaults to a field named \"name\" or the first text field.",
     "validation": {
       "nameRequired": "Collection name is required",
       "nameTooLong": "Collection name must be 50 characters or less",

--- a/kelta-ui/app/src/pages/CollectionFormPage/CollectionFormPage.test.tsx
+++ b/kelta-ui/app/src/pages/CollectionFormPage/CollectionFormPage.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * CollectionFormPage tests — edit-mode read/write of displayName + displayFieldId.
+ *
+ * Regression coverage for two bugs:
+ *  - the update payload dropped `displayName` (and `active`), so display-name edits never saved;
+ *  - the edit query read only `attributes`, never the `displayFieldId` relationship, so the saved
+ *    display field reset to "Auto-detect" on reload and looked unsaved.
+ */
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter } from 'react-router-dom'
+import { CollectionFormPage } from './CollectionFormPage'
+import { I18nProvider } from '../../context/I18nContext'
+
+const mockNavigate = vi.fn()
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom')
+  return { ...actual, useNavigate: () => mockNavigate, useParams: () => ({ id: 'col-123' }) }
+})
+
+// JSON:API GET payload: displayName is empty, displayFieldId lives in `relationships` (a lookup),
+// and the collection's fields arrive via ?include=fields.
+const getResponse = {
+  data: {
+    type: 'collections',
+    id: 'col-123',
+    attributes: {
+      name: 'providers',
+      displayName: '',
+      description: 'Streaming providers',
+      active: true,
+    },
+    relationships: { displayFieldId: { data: { type: 'fields', id: 'field-name' } } },
+  },
+  included: [
+    {
+      type: 'fields',
+      id: 'field-name',
+      attributes: { name: 'name', displayName: 'Name', active: true },
+    },
+    {
+      type: 'fields',
+      id: 'field-slug',
+      attributes: { name: 'slug', displayName: 'Slug', active: true },
+    },
+  ],
+}
+
+const getMock = vi.fn()
+const updateMock = vi.fn()
+vi.mock('../../context/ApiContext', () => ({
+  useApi: () => ({
+    apiClient: { get: getMock },
+    keltaClient: { admin: { collections: { update: updateMock, create: vi.fn() } } },
+  }),
+}))
+
+function renderPage() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <I18nProvider>
+        <MemoryRouter initialEntries={['/t/collections/col-123/edit']}>
+          <CollectionFormPage />
+        </MemoryRouter>
+      </I18nProvider>
+    </QueryClientProvider>
+  )
+}
+
+describe('CollectionFormPage (edit mode)', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear()
+    getMock.mockReset().mockResolvedValue(getResponse)
+    updateMock.mockReset().mockResolvedValue({ id: 'col-123' })
+  })
+
+  it('maps the displayFieldId relationship into the Display Field select', async () => {
+    renderPage()
+    const select = (await screen.findByTestId(
+      'collection-display-field-select'
+    )) as HTMLSelectElement
+    // Read fix: the saved relationship (field-name) is reflected, not reset to "Auto-detect".
+    expect(select.value).toBe('field-name')
+    // i18n keys now exist — the label renders text, not the raw key.
+    expect(screen.getByText('Display Field')).toBeInTheDocument()
+  })
+
+  it('includes displayName, active and displayFieldId in the update payload', async () => {
+    renderPage()
+    const displayName = (await screen.findByTestId(
+      'collection-display-name-input'
+    )) as HTMLInputElement
+    fireEvent.change(displayName, { target: { value: 'Providers' } })
+
+    fireEvent.click(screen.getByTestId('collection-form-submit'))
+
+    await waitFor(() => expect(updateMock).toHaveBeenCalledTimes(1))
+    const [calledId, payload] = updateMock.mock.calls[0]
+    expect(calledId).toBe('col-123')
+    expect(payload).toMatchObject({
+      name: 'providers',
+      displayName: 'Providers',
+      active: true,
+      displayFieldId: 'field-name',
+    })
+  })
+})

--- a/kelta-ui/app/src/pages/CollectionFormPage/CollectionFormPage.tsx
+++ b/kelta-ui/app/src/pages/CollectionFormPage/CollectionFormPage.tsx
@@ -58,7 +58,12 @@ export function CollectionFormPage({
     queryKey: ['collection', id],
     queryFn: async () => {
       const raw = await apiClient.get<{
-        data: { type: string; id: string; attributes: Record<string, unknown> }
+        data: {
+          type: string
+          id: string
+          attributes: Record<string, unknown>
+          relationships?: Record<string, { data?: { type: string; id: string } | null }>
+        }
         included?: { type: string; id: string; attributes: Record<string, unknown> }[]
       }>(`/api/collections/${id}?include=fields`)
 
@@ -66,6 +71,10 @@ export function CollectionFormPage({
         id: raw.data.id,
         ...(raw.data.attributes as Omit<CollectionWithFields, 'id' | 'fields'>),
       } as CollectionWithFields
+
+      // `displayFieldId` is a lookup (relationship), not an attribute — surface it so the
+      // form's Display Field select reflects the saved value and can round-trip it.
+      result.displayFieldId = raw.data.relationships?.displayFieldId?.data?.id ?? undefined
 
       if (raw.included && raw.included.length > 0) {
         result.fields = raw.included
@@ -102,7 +111,9 @@ export function CollectionFormPage({
         // Update existing collection
         const requestData: Record<string, unknown> = {
           name: data.name,
+          displayName: data.displayName,
           description: data.description || '',
+          active: data.active,
         }
         // Include displayFieldId — empty string clears it, undefined means no change
         if (data.displayFieldId !== undefined) {


### PR DESCRIPTION
## Summary
Editing a collection's **Display Name** and **Display Field** on `/{tenant}/collections/{id}/edit` did not save. Root causes:

1. **`displayName` dropped on write** — `CollectionFormPage.handleSubmit` built the update payload with `name`/`description`/`displayFieldId` only, omitting `displayName` (and `active`). The form captured `displayName`, but the page never sent it.
2. **`displayFieldId` not read back** — the edit query mapped only `data.attributes`. `displayFieldId` is a **lookup**, returned by the API as a JSON:API *relationship*, so the Display Field select always reset to "Auto-detect" on load — a saved value looked unsaved (and risked being cleared on the next save). The value itself *was* persisting server-side; only the round-trip display was broken.
3. **Missing i18n** — the Display Field label/hint rendered as raw keys (`collections.displayField`, `collectionForm.displayFieldHint`).

## Changes
- `pages/CollectionFormPage/CollectionFormPage.tsx`
  - Write: include `displayName` and `active` in the update payload.
  - Read: surface `data.relationships.displayFieldId.data.id` into `collection.displayFieldId` so the select reflects the saved value.
- `i18n/translations/en.json` — add `collections.displayField`, `collectionForm.displayFieldHint`, `collectionForm.displayFieldNone` (other locales fall back to en).
- `pages/CollectionFormPage/CollectionFormPage.test.tsx` — **new**: asserts the relationship→select mapping and that the update payload contains `displayName`/`active`/`displayFieldId`.

## Testing
- `vitest` CollectionFormPage (2) + CollectionForm (38) → **40/40 pass**.
- `eslint`/`prettier`/`tsc` clean on changed files; `en.json` valid.
- Verified against the live worker: PATCHing `collections` with `displayName` in `attributes` persists (`displayName: "Providers"`), and `displayFieldId` round-trips as a relationship.

> Note: `npm run lint` still reports one **pre-existing** error in `src/context/TenantContext.tsx:144`, unrelated to this change and fixed in #1100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)