### PR TITLE
fix(gateway): lazily resolve tenant slug on cache miss

### DIFF
--- a/.claude/docs/architecture.md
+++ b/.claude/docs/architecture.md
@@ -144,6 +144,15 @@ jobs. RLS then scopes every query automatically.
 
 ## Data Flow
 
+**Tenant-slug resolution (cold-cache safe).** `TenantSlugExtractionFilter` resolves the URL slug via
+`GatewayCacheManager.resolveTenantSlug`, backed by a Caffeine cache refreshed from the worker
+(`/internal/tenants/slug-map`) every 60s. On a **cache miss** it now **lazily fetches** the map from
+the worker (bounded 2s), merges it, and negative-caches a still-missing slug (mirroring
+`resolveCustomDomain`) — so a valid tenant resolves immediately during the cold-cache window
+(gateway restart, or a refresh that failed while the worker was briefly unreachable) instead of
+returning `404 TENANT_NOT_FOUND` for every `/{slug}/api/**` request (which strands the UI before it
+can even reach login). A fetch error never negative-caches a valid slug; the next request retries.
+
 **HTTP Request (Client -> Gateway -> Worker):**
 1. Client sends request (e.g., GET /api/contacts)
 2. TenantSlugExtractionFilter extracts tenant from URL

--- a/kelta-gateway/src/main/java/io/kelta/gateway/cache/GatewayCacheManager.java
+++ b/kelta-gateway/src/main/java/io/kelta/gateway/cache/GatewayCacheManager.java
@@ -105,14 +105,54 @@ public class GatewayCacheManager {
         if (slug == null || slug.isBlank()) {
             return Optional.empty();
         }
-        return Optional.ofNullable(tenantSlugCache.getIfPresent(slug));
+        String cached = tenantSlugCache.getIfPresent(slug);
+        if (cached != null) {
+            return SLUG_NOT_FOUND.equals(cached) ? Optional.empty() : Optional.of(cached);
+        }
+
+        // Cache miss. The scheduled refresh may not have run yet (cold start, or a refresh that
+        // failed while the worker was briefly unreachable), or this is a brand-new tenant. Without a
+        // fallback, a VALID tenant 404s for up to one refresh interval — every request to
+        // /{slug}/api/** fails, so the UI can't even load. Lazily pull the slug→tenant map from the
+        // worker, merge it, and re-check (mirrors resolveCustomDomain's lazy lookup).
+        Map<String, String> mapping = fetchTenantSlugMap();
+        if (mapping != null && !mapping.isEmpty()) {
+            tenantSlugCache.putAll(mapping);
+            String resolved = mapping.get(slug);
+            if (resolved != null) {
+                return Optional.of(resolved);
+            }
+            // Fetched successfully but the slug genuinely isn't a tenant — negative-cache so an
+            // unknown slug doesn't re-fetch on every request (cleared by the next full refresh).
+            tenantSlugCache.put(slug, SLUG_NOT_FOUND);
+        }
+        // On a fetch error we intentionally do NOT negative-cache: a transient worker blip must not
+        // pin a valid tenant to "not found" — the next request retries.
+        return Optional.empty();
     }
 
     /**
-     * Checks whether the given string is a known tenant slug.
+     * Fetches the slug→tenantId map from the worker (bounded). Returns null on any failure so a
+     * transient error never poisons the cache.
+     */
+    private Map<String, String> fetchTenantSlugMap() {
+        try {
+            return webClient.get()
+                    .uri("/internal/tenants/slug-map")
+                    .retrieve()
+                    .bodyToMono(new ParameterizedTypeReference<Map<String, String>>() {})
+                    .block(Duration.ofSeconds(2));
+        } catch (Exception e) {
+            log.warn("Lazy tenant slug-map fetch failed: {}", e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * Checks whether the given string is a known tenant slug (lazily resolving on a cache miss).
      */
     public boolean isKnownSlug(String slug) {
-        return slug != null && tenantSlugCache.getIfPresent(slug) != null;
+        return resolveTenantSlug(slug).isPresent();
     }
 
     /**
@@ -262,6 +302,12 @@ public class GatewayCacheManager {
      * Cached to avoid repeated worker API calls for regular subdomain-based tenants.
      */
     private static final String DOMAIN_NOT_FOUND = "__NOT_FOUND__";
+
+    /**
+     * Sentinel value indicating a slug was looked up against the worker and is not a known tenant.
+     * Negative-cached so an unknown slug doesn't trigger a worker fetch on every request.
+     */
+    private static final String SLUG_NOT_FOUND = "__NOT_FOUND__";
 
     /**
      * Resolves a custom domain to a tenant slug.

--- a/kelta-gateway/src/test/java/io/kelta/gateway/cache/GatewayCacheManagerTest.java
+++ b/kelta-gateway/src/test/java/io/kelta/gateway/cache/GatewayCacheManagerTest.java
@@ -258,6 +258,48 @@ class GatewayCacheManagerTest {
             assertThat(cacheManager.resolveTenantSlug("globex")).contains("tenant-id-2");
             assertThat(cacheManager.tenantSlugCacheSize()).isEqualTo(2);
         }
+
+        @Test
+        void resolveLazilyFetchesFromWorkerOnCacheMiss() {
+            // Cold cache (scheduled refresh hasn't run): a valid tenant must still resolve.
+            stubRefreshResponse(Mono.just(Map.of("couchpicks", "tenant-cp")));
+
+            assertThat(cacheManager.resolveTenantSlug("couchpicks")).contains("tenant-cp");
+
+            // The lazy fetch warmed the cache — a second resolve hits it, no further worker call.
+            reset(webClient);
+            assertThat(cacheManager.resolveTenantSlug("couchpicks")).contains("tenant-cp");
+            verifyNoInteractions(webClient);
+        }
+
+        @Test
+        void resolveNegativeCachesUnknownSlugAfterLazyFetch() {
+            stubRefreshResponse(Mono.just(Map.of("acme", "tenant-id-1")));
+
+            assertThat(cacheManager.resolveTenantSlug("ghost")).isEmpty();
+
+            // A genuinely-unknown slug is negative-cached — no repeat worker fetch.
+            reset(webClient);
+            assertThat(cacheManager.resolveTenantSlug("ghost")).isEmpty();
+            verifyNoInteractions(webClient);
+        }
+
+        @Test
+        void resolveDoesNotPinValidTenantToNotFoundOnFetchError() {
+            // A transient worker error must NOT poison a valid tenant to "not found".
+            stubRefreshResponse(Mono.error(new RuntimeException("worker down")));
+            assertThat(cacheManager.resolveTenantSlug("couchpicks")).isEmpty();
+
+            // Worker recovers — the retry resolves.
+            stubRefreshResponse(Mono.just(Map.of("couchpicks", "tenant-cp")));
+            assertThat(cacheManager.resolveTenantSlug("couchpicks")).contains("tenant-cp");
+        }
+
+        @Test
+        void isKnownSlugLazilyResolvesOnCacheMiss() {
+            stubRefreshResponse(Mono.just(Map.of("acme", "tenant-id-1")));
+            assertThat(cacheManager.isKnownSlug("acme")).isTrue();
+        }
     }
 
     // ── Governor Limit Cache Tests ────────────────────────────────────


### PR DESCRIPTION
## Summary
Diagnosed from a network trace: every `https://api.kelta.io/couchpicks/api/*` request — including the bootstrap config and the login page's `oidc-providers` / `tenants` lookups — returned **404 `TENANT_NOT_FOUND`**. That comes from `TenantSlugExtractionFilter` when `GatewayCacheManager.resolveTenantSlug("couchpicks")` is empty.

`resolveTenantSlug` read **only** a Caffeine cache refreshed from the worker every 60s, with **no lazy fallback**. So during the cold-cache window — gateway restart, or a scheduled refresh that failed while the worker was briefly unreachable — a **valid** tenant 404s for *everything*. The UI can't load, can't reach login, and appears stuck "needing a token."

(Note `resolveCustomDomain` already does lazy worker resolution on a miss — `resolveTenantSlug` was the asymmetric gap.)

## Fix
`resolveTenantSlug` now, on a cache miss:
1. Lazily fetches the slug→tenant map from the worker (`/internal/tenants/slug-map`, bounded 2s), merges it, and re-checks — a valid tenant resolves immediately.
2. Negative-caches a genuinely-unknown slug (so it doesn't re-fetch every request; cleared by the next full refresh).
3. Does **not** negative-cache on a fetch error — a transient worker blip never pins a valid tenant to "not found"; the next request retries.

`isKnownSlug` delegates to `resolveTenantSlug` so slug validation benefits too.

## Changes
- `cache/GatewayCacheManager.java` — lazy `resolveTenantSlug` + `fetchTenantSlugMap` helper + `SLUG_NOT_FOUND` sentinel; `isKnownSlug` delegates.
- `cache/GatewayCacheManagerTest.java` — lazy fetch on miss; unknown-slug negative cache (no repeat fetch); error doesn't poison a valid tenant; `isKnownSlug` lazy-resolves.
- `architecture.md` — tenant-slug resolution note.

## Testing
- `mvn test -Dtest=GatewayCacheManagerTest` → green (4 new + existing).

## Note
This is the **root cause** of the reported "UI stuck, can't auto-redirect to login" — the failures were `404` (tenant unresolved), not `401`, so the FE's 401-redirect couldn't fire. With the tenant resolving, auth-required endpoints return `401` and the existing interceptor redirects normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)