### PR TITLE
docs(native): push pipeline complete + iOS APNs runbook

### DIFF
--- a/kelta-ui/app/NATIVE.md
+++ b/kelta-ui/app/NATIVE.md
@@ -14,15 +14,17 @@ separate, toolchain-bound step that cannot run in the standard frontend CI.
 
 The Capacitor toolchain is **not** a committed dependency — it would pull native
 tooling into the web app's install and isn't needed by the web CI. Install it on
-the machine that builds the native shells:
+the machine that builds the native shells (include `@capacitor/push-notifications`
+so the already-wired token registration resolves on device — see Push below):
 
 ```bash
 cd kelta-ui/app
 npm install
-npm i -D @capacitor/cli @capacitor/core @capacitor/ios @capacitor/android
+npm i -D @capacitor/cli @capacitor/core @capacitor/ios @capacitor/android @capacitor/push-notifications
 npm run build            # produce dist/ (the web bundle Capacitor wraps)
 npm run cap:add:ios      # generates ios/      (needs macOS + Xcode)
 npm run cap:add:android  # generates android/  (needs Android SDK)
+npm run cap:sync         # copy the web bundle + plugins into the native projects
 ```
 
 > The `cap:*` npm scripts are pre-wired in `package.json`; they run once the
@@ -41,8 +43,48 @@ Config lives in [`capacitor.config.json`](./capacitor.config.json)
 
 ## Push notifications
 
-The backend push pipeline already exists (`PushProvider` SPI + `FcmPushProvider`
-in `kelta-worker`). To wire native push, add `@capacitor/push-notifications`,
-register the device token, and POST it to the worker's push-device endpoint so
-the existing provider can deliver to it. (APNs delivery provider is a follow-up;
-FCM is implemented.)
+The full push pipeline is implemented — only the on-device build/verification is
+left (it needs the native toolchain + an Apple Developer account, so it can't run
+in CI):
+
+- **Backend delivery**: `PushProvider` SPI in `kelta-worker` with both
+  `FcmPushProvider` (Android/web) and `ApnsPushProvider` (iOS, token/JWT auth over
+  HTTP/2). Per-tenant credential overrides via `tenant.settings.push.{fcm,apns}`.
+- **Token registration**: `kelta-ui/app/src/push/deviceRegistration.ts`.
+  `initPushNotifications()` (called from `EndUserShell`) requests permission,
+  registers with APNs/FCM via `@capacitor/push-notifications`, and POSTs the token
+  to `POST /api/devices` (the `push_device` table). It is a **no-op on the web**
+  and loads the plugin via a variable-specifier dynamic import, so the web build
+  never bundles it — installing `@capacitor/push-notifications` (above) is all it
+  needs to activate on device.
+
+### iOS (APNs) on-device checklist
+
+1. **Apple Developer** (paid membership required for push):
+   - Register App ID **`io.kelta.app`** (must match `capacitor.config.json`) and
+     enable the **Push Notifications** capability.
+   - Create an **APNs Auth Key** → download the `.p8` (one-time). Record the
+     **Key ID** and your **Team ID**.
+2. **Xcode** (`npm run cap:open:ios`) → App target → Signing & Capabilities: set
+   your Team, bundle id `io.kelta.app`, add **Push Notifications** + **Background
+   Modes → Remote notifications**. Run on a physical device (the Simulator can't
+   receive real APNs).
+3. **Worker config** (env → `application.yml` binding; mount the `.p8` as a secret):
+   ```
+   KELTA_PUSH_PROVIDER=apns
+   KELTA_PUSH_APNS_TEAM_ID=<TeamID>
+   KELTA_PUSH_APNS_KEY_ID=<KeyID>
+   KELTA_PUSH_APNS_BUNDLE_ID=io.kelta.app
+   KELTA_PUSH_APNS_AUTH_KEY_PATH=/var/secrets/apns/AuthKey_<KeyID>.p8
+   KELTA_PUSH_APNS_SANDBOX=true   # Xcode debug builds → sandbox host; TestFlight/App Store → false
+   ```
+   > **Sandbox must match the build.** A development-signed build's token is only
+   > valid on the APNs sandbox host; a mismatch returns `BadDeviceToken` (the
+   > worker then prunes the stale token).
+4. **Verify**: launch → allow notifications → confirm a row in `push_device`
+   (`platform='ios'`), then trigger a send (`DefaultPushService.sendToUser`, e.g.
+   from a flow push action) and watch for "APNs push sent successfully".
+
+Android push uses the same registration path with FCM; wire the FCM
+`google-services.json` per the Capacitor + Firebase docs and set
+`KELTA_PUSH_PROVIDER=fcm`.


### PR DESCRIPTION
## Summary
Refreshes `kelta-ui/app/NATIVE.md` — the Push section still said APNs delivery was a follow-up, but both providers (FCM + `ApnsPushProvider`) and the native token registration (`src/push/deviceRegistration.ts`) now ship.

## Changes
- Documents the completed delivery + registration pipeline.
- Adds the **iOS/APNs on-device checklist**: App ID + Push capability, APNs `.p8` auth key (Team ID / Key ID), Xcode signing + Background Modes, `KELTA_PUSH_APNS_*` worker config, the sandbox-vs-build caveat, and end-to-end verification.
- Adds `@capacitor/push-notifications` to the one-time setup.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)