### PR TITLE
feat(bulk): file upload for bulk jobs (POST /api/bulk-jobs/upload)

### DIFF
--- a/kelta-worker/src/main/java/io/kelta/worker/controller/BulkOperationsController.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/controller/BulkOperationsController.java
@@ -3,12 +3,15 @@ package io.kelta.worker.controller;
 import tools.jackson.databind.ObjectMapper;
 import io.kelta.jsonapi.JsonApiResponseBuilder;
 import io.kelta.worker.repository.BulkJobRepository;
+import io.kelta.worker.service.CsvImportService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.*;
 
@@ -38,13 +41,16 @@ public class BulkOperationsController {
     private final BulkJobRepository bulkJobRepository;
     private final ObjectMapper objectMapper;
     private final JdbcTemplate jdbcTemplate;
+    private final CsvImportService csvImportService;
 
     public BulkOperationsController(BulkJobRepository bulkJobRepository,
                                      ObjectMapper objectMapper,
-                                     JdbcTemplate jdbcTemplate) {
+                                     JdbcTemplate jdbcTemplate,
+                                     CsvImportService csvImportService) {
         this.bulkJobRepository = bulkJobRepository;
         this.objectMapper = objectMapper;
         this.jdbcTemplate = jdbcTemplate;
+        this.csvImportService = csvImportService;
     }
 
     /**
@@ -104,12 +110,91 @@ public class BulkOperationsController {
                             "Collection " + collectionId + " not found or inactive"));
         }
 
-        // Validate batch size
+        return queueJob(tenantId, userEmail, collectionId, operation, externalIdField, batchSize, records);
+    }
+
+    /**
+     * Creates a bulk job from an uploaded CSV or JSON file (for payloads larger than a
+     * practical inline request). The file is parsed to records here; each record is then
+     * processed asynchronously through the normal write path (which coerces + validates
+     * per field). CSV values are strings — use a JSON file for pre-typed values.
+     */
+    @PostMapping(value = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @SuppressWarnings("unchecked")
+    public ResponseEntity<Map<String, Object>> uploadJob(
+            @RequestHeader("X-Tenant-ID") String tenantId,
+            @RequestHeader("X-User-Email") String userEmail,
+            @RequestParam("file") MultipartFile file,
+            @RequestParam("collectionId") String collectionId,
+            @RequestParam("operation") String operation,
+            @RequestParam(value = "externalIdField", required = false) String externalIdField,
+            @RequestParam(value = "batchSize", required = false) Integer batchSize) {
+
+        if (file == null || file.isEmpty()) {
+            return ResponseEntity.badRequest().body(
+                    JsonApiResponseBuilder.error("400", "Missing file", "file is required and must be non-empty"));
+        }
+        if (collectionId == null || collectionId.isBlank()) {
+            return ResponseEntity.badRequest().body(
+                    JsonApiResponseBuilder.error("400", "Missing field", "collectionId is required"));
+        }
+        if (operation == null || !VALID_OPERATIONS.contains(operation.toUpperCase())) {
+            return ResponseEntity.badRequest().body(
+                    JsonApiResponseBuilder.error("400", "Invalid operation",
+                            "operation must be one of: INSERT, UPDATE, UPSERT, DELETE"));
+        }
+        operation = operation.toUpperCase();
+
+        List<Map<String, Object>> records;
+        try {
+            String name = file.getOriginalFilename() != null ? file.getOriginalFilename().toLowerCase() : "";
+            String contentType = file.getContentType() != null ? file.getContentType().toLowerCase() : "";
+            boolean json = name.endsWith(".json") || contentType.contains("json");
+            if (json) {
+                records = objectMapper.readValue(file.getInputStream(),
+                        new tools.jackson.core.type.TypeReference<List<Map<String, Object>>>() {});
+            } else {
+                records = csvImportService.parseCsvToRecords(file.getInputStream());
+            }
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().body(
+                    JsonApiResponseBuilder.error("400", "Parse error",
+                            "Failed to parse uploaded file: " + e.getMessage()));
+        }
+
+        if (records == null || records.isEmpty()) {
+            return ResponseEntity.badRequest().body(
+                    JsonApiResponseBuilder.error("400", "Empty file", "The uploaded file contained no records"));
+        }
+        if (records.size() > MAX_INLINE_RECORDS) {
+            return ResponseEntity.unprocessableEntity().body(
+                    JsonApiResponseBuilder.error("422", "Too many records",
+                            "Maximum " + MAX_INLINE_RECORDS + " records per upload"));
+        }
+        if ("UPSERT".equals(operation) && (externalIdField == null || externalIdField.isBlank())) {
+            externalIdField = null;
+        }
+        if (!collectionExists(collectionId, tenantId)) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(
+                    JsonApiResponseBuilder.error("404", "Collection not found",
+                            "Collection " + collectionId + " not found or inactive"));
+        }
+
+        return queueJob(tenantId, userEmail, collectionId, operation, externalIdField, batchSize, records);
+    }
+
+    /**
+     * Serializes the records, creates a QUEUED bulk job, and returns the JSON:API resource.
+     * Shared by the inline-JSON ({@code POST}) and file-upload ({@code POST /upload}) paths.
+     */
+    private ResponseEntity<Map<String, Object>> queueJob(
+            String tenantId, String userEmail, String collectionId, String operation,
+            String externalIdField, Integer batchSize, List<Map<String, Object>> records) {
+
         int effectiveBatchSize = batchSize != null
                 ? Math.min(Math.max(batchSize, 1), MAX_BATCH_SIZE)
                 : DEFAULT_BATCH_SIZE;
 
-        // Serialize records to JSON
         String dataPayload;
         try {
             dataPayload = objectMapper.writeValueAsString(records);
@@ -119,7 +204,6 @@ public class BulkOperationsController {
                             "Failed to serialize records: " + e.getMessage()));
         }
 
-        // Create the job
         String jobId = bulkJobRepository.create(
                 tenantId, collectionId, operation,
                 "application/json", effectiveBatchSize, externalIdField,
@@ -131,7 +215,6 @@ public class BulkOperationsController {
         log.info("Bulk job created: jobId={}, operation={}, collection={}, records={}, batchSize={}",
                 jobId, operation, collectionId, records.size(), effectiveBatchSize);
 
-        // Return the created job
         Map<String, Object> attributes = new LinkedHashMap<>();
         attributes.put("status", "QUEUED");
         attributes.put("operation", operation);

--- a/kelta-worker/src/main/java/io/kelta/worker/service/CsvImportService.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/service/CsvImportService.java
@@ -138,6 +138,42 @@ public class CsvImportService {
         return new ImportResult(dataRowCount, imported, errors);
     }
 
+    /**
+     * Parses CSV into raw, header-keyed string records — no field coercion or validation.
+     *
+     * <p>Used by the bulk-job file-upload path: the resulting records are queued and each is
+     * written through the normal create/update path (which coerces + validates per field and
+     * records per-row errors), so this method stays collection-agnostic. Blank rows and blank
+     * header columns are skipped. Values are strings; use a JSON upload for pre-typed values.
+     *
+     * @param csvStream the CSV input
+     * @return one map per data row, keyed by trimmed header name
+     */
+    public List<Map<String, Object>> parseCsvToRecords(InputStream csvStream) throws IOException {
+        List<String[]> rows = parseCsv(csvStream);
+        if (rows.isEmpty()) {
+            return List.of();
+        }
+        String[] headers = rows.get(0);
+        List<Map<String, Object>> records = new ArrayList<>();
+        for (int i = 1; i < rows.size(); i++) {
+            String[] cells = rows.get(i);
+            if (isBlankRow(cells)) {
+                continue;
+            }
+            Map<String, Object> record = new LinkedHashMap<>();
+            for (int c = 0; c < headers.length; c++) {
+                String key = headers[c].trim();
+                if (key.isBlank()) {
+                    continue;
+                }
+                record.put(key, c < cells.length ? cells[c].trim() : "");
+            }
+            records.add(record);
+        }
+        return records;
+    }
+
     // =========================================================================
     // CSV parsing (RFC 4180)
     // =========================================================================

--- a/kelta-worker/src/test/java/io/kelta/worker/controller/BulkOperationsControllerTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/controller/BulkOperationsControllerTest.java
@@ -2,6 +2,7 @@ package io.kelta.worker.controller;
 
 import tools.jackson.databind.ObjectMapper;
 import io.kelta.worker.repository.BulkJobRepository;
+import io.kelta.worker.service.CsvImportService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -12,7 +13,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -28,6 +32,8 @@ class BulkOperationsControllerTest {
     @Mock
     private JdbcTemplate jdbcTemplate;
 
+    private CsvImportService csvImportService;
+
     private BulkOperationsController controller;
 
     private static final String TENANT_ID = "tenant-1";
@@ -37,7 +43,9 @@ class BulkOperationsControllerTest {
 
     @BeforeEach
     void setUp() {
-        controller = new BulkOperationsController(bulkJobRepository, new ObjectMapper(), jdbcTemplate);
+        csvImportService = mock(CsvImportService.class);
+        controller = new BulkOperationsController(bulkJobRepository, new ObjectMapper(), jdbcTemplate,
+                csvImportService);
     }
 
     @SuppressWarnings("unchecked")
@@ -430,6 +438,73 @@ class BulkOperationsControllerTest {
             ResponseEntity<Map<String, Object>> response = controller.abortJob(JOB_ID, TENANT_ID, USER_EMAIL);
 
             assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY);
+        }
+    }
+
+    @Nested
+    @DisplayName("uploadJob (file)")
+    class UploadJob {
+
+        private void stubCollectionExistsAndCreate() {
+            when(jdbcTemplate.queryForList(anyString(), eq(COLLECTION_ID), eq(TENANT_ID)))
+                    .thenReturn(List.of(Map.of("id", COLLECTION_ID)));
+            when(bulkJobRepository.create(anyString(), anyString(), anyString(),
+                    anyString(), anyInt(), any(), anyString(), anyString(), any(), anyInt()))
+                    .thenReturn(JOB_ID);
+        }
+
+        @Test
+        @DisplayName("queues a job from a JSON file")
+        void jsonUpload() {
+            stubCollectionExistsAndCreate();
+            MultipartFile file = new MockMultipartFile("file", "data.json", "application/json",
+                    "[{\"name\":\"A\"},{\"name\":\"B\"}]".getBytes(StandardCharsets.UTF_8));
+
+            ResponseEntity<Map<String, Object>> response = controller.uploadJob(
+                    TENANT_ID, USER_EMAIL, file, COLLECTION_ID, "INSERT", null, null);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+            assertThat(getAttributes(response.getBody())).containsEntry("totalRecords", 2);
+        }
+
+        @Test
+        @DisplayName("queues a job from a CSV file (parsed via CsvImportService)")
+        void csvUpload() throws Exception {
+            stubCollectionExistsAndCreate();
+            when(csvImportService.parseCsvToRecords(any())).thenReturn(List.of(
+                    Map.of("name", "A"), Map.of("name", "B"), Map.of("name", "C")));
+            MultipartFile file = new MockMultipartFile("file", "data.csv", "text/csv",
+                    "name\nA\nB\nC".getBytes(StandardCharsets.UTF_8));
+
+            ResponseEntity<Map<String, Object>> response = controller.uploadJob(
+                    TENANT_ID, USER_EMAIL, file, COLLECTION_ID, "INSERT", null, null);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+            assertThat(getAttributes(response.getBody())).containsEntry("totalRecords", 3);
+        }
+
+        @Test
+        @DisplayName("rejects an empty file with 400")
+        void emptyFile() {
+            MultipartFile file = new MockMultipartFile("file", "data.csv", "text/csv", new byte[0]);
+
+            ResponseEntity<Map<String, Object>> response = controller.uploadJob(
+                    TENANT_ID, USER_EMAIL, file, COLLECTION_ID, "INSERT", null, null);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+            verifyNoInteractions(bulkJobRepository);
+        }
+
+        @Test
+        @DisplayName("rejects an invalid operation with 400")
+        void invalidOperation() {
+            MultipartFile file = new MockMultipartFile("file", "data.json", "application/json",
+                    "[{\"name\":\"A\"}]".getBytes(StandardCharsets.UTF_8));
+
+            ResponseEntity<Map<String, Object>> response = controller.uploadJob(
+                    TENANT_ID, USER_EMAIL, file, COLLECTION_ID, "FROB", null, null);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
         }
     }
 }


### PR DESCRIPTION
## Phase 3 — bulk-job file upload

Bulk jobs accepted only an inline `records` array; large payloads (the whole point of bulk ops) had no path.

- `BulkOperationsController.uploadJob` (multipart): **JSON** files → Jackson (pre-typed); **CSV** files → new reusable `CsvImportService.parseCsvToRecords` (header-keyed; the normal write path coerces/validates per field). Extracted a shared `queueJob(...)` so inline + upload share one path. `/api/bulk-jobs/**` already routed.
- Tests: +4 (JSON/CSV/empty/invalid-op); `BulkOperationsControllerTest`+`CsvImportServiceTest` green (23).

FE file-picker wiring on `BulkOperationsPage` is a follow-up; the API gap is closed. Docs reconciled in a later status.md pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)