### PR TITLE
feat(scripts): standalone script execution endpoint + wire useScriptExecution

### DIFF
--- a/.claude/docs/status.md
+++ b/.claude/docs/status.md
@@ -39,6 +39,7 @@ ship a change that moves a row.
 | Configuration packages | `PackageController` (`/api/packages/{export,import/preview,import,history}`) + `PackageService` — real export/import/dry-run. `packages`/`package-items` system collections. (Verified 2026-07-02; the prior 🔴 "no PackageController" was stale.) |
 | SCIM 2.0 provisioning | Full `scim/` package: `ScimUser/Group/DiscoveryController` + services + `ScimFilterParser` + `ScimAuthenticationFilter`; gateway route `/scim/v2/**`; 6 test classes. (Verified 2026-07-02; the prior ⚪ "not started" was stale.) |
 | Data export | `DataExportController` (`/api/data-exports`, CSV/JSON, presigned-download) + `DataExportService`; gateway static route added + gated on `VIEW_ALL_DATA` (2026-07-02). Scheduled `DATA_EXPORT`/`REPORT_EXPORT`/`FLOW` jobs run via `ScheduledJobExecutorService` |
+| Standalone script execution | `ScriptExecutionController` `POST /api/scripts/{id}/execute` runs an active, HTTP-invocable (`API_ENDPOINT`/`EVENT_HANDLER`) script through the sandboxed `GraalVmScriptExecutor` with `input`+`context` bindings; logs to `script_execution_log`; end-user Quick Actions `useScriptExecution` calls it (script `output.action` drives refresh/redirect/toast/open_record). Per-script authz is a follow-up |
 
 ## 🟡 Partial — backend exists, gaps remain
 
@@ -74,7 +75,6 @@ ship a change that moves a row.
 | Record types | Data model + Record Type editor | No runtime enforcement of picklist restriction or layout association (backend reachability unverified) |
 | Record sharing | `ResourceDetailPage` sharing panel | `record-shares` is **not** a system collection and has no controller; UI try/catches `/api/record-shares` → `[]`. Genuine UI-without-backend gap |
 | Quick actions | `QuickActionsMenu` (record detail) | `useQuickActions` returns `[]` (no source); the four action handlers fire "coming soon" toasts. No backend |
-| Standalone script execution | `useScriptExecution` / run buttons | No `ScriptController`, no `/api/scripts/{id}/execute`; scripts run only via flow `InvokeScript` + record-event hooks. `useScriptExecution` returns "temporarily unavailable" |
 | Schema migration planner | `MigrationsPage` (plan/execute) | UI calls `/api/migrations`, `/api/migrations/plan`, `/api/migrations/execute` — **no controller maps these** (only `/api/migration-runs`, a system collection, exists). Genuine gap |
 
 ## ⚪ Planned / enterprise gaps (not started)

--- a/kelta-ui/app/src/hooks/useScriptExecution.test.ts
+++ b/kelta-ui/app/src/hooks/useScriptExecution.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import React from 'react'
+import { useScriptExecution } from './useScriptExecution'
+import type { QuickActionExecutionContext } from '@/types/quickActions'
+
+const mockPost = vi.fn()
+vi.mock('../context/ApiContext', () => ({
+  useApi: vi.fn(() => ({
+    apiClient: { post: (...args: unknown[]) => mockPost(...args) },
+  })),
+}))
+
+const mockNavigate = vi.fn()
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+}))
+
+const mockToast = { success: vi.fn(), error: vi.fn() }
+vi.mock('sonner', () => ({
+  toast: Object.assign((...args: unknown[]) => mockToast.success(...args), {
+    success: (...args: unknown[]) => mockToast.success(...args),
+    error: (...args: unknown[]) => mockToast.error(...args),
+  }),
+}))
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return React.createElement(QueryClientProvider, { client: queryClient }, children)
+}
+
+const context: QuickActionExecutionContext = {
+  collectionName: 'orders',
+  recordId: 'r1',
+  tenantSlug: 'acme',
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('useScriptExecution', () => {
+  it('posts to the execute endpoint with input + record context', async () => {
+    mockPost.mockResolvedValue({ success: true, output: {}, executionTimeMs: 5 })
+
+    const { result } = renderHook(() => useScriptExecution(), { wrapper })
+    await result.current.execute({ scriptId: 's1', context, parameters: { amount: 10 } })
+
+    expect(mockPost).toHaveBeenCalledWith('/api/scripts/s1/execute', {
+      input: { amount: 10 },
+      context: { collectionName: 'orders', recordId: 'r1' },
+    })
+  })
+
+  it('maps a successful response and surfaces the script action', async () => {
+    mockPost.mockResolvedValue({
+      success: true,
+      output: { action: { type: 'toast', message: 'Done', variant: 'success' } },
+      executionTimeMs: 3,
+    })
+
+    const { result } = renderHook(() => useScriptExecution(), { wrapper })
+    const res = await result.current.execute({ scriptId: 's1', context })
+
+    expect(res.success).toBe(true)
+    await waitFor(() => expect(mockToast.success).toHaveBeenCalledWith('Done'))
+  })
+
+  it('returns a failure result when the request throws', async () => {
+    mockPost.mockRejectedValue(new Error('network'))
+
+    const { result } = renderHook(() => useScriptExecution(), { wrapper })
+    const res = await result.current.execute({ scriptId: 's1', context })
+
+    expect(res.success).toBe(false)
+    expect(mockToast.error).toHaveBeenCalled()
+  })
+
+  it('navigates on an open_record action returned by the script', async () => {
+    mockPost.mockResolvedValue({
+      success: true,
+      output: { action: { type: 'open_record', collection: 'invoices', recordId: 'inv-9' } },
+    })
+
+    const { result } = renderHook(() => useScriptExecution(), { wrapper })
+    await result.current.execute({ scriptId: 's1', context })
+
+    expect(mockNavigate).toHaveBeenCalledWith('/acme/app/o/invoices/inv-9')
+  })
+})

--- a/kelta-ui/app/src/hooks/useScriptExecution.ts
+++ b/kelta-ui/app/src/hooks/useScriptExecution.ts
@@ -7,15 +7,22 @@
  * Scripts are executed with a record context (collection, record ID,
  * record data) and optional user-provided parameters.
  *
- * Script execution is not yet available via JSON:API — returns a
- * graceful error message.
+ * Runs the script server-side via `POST /api/scripts/{id}/execute` (sandboxed
+ * GraalVM). The script's returned `output` may carry `{ action, message }` to
+ * drive the post-run UI behavior handled below.
  */
 
 import { useCallback } from 'react'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { useNavigate } from 'react-router-dom'
 import { toast } from 'sonner'
-import type { ScriptExecutionResult, QuickActionExecutionContext } from '@/types/quickActions'
+import { useApi } from '../context/ApiContext'
+import { parseAxiosError } from '../services/apiClient'
+import type {
+  ScriptExecutionResult,
+  ScriptResultAction,
+  QuickActionExecutionContext,
+} from '@/types/quickActions'
 
 export interface ExecuteScriptParams {
   /** Script ID to execute */
@@ -47,9 +54,27 @@ export interface UseScriptExecutionReturn {
  *
  * @returns Script execution function and state
  */
+/** Shape of the worker `POST /api/scripts/{id}/execute` response. */
+interface ScriptExecuteResponse {
+  success: boolean
+  output?: Record<string, unknown> | null
+  executionTimeMs?: number
+  message?: string
+}
+
+/** Maps the worker execute response onto the UI's ScriptExecutionResult contract. */
+function toScriptResult(response: ScriptExecuteResponse): ScriptExecutionResult {
+  const output = (response.output ?? {}) as Record<string, unknown>
+  const action = output.action as ScriptResultAction | undefined
+  const message =
+    response.message ?? (typeof output.message === 'string' ? output.message : undefined)
+  return { success: response.success, action, message, data: output }
+}
+
 export function useScriptExecution(): UseScriptExecutionReturn {
   const navigate = useNavigate()
   const queryClient = useQueryClient()
+  const { apiClient } = useApi()
 
   const handleResultAction = useCallback(
     (result: ScriptExecutionResult, context: QuickActionExecutionContext) => {
@@ -111,12 +136,21 @@ export function useScriptExecution(): UseScriptExecutionReturn {
   )
 
   const mutation = useMutation({
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    mutationFn: async (_params: ExecuteScriptParams): Promise<ScriptExecutionResult> => {
-      // Script execution is not yet available via JSON:API
-      return {
-        success: false,
-        message: 'Script execution is temporarily unavailable.',
+    mutationFn: async (params: ExecuteScriptParams): Promise<ScriptExecutionResult> => {
+      try {
+        const response = await apiClient.post<ScriptExecuteResponse>(
+          `/api/scripts/${params.scriptId}/execute`,
+          {
+            input: params.parameters ?? {},
+            context: {
+              collectionName: params.context.collectionName,
+              recordId: params.context.recordId,
+            },
+          }
+        )
+        return toScriptResult(response)
+      } catch (err) {
+        return { success: false, message: parseAxiosError(err).message }
       }
     },
   })

--- a/kelta-worker/src/main/java/io/kelta/worker/controller/ScriptExecutionController.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/controller/ScriptExecutionController.java
@@ -1,0 +1,131 @@
+package io.kelta.worker.controller;
+
+import io.kelta.runtime.module.integration.spi.ScriptExecutor;
+import io.kelta.runtime.module.integration.spi.ScriptExecutor.ScriptExecutionRequest;
+import io.kelta.runtime.module.integration.spi.ScriptExecutor.ScriptExecutionResult;
+import io.kelta.worker.repository.ScriptRepository;
+import io.kelta.worker.repository.ScriptRepository.Script;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Synchronous, HTTP-invoked execution of an admin-authored server script.
+ *
+ * <p>Backs the end-user Quick Actions "run script" path (`useScriptExecution`). The script
+ * source is admin-authored and runs in the sandboxed {@link ScriptExecutor} (GraalVM) with a
+ * timeout; a caller supplies only an {@code input} payload and an optional record
+ * {@code context}. Only scripts whose {@code scriptType} is HTTP-invocable
+ * ({@code API_ENDPOINT} / {@code EVENT_HANDLER}) and that are {@code active} may be run this
+ * way — trigger/validation/scheduled scripts run only in their own lifecycle contexts.
+ *
+ * <p>Reads are tenant-scoped by RLS. The route lives under {@code /api/scripts/**} (already
+ * gateway-routed) and gets the blanket {@code API_ACCESS} check; per-script authorization is
+ * a follow-up (the script itself is trusted platform config).
+ *
+ * @since 1.0.0
+ */
+@RestController
+@RequestMapping("/api/scripts")
+public class ScriptExecutionController {
+
+    private static final Logger log = LoggerFactory.getLogger(ScriptExecutionController.class);
+
+    /** Script types that may be invoked over HTTP. Trigger/validation/scheduled run elsewhere. */
+    private static final Set<String> INVOCABLE_TYPES = Set.of("API_ENDPOINT", "EVENT_HANDLER");
+
+    private final ScriptRepository scriptRepository;
+    private final ScriptExecutor scriptExecutor;
+
+    public ScriptExecutionController(ScriptRepository scriptRepository, ScriptExecutor scriptExecutor) {
+        this.scriptRepository = scriptRepository;
+        this.scriptExecutor = scriptExecutor;
+    }
+
+    @PostMapping("/{id}/execute")
+    @SuppressWarnings("unchecked")
+    public ResponseEntity<Map<String, Object>> execute(
+            @PathVariable String id,
+            @RequestHeader("X-Tenant-ID") String tenantId,
+            @RequestHeader(value = "X-User-Id", required = false) String userId,
+            @RequestBody(required = false) Map<String, Object> body) {
+
+        Optional<Script> scriptOpt = scriptRepository.findById(id);
+        if (scriptOpt.isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+        Script script = scriptOpt.get();
+
+        if (!script.active()) {
+            return error(HttpStatus.UNPROCESSABLE_ENTITY, "Script is not active");
+        }
+        if (!INVOCABLE_TYPES.contains(script.scriptType())) {
+            return error(HttpStatus.UNPROCESSABLE_ENTITY,
+                    "Script type " + script.scriptType() + " cannot be invoked via the execute endpoint");
+        }
+        if (script.source() == null || script.source().isBlank()) {
+            return error(HttpStatus.UNPROCESSABLE_ENTITY, "Script has no source");
+        }
+
+        Map<String, Object> requestBody = body != null ? body : Map.of();
+        Map<String, Object> input = requestBody.get("input") instanceof Map<?, ?> m
+                ? (Map<String, Object>) m : Map.of();
+        Map<String, Object> callerContext = requestBody.get("context") instanceof Map<?, ?> c
+                ? (Map<String, Object>) c : Map.of();
+        String recordId = callerContext.get("recordId") instanceof String s ? s : null;
+
+        Map<String, Object> bindings = new HashMap<>();
+        bindings.put("input", input);
+        bindings.put("context", Map.of(
+                "tenantId", tenantId != null ? tenantId : "",
+                "userId", userId != null ? userId : "",
+                "scriptId", script.id(),
+                "collectionName", callerContext.getOrDefault("collectionName", ""),
+                "recordId", recordId != null ? recordId : ""));
+
+        ScriptExecutionResult result;
+        try {
+            result = scriptExecutor.execute(new ScriptExecutionRequest(script.source(), bindings, 0));
+        } catch (RuntimeException ex) {
+            log.warn("Script {} execution threw: {}", id, ex.getMessage());
+            result = ScriptExecutionResult.failure(ex.getMessage(), 0L);
+        }
+
+        safeLog(tenantId, script.id(), result, recordId);
+
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("success", result.success());
+        response.put("output", result.output());
+        response.put("executionTimeMs", result.executionTimeMs());
+        if (!result.success()) {
+            response.put("message", result.errorMessage());
+        }
+        return ResponseEntity.ok(response);
+    }
+
+    private void safeLog(String tenantId, String scriptId, ScriptExecutionResult result, String recordId) {
+        try {
+            scriptRepository.insertExecutionLog(tenantId, scriptId,
+                    result.success() ? "SUCCESS" : "FAILURE",
+                    result.executionTimeMs(), recordId, result.errorMessage());
+        } catch (RuntimeException ex) {
+            // Never let audit-log persistence failure mask the execution result.
+            log.warn("Failed to write script_execution_log for script {}: {}", scriptId, ex.getMessage());
+        }
+    }
+
+    private ResponseEntity<Map<String, Object>> error(HttpStatus status, String message) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("success", false);
+        body.put("message", message);
+        return ResponseEntity.status(status).body(body);
+    }
+}

--- a/kelta-worker/src/main/java/io/kelta/worker/repository/ScriptRepository.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/repository/ScriptRepository.java
@@ -1,0 +1,85 @@
+package io.kelta.worker.repository;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * JDBC access to the {@code script} table for standalone (HTTP-invoked) script execution.
+ *
+ * <p>Reads are tenant-scoped by Postgres RLS via the request-bound {@code TenantContext};
+ * this repository never adds an explicit {@code tenant_id} filter for that reason (RLS is
+ * the single source of truth, consistent with the rest of the worker).
+ *
+ * @since 1.0.0
+ */
+@Repository
+public class ScriptRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public ScriptRepository(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    /**
+     * Loads a script by id (RLS scopes it to the current tenant).
+     *
+     * @param id the script id
+     * @return the script, or empty if not found for this tenant
+     */
+    public Optional<Script> findById(String id) {
+        return jdbcTemplate.query(
+                "SELECT id, name, script_type, language, source_code, active "
+                        + "FROM script WHERE id = ?",
+                rs -> {
+                    if (!rs.next()) {
+                        return Optional.<Script>empty();
+                    }
+                    return Optional.of(new Script(
+                            rs.getString("id"),
+                            rs.getString("name"),
+                            rs.getString("script_type"),
+                            rs.getString("language"),
+                            rs.getString("source_code"),
+                            rs.getBoolean("active")));
+                },
+                id);
+    }
+
+    /**
+     * Records a single execution in {@code script_execution_log} for auditability.
+     *
+     * @param tenantId    the tenant id
+     * @param scriptId    the executed script id
+     * @param status      one of SUCCESS / FAILURE / TIMEOUT / GOVERNOR_LIMIT
+     * @param durationMs  wall-clock execution time
+     * @param recordId    the record context id, if any
+     * @param errorMessage the failure message, if any
+     */
+    public void insertExecutionLog(String tenantId, String scriptId, String status,
+                                   long durationMs, String recordId, String errorMessage) {
+        jdbcTemplate.update(
+                "INSERT INTO script_execution_log "
+                        + "(id, tenant_id, script_id, status, trigger_type, record_id, duration_ms, error_message) "
+                        + "VALUES (?, ?, ?, ?, 'API_ENDPOINT', ?, ?, ?)",
+                UUID.randomUUID().toString(), tenantId, scriptId, status,
+                recordId, (int) Math.min(durationMs, Integer.MAX_VALUE), errorMessage);
+    }
+
+    /**
+     * A script row relevant to standalone execution.
+     *
+     * @param id         the script id
+     * @param name       the human-readable name
+     * @param scriptType one of the {@code chk_script_type} enum values
+     * @param language   the script language (e.g. {@code javascript})
+     * @param source     the source code
+     * @param active     whether the script is active
+     */
+    public record Script(String id, String name, String scriptType, String language,
+                         String source, boolean active) {
+    }
+}

--- a/kelta-worker/src/test/java/io/kelta/worker/controller/ScriptExecutionControllerTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/controller/ScriptExecutionControllerTest.java
@@ -1,0 +1,155 @@
+package io.kelta.worker.controller;
+
+import io.kelta.runtime.module.integration.spi.ScriptExecutor;
+import io.kelta.runtime.module.integration.spi.ScriptExecutor.ScriptExecutionRequest;
+import io.kelta.runtime.module.integration.spi.ScriptExecutor.ScriptExecutionResult;
+import io.kelta.worker.repository.ScriptRepository;
+import io.kelta.worker.repository.ScriptRepository.Script;
+import org.junit.jupiter.api.*;
+
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@DisplayName("ScriptExecutionController")
+class ScriptExecutionControllerTest {
+
+    private ScriptRepository scriptRepository;
+    private ScriptExecutor scriptExecutor;
+    private ScriptExecutionController controller;
+
+    @BeforeEach
+    void setUp() {
+        scriptRepository = mock(ScriptRepository.class);
+        scriptExecutor = mock(ScriptExecutor.class);
+        controller = new ScriptExecutionController(scriptRepository, scriptExecutor);
+    }
+
+    private Script apiScript(String source, boolean active) {
+        return new Script("s1", "My Script", "API_ENDPOINT", "javascript", source, active);
+    }
+
+    @Test
+    @DisplayName("returns 404 when the script is not found")
+    void notFound() {
+        when(scriptRepository.findById("s1")).thenReturn(Optional.empty());
+
+        var response = controller.execute("s1", "t1", "u1", Map.of());
+
+        assertThat(response.getStatusCode().value()).isEqualTo(404);
+        verifyNoInteractions(scriptExecutor);
+    }
+
+    @Test
+    @DisplayName("returns 422 when the script is inactive")
+    void inactive() {
+        when(scriptRepository.findById("s1")).thenReturn(Optional.of(apiScript("return {}", false)));
+
+        var response = controller.execute("s1", "t1", "u1", Map.of());
+
+        assertThat(response.getStatusCode().value()).isEqualTo(422);
+        verifyNoInteractions(scriptExecutor);
+    }
+
+    @Test
+    @DisplayName("returns 422 when the script type is not HTTP-invocable")
+    void nonInvocableType() {
+        when(scriptRepository.findById("s1")).thenReturn(Optional.of(
+                new Script("s1", "Validator", "VALIDATION", "javascript", "return true", true)));
+
+        var response = controller.execute("s1", "t1", "u1", Map.of());
+
+        assertThat(response.getStatusCode().value()).isEqualTo(422);
+        assertThat(response.getBody()).containsEntry("success", false);
+        verifyNoInteractions(scriptExecutor);
+    }
+
+    @Test
+    @DisplayName("returns 422 when the script has no source")
+    void blankSource() {
+        when(scriptRepository.findById("s1")).thenReturn(Optional.of(apiScript("   ", true)));
+
+        var response = controller.execute("s1", "t1", "u1", Map.of());
+
+        assertThat(response.getStatusCode().value()).isEqualTo(422);
+        verifyNoInteractions(scriptExecutor);
+    }
+
+    @Test
+    @DisplayName("executes an active API_ENDPOINT script and returns the output")
+    void executesSuccessfully() {
+        when(scriptRepository.findById("s1")).thenReturn(Optional.of(apiScript("return {ok:true}", true)));
+        when(scriptExecutor.execute(any(ScriptExecutionRequest.class)))
+                .thenReturn(ScriptExecutionResult.success(Map.of("ok", true), 12L));
+
+        var body = new HashMap<String, Object>();
+        body.put("input", Map.of("x", 1));
+        body.put("context", Map.of("collectionName", "orders", "recordId", "r1"));
+
+        var response = controller.execute("s1", "t1", "u1", body);
+
+        assertThat(response.getStatusCode().value()).isEqualTo(200);
+        assertThat(response.getBody()).containsEntry("success", true);
+        assertThat(response.getBody()).containsEntry("output", Map.of("ok", true));
+        assertThat(response.getBody()).containsEntry("executionTimeMs", 12L);
+        verify(scriptRepository).insertExecutionLog("t1", "s1", "SUCCESS", 12L, "r1", null);
+    }
+
+    @Test
+    @DisplayName("passes input and context bindings to the executor")
+    @SuppressWarnings("unchecked")
+    void passesBindings() {
+        when(scriptRepository.findById("s1")).thenReturn(Optional.of(apiScript("return {}", true)));
+        when(scriptExecutor.execute(any(ScriptExecutionRequest.class)))
+                .thenReturn(ScriptExecutionResult.success(Map.of(), 1L));
+
+        var body = new HashMap<String, Object>();
+        body.put("input", Map.of("amount", 42));
+        body.put("context", Map.of("collectionName", "orders", "recordId", "r1"));
+
+        controller.execute("s1", "t1", "u1", body);
+
+        var captor = org.mockito.ArgumentCaptor.forClass(ScriptExecutionRequest.class);
+        verify(scriptExecutor).execute(captor.capture());
+        Map<String, Object> bindings = captor.getValue().bindings();
+        assertThat(bindings).containsEntry("input", Map.of("amount", 42));
+        assertThat((Map<String, Object>) bindings.get("context"))
+                .containsEntry("tenantId", "t1")
+                .containsEntry("userId", "u1")
+                .containsEntry("scriptId", "s1")
+                .containsEntry("collectionName", "orders")
+                .containsEntry("recordId", "r1");
+    }
+
+    @Test
+    @DisplayName("returns 200 with success=false when the script fails at runtime")
+    void scriptRuntimeFailure() {
+        when(scriptRepository.findById("s1")).thenReturn(Optional.of(apiScript("throw new Error('boom')", true)));
+        when(scriptExecutor.execute(any(ScriptExecutionRequest.class)))
+                .thenReturn(ScriptExecutionResult.failure("boom", 3L));
+
+        var response = controller.execute("s1", "t1", "u1", Map.of());
+
+        assertThat(response.getStatusCode().value()).isEqualTo(200);
+        assertThat(response.getBody()).containsEntry("success", false);
+        assertThat(response.getBody()).containsEntry("message", "boom");
+        verify(scriptRepository).insertExecutionLog("t1", "s1", "FAILURE", 3L, null, "boom");
+    }
+
+    @Test
+    @DisplayName("does not fail the request when audit logging throws")
+    void auditLogFailureIsSwallowed() {
+        when(scriptRepository.findById("s1")).thenReturn(Optional.of(apiScript("return {}", true)));
+        when(scriptExecutor.execute(any(ScriptExecutionRequest.class)))
+                .thenReturn(ScriptExecutionResult.success(Map.of(), 1L));
+        doThrow(new RuntimeException("db down")).when(scriptRepository)
+                .insertExecutionLog(anyString(), anyString(), anyString(), anyLong(), any(), any());
+
+        var response = controller.execute("s1", "t1", "u1", Map.of());
+
+        assertThat(response.getStatusCode().value()).isEqualTo(200);
+        assertThat(response.getBody()).containsEntry("success", true);
+    }
+}


### PR DESCRIPTION
## Phase 2 (a) — close the standalone-script-execution stub

**⚠️ Security-relevant** (new HTTP code-execution surface) — please review before merge; not auto-merged.

### What & why
`useScriptExecution` (end-user Quick Actions "run script") returned *"temporarily unavailable"* — there was no HTTP entry point into the already-sandboxed GraalVM runtime (only flow `InvokeScript` + record-event hooks reached it).

### Changes
- **Backend:** `ScriptExecutionController` `POST /api/scripts/{id}/execute` + `ScriptRepository`. Loads the script (RLS-scoped), requires `active` + an HTTP-invocable `scriptType` (`API_ENDPOINT`/`EVENT_HANDLER`; trigger/validation/scheduled rejected → 422), runs it through the sandboxed `GraalVmScriptExecutor` with `{input, context}` bindings, audits to `script_execution_log`. `/api/scripts/**` was already gateway-routed.
- **Frontend:** `useScriptExecution` now POSTs to the endpoint and maps the script's `output.action` → refresh/redirect/toast/open_record.

### Tests
- `ScriptExecutionControllerTest` 8/8 (404 / inactive / non-invocable type / blank source / success / bindings / runtime-failure / audit-failure-swallowed).
- `useScriptExecution.test.ts` 4/4. tsc `--noEmit` + eslint clean.

### Security posture / follow-up
Gated by the blanket `API_ACCESS` only (scripts are admin-authored, trusted, sandboxed with a timeout). **Per-script authorization is a documented follow-up.** Supersedes the "Standalone script execution" 🔴 row added in #1132 (this flips it to ✅).

🤖 Generated with [Claude Code](https://claude.com/claude-code)