### PR TITLE
ci(e2e): gate E2E on worker rollout to this commit's image

### DIFF
--- a/.claude/docs/ci-cd.md
+++ b/.claude/docs/ci-cd.md
@@ -45,6 +45,12 @@ Trigger: `push` → `main` (path-filtered), plus `workflow_dispatch`.
 5. **`rollback-on-smoke-failure`** — `git revert HEAD` in `homelab-argo` if smoke fails.
 6. **`e2e-test`** — Playwright against production (`app.kelta.io`, `api.kelta.io`) using
    E2E token + Authentik secrets. Timeout 25 min. Files failing-E2E bug tasks to `emf-queue`.
+   Because ArgoCD rolls the worker out **asynchronously** after `deploy` commits the tag,
+   this job first blocks until the `emf-worker` Deployment targets **this commit's**
+   `main-<short-sha>` image and its rollout is fully complete (all pods on the new
+   revision) — *then* polls `/api/collections` for data readiness. Without the rollout gate,
+   the gateway load-balances to not-yet-updated pods that 404 brand-new endpoints, and the
+   data poll can't detect it (it hits an endpoint that exists on the old image too).
 
 ## `auto-merge.yml`
 

--- a/.github/workflows/build-and-publish-containers.yml
+++ b/.github/workflows/build-and-publish-containers.yml
@@ -539,6 +539,40 @@ jobs:
         working-directory: e2e-tests
         run: npx playwright install --with-deps chromium
 
+      # Deploys are GitOps: the pipeline bumps the kustomize image tag and ArgoCD rolls the
+      # worker out ASYNCHRONOUSLY. Until every worker pod is the new revision the gateway
+      # load-balances some requests to OLD pods, which 404 any brand-new endpoint (e.g. a
+      # just-added admin controller) even though the feature is correct. The data-serving
+      # poll below can't catch this — it hits /api/collections, which exists on the old image
+      # too. So first block until the Deployment actually targets THIS commit's image tag
+      # (ArgoCD synced) and the rollout is fully complete. No "|| true": a stalled rollout
+      # must fail E2E, not silently race it.
+      - name: Wait for worker rollout to this commit's image (avoid old-pod 404s)
+        run: |
+          if kubectl -n kelta get deploy kelta-worker &>/dev/null; then
+            NS=kelta; WORKER=kelta-worker
+          else
+            NS=emf; WORKER=emf-worker
+          fi
+          EXPECT="main-$(echo "${GITHUB_SHA}" | cut -c1-7)"
+          echo "Waiting for ${NS}/${WORKER} Deployment to target *:${EXPECT} (ArgoCD sync)…"
+          for i in $(seq 1 50); do
+            IMG=$(kubectl -n "${NS}" get deploy "${WORKER}" \
+              -o jsonpath='{.spec.template.spec.containers[0].image}')
+            case "${IMG}" in
+              *:"${EXPECT}")
+                echo "Deployment targets ${IMG} — waiting for rollout to complete."
+                kubectl -n "${NS}" rollout status deploy/"${WORKER}" --timeout=300s
+                echo "Worker fully rolled out to ${EXPECT} — all pods on the new image."
+                exit 0
+                ;;
+            esac
+            echo "attempt ${i}/50: Deployment still on ${IMG}, want *:${EXPECT} (ArgoCD not synced yet) — retry 6s"
+            sleep 6
+          done
+          echo "::error::Worker Deployment never advanced to main-$(echo "${GITHUB_SHA}" | cut -c1-7) within ~5 min. ArgoCD sync or rollout stalled — E2E would race old pods."
+          exit 1
+
       # The smoke test only proves the GATEWAY is live. A migration-bearing deploy restarts
       # the WORKER (Flyway runs at startup), so the gateway can be UP while data calls still
       # 502/503. Running Playwright in that window fails every data-dependent test and burns


### PR DESCRIPTION
## Problem

The post-deploy E2E job failed on `main` after the campaigns feature merged (#1151): every `campaigns.spec.ts` test got **404** on `GET /api/admin/campaigns` and `/suppressions`.

Not a campaigns bug — the feature is correct. Verified against the live deployment (real token): the same endpoints return **200**. The worker mapping exists (in-pod unauth → 403, not 404); the gateway `static-admin` route → worker is registered.

## Root cause: rollout race

Deploys are GitOps — the pipeline bumps the kustomize image tag and **ArgoCD rolls the worker out asynchronously**. During the flip, the gateway load-balances some requests to **old-image worker pods** that don't have the brand-new campaigns controller → 404. Campaigns specs are the first tests to touch a new-image-only endpoint, so they're uniquely exposed.

The existing readiness gate can't catch it — it polls `/api/collections`, which exists on the **old** image too, so it goes green while old pods still serve.

## Fix

Add a rollout gate to the `e2e-test` job, before the data-serving poll: block until the `emf-worker` Deployment targets **this commit's** `main-<short-sha>` image (ArgoCD synced) and `kubectl rollout status` reports complete (all pods on the new revision). No `|| true` — a stalled rollout fails E2E instead of racing it.

- `.github/workflows/build-and-publish-containers.yml` — new gate step
- `.claude/docs/ci-cd.md` — documents the gate

The failed run's E2E was re-run separately and is expected to pass (rollout since complete). This prevents the recurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)