### PR TITLE
fix(field-editor): allow setting the target collection on LOOKUP fields

### DIFF
--- a/kelta-ui/app/src/components/FieldEditor/FieldEditor.test.tsx
+++ b/kelta-ui/app/src/components/FieldEditor/FieldEditor.test.tsx
@@ -246,7 +246,7 @@ describe('FieldEditor Component', () => {
       const select = screen.getByTestId('field-type-select')
       const options = select.querySelectorAll('option')
 
-      expect(options).toHaveLength(21)
+      expect(options).toHaveLength(22)
       expect(options[0]).toHaveValue('string')
       expect(options[1]).toHaveValue('number')
       expect(options[2]).toHaveValue('boolean')
@@ -254,10 +254,10 @@ describe('FieldEditor Component', () => {
       expect(options[4]).toHaveValue('datetime')
       expect(options[5]).toHaveValue('json')
       expect(options[6]).toHaveValue('master_detail')
-      expect(options[7]).toHaveValue('picklist')
-      expect(options[8]).toHaveValue('multi_picklist')
-      expect(options[9]).toHaveValue('currency')
-      expect(options[10]).toHaveValue('percent')
+      expect(options[7]).toHaveValue('lookup')
+      expect(options[8]).toHaveValue('picklist')
+      expect(options[9]).toHaveValue('multi_picklist')
+      expect(options[10]).toHaveValue('currency')
     })
 
     it('should default to string type in create mode', () => {
@@ -271,6 +271,17 @@ describe('FieldEditor Component', () => {
       renderWithProviders(<FieldEditor {...defaultProps} collections={mockCollections} />)
 
       await user.selectOptions(screen.getByTestId('field-type-select'), 'master_detail')
+
+      expect(screen.getByTestId('field-reference-target-select')).toBeInTheDocument()
+    })
+
+    it('should show reference target dropdown when LOOKUP type is selected (regression)', async () => {
+      // Regression: a lookup field must let the user pick its target collection — previously the
+      // dropdown only appeared for master_detail, so lookups were created with a null referenceTarget.
+      const user = userEvent.setup()
+      renderWithProviders(<FieldEditor {...defaultProps} collections={mockCollections} />)
+
+      await user.selectOptions(screen.getByTestId('field-type-select'), 'lookup')
 
       expect(screen.getByTestId('field-reference-target-select')).toBeInTheDocument()
     })

--- a/kelta-ui/app/src/components/FieldEditor/FieldEditor.tsx
+++ b/kelta-ui/app/src/components/FieldEditor/FieldEditor.tsx
@@ -174,6 +174,7 @@ export const FIELD_TYPES: FieldType[] = [
   'datetime',
   'json',
   'master_detail',
+  'lookup',
   'picklist',
   'multi_picklist',
   'currency',
@@ -292,8 +293,11 @@ export const fieldEditorSchema = z
   })
   .refine(
     (data) => {
-      // master_detail type requires referenceTarget
-      if (data.type === 'master_detail' && !data.referenceTarget) {
+      // Relationship fields (lookup / master_detail / reference) require a target collection.
+      if (
+        (data.type === 'master_detail' || data.type === 'lookup' || data.type === 'reference') &&
+        !data.referenceTarget
+      ) {
         return false
       }
       return true
@@ -666,7 +670,8 @@ export function FieldEditor({
         fieldTypeConfig = config
       }
 
-      const needsReferenceTarget = data.type === 'master_detail'
+      const needsReferenceTarget =
+        data.type === 'master_detail' || data.type === 'lookup' || data.type === 'reference'
 
       // Map validation rules to constraints object for backend
       let constraints: Record<string, unknown> | undefined = undefined
@@ -870,8 +875,10 @@ export function FieldEditor({
         )}
       </div>
 
-      {/* Reference Target (for master_detail type) */}
-      {watchedType === 'master_detail' && (
+      {/* Reference Target (for relationship types: lookup / master_detail / reference) */}
+      {(watchedType === 'master_detail' ||
+        watchedType === 'lookup' ||
+        watchedType === 'reference') && (
         <div className="flex flex-col gap-1">
           <label
             htmlFor="field-reference-target"


### PR DESCRIPTION
## Summary
The field editor wouldn't let you set a **lookup** column's target collection — the cause of the null `reference_target` behind the raw-FK-id display issue.

Three places treated only `master_detail` as a relationship:
- `lookup` was **missing from `FIELD_TYPES`**, so it wasn't even offered in the type dropdown.
- the reference-target `<select>` rendered only for `master_detail` (so editing an existing lookup showed no target picker).
- submit sent `referenceTarget` only for `master_detail` — a lookup always saved with `referenceTarget: undefined`.

A lookup saved with a null `reference_target` loses its `ReferenceConfig` server-side, so the column serializes a raw FK id (see #1104).

## Changes
- `FieldEditor.tsx` — add `lookup` to `FIELD_TYPES` (grouped next to `master_detail`); show the reference-target dropdown for `lookup`/`master_detail`/`reference`; require + submit `referenceTarget` for all three.
- `FieldEditor.test.tsx` — `lookup` is offered in the type list (22 options); selecting `lookup` reveals the reference-target dropdown.

## Testing
- `vitest` FieldEditor → **75 passed**.
- `eslint` / `prettier --check` / `tsc --noEmit` clean.

## Related
Complements #1104 (worker derives `reference_target` from `reference_collection_id`; FE list/detail/related include by field name). This PR fixes the **create/edit** path so new lookups carry a target from the start.

> Note: `npm run lint` still reports the pre-existing `TenantContext.tsx:144` error (unrelated; fixed in #1100).

🤖 Generated with [Claude Code](https://claude.com/claude-code)