### PR TITLE
docs(concerns): guard against gateway native-image bootstrap-DTO reflection gaps

### DIFF
--- a/.claude/docs/concerns.md
+++ b/.claude/docs/concerns.md
@@ -85,6 +85,20 @@ for removal ("inline the current value"). Findings:
 
 ## Dependency Risks
 
+- **Gateway is a GraalVM native image — every DTO deserialized from `/internal/bootstrap` MUST be
+  in `reflect-config.json`.** Root cause of the 2026-07-02 total-API outage: V148 added
+  `ipAllowlists: Map<String,TenantIpConfig>` to `kelta-gateway/.../config/BootstrapConfig` + the
+  `TenantIpConfig` DTO, but nobody added `TenantIpConfig` to
+  `kelta-gateway/src/main/resources/META-INF/native-image/io.kelta/kelta-gateway/reflect-config.json`.
+  In the JVM this is invisible (reflection is free); in the native image Jackson can't construct the
+  class → the whole bootstrap fails to deserialize → the gateway loads ~2 routes instead of ~148 →
+  every `/{tenant}/api/*` 404s (`No static resource`) → app + login down. It stayed latent until the
+  first gateway rebuild after V148. **Rule: any class reachable from `BootstrapConfig` (or any
+  reflectively-deserialized gateway type) gets a `reflect-config.json` entry in the same PR.** The
+  route loader is now hardened (`RouteConfigService.refreshRoutes` registers the static routes
+  *before/independent of* the bootstrap fetch), so a future missed DTO degrades (loses only dynamic
+  collection routes) instead of taking the entire API offline — but the reflect-config entry is still
+  required for the bootstrap to fully load.
 - Multiple BOM version overrides in worker POM increase transitive conflict risk (`kelta-worker/pom.xml`). Audit on every Spring Boot bump.
 - **pgvector required for VECTOR fields / semantic search.** `PhysicalTableStorageAdapter.initializeCollection` runs `CREATE EXTENSION IF NOT EXISTS vector` lazily — only when a collection actually has a VECTOR field — and throws an actionable `StorageException` if it can't. Local dev + CI use the `pgvector/pgvector:pg15` image (docker-compose + `KeltaStack` Testcontainers). **The standalone prod Postgres at `192.168.0.5` is plain `postgres:15` and must have the pgvector extension installed** (the `.so` available + the worker's DB role allowed to `CREATE EXTENSION`, or an admin pre-creates it) before any tenant defines a VECTOR field; otherwise that collection's table creation fails with the guidance above. Collections without VECTOR fields are unaffected.
 - **Stale `spring-kafka` dependency retired** (Phase 0): `runtime-core/pom.xml` previously declared `spring-kafka`, `spring-kafka-test`, and `testcontainers-kafka` despite the platform using NATS JetStream exclusively. Removed; the misnamed `KafkaRecordEventPublisher` was renamed to `NatsRecordEventPublisher`. The stale event-bus comments and docs that mislabeled NATS as the previous broker have since been corrected to NATS across the codebase.


### PR DESCRIPTION
Post-incident note for the 2026-07-02 outage (#1143). The gateway is a GraalVM native image → any DTO reachable from `BootstrapConfig` must be in `reflect-config.json` or the whole bootstrap deserialization fails and the gateway loads ~2 routes instead of ~148 (total API 404, no login). Documents the rule + the loader hardening from #1143. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)