### PR TITLE
ci(e2e): gate post-deploy E2E on worker readiness, not a blind sleep

### DIFF
--- a/.github/workflows/build-and-publish-containers.yml
+++ b/.github/workflows/build-and-publish-containers.yml
@@ -539,8 +539,31 @@ jobs:
         working-directory: e2e-tests
         run: npx playwright install --with-deps chromium
 
-      - name: Wait for services to stabilize
-        run: sleep 30
+      # The smoke test only proves the GATEWAY is live. A migration-bearing deploy restarts
+      # the WORKER (Flyway runs at startup), so the gateway can be UP while data calls still
+      # 502/503. Running Playwright in that window fails every data-dependent test and burns
+      # the full 18-min timeout. Poll an authenticated data path until the worker actually
+      # serves, then run — or fail fast with a clear message instead of a cascade of timeouts.
+      - name: Wait for the worker to serve data (post-deploy readiness)
+        env:
+          E2E_API_BASE_URL: https://api.kelta.io
+          E2E_TENANT_SLUG: default
+          E2E_API_TOKEN: ${{ secrets.E2E_API_TOKEN }}
+        run: |
+          url="${E2E_API_BASE_URL}/${E2E_TENANT_SLUG}/api/collections"
+          echo "Waiting for authenticated data from ${url} …"
+          for i in $(seq 1 40); do
+            code=$(curl -sk -g -m 10 -o /dev/null -w '%{http_code}' \
+              -H "Authorization: Bearer ${E2E_API_TOKEN}" "${url}" || echo 000)
+            if [ "${code}" = "200" ]; then
+              echo "Worker serving data (HTTP 200) after ~$((i*6))s — running E2E."
+              exit 0
+            fi
+            echo "attempt ${i}/40: HTTP ${code} — worker not ready, retrying in 6s"
+            sleep 6
+          done
+          echo "::error::Worker did not serve data within ~4 min of deploy; failing fast instead of an 18-min Playwright timeout. Check the worker rollout / Flyway migration."
+          exit 1
 
       - name: Run E2E tests
         timeout-minutes: 18


### PR DESCRIPTION
## Fixes the recurring post-deploy E2E failures

The #1139 (quick-actions/V151) post-merge **Build and Deploy → E2E** timed out after 18 min, every data-dependent test failing. **Not a code bug** — a deploy-window flake:

- The smoke gate proves only the **gateway** is live.
- A migration-bearing deploy restarts the **worker** (Flyway runs at startup) → gateway UP but data calls 502/503.
- The E2E job ran Playwright on a blind `sleep 30`, so it hit a not-yet-ready backend → every "shows table" test times out (8.5s each) → 18-min job timeout + auto-filed bug.
- The failing specs (approvals/flows/email/scheduled-jobs) were **unrelated** to the merged PR and pass once the worker is ready (live env is healthy now).

**Fix:** replace `sleep 30` with a readiness poll against the authenticated data path `${API}/${tenant}/api/collections` (the same path the e2e DataFactory uses) until HTTP 200, up to ~4 min, then run E2E — else fail fast with an actionable message. YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)