### PR TITLE
fix(gateway): TenantIpConfig native-image reflection + unconditional static routes (PROD OUTAGE)

### DIFF
--- a/kelta-gateway/src/main/java/io/kelta/gateway/service/RouteConfigService.java
+++ b/kelta-gateway/src/main/java/io/kelta/gateway/service/RouteConfigService.java
@@ -81,14 +81,16 @@ public class RouteConfigService {
     public void refreshRoutes() {
         logger.info("Starting route refresh");
 
+        // Register static routes UNCONDITIONALLY, before the bootstrap fetch. These are the
+        // default admin/config/API routes (collections, users, flows, …). They must NOT depend
+        // on the bootstrap response deserializing — otherwise any single bad DTO in the payload
+        // (e.g. a native-image reflection gap) drops every static route and takes the whole API
+        // offline. Bootstrap collection routes are registered afterwards and overwrite any
+        // static route sharing the same path (bootstrap routes are more specific).
+        registerStaticRoutes();
+
         fetchBootstrapConfig()
                 .doOnNext(config -> {
-                    // Register static routes FIRST — these are default routes for
-                    // admin/config endpoints.  Bootstrap collection routes are
-                    // registered afterwards and will overwrite any static route
-                    // that shares the same path (bootstrap routes are more specific).
-                    registerStaticRoutes();
-
                     if (config.getCollections() != null) {
                         int validRoutes = 0;
                         int invalidRoutes = 0;

--- a/kelta-gateway/src/main/resources/META-INF/native-image/io.kelta/kelta-gateway/reflect-config.json
+++ b/kelta-gateway/src/main/resources/META-INF/native-image/io.kelta/kelta-gateway/reflect-config.json
@@ -30,6 +30,12 @@
     "allDeclaredFields": true
   },
   {
+    "name": "io.kelta.gateway.config.TenantIpConfig",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
     "name": "io.kelta.runtime.event.PlatformEvent",
     "allDeclaredConstructors": true,
     "allDeclaredMethods": true,


### PR DESCRIPTION
## Production outage — gateway loaded 0 usable routes

**Symptom:** app can't load data / users can't login; every `/{tenant}/api/*` → 404 `No static resource`.

**Root cause:** the gateway is a GraalVM native image. V148 added `ipAllowlists: Map<String,TenantIpConfig>` to `BootstrapConfig` + the `TenantIpConfig` DTO, but **never added `TenantIpConfig` to `reflect-config.json`**. Jackson can't reflectively construct it in a native image → `/internal/bootstrap` deserialization throws → `refreshRoutes()` fails → gateway loads only 2 routes (should be ~44). Latent since V148; surfaced when an unrelated route change triggered the first gateway rebuild since.

**Fixes:**
1. Add `io.kelta.gateway.config.TenantIpConfig` to `reflect-config.json` (root cause).
2. **Resilience:** `registerStaticRoutes()` ran *inside* `.doOnNext(config→)`, so it only executed on a successful bootstrap deserialize. Moved it to run **unconditionally** before the fetch — one bad bootstrap DTO can never again drop every static admin/API route.

Merging this triggers a gateway rebuild+deploy; on restart the bootstrap deserializes and all routes load. `RouteConfigServiceTest` 8/8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)