### PR TITLE
fix(lookups): resolve reference fields to display values in list/detail views

### DIFF
--- a/.claude/docs/architecture.md
+++ b/.claude/docs/architecture.md
@@ -187,6 +187,20 @@ by `sectionId IN (section ids)` after `layout-sections` resolves directly).
 Includes are skipped silently when the target is unresolvable — `200` with
 no `included` entry — never `5xx`.
 
+The field-name path and the always-on relationship serialization both require the field's
+`referenceConfig` to be present. `CollectionLifecycleManager.loadFieldsFromDb` builds it from the
+`reference_target` column, but many LOOKUP/MASTER_DETAIL fields were persisted with a **null
+`reference_target`** (only `reference_collection_id` set) — those silently lost their
+`referenceConfig`, so the worker serialized a raw FK-id attribute and `?include=<field>` resolved
+nothing. The loader now **derives the target name from `reference_collection_id`** (via
+`resolveReferenceTarget`) when `reference_target` is blank, so such fields serialize as relationships
+and resolve includes. **Consumer contract:** clients request a *forward* lookup by the **field name**
+(`?include=title`), NOT the target collection name (`?include=titles`); the end-user list/detail/
+related views build `?include=` from reference field names accordingly (see
+`ObjectListPage/listIncludes.ts`). Resolving a forward lookup's display value also needs the **target
+collection to have a display field** (`collection.display_field_id`), else the included row has no
+label to show.
+
 **Read-side field-level security** — `CerbosFieldSecurityAdvice`
 (`@ControllerAdvice`, order 10, after record-level authz) strips fields the
 caller cannot `read` from outgoing JSON:API responses. For the primary `data`

--- a/kelta-ui/app/src/components/RelatedList/RelatedList.tsx
+++ b/kelta-ui/app/src/components/RelatedList/RelatedList.tsx
@@ -165,11 +165,11 @@ export function RelatedList({
     [visibleFields]
   )
 
-  // Build include param from reference target collection names
+  // Build include param from the reference FIELD names. The worker resolves `?include=` by field
+  // name (e.g. `title`), not by target collection name (e.g. `titles`) — see ObjectListPage.
   const includeParam = useMemo(() => {
     if (referenceFields.length === 0) return undefined
-    const uniqueTargets = [...new Set(referenceFields.map((f) => f.referenceTarget!))]
-    return uniqueTargets.join(',')
+    return [...new Set(referenceFields.map((f) => f.name))].join(',')
   }, [referenceFields])
 
   // Extract pre-loaded records from the parent's included resources when available.

--- a/kelta-ui/app/src/pages/app/ObjectDetailPage/ObjectDetailPage.tsx
+++ b/kelta-ui/app/src/pages/app/ObjectDetailPage/ObjectDetailPage.tsx
@@ -265,9 +265,10 @@ export function ObjectDetailPage(): React.ReactElement {
   const includeParam = useMemo(() => {
     const includes = new Set<string>()
 
-    // Forward includes from reference fields on this collection
+    // Forward includes from reference fields on this collection — by FIELD name (the worker resolves
+    // forward `include` by field name, not target collection name; reverse/nested below use names).
     for (const f of referenceFields) {
-      includes.add(f.referenceTarget!)
+      includes.add(f.name)
     }
 
     // Always include users for createdBy/updatedBy display name resolution

--- a/kelta-ui/app/src/pages/app/ObjectListPage/ObjectListPage.tsx
+++ b/kelta-ui/app/src/pages/app/ObjectListPage/ObjectListPage.tsx
@@ -45,6 +45,7 @@ import { useCollectionRecords } from '@/hooks/useCollectionRecords'
 import { useRecordMutation } from '@/hooks/useRecordMutation'
 import { useCollectionPermissions } from '@/hooks/useCollectionPermissions'
 import { buildIncludedDisplayMap } from '@/utils/jsonapi'
+import { REFERENCE_FIELD_TYPES, referenceIncludeParam } from './listIncludes'
 import type { SortState, FilterCondition, CollectionRecord } from '@/hooks/useCollectionRecords'
 import { ObjectDataTable } from '@/components/ObjectDataTable/ObjectDataTable'
 import { DataTablePagination } from '@/components/ObjectDataTable/DataTablePagination'
@@ -144,9 +145,6 @@ function parseListViewParams(searchParams: URLSearchParams): {
   }
 }
 
-/** Reference field types that indicate a foreign key to another collection */
-const REFERENCE_FIELD_TYPES = new Set(['master_detail', 'lookup', 'reference'])
-
 export function ObjectListPage(): React.ReactElement {
   const { tenantSlug, collection: collectionName } = useParams<{
     tenantSlug: string
@@ -203,12 +201,8 @@ export function ObjectListPage(): React.ReactElement {
     [visibleFields]
   )
 
-  // Build include param from reference target collection names (deduplicated)
-  const includeParam = useMemo(() => {
-    if (referenceFields.length === 0) return undefined
-    const uniqueTargets = [...new Set(referenceFields.map((f) => f.referenceTarget!))]
-    return uniqueTargets.join(',')
-  }, [referenceFields])
+  // Build the JSON:API `include` param from the reference FIELD names (see referenceIncludeParam).
+  const includeParam = useMemo(() => referenceIncludeParam(referenceFields), [referenceFields])
 
   // Fetch records with includes for reference fields
   const {

--- a/kelta-ui/app/src/pages/app/ObjectListPage/listIncludes.test.ts
+++ b/kelta-ui/app/src/pages/app/ObjectListPage/listIncludes.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest'
+import { referenceIncludeParam, REFERENCE_FIELD_TYPES } from './listIncludes'
+
+describe('referenceIncludeParam', () => {
+  it('returns undefined when there are no reference fields', () => {
+    expect(referenceIncludeParam([])).toBeUndefined()
+  })
+
+  it('uses the reference FIELD names, not target collection names', () => {
+    // Regression: the worker resolves include by field name (title/provider), not target type
+    // (titles/providers). Passing target names returns no included resources → raw ids.
+    expect(referenceIncludeParam([{ name: 'title' }, { name: 'provider' }])).toBe('title,provider')
+  })
+
+  it('dedupes repeated field names', () => {
+    expect(referenceIncludeParam([{ name: 'title' }, { name: 'title' }])).toBe('title')
+  })
+
+  it('recognises the reference field types', () => {
+    expect(REFERENCE_FIELD_TYPES.has('lookup')).toBe(true)
+    expect(REFERENCE_FIELD_TYPES.has('master_detail')).toBe(true)
+    expect(REFERENCE_FIELD_TYPES.has('reference')).toBe(true)
+    expect(REFERENCE_FIELD_TYPES.has('string')).toBe(false)
+  })
+})

--- a/kelta-ui/app/src/pages/app/ObjectListPage/listIncludes.ts
+++ b/kelta-ui/app/src/pages/app/ObjectListPage/listIncludes.ts
@@ -1,0 +1,21 @@
+/**
+ * Helpers for resolving reference (lookup/master-detail) columns in the object list view.
+ */
+
+/** Field types that hold a foreign key to another collection. */
+export const REFERENCE_FIELD_TYPES = new Set(['master_detail', 'lookup', 'reference'])
+
+/**
+ * Build the JSON:API `?include=` value for a list view from its reference fields.
+ *
+ * The worker resolves `include` by **field name** (e.g. `title`), not by the target collection name
+ * (e.g. `titles`). Using target names matches no relationship, so no `included` resources come back
+ * and reference cells fall back to raw FK ids. Returns the deduped field names, or `undefined` when
+ * there are no reference fields.
+ */
+export function referenceIncludeParam(
+  referenceFields: Array<{ name: string }>
+): string | undefined {
+  if (referenceFields.length === 0) return undefined
+  return [...new Set(referenceFields.map((f) => f.name))].join(',')
+}

--- a/kelta-worker/src/main/java/io/kelta/worker/service/CollectionLifecycleManager.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/service/CollectionLifecycleManager.java
@@ -12,6 +12,7 @@ import tools.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
 
@@ -67,11 +68,15 @@ public class CollectionLifecycleManager {
 
     private static final String SELECT_FIELDS_BY_COLLECTION = """
             SELECT name, type, required, unique_constraint, indexed, default_value,
-                   constraints, field_type_config, reference_target, relationship_type,
-                   relationship_name, cascade_delete, field_order, column_name, immutable,
-                   searchable
+                   constraints, field_type_config, reference_target, reference_collection_id,
+                   relationship_type, relationship_name, cascade_delete, field_order, column_name,
+                   immutable, searchable
             FROM field WHERE collection_id = ? AND active = true
             ORDER BY field_order
+            """;
+
+    private static final String SELECT_COLLECTION_NAME_BY_ID = """
+            SELECT name FROM collection WHERE id = ? AND active = true
             """;
 
     private static final String SELECT_SEARCHABLE_FIELDS = """
@@ -518,6 +523,31 @@ public class CollectionLifecycleManager {
     }
 
     /**
+     * Resolves a relationship field's target collection NAME. Prefers the denormalized
+     * {@code reference_target} column; when it is null/blank, derives the name from
+     * {@code reference_collection_id} so fields persisted without the denormalized name still build a
+     * {@link ReferenceConfig}. Package-private for unit testing.
+     *
+     * @param referenceTarget     the denormalized target collection name (may be null/blank)
+     * @param referenceCollectionId the FK to the target collection (may be null)
+     * @return the resolved target collection name, or {@code null} if neither source yields one
+     */
+    String resolveReferenceTarget(String referenceTarget, Object referenceCollectionId) {
+        if (referenceTarget != null && !referenceTarget.isBlank()) {
+            return referenceTarget;
+        }
+        if (referenceCollectionId == null) {
+            return null;
+        }
+        try {
+            return jdbcTemplate.queryForObject(
+                    SELECT_COLLECTION_NAME_BY_ID, String.class, referenceCollectionId.toString());
+        } catch (EmptyResultDataAccessException ex) {
+            return null;
+        }
+    }
+
+    /**
      * Loads field definitions from the database for a given collection.
      */
     private List<FieldDefinition> loadFieldsFromDb(String collectionId) {
@@ -540,10 +570,19 @@ public class CollectionLifecycleManager {
             boolean immutable = Boolean.TRUE.equals(row.get("immutable"));
             String columnName = (String) row.get("column_name");
 
-            // Parse reference config
+            // Parse reference config. `reference_target` (the denormalized target collection NAME)
+            // is the primary source, but many relationship fields were persisted with only
+            // `reference_collection_id` set and a NULL `reference_target` — in that case the field
+            // would otherwise lose its ReferenceConfig entirely, so the JSON:API serializer emits a
+            // raw FK id attribute (no relationship, no `include` resolution). Derive the target name
+            // from `reference_collection_id` so those fields still resolve. (#lookup-display)
             ReferenceConfig refConfig = null;
-            String referenceTarget = (String) row.get("reference_target");
             String relationshipType = (String) row.get("relationship_type");
+            if (relationshipType == null && fieldType != null && fieldType.isRelationship()) {
+                relationshipType = fieldType.name();
+            }
+            String referenceTarget = resolveReferenceTarget(
+                    (String) row.get("reference_target"), row.get("reference_collection_id"));
             if (referenceTarget != null && !referenceTarget.isBlank()) {
                 String relationshipName = (String) row.get("relationship_name");
                 if ("MASTER_DETAIL".equals(relationshipType)) {

--- a/kelta-worker/src/test/java/io/kelta/worker/service/CollectionLifecycleManagerReferenceTargetTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/service/CollectionLifecycleManagerReferenceTargetTest.java
@@ -1,0 +1,70 @@
+package io.kelta.worker.service;
+
+import io.kelta.runtime.registry.CollectionRegistry;
+import io.kelta.runtime.storage.StorageAdapter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import tools.jackson.databind.ObjectMapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@DisplayName("CollectionLifecycleManager.resolveReferenceTarget (lookup display fix)")
+class CollectionLifecycleManagerReferenceTargetTest {
+
+    private JdbcTemplate jdbcTemplate;
+    private CollectionLifecycleManager manager;
+
+    @BeforeEach
+    void setUp() {
+        jdbcTemplate = mock(JdbcTemplate.class);
+        manager = new CollectionLifecycleManager(
+                mock(CollectionRegistry.class),
+                mock(StorageAdapter.class),
+                jdbcTemplate,
+                new ObjectMapper());
+    }
+
+    @Test
+    @DisplayName("prefers the denormalized reference_target without hitting the database")
+    void prefersDenormalizedTarget() {
+        String target = manager.resolveReferenceTarget("titles", "collection-id-1");
+
+        assertThat(target).isEqualTo("titles");
+        verifyNoInteractions(jdbcTemplate);
+    }
+
+    @Test
+    @DisplayName("derives the target name from reference_collection_id when reference_target is null")
+    void derivesFromCollectionId() {
+        when(jdbcTemplate.queryForObject(any(String.class), eq(String.class), eq("col-titles")))
+                .thenReturn("titles");
+
+        assertThat(manager.resolveReferenceTarget(null, "col-titles")).isEqualTo("titles");
+        assertThat(manager.resolveReferenceTarget("   ", "col-titles")).isEqualTo("titles");
+    }
+
+    @Test
+    @DisplayName("returns null when neither a target name nor a collection id is available")
+    void nullWhenNothingToResolve() {
+        assertThat(manager.resolveReferenceTarget(null, null)).isNull();
+        assertThat(manager.resolveReferenceTarget("", null)).isNull();
+        verifyNoInteractions(jdbcTemplate);
+    }
+
+    @Test
+    @DisplayName("returns null (never throws) when the referenced collection row is missing")
+    void nullWhenCollectionMissing() {
+        when(jdbcTemplate.queryForObject(any(String.class), eq(String.class), eq("ghost")))
+                .thenThrow(new EmptyResultDataAccessException(1));
+
+        assertThat(manager.resolveReferenceTarget(null, "ghost")).isNull();
+    }
+}


### PR DESCRIPTION
## Summary
Lookup/master-detail columns rendered raw FK **UUIDs** instead of the related record's display field — e.g. the `availabilities` list showed `title`/`provider` as ids. Two root causes, fixed across the stack.

### Backend — null `reference_target` dropped the ReferenceConfig
`CollectionLifecycleManager.loadFieldsFromDb` built a field's `ReferenceConfig` **only** from the `reference_target` column. Many LOOKUP/MASTER_DETAIL fields were persisted with a **null `reference_target`** (only `reference_collection_id` set) — so they lost their `ReferenceConfig` entirely. Consequences (verified live):
- `DynamicCollectionRouter.toJsonApiResourceObject` emitted a **raw FK-id attribute**, no `relationships`.
- `?include=<field>` resolved **nothing** (`resolveFieldInclude` requires a non-null `referenceConfig.targetCollection()`).

Fix: `resolveReferenceTarget` derives the target collection **name** from `reference_collection_id` when `reference_target` is blank. No migration — applies on the next config load, fixing all such fields tenant-wide. (Proven live: after populating `reference_target`, `?include=title` returns `relationships.title` + the hydrated `included` title row.)

### Frontend — forward `include` used the wrong name
The end-user list/detail/related views built `?include=` from the target collection **name** (`titles`), but the worker resolves a *forward* include by **field name** (`title`). So no `included` came back and cells fell back to raw ids. `ObjectListPage`, `RelatedList`, and `ObjectDetailPage` now build forward includes from reference **field** names (reverse/nested includes still use collection names, which is correct).

## Changes
- `kelta-worker/.../CollectionLifecycleManager.java` — `resolveReferenceTarget` + select `reference_collection_id`; derive `reference_target` when blank; infer `relationship_type` from the field type when null.
- `kelta-ui/.../ObjectListPage/listIncludes.ts` (new) — `referenceIncludeParam` (field names) + `REFERENCE_FIELD_TYPES`.
- `ObjectListPage.tsx`, `RelatedList.tsx`, `ObjectDetailPage.tsx` — forward include by field name.
- Tests: worker `CollectionLifecycleManagerReferenceTargetTest` (4); FE `listIncludes.test.ts` (4).
- `.claude/docs/architecture.md` — include-resolution section updated.

## Testing
- Worker: `mvn test -Dtest=CollectionLifecycleManagerReferenceTargetTest` → green (runtime libs built).
- FE: `listIncludes` (4) + existing `RelatedList` (10) → pass; `tsc`/`eslint`/`prettier` clean.
- Live API verified end-to-end on couchpicks (`include=title` → hydrated title with display field).

## Data (couchpicks, done via API)
- Set `titles.displayFieldId` → `title` field and `providers.displayFieldId` → `name` so forward lookups have a label. (The backend derivation handles `reference_target` for all 22 lookup fields on deploy.)

> Note: `npm run lint` still reports the pre-existing `TenantContext.tsx:144` error (unrelated; fixed in #1100).

🤖 Generated with [Claude Code](https://claude.com/claude-code)