### PR TITLE
feat(dedup): read-only duplicate detection (POST /api/collections/{name}/duplicates)

### DIFF
--- a/.claude/docs/status.md
+++ b/.claude/docs/status.md
@@ -40,6 +40,7 @@ ship a change that moves a row.
 | SCIM 2.0 provisioning | Full `scim/` package: `ScimUser/Group/DiscoveryController` + services + `ScimFilterParser` + `ScimAuthenticationFilter`; gateway route `/scim/v2/**`; 6 test classes. (Verified 2026-07-02; the prior ⚪ "not started" was stale.) |
 | Data export | `DataExportController` (`/api/data-exports`, CSV/JSON, presigned-download) + `DataExportService`; gateway static route added + gated on `VIEW_ALL_DATA` (2026-07-02). Scheduled `DATA_EXPORT`/`REPORT_EXPORT`/`FLOW` jobs run via `ScheduledJobExecutorService` |
 | Standalone script execution | `ScriptExecutionController` `POST /api/scripts/{id}/execute` runs an active, HTTP-invocable (`API_ENDPOINT`/`EVENT_HANDLER`) script through the sandboxed `GraalVmScriptExecutor` with `input`+`context` bindings; logs to `script_execution_log`; end-user Quick Actions `useScriptExecution` calls it (script `output.action` drives refresh/redirect/toast/open_record). Per-script authz is a follow-up |
+| Duplicate detection | `POST /api/collections/{name}/duplicates` `{matchFields,limit}` → groups of records sharing the same match-field values (`DuplicateDetectionService`, read-only, MANAGE_DATA-gated). Bounded scan (5000 rows via the authorized query path — no raw SQL, schema/RLS-safe); reports `truncated`. 4 unit tests | Merge/resolve UI + write path is a follow-up |
 
 ## 🟡 Partial — backend exists, gaps remain
 

--- a/kelta-worker/src/main/java/io/kelta/worker/controller/DuplicateDetectionController.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/controller/DuplicateDetectionController.java
@@ -1,0 +1,102 @@
+package io.kelta.worker.controller;
+
+import io.kelta.runtime.query.InvalidQueryException;
+import io.kelta.worker.repository.BootstrapRepository;
+import io.kelta.worker.service.CerbosPermissionResolver;
+import io.kelta.worker.service.DuplicateDetectionService;
+import io.kelta.worker.service.DuplicateDetectionService.Result;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Read-only duplicate detection for a collection: {@code POST /api/collections/{name}/duplicates}
+ * with {@code {matchFields:[...], limit?}} returns groups of records sharing the same match-field
+ * values. Delegates to {@link DuplicateDetectionService} (authorized query path, no raw SQL).
+ *
+ * <p>Under the already-routed {@code /api/collections/**}; gated in-controller on
+ * {@code MANAGE_DATA} (a cross-record data-management view).
+ *
+ * @since 1.0.0
+ */
+@RestController
+@RequestMapping("/api/collections/{collectionName}/duplicates")
+public class DuplicateDetectionController {
+
+    private static final String PERMISSION = "MANAGE_DATA";
+
+    private final DuplicateDetectionService detectionService;
+    private final CerbosPermissionResolver permissionResolver;
+    private final BootstrapRepository bootstrapRepository;
+
+    public DuplicateDetectionController(DuplicateDetectionService detectionService,
+                                        CerbosPermissionResolver permissionResolver,
+                                        BootstrapRepository bootstrapRepository) {
+        this.detectionService = detectionService;
+        this.permissionResolver = permissionResolver;
+        this.bootstrapRepository = bootstrapRepository;
+    }
+
+    @PostMapping
+    @SuppressWarnings("unchecked")
+    public ResponseEntity<Map<String, Object>> findDuplicates(
+            @PathVariable String collectionName,
+            @RequestBody Map<String, Object> body,
+            HttpServletRequest request) {
+
+        requirePermission(request);
+
+        List<String> matchFields = body.get("matchFields") instanceof List<?> l
+                ? l.stream().filter(String.class::isInstance).map(String.class::cast).toList()
+                : List.of();
+        if (matchFields.isEmpty()) {
+            return ResponseEntity.badRequest().body(error("matchFields must be a non-empty array"));
+        }
+        int limit = body.get("limit") instanceof Number n ? n.intValue() : 100;
+
+        try {
+            Result result = detectionService.findDuplicates(collectionName, matchFields, limit);
+            Map<String, Object> out = new LinkedHashMap<>();
+            out.put("collectionName", collectionName);
+            out.put("matchFields", matchFields);
+            out.put("scanned", result.scanned());
+            out.put("truncated", result.truncated());
+            out.put("groups", result.groups().stream().map(g -> {
+                Map<String, Object> gm = new LinkedHashMap<>();
+                gm.put("values", g.values());
+                gm.put("count", g.count());
+                gm.put("recordIds", g.recordIds());
+                return gm;
+            }).toList());
+            return ResponseEntity.ok(out);
+        } catch (IllegalArgumentException | InvalidQueryException e) {
+            // Unknown collection or an invalid match field → 400 (client error).
+            return ResponseEntity.badRequest().body(error(e.getMessage()));
+        }
+    }
+
+    private void requirePermission(HttpServletRequest request) {
+        String profileId = permissionResolver.getProfileId(request);
+        if (profileId == null || profileId.isBlank()) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "No identity");
+        }
+        boolean granted = bootstrapRepository.findProfileSystemPermissions(profileId).stream()
+                .anyMatch(p -> PERMISSION.equals(p.get("permission_name"))
+                        && Boolean.TRUE.equals(p.get("granted")));
+        if (!granted) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, PERMISSION + " permission required");
+        }
+    }
+
+    private static Map<String, Object> error(String message) {
+        Map<String, Object> m = new LinkedHashMap<>();
+        m.put("error", message);
+        return m;
+    }
+}

--- a/kelta-worker/src/main/java/io/kelta/worker/service/DuplicateDetectionService.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/service/DuplicateDetectionService.java
@@ -1,0 +1,154 @@
+package io.kelta.worker.service;
+
+import io.kelta.runtime.model.CollectionDefinition;
+import io.kelta.runtime.query.Pagination;
+import io.kelta.runtime.query.QueryEngine;
+import io.kelta.runtime.query.QueryRequest;
+import io.kelta.runtime.query.QueryResult;
+import io.kelta.runtime.registry.CollectionRegistry;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Finds groups of duplicate records within a collection, matched on a caller-chosen set of fields.
+ *
+ * <p>Detection is <em>read-only</em>. It scans up to {@link #MAX_SCAN} records through the
+ * authorized {@link QueryEngine} (which validates field names against the collection definition
+ * and resolves the correct per-tenant schema / RLS) and groups them in memory — deliberately
+ * avoiding raw SQL on the dynamic user tables. Merging duplicates is a separate, guarded write
+ * path (follow-up).
+ *
+ * @since 1.0.0
+ */
+@Service
+public class DuplicateDetectionService {
+
+    /** Upper bound on records scanned per call; larger collections report {@code truncated=true}. */
+    static final int MAX_SCAN = 5000;
+
+    /** Page size for the bounded scan (the query engine caps a single page at 1000). */
+    static final int PAGE_SIZE = 1000;
+
+    /** Composite-key separator — a control char unlikely to appear in field values. */
+    private static final String KEY_SEP = "\u0001";
+
+    private final QueryEngine queryEngine;
+    private final CollectionRegistry collectionRegistry;
+
+    public DuplicateDetectionService(QueryEngine queryEngine, CollectionRegistry collectionRegistry) {
+        this.queryEngine = queryEngine;
+        this.collectionRegistry = collectionRegistry;
+    }
+
+    /** A set of records that share the same values on the match fields. */
+    public record DuplicateGroup(Map<String, Object> values, int count, List<String> recordIds) {
+    }
+
+    /** Detection outcome: the duplicate groups plus how much was scanned. */
+    public record Result(List<DuplicateGroup> groups, int scanned, boolean truncated) {
+    }
+
+    /**
+     * Finds duplicate groups in a collection.
+     *
+     * @param collectionName the collection to scan
+     * @param matchFields    the fields whose equal values define a duplicate (non-empty)
+     * @param maxGroups      max groups to return (clamped 1..500)
+     * @return the duplicate groups (largest first) + scan stats
+     * @throws IllegalArgumentException if the collection is unknown or matchFields is empty
+     */
+    public Result findDuplicates(String collectionName, List<String> matchFields, int maxGroups) {
+        if (matchFields == null || matchFields.isEmpty()) {
+            throw new IllegalArgumentException("matchFields must be non-empty");
+        }
+        CollectionDefinition def = collectionRegistry.get(collectionName);
+        if (def == null) {
+            throw new IllegalArgumentException("Collection not found: " + collectionName);
+        }
+        int clampedGroups = Math.min(Math.max(maxGroups, 1), 500);
+
+        // Select the match fields + id. The QueryEngine validates the field names against the
+        // definition (unknown field -> InvalidQueryException), so no identifier can be injected.
+        List<String> selectFields = new ArrayList<>(matchFields);
+        if (!selectFields.contains("id")) {
+            selectFields.add("id");
+        }
+        // Bounded scan: page through in PAGE_SIZE chunks (the engine caps a page at 1000) up to
+        // MAX_SCAN. Stop early on a short/empty page.
+        List<Map<String, Object>> rows = new ArrayList<>();
+        int page = 1;
+        while (rows.size() < MAX_SCAN) {
+            QueryRequest request = new QueryRequest(
+                    new Pagination(page, PAGE_SIZE), List.of(), selectFields, List.of());
+            QueryResult result = queryEngine.executeQuery(def, request);
+            List<Map<String, Object>> data = result.data();
+            if (data.isEmpty()) {
+                break;
+            }
+            rows.addAll(data);
+            if (data.size() < PAGE_SIZE) {
+                break;
+            }
+            page++;
+        }
+
+        // Group by the composite of match-field values. Rows with a null/blank value in ANY match
+        // field are skipped (nulls are not treated as equal -- avoids false "duplicates").
+        Map<String, List<Map<String, Object>>> byKey = new LinkedHashMap<>();
+        for (Map<String, Object> row : rows) {
+            String key = compositeKey(row, matchFields);
+            if (key == null) {
+                continue;
+            }
+            byKey.computeIfAbsent(key, k -> new ArrayList<>()).add(row);
+        }
+
+        List<DuplicateGroup> groups = new ArrayList<>();
+        for (List<Map<String, Object>> members : byKey.values()) {
+            if (members.size() < 2) {
+                continue;
+            }
+            Map<String, Object> values = new LinkedHashMap<>();
+            for (String f : matchFields) {
+                values.put(f, members.get(0).get(f));
+            }
+            List<String> ids = new ArrayList<>();
+            for (Map<String, Object> m : members) {
+                Object id = m.get("id");
+                if (id != null) {
+                    ids.add(String.valueOf(id));
+                }
+            }
+            groups.add(new DuplicateGroup(values, members.size(), ids));
+        }
+
+        groups.sort((a, b) -> Integer.compare(b.count(), a.count()));
+        if (groups.size() > clampedGroups) {
+            groups = new ArrayList<>(groups.subList(0, clampedGroups));
+        }
+
+        boolean truncated = rows.size() >= MAX_SCAN;
+        return new Result(groups, rows.size(), truncated);
+    }
+
+    /** Composite key of the match-field values, or null if any value is null/blank. */
+    private static String compositeKey(Map<String, Object> row, List<String> matchFields) {
+        StringBuilder sb = new StringBuilder();
+        for (String f : matchFields) {
+            Object v = row.get(f);
+            if (v == null) {
+                return null;
+            }
+            String s = String.valueOf(v).trim();
+            if (s.isEmpty()) {
+                return null;
+            }
+            sb.append(s).append(KEY_SEP);
+        }
+        return sb.toString();
+    }
+}

--- a/kelta-worker/src/test/java/io/kelta/worker/service/DuplicateDetectionServiceTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/service/DuplicateDetectionServiceTest.java
@@ -1,0 +1,114 @@
+package io.kelta.worker.service;
+
+import io.kelta.runtime.model.CollectionDefinition;
+import io.kelta.runtime.model.FieldDefinition;
+import io.kelta.runtime.model.StorageConfig;
+import io.kelta.runtime.query.Pagination;
+import io.kelta.runtime.query.QueryEngine;
+import io.kelta.runtime.query.QueryRequest;
+import io.kelta.runtime.query.QueryResult;
+import io.kelta.runtime.registry.CollectionRegistry;
+import io.kelta.worker.service.DuplicateDetectionService.Result;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@DisplayName("DuplicateDetectionService")
+class DuplicateDetectionServiceTest {
+
+    private QueryEngine queryEngine;
+    private CollectionRegistry collectionRegistry;
+    private DuplicateDetectionService service;
+
+    @BeforeEach
+    void setUp() {
+        queryEngine = mock(QueryEngine.class);
+        collectionRegistry = mock(CollectionRegistry.class);
+        service = new DuplicateDetectionService(queryEngine, collectionRegistry);
+    }
+
+    private CollectionDefinition contactsDef() {
+        return CollectionDefinition.builder()
+                .name("contacts")
+                .storageConfig(StorageConfig.physicalTable("contacts"))
+                .addField(FieldDefinition.string("email"))
+                .build();
+    }
+
+    private void stubQuery(List<Map<String, Object>> rows) {
+        when(collectionRegistry.get("contacts")).thenReturn(contactsDef());
+        when(queryEngine.executeQuery(any(CollectionDefinition.class), any(QueryRequest.class)))
+                .thenReturn(QueryResult.of(rows, rows.size(), new Pagination(1, 1000)));
+    }
+
+    @Test
+    @DisplayName("groups records with equal match-field values, largest first")
+    void detectsDuplicates() {
+        stubQuery(List.of(
+                Map.of("id", "1", "email", "a@x.com"),
+                Map.of("id", "2", "email", "a@x.com"),
+                Map.of("id", "3", "email", "a@x.com"),
+                Map.of("id", "4", "email", "b@x.com"),
+                Map.of("id", "5", "email", "b@x.com"),
+                Map.of("id", "6", "email", "unique@x.com")));
+
+        Result result = service.findDuplicates("contacts", List.of("email"), 100);
+
+        assertThat(result.scanned()).isEqualTo(6);
+        assertThat(result.truncated()).isFalse();
+        assertThat(result.groups()).hasSize(2);
+        // Largest group first: a@x.com (3) then b@x.com (2).
+        assertThat(result.groups().get(0).count()).isEqualTo(3);
+        assertThat(result.groups().get(0).values()).containsEntry("email", "a@x.com");
+        assertThat(result.groups().get(0).recordIds()).containsExactlyInAnyOrder("1", "2", "3");
+        assertThat(result.groups().get(1).count()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("skips rows with a null/blank match value (nulls are not duplicates)")
+    void ignoresNulls() {
+        java.util.Map<String, Object> nullRow1 = new java.util.HashMap<>();
+        nullRow1.put("id", "1");
+        nullRow1.put("email", null);
+        java.util.Map<String, Object> nullRow2 = new java.util.HashMap<>();
+        nullRow2.put("id", "2");
+        nullRow2.put("email", null);
+        stubQuery(List.of(nullRow1, nullRow2, Map.of("id", "3", "email", "")));
+
+        Result result = service.findDuplicates("contacts", List.of("email"), 100);
+
+        assertThat(result.groups()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("rejects empty matchFields and unknown collection")
+    void validation() {
+        assertThatThrownBy(() -> service.findDuplicates("contacts", List.of(), 100))
+                .isInstanceOf(IllegalArgumentException.class);
+
+        when(collectionRegistry.get("missing")).thenReturn(null);
+        assertThatThrownBy(() -> service.findDuplicates("missing", List.of("email"), 100))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("selects the match fields plus id, capped at MAX_SCAN")
+    void queryShape() {
+        stubQuery(List.of(Map.of("id", "1", "email", "a@x.com")));
+
+        service.findDuplicates("contacts", List.of("email"), 100);
+
+        verify(queryEngine).executeQuery(any(CollectionDefinition.class), org.mockito.ArgumentMatchers.argThat(req ->
+                req.fields().contains("email") && req.fields().contains("id")
+                        && req.pagination().pageSize() == DuplicateDetectionService.PAGE_SIZE));
+    }
+}


### PR DESCRIPTION
Finds groups of records sharing the same `matchFields` values — a real CRM gap. Scans up to 5000 records via the **authorized QueryEngine** (validates fields + resolves per-tenant schema/RLS — **no raw SQL, no injection surface**) and groups in memory; null/blank match values skipped; bounded scan reports `truncated`. `POST /api/collections/{name}/duplicates {matchFields,limit}`, under `/api/collections/**`, gated on `MANAGE_DATA`. 4 unit tests. Merge/resolve write path is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)