### PR TITLE
fix(ui): replace removed Kafka with NATS on dashboard health cards

### DIFF
--- a/kelta-ui/app/src/pages/DashboardPage/DashboardPage.test.tsx
+++ b/kelta-ui/app/src/pages/DashboardPage/DashboardPage.test.tsx
@@ -14,7 +14,7 @@
  *
  * Requirements tested:
  * - 13.1: Dashboard displays system health status
- * - 13.2: Dashboard displays health status for control plane, database, Kafka, and Redis
+ * - 13.2: Dashboard displays health status for control plane, database, NATS, and Redis
  * - 13.3: Dashboard displays key API metrics including request rate, error rate, and latency
  * - 13.4: Dashboard displays recent errors and warnings from the system logs
  * - 13.5: Dashboard allows configuring time range for metrics display
@@ -49,7 +49,7 @@ const mockHealthStatuses: HealthStatus[] = [
     lastChecked: '2024-01-20T10:00:00Z',
   },
   {
-    service: 'Kafka',
+    service: 'NATS',
     status: 'unhealthy',
     details: 'Connection timeout',
     lastChecked: '2024-01-20T10:00:00Z',
@@ -66,8 +66,8 @@ const mockRecentErrors: RecentError[] = [
     id: '1',
     timestamp: '2024-01-20T09:55:00Z',
     level: 'error',
-    message: 'Failed to connect to Kafka broker',
-    source: 'kafka-consumer',
+    message: 'Failed to connect to NATS server',
+    source: 'nats-consumer',
     traceId: 'abc123def456',
   },
   {
@@ -200,10 +200,10 @@ describe('DashboardPage', () => {
       render(<DashboardPage />, { wrapper: createTestWrapper() })
 
       await waitFor(() => {
-        // Use getAllByText since Kafka appears in both health alerts and health cards
+        // Use getAllByText since NATS appears in both health alerts and health cards
         expect(screen.getAllByText('Control Plane').length).toBeGreaterThanOrEqual(1)
         expect(screen.getAllByText('Database').length).toBeGreaterThanOrEqual(1)
-        expect(screen.getAllByText('Kafka').length).toBeGreaterThanOrEqual(1)
+        expect(screen.getAllByText('NATS').length).toBeGreaterThanOrEqual(1)
         expect(screen.getAllByText('Redis').length).toBeGreaterThanOrEqual(1)
       })
     })
@@ -355,7 +355,7 @@ describe('DashboardPage', () => {
       render(<DashboardPage />, { wrapper: createTestWrapper() })
 
       await waitFor(() => {
-        expect(screen.getByText('Failed to connect to Kafka broker')).toBeInTheDocument()
+        expect(screen.getByText('Failed to connect to NATS server')).toBeInTheDocument()
         expect(screen.getByText('High memory usage detected')).toBeInTheDocument()
         expect(screen.getByText('Database query timeout')).toBeInTheDocument()
       })
@@ -377,7 +377,7 @@ describe('DashboardPage', () => {
       render(<DashboardPage />, { wrapper: createTestWrapper() })
 
       await waitFor(() => {
-        expect(screen.getByText('kafka-consumer')).toBeInTheDocument()
+        expect(screen.getByText('nats-consumer')).toBeInTheDocument()
         expect(screen.getByText('system-monitor')).toBeInTheDocument()
         expect(screen.getByText('query-engine')).toBeInTheDocument()
       })
@@ -623,16 +623,16 @@ describe('DashboardPage', () => {
       })
     })
 
-    it('should display alert for unhealthy Kafka service', async () => {
+    it('should display alert for unhealthy NATS service', async () => {
       mockAxios.get.mockResolvedValue({ data: mockDashboardData })
 
       render(<DashboardPage />, { wrapper: createTestWrapper() })
 
       await waitFor(() => {
-        expect(screen.getByTestId('health-alert-kafka')).toBeInTheDocument()
+        expect(screen.getByTestId('health-alert-nats')).toBeInTheDocument()
         // Use within to scope the query to the health alerts section
-        const alertItem = screen.getByTestId('health-alert-kafka')
-        expect(alertItem).toHaveTextContent('Kafka')
+        const alertItem = screen.getByTestId('health-alert-nats')
+        expect(alertItem).toHaveTextContent('NATS')
         expect(alertItem).toHaveTextContent('Connection timeout')
       })
     })

--- a/kelta-ui/app/src/pages/DashboardPage/DashboardPage.tsx
+++ b/kelta-ui/app/src/pages/DashboardPage/DashboardPage.tsx
@@ -6,7 +6,7 @@
  *
  * Requirements:
  * - 13.1: Dashboard displays system health status
- * - 13.2: Dashboard displays health status for control plane, database, Kafka, and Redis
+ * - 13.2: Dashboard displays health status for control plane, database, NATS, and Redis
  * - 13.3: Dashboard displays key API metrics including request rate, error rate, and latency
  * - 13.4: Dashboard displays recent errors and warnings from the system logs
  * - 13.5: Dashboard allows configuring time range for metrics display
@@ -607,7 +607,7 @@ export function DashboardPage({
           lastChecked: new Date().toISOString(),
         },
         { service: 'Database', status: 'unknown' as const, lastChecked: new Date().toISOString() },
-        { service: 'Kafka', status: 'unknown' as const, lastChecked: new Date().toISOString() },
+        { service: 'NATS', status: 'unknown' as const, lastChecked: new Date().toISOString() },
         { service: 'Redis', status: 'unknown' as const, lastChecked: new Date().toISOString() },
       ]
     }


### PR DESCRIPTION
## Summary
- Kafka is fully removed from the platform (messaging is NATS JetStream only), but the dashboard health-monitoring cards still listed Kafka as an infrastructure service
- Replaced the Kafka card with NATS in the default health statuses and updated all test fixtures/assertions to match

## Changes
- `kelta-ui/app/src/pages/DashboardPage/DashboardPage.tsx` — default health card `Kafka` → `NATS` (+ requirements comment)
- `kelta-ui/app/src/pages/DashboardPage/DashboardPage.test.tsx` — mock health/error fixtures and assertions updated (`health-alert-nats`, `nats-consumer`, etc.)

## Testing
- `npx vitest run src/pages/DashboardPage` — 43/43 passed
- /verify: runtime modules build, gateway + worker tests (1540) green, kelta-web lint/typecheck/format/coverage green (896 tests)
- kelta-ui: DashboardPage suite green; two pre-existing main failures (prettier on 7 unrelated files, AiAgentsPage delete test) confirmed present on clean main and spun off as a separate task — main CI is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)