### PR TITLE
fix(ui): show inspector properties for nested page-builder components

### DIFF
--- a/kelta-ui/app/src/pages/PageBuilderPage/PageBuilderPage.test.tsx
+++ b/kelta-ui/app/src/pages/PageBuilderPage/PageBuilderPage.test.tsx
@@ -961,6 +961,58 @@ describe('PageBuilderPage', () => {
       })
     })
 
+    it('shows inspector properties for a NESTED component, not just top-level (regression)', async () => {
+      // A heading nested inside a card inside the tree — selecting it must resolve via a recursive
+      // tree walk, not a top-level `.find`, or the inspector shows the empty "select a component" state.
+      const nestedPage: UIPage = {
+        id: 'np1',
+        name: 'nested',
+        path: '/nested',
+        title: 'Nested',
+        layout: { type: 'single' },
+        components: [
+          {
+            id: 'card-1',
+            type: 'card',
+            props: {},
+            children: [
+              { id: 'nested-heading', type: 'heading', props: { text: 'Inner', level: 'h2' } },
+            ],
+          },
+        ],
+        published: false,
+        createdAt: '2024-01-01T00:00:00Z',
+        updatedAt: '2024-01-01T00:00:00Z',
+      }
+      mockAxios.get.mockReset()
+      mockAxios.get.mockImplementation((url: string) =>
+        url.includes('/api/ui-pages/np1')
+          ? Promise.resolve({ data: nestedPage })
+          : Promise.resolve({ data: [nestedPage] })
+      )
+
+      const user = userEvent.setup()
+      render(<PageBuilderPage />, { wrapper: createTestWrapper() })
+
+      await waitFor(() => {
+        expect(screen.getByText('nested')).toBeInTheDocument()
+      })
+      await user.click(screen.getByTestId('page-name-0'))
+
+      // The nested heading renders as its own selectable canvas node.
+      await waitFor(() => {
+        expect(screen.getByTestId('canvas-component-nested-heading')).toBeInTheDocument()
+      })
+
+      // Select the NESTED heading (not a top-level node).
+      await user.click(screen.getByTestId('canvas-component-nested-heading'))
+
+      await waitFor(() => {
+        expect(screen.getByTestId('property-type')).toHaveTextContent('heading')
+        expect(screen.getByTestId('property-text')).toBeInTheDocument()
+      })
+    })
+
     it('should delete component when delete button is clicked', async () => {
       const user = userEvent.setup()
       render(<PageBuilderPage />, { wrapper: createTestWrapper() })

--- a/kelta-ui/app/src/pages/PageBuilderPage/PageBuilderPage.tsx
+++ b/kelta-ui/app/src/pages/PageBuilderPage/PageBuilderPage.tsx
@@ -37,7 +37,7 @@ import { RenderTree } from './widgets/renderTree'
 import { widgetRegistry } from './widgets/registry'
 import './widgets/builtins'
 import type { PageComponent as ModelPageComponent, ResponsiveSpan } from './model/pageModel'
-import { insertNode } from './model/treeOps'
+import { insertNode, findNode } from './model/treeOps'
 import { migrateTree, needsMigration } from './model/migrate'
 
 /**
@@ -556,7 +556,9 @@ export function PageBuilderPage({
   const [pageDataSources, setPageDataSources] = useState<PageDataSource[]>([])
   // Slice 1h: optional per-page access restriction (a system-permission name). `undefined` ⇒ untouched
   // (no key written); `{}` ⇒ explicitly cleared (no restriction).
-  const [pageAccess, setPageAccess] = useState<{ requiredPermission?: string } | undefined>(undefined)
+  const [pageAccess, setPageAccess] = useState<{ requiredPermission?: string } | undefined>(
+    undefined
+  )
   const [pageSettingsOpen, setPageSettingsOpen] = useState(false)
 
   // Preview mode state (Requirement 7.7)
@@ -928,7 +930,14 @@ export function PageBuilderPage({
     [duplicateMutation]
   )
 
-  const selectedComponent = components.find((c) => c.id === selectedComponentId) || null
+  // Resolve the selected node anywhere in the tree (NOT just top-level) so the inspector shows
+  // properties for nested children (e.g. a heading inside a card inside a grid), matching the
+  // recursive patch/delete handlers above.
+  const selectedComponent: PageComponent | null = selectedComponentId
+    ? ((findNode(components as ModelPageComponent[], selectedComponentId)?.node as
+        | PageComponent
+        | undefined) ?? null)
+    : null
   const isSubmitting = createMutation.isPending || updateMutation.isPending
   const isPublishing = publishMutation.isPending || unpublishMutation.isPending
   const isDuplicating = duplicateMutation.isPending


### PR DESCRIPTION
## Summary
In the page builder, selecting a component **nested inside a container** (e.g. a heading inside a card inside a grid) left the Properties panel on its empty "Select a component to edit its properties" state — even though the node was clearly outlined/selected on the canvas.

**Root cause:** the selected node was resolved with a top-level `components.find((c) => c.id === selectedComponentId)`, which never matched nested children. The patch (`handleComponentChange`) and delete (`handleDeleteComponent`) handlers already recursed the tree — only the inspector's node lookup did not, so it received `null`.

## Changes
- `pages/PageBuilderPage/PageBuilderPage.tsx` — resolve `selectedComponent` via the existing recursive `treeOps.findNode(...)` instead of a shallow `.find`, so the inspector shows properties for a node at any depth. (Also a one-line pre-existing prettier tidy on an adjacent `useState`.)
- `pages/PageBuilderPage/PageBuilderPage.test.tsx` — **new regression test**: seeds a `card > heading` tree, selects the nested heading, asserts the inspector renders its `type`/`text` properties.

## Testing
- `vitest` PageBuilderPage suite → **75 passed / 2 skipped** (incl. the new nested-selection test).
- `eslint` / `prettier --check` / `tsc --noEmit` clean.

> Note: the user also flagged the dashboard's fixed-text KPI tiles (the "aggregate gap" — should use live `meta.totalCount`). That's a separate feature (a count/metric widget) and will follow in its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)