### PR TITLE
feat(listviews): schema-driven editor with multi-field sort

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,7 +142,7 @@ visual system.
 | Frontend | React | 19.2 | `kelta-ui/app/package.json` |
 | Frontend build | Vite / Vitest | web 5.1/1.3, ui 7.2/4.0 | package.json (npm, Node 18 in CI) |
 | E2E | Playwright | 1.50 | `e2e-tests/package.json` |
-| Migrations | Flyway | head **V146**, next **V147** | `kelta-worker/.../db/migration/` |
+| Migrations | Flyway | head **V147**, next **V148** | `kelta-worker/.../db/migration/` |
 
 Check the relevant `pom.xml` / `package.json` for exact current versions before pinning.
 
@@ -242,7 +242,7 @@ Java tests: surefire runs `*Test`/`*Tests`/`*Properties` in parallel; failsafe r
 ## Database Migrations
 
 - Location: `kelta-worker/src/main/resources/db/migration/`
-- Naming: `V<n>__<snake_description>.sql`. **Head is V145; next new migration is V146.**
+- Naming: `V<n>__<snake_description>.sql`. **Head is V147; next new migration is V148.**
   Check the directory for the true highest number before creating one — never reuse/skip.
 - Flyway runs at worker startup. Migrations execute under the platform sentinel tenant.
 

--- a/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/model/system/SystemCollectionDefinitions.java
+++ b/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/model/system/SystemCollectionDefinitions.java
@@ -332,6 +332,7 @@ public final class SystemCollectionDefinitions {
             .addField(FieldDefinition.string("sortField").withColumnName("sort_field"))
             .addField(FieldDefinition.string("sortDirection", 4).withColumnName("sort_direction")
                 .withDefault("ASC"))
+            .addField(FieldDefinition.json("sort"))
             .addField(FieldDefinition.integer("rowLimit").withColumnName("row_limit")
                 .withDefault(50))
             .addField(FieldDefinition.json("chartConfig").withColumnName("chart_config"))

--- a/kelta-ui/app/src/pages/ListViewsPage/ListViewEditors.test.tsx
+++ b/kelta-ui/app/src/pages/ListViewsPage/ListViewEditors.test.tsx
@@ -1,0 +1,111 @@
+/**
+ * Tests for the schema-driven List View editors (columns / filters / sort).
+ */
+import React, { useState } from 'react'
+import { describe, it, expect } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import {
+  ColumnsEditor,
+  FilterEditor,
+  SortEditor,
+  type EditorField,
+  type FilterRow,
+  type SortRow,
+} from './ListViewEditors'
+
+const FIELDS: EditorField[] = [
+  { name: 'title', label: 'Title' },
+  { name: 'year', label: 'Year' },
+  { name: 'status', label: 'Status' },
+]
+
+describe('ColumnsEditor', () => {
+  function Harness() {
+    const [value, setValue] = useState<string[]>([])
+    return (
+      <>
+        <ColumnsEditor fields={FIELDS} value={value} onChange={setValue} />
+        <output data-testid="out">{value.join(',')}</output>
+      </>
+    )
+  }
+
+  it('prompts to pick a collection when there are no fields', () => {
+    render(<ColumnsEditor fields={[]} value={[]} onChange={() => {}} />)
+    expect(screen.getByText(/select a collection first/i)).toBeInTheDocument()
+  })
+
+  it('adds, reorders and removes columns', () => {
+    render(<Harness />)
+    fireEvent.click(screen.getByTestId('listview-add-column-title'))
+    fireEvent.click(screen.getByTestId('listview-add-column-year'))
+    expect(screen.getByTestId('out')).toHaveTextContent('title,year')
+
+    // Move "year" up → year,title
+    fireEvent.click(screen.getByLabelText('Move year up'))
+    expect(screen.getByTestId('out')).toHaveTextContent('year,title')
+
+    // Remove "year"
+    fireEvent.click(screen.getByLabelText('Remove year'))
+    expect(screen.getByTestId('out')).toHaveTextContent('title')
+  })
+})
+
+describe('FilterEditor', () => {
+  function Harness() {
+    const [value, setValue] = useState<FilterRow[]>([])
+    return (
+      <>
+        <FilterEditor fields={FIELDS} value={value} onChange={setValue} />
+        <output data-testid="out">{JSON.stringify(value)}</output>
+      </>
+    )
+  }
+
+  it('adds a filter row defaulting to the first field + equals, and edits it', () => {
+    render(<Harness />)
+    fireEvent.click(screen.getByTestId('listview-add-filter'))
+    expect(screen.getByTestId('out')).toHaveTextContent('[{"field":"title","op":"eq","value":""}]')
+
+    fireEvent.change(screen.getByTestId('listview-filter-field-0'), { target: { value: 'status' } })
+    fireEvent.change(screen.getByTestId('listview-filter-op-0'), { target: { value: 'contains' } })
+    fireEvent.change(screen.getByTestId('listview-filter-value-0'), { target: { value: 'active' } })
+    expect(screen.getByTestId('out')).toHaveTextContent(
+      '[{"field":"status","op":"contains","value":"active"}]'
+    )
+  })
+
+  it('hides the value input for a valueless operator (is empty)', () => {
+    render(<Harness />)
+    fireEvent.click(screen.getByTestId('listview-add-filter'))
+    fireEvent.change(screen.getByTestId('listview-filter-op-0'), { target: { value: 'isnull' } })
+    expect(screen.queryByTestId('listview-filter-value-0')).not.toBeInTheDocument()
+  })
+})
+
+describe('SortEditor', () => {
+  function Harness() {
+    const [value, setValue] = useState<SortRow[]>([])
+    return (
+      <>
+        <SortEditor fields={FIELDS} value={value} onChange={setValue} />
+        <output data-testid="out">{JSON.stringify(value)}</output>
+      </>
+    )
+  }
+
+  it('adds sort rows, sets direction, and reorders', () => {
+    render(<Harness />)
+    fireEvent.click(screen.getByTestId('listview-add-sort'))
+    fireEvent.change(screen.getByTestId('listview-sort-direction-0'), { target: { value: 'DESC' } })
+    expect(screen.getByTestId('out')).toHaveTextContent('[{"field":"title","direction":"DESC"}]')
+
+    fireEvent.click(screen.getByTestId('listview-add-sort'))
+    fireEvent.change(screen.getByTestId('listview-sort-field-1'), { target: { value: 'year' } })
+    // Move row 1 up → year first
+    fireEvent.click(screen.getAllByLabelText('Move sort up')[1])
+    expect(screen.getByTestId('out')).toHaveTextContent(
+      '[{"field":"year","direction":"ASC"},{"field":"title","direction":"DESC"}]'
+    )
+  })
+})

--- a/kelta-ui/app/src/pages/ListViewsPage/ListViewEditors.tsx
+++ b/kelta-ui/app/src/pages/ListViewsPage/ListViewEditors.tsx
@@ -1,0 +1,318 @@
+/**
+ * Schema-driven editors for the List View form — replace the raw-JSON textareas so authors never
+ * type field names or JSON:
+ *  - {@link ColumnsEditor}  — pick + reorder which fields are columns.
+ *  - {@link FilterEditor}   — rows of field / operator / value.
+ *  - {@link SortEditor}     — reorderable rows of field + direction.
+ *
+ * All three are controlled (value + onChange) and pure-presentational; the parent owns persistence.
+ */
+/* eslint-disable react-refresh/only-export-components -- shared editor module: exports the operator
+   list + types alongside the editor components (not an HMR component file). */
+import React from 'react'
+import { ArrowUp, ArrowDown, X, Plus } from 'lucide-react'
+
+/** A field the user can choose from (subset of the collection schema). */
+export interface EditorField {
+  name: string
+  label: string
+}
+
+export interface FilterRow {
+  field: string
+  op: string
+  value: string
+}
+
+export interface SortRow {
+  field: string
+  direction: 'ASC' | 'DESC'
+}
+
+/** Filter operators. `value` is the stored op code; `valueless` ops (is empty / not empty) hide the input. */
+export const FILTER_OPERATORS: Array<{ value: string; label: string; valueless?: boolean }> = [
+  { value: 'eq', label: 'equals' },
+  { value: 'neq', label: 'not equals' },
+  { value: 'contains', label: 'contains' },
+  { value: 'starts', label: 'starts with' },
+  { value: 'ends', label: 'ends with' },
+  { value: 'gt', label: 'greater than' },
+  { value: 'gte', label: 'greater or equal' },
+  { value: 'lt', label: 'less than' },
+  { value: 'lte', label: 'less or equal' },
+  { value: 'isnull', label: 'is empty', valueless: true },
+  { value: 'notnull', label: 'is not empty', valueless: true },
+]
+
+const SELECT_CLASS =
+  'rounded-md border border-border bg-background px-2 py-1.5 text-sm text-foreground focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary'
+const INPUT_CLASS =
+  'flex-1 rounded-md border border-border bg-background px-2 py-1.5 text-sm text-foreground focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary'
+const ICON_BTN =
+  'rounded p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground disabled:opacity-30 disabled:hover:bg-transparent'
+const ADD_BTN =
+  'inline-flex items-center gap-1.5 rounded-md border border-dashed border-border px-3 py-1.5 text-sm text-muted-foreground hover:border-primary hover:text-foreground'
+
+/** Move item at `i` by `delta` (±1), returning a new array (no-op at the ends). */
+function move<T>(arr: T[], i: number, delta: number): T[] {
+  const j = i + delta
+  if (j < 0 || j >= arr.length) return arr
+  const next = arr.slice()
+  ;[next[i], next[j]] = [next[j], next[i]]
+  return next
+}
+
+function labelFor(fields: EditorField[], name: string): string {
+  return fields.find((f) => f.name === name)?.label ?? name
+}
+
+function NoCollection(): React.ReactElement {
+  return <p className="text-xs text-muted-foreground">Select a collection first.</p>
+}
+
+/** A `<select>` of fields with a leading placeholder. */
+function FieldSelect({
+  fields,
+  value,
+  onChange,
+  testId,
+}: {
+  fields: EditorField[]
+  value: string
+  onChange: (v: string) => void
+  testId?: string
+}): React.ReactElement {
+  return (
+    <select
+      className={SELECT_CLASS}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      data-testid={testId}
+    >
+      <option value="">Select field…</option>
+      {fields.map((f) => (
+        <option key={f.name} value={f.name}>
+          {f.label}
+        </option>
+      ))}
+    </select>
+  )
+}
+
+/** Pick which fields are columns + order them. */
+export function ColumnsEditor({
+  fields,
+  value,
+  onChange,
+}: {
+  fields: EditorField[]
+  value: string[]
+  onChange: (next: string[]) => void
+}): React.ReactElement {
+  if (fields.length === 0) return <NoCollection />
+  const available = fields.filter((f) => !value.includes(f.name))
+  return (
+    <div className="flex flex-col gap-2" data-testid="listview-columns-editor">
+      {value.length === 0 ? (
+        <p className="text-xs text-muted-foreground">No columns selected — all fields shown.</p>
+      ) : (
+        <ul className="flex flex-col gap-1">
+          {value.map((name, i) => (
+            <li
+              key={name}
+              className="flex items-center gap-1 rounded-md border border-border bg-background px-2 py-1"
+              data-testid={`listview-column-${name}`}
+            >
+              <span className="flex-1 text-sm text-foreground">{labelFor(fields, name)}</span>
+              <button
+                type="button"
+                className={ICON_BTN}
+                disabled={i === 0}
+                onClick={() => onChange(move(value, i, -1))}
+                aria-label={`Move ${name} up`}
+              >
+                <ArrowUp className="h-4 w-4" />
+              </button>
+              <button
+                type="button"
+                className={ICON_BTN}
+                disabled={i === value.length - 1}
+                onClick={() => onChange(move(value, i, 1))}
+                aria-label={`Move ${name} down`}
+              >
+                <ArrowDown className="h-4 w-4" />
+              </button>
+              <button
+                type="button"
+                className={ICON_BTN}
+                onClick={() => onChange(value.filter((c) => c !== name))}
+                aria-label={`Remove ${name}`}
+              >
+                <X className="h-4 w-4" />
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+      {available.length > 0 && (
+        <div className="flex flex-wrap gap-1.5">
+          {available.map((f) => (
+            <button
+              key={f.name}
+              type="button"
+              className={ADD_BTN}
+              onClick={() => onChange([...value, f.name])}
+              data-testid={`listview-add-column-${f.name}`}
+            >
+              <Plus className="h-3.5 w-3.5" />
+              {f.label}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+/** Rows of field / operator / value. */
+export function FilterEditor({
+  fields,
+  value,
+  onChange,
+}: {
+  fields: EditorField[]
+  value: FilterRow[]
+  onChange: (next: FilterRow[]) => void
+}): React.ReactElement {
+  if (fields.length === 0) return <NoCollection />
+  const update = (i: number, patch: Partial<FilterRow>) =>
+    onChange(value.map((row, j) => (j === i ? { ...row, ...patch } : row)))
+  return (
+    <div className="flex flex-col gap-2" data-testid="listview-filters-editor">
+      {value.map((row, i) => {
+        const valueless = FILTER_OPERATORS.find((o) => o.value === row.op)?.valueless
+        return (
+          <div key={i} className="flex items-center gap-1" data-testid={`listview-filter-row-${i}`}>
+            <FieldSelect
+              fields={fields}
+              value={row.field}
+              onChange={(v) => update(i, { field: v })}
+              testId={`listview-filter-field-${i}`}
+            />
+            <select
+              className={SELECT_CLASS}
+              value={row.op}
+              onChange={(e) => update(i, { op: e.target.value })}
+              data-testid={`listview-filter-op-${i}`}
+            >
+              {FILTER_OPERATORS.map((o) => (
+                <option key={o.value} value={o.value}>
+                  {o.label}
+                </option>
+              ))}
+            </select>
+            {!valueless && (
+              <input
+                className={INPUT_CLASS}
+                value={row.value}
+                onChange={(e) => update(i, { value: e.target.value })}
+                placeholder="Value"
+                data-testid={`listview-filter-value-${i}`}
+              />
+            )}
+            <button
+              type="button"
+              className={ICON_BTN}
+              onClick={() => onChange(value.filter((_, j) => j !== i))}
+              aria-label="Remove filter"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </div>
+        )
+      })}
+      <button
+        type="button"
+        className={ADD_BTN}
+        onClick={() => onChange([...value, { field: fields[0]?.name ?? '', op: 'eq', value: '' }])}
+        data-testid="listview-add-filter"
+      >
+        <Plus className="h-3.5 w-3.5" />
+        Add filter
+      </button>
+    </div>
+  )
+}
+
+/** Reorderable rows of field + direction. */
+export function SortEditor({
+  fields,
+  value,
+  onChange,
+}: {
+  fields: EditorField[]
+  value: SortRow[]
+  onChange: (next: SortRow[]) => void
+}): React.ReactElement {
+  if (fields.length === 0) return <NoCollection />
+  const update = (i: number, patch: Partial<SortRow>) =>
+    onChange(value.map((row, j) => (j === i ? { ...row, ...patch } : row)))
+  return (
+    <div className="flex flex-col gap-2" data-testid="listview-sort-editor">
+      {value.map((row, i) => (
+        <div key={i} className="flex items-center gap-1" data-testid={`listview-sort-row-${i}`}>
+          <FieldSelect
+            fields={fields}
+            value={row.field}
+            onChange={(v) => update(i, { field: v })}
+            testId={`listview-sort-field-${i}`}
+          />
+          <select
+            className={SELECT_CLASS}
+            value={row.direction}
+            onChange={(e) => update(i, { direction: e.target.value as 'ASC' | 'DESC' })}
+            data-testid={`listview-sort-direction-${i}`}
+          >
+            <option value="ASC">Ascending</option>
+            <option value="DESC">Descending</option>
+          </select>
+          <button
+            type="button"
+            className={ICON_BTN}
+            disabled={i === 0}
+            onClick={() => onChange(move(value, i, -1))}
+            aria-label="Move sort up"
+          >
+            <ArrowUp className="h-4 w-4" />
+          </button>
+          <button
+            type="button"
+            className={ICON_BTN}
+            disabled={i === value.length - 1}
+            onClick={() => onChange(move(value, i, 1))}
+            aria-label="Move sort down"
+          >
+            <ArrowDown className="h-4 w-4" />
+          </button>
+          <button
+            type="button"
+            className={ICON_BTN}
+            onClick={() => onChange(value.filter((_, j) => j !== i))}
+            aria-label="Remove sort"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+      ))}
+      <button
+        type="button"
+        className={ADD_BTN}
+        onClick={() => onChange([...value, { field: fields[0]?.name ?? '', direction: 'ASC' }])}
+        data-testid="listview-add-sort"
+      >
+        <Plus className="h-3.5 w-3.5" />
+        Add sort
+      </button>
+    </div>
+  )
+}

--- a/kelta-ui/app/src/pages/ListViewsPage/ListViewsPage.tsx
+++ b/kelta-ui/app/src/pages/ListViewsPage/ListViewsPage.tsx
@@ -3,10 +3,19 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useI18n } from '../../context/I18nContext'
 import { useApi } from '../../context/ApiContext'
 import { useCollectionSummaries, type CollectionSummary } from '../../hooks/useCollectionSummaries'
+import { useCollectionSchema } from '../../hooks/useCollectionSchema'
 import { useToast, ConfirmDialog, LoadingSpinner, ErrorMessage } from '../../components'
 import type { CreateListViewRequest } from '@kelta/sdk'
 import { cn } from '@/lib/utils'
 import { AdminDataTable, type AdminColumn } from '@/components/AdminDataTable'
+import {
+  ColumnsEditor,
+  FilterEditor,
+  SortEditor,
+  type EditorField,
+  type FilterRow,
+  type SortRow,
+} from './ListViewEditors'
 
 interface ListView {
   id: string
@@ -20,23 +29,23 @@ interface ListView {
   updatedAt: string
   columns: string[]
   filters: Record<string, unknown>[]
+  /** Multi-field sort (V147); first entry mirrors sortField/sortDirection for back-compat. */
+  sort?: SortRow[]
 }
 
+/** Structured form state — no raw JSON. Columns/filters/sort are edited via schema-driven pickers. */
 interface ListViewFormData {
   name: string
   collectionId: string
   visibility: string
-  columns: string
-  filters: string
-  sortField: string
-  sortDirection: string
+  columns: string[]
+  filters: FilterRow[]
+  sort: SortRow[]
 }
 
 interface FormErrors {
   name?: string
   collectionId?: string
-  columns?: string
-  filters?: string
 }
 
 export interface ListViewsPageProps {
@@ -53,21 +62,49 @@ function validateForm(data: ListViewFormData): FormErrors {
   if (!data.collectionId) {
     errors.collectionId = 'Collection is required'
   }
-  if (data.columns.trim()) {
-    try {
-      JSON.parse(data.columns)
-    } catch {
-      errors.columns = 'Columns must be valid JSON'
-    }
-  }
-  if (data.filters.trim()) {
-    try {
-      JSON.parse(data.filters)
-    } catch {
-      errors.filters = 'Filters must be valid JSON'
-    }
-  }
   return errors
+}
+
+/** Map a stored list view's filters (loose objects) to the editor's {field, op, value} rows. */
+function toFilterRows(filters: Record<string, unknown>[] | undefined): FilterRow[] {
+  if (!Array.isArray(filters)) return []
+  return filters.map((f) => ({
+    field: typeof f.field === 'string' ? f.field : '',
+    op: typeof f.op === 'string' ? f.op : 'eq',
+    value: f.value == null ? '' : String(f.value),
+  }))
+}
+
+/** Seed the sort rows: prefer the multi-sort array, else the legacy single sortField/sortDirection. */
+function toSortRows(listView: ListView | undefined): SortRow[] {
+  if (listView?.sort && Array.isArray(listView.sort) && listView.sort.length > 0) {
+    return listView.sort.map((s) => ({
+      field: s.field,
+      direction: s.direction === 'DESC' ? 'DESC' : 'ASC',
+    }))
+  }
+  if (listView?.sortField) {
+    return [
+      { field: listView.sortField, direction: listView.sortDirection === 'DESC' ? 'DESC' : 'ASC' },
+    ]
+  }
+  return []
+}
+
+/**
+ * Serialize structured form data into the list-view API body: columns/filters/sort as JSON strings
+ * (matching the existing JSON-column contract), plus the legacy single `sortField`/`sortDirection`
+ * derived from the first sort row for back-compat.
+ */
+function serializeListViewBody(data: ListViewFormData) {
+  const first = data.sort[0]
+  return {
+    columns: JSON.stringify(data.columns),
+    filters: JSON.stringify(data.filters),
+    sort: JSON.stringify(data.sort),
+    sortField: first?.field ?? '',
+    sortDirection: first?.direction ?? 'ASC',
+  }
 }
 
 interface ListViewFormProps {
@@ -90,10 +127,9 @@ function ListViewForm({
     name: listView?.name ?? '',
     collectionId: listView?.collectionId ?? '',
     visibility: listView?.visibility ?? 'PRIVATE',
-    columns: listView?.columns ? JSON.stringify(listView.columns, null, 2) : '',
-    filters: listView?.filters ? JSON.stringify(listView.filters, null, 2) : '',
-    sortField: listView?.sortField ?? '',
-    sortDirection: listView?.sortDirection ?? 'ASC',
+    columns: listView?.columns ?? [],
+    filters: toFilterRows(listView?.filters),
+    sort: toSortRows(listView),
   })
   const [errors, setErrors] = useState<FormErrors>({})
   const [touched, setTouched] = useState<Record<string, boolean>>({})
@@ -103,8 +139,22 @@ function ListViewForm({
     nameInputRef.current?.focus()
   }, [])
 
+  // Load the selected collection's fields so columns/filters/sort are pick-lists (no typing names).
+  const collectionName = useMemo(
+    () => collections.find((c) => c.id === formData.collectionId)?.name,
+    [collections, formData.collectionId]
+  )
+  const { fields: schemaFields } = useCollectionSchema(collectionName)
+  const editorFields: EditorField[] = useMemo(
+    () =>
+      schemaFields
+        .filter((f) => !['createdAt', 'updatedAt', 'createdBy', 'updatedBy'].includes(f.name))
+        .map((f) => ({ name: f.name, label: f.displayName || f.name })),
+    [schemaFields]
+  )
+
   const handleChange = useCallback(
-    (field: keyof ListViewFormData, value: string) => {
+    (field: 'name' | 'collectionId' | 'visibility', value: string) => {
       setFormData((prev) => ({ ...prev, [field]: value }))
       if (errors[field as keyof FormErrors]) {
         setErrors((prev) => ({ ...prev, [field]: undefined }))
@@ -112,6 +162,11 @@ function ListViewForm({
     },
     [errors]
   )
+
+  // Setters for the structured (non-string) editors.
+  const setColumns = useCallback((v: string[]) => setFormData((p) => ({ ...p, columns: v })), [])
+  const setFilters = useCallback((v: FilterRow[]) => setFormData((p) => ({ ...p, filters: v })), [])
+  const setSort = useCallback((v: SortRow[]) => setFormData((p) => ({ ...p, sort: v })), [])
 
   const handleBlur = useCallback(
     (field: keyof FormErrors) => {
@@ -129,7 +184,7 @@ function ListViewForm({
       e.preventDefault()
       const validationErrors = validateForm(formData)
       setErrors(validationErrors)
-      setTouched({ name: true, collectionId: true, columns: true, filters: true })
+      setTouched({ name: true, collectionId: true })
       if (Object.keys(validationErrors).length === 0) {
         onSubmit(formData)
       }
@@ -275,104 +330,18 @@ function ListViewForm({
             </div>
 
             <div>
-              <label
-                htmlFor="listview-columns"
-                className="mb-1 block text-sm font-medium text-foreground"
-              >
-                Columns
-              </label>
-              <textarea
-                id="listview-columns"
-                className={cn(
-                  'w-full rounded-md border px-3 py-2 text-sm text-foreground bg-background font-mono focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary',
-                  touched.columns && errors.columns ? 'border-destructive' : 'border-border'
-                )}
-                value={formData.columns}
-                onChange={(e) => handleChange('columns', e.target.value)}
-                onBlur={() => handleBlur('columns')}
-                placeholder='["field1", "field2"]'
-                disabled={isSubmitting}
-                rows={3}
-                data-testid="listview-columns-input"
-              />
-              <span className="mt-1 block text-xs text-muted-foreground">
-                JSON array of column field names
-              </span>
-              {touched.columns && errors.columns && (
-                <span className="mt-1 block text-xs text-destructive" role="alert">
-                  {errors.columns}
-                </span>
-              )}
+              <span className="mb-1 block text-sm font-medium text-foreground">Columns</span>
+              <ColumnsEditor fields={editorFields} value={formData.columns} onChange={setColumns} />
             </div>
 
             <div>
-              <label
-                htmlFor="listview-filters"
-                className="mb-1 block text-sm font-medium text-foreground"
-              >
-                Filters
-              </label>
-              <textarea
-                id="listview-filters"
-                className={cn(
-                  'w-full rounded-md border px-3 py-2 text-sm text-foreground bg-background font-mono focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary',
-                  touched.filters && errors.filters ? 'border-destructive' : 'border-border'
-                )}
-                value={formData.filters}
-                onChange={(e) => handleChange('filters', e.target.value)}
-                onBlur={() => handleBlur('filters')}
-                placeholder='[{"field": "status", "op": "eq", "value": "active"}]'
-                disabled={isSubmitting}
-                rows={3}
-                data-testid="listview-filters-input"
-              />
-              <span className="mt-1 block text-xs text-muted-foreground">
-                JSON array of filter objects
-              </span>
-              {touched.filters && errors.filters && (
-                <span className="mt-1 block text-xs text-destructive" role="alert">
-                  {errors.filters}
-                </span>
-              )}
+              <span className="mb-1 block text-sm font-medium text-foreground">Filters</span>
+              <FilterEditor fields={editorFields} value={formData.filters} onChange={setFilters} />
             </div>
 
             <div>
-              <label
-                htmlFor="listview-sortField"
-                className="mb-1 block text-sm font-medium text-foreground"
-              >
-                Sort Field
-              </label>
-              <input
-                id="listview-sortField"
-                type="text"
-                className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
-                value={formData.sortField}
-                onChange={(e) => handleChange('sortField', e.target.value)}
-                placeholder="Enter sort field name"
-                disabled={isSubmitting}
-                data-testid="listview-sortField-input"
-              />
-            </div>
-
-            <div>
-              <label
-                htmlFor="listview-sortDirection"
-                className="mb-1 block text-sm font-medium text-foreground"
-              >
-                Sort Direction
-              </label>
-              <select
-                id="listview-sortDirection"
-                className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
-                value={formData.sortDirection}
-                onChange={(e) => handleChange('sortDirection', e.target.value)}
-                disabled={isSubmitting}
-                data-testid="listview-sortDirection-input"
-              >
-                <option value="ASC">ASC</option>
-                <option value="DESC">DESC</option>
-              </select>
+              <span className="mb-1 block text-sm font-medium text-foreground">Sort</span>
+              <SortEditor fields={editorFields} value={formData.sort} onChange={setSort} />
             </div>
 
             <div className="flex justify-end gap-2 pt-2">
@@ -442,10 +411,7 @@ export function ListViewsPage({
         collectionId: data.collectionId,
         name: data.name,
         visibility: data.visibility,
-        columns: data.columns.trim() || '[]',
-        filters: data.filters.trim() || '[]',
-        sortField: data.sortField,
-        sortDirection: data.sortDirection,
+        ...serializeListViewBody(data),
       }
       return keltaClient.admin.listViews.create('', '', payload as CreateListViewRequest)
     },
@@ -464,10 +430,7 @@ export function ListViewsPage({
       const payload = {
         name: data.name,
         visibility: data.visibility,
-        columns: data.columns.trim() || '[]',
-        filters: data.filters.trim() || '[]',
-        sortField: data.sortField,
-        sortDirection: data.sortDirection,
+        ...serializeListViewBody(data),
       }
       return keltaClient.admin.listViews.update(id, payload as Partial<CreateListViewRequest>)
     },

--- a/kelta-worker/src/main/resources/db/migration/V147__add_list_view_sort.sql
+++ b/kelta-worker/src/main/resources/db/migration/V147__add_list_view_sort.sql
@@ -1,0 +1,7 @@
+-- Multi-field sort for list views.
+--
+-- The legacy model stored a single sort_field + sort_direction. The list-view editor now supports
+-- multiple sort keys (each with its own direction), persisted as a JSON array of {field, direction}.
+-- sort_field/sort_direction remain populated with the first entry for back-compat with any consumer
+-- that still reads the single-sort columns.
+ALTER TABLE list_view ADD COLUMN IF NOT EXISTS sort jsonb;


### PR DESCRIPTION
## Summary
The List View create/edit form required hand-written **JSON** for Columns and Filters and a free-text **Sort Field** — the author had to know exact field names. This replaces all of that with schema-driven pickers and adds multi-field sort.

> "all fields should be selectable and orderable … a filter editor with field names … sort should be fields that are orderable and asc or desc selected for each … no reason to need to know fields."

## Frontend (`ListViewsPage` + new `ListViewEditors`)
- **Columns** — pick + reorder fields from the selected collection's schema (up/down, add/remove). No JSON.
- **Filters** — rows of **field / operator / value** (field + op are dropdowns; valueless ops like *is empty* hide the value box).
- **Sort** — reorderable rows of **field + ASC/DESC each** (multi-field).
- Fields come from `useCollectionSchema(collectionName)`; columns/filters/sort persist as JSON strings (existing contract) plus a new `sort` array. The legacy single `sortField`/`sortDirection` are derived from the first sort row for back-compat.

## Backend
- `list-views` gains a **`sort` JSON column** (Flyway **V147**) + a `sort` field on the system-collection definition. The generic CRUD path persists it; the SDK already passes all attributes through (`toJsonApiBody` / `unwrapJsonApiList`), so multi-sort round-trips on create, read, and edit.

## Testing
- `vitest` `ListViewEditors` (5): add/reorder/remove columns; filter add/edit + valueless-op hides input; multi-sort add/direction/reorder.
- runtime-core `SystemCollectionDefinitionsTest` green (def compiles; `>=50` collections + unique names hold).
- `tsc` / `eslint` / `prettier` clean.

## Notes
- Filter operators: eq/neq/contains/starts/ends/gt/gte/lt/lte/isnull/notnull (the existing `{field, op, value}` shape).
- `npm run lint` still reports the pre-existing `TenantContext.tsx:144` error (unrelated; fixed in #1100).
- Ships a migration → worker + frontend deploy together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)