### PR TITLE
fix(ui): stop overriding Radix ids in ConfirmDialog title/description

### DIFF
--- a/kelta-ui/app/src/components/ConfirmDialog/ConfirmDialog.test.tsx
+++ b/kelta-ui/app/src/components/ConfirmDialog/ConfirmDialog.test.tsx
@@ -130,40 +130,47 @@ describe('ConfirmDialog Component', () => {
       expect(dialog).toHaveAttribute('role', 'alertdialog')
     })
 
-    it('should have custom id on title', () => {
-      renderWithI18n(<ConfirmDialog {...defaultProps} id="test-dialog" />)
+    it('should label the dialog with the title via aria-labelledby', () => {
+      renderWithI18n(<ConfirmDialog {...defaultProps} />)
 
+      const dialog = screen.getByTestId('confirm-dialog')
       const title = screen.getByTestId('confirm-dialog-title')
-      expect(title).toHaveAttribute('id', 'test-dialog-title')
+      expect(title).toHaveAttribute('id')
+      expect(dialog).toHaveAttribute('aria-labelledby', title.getAttribute('id'))
     })
 
-    it('should have custom id on description', () => {
-      renderWithI18n(<ConfirmDialog {...defaultProps} id="test-dialog" />)
+    it('should describe the dialog with the message via aria-describedby', () => {
+      renderWithI18n(<ConfirmDialog {...defaultProps} />)
 
+      const dialog = screen.getByTestId('confirm-dialog')
       const message = screen.getByTestId('confirm-dialog-message')
-      expect(message).toHaveAttribute('id', 'test-dialog-description')
+      expect(message).toHaveAttribute('id')
+      expect(dialog).toHaveAttribute('aria-describedby', message.getAttribute('id'))
+    })
+
+    it('should not log Radix accessibility warnings', () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      try {
+        renderWithI18n(<ConfirmDialog {...defaultProps} />)
+
+        const radixWarnings = [...errorSpy.mock.calls, ...warnSpy.mock.calls].filter((call) =>
+          String(call[0]).includes('AlertDialogContent')
+        )
+        expect(radixWarnings).toEqual([])
+      } finally {
+        errorSpy.mockRestore()
+        warnSpy.mockRestore()
+      }
     })
   })
 
   describe('Custom ID', () => {
-    it('should use custom id for accessibility attributes', () => {
+    it('should apply the custom id to the dialog element', () => {
       renderWithI18n(<ConfirmDialog {...defaultProps} id="custom-dialog" />)
 
-      const title = screen.getByTestId('confirm-dialog-title')
-      expect(title).toHaveAttribute('id', 'custom-dialog-title')
-
-      const message = screen.getByTestId('confirm-dialog-message')
-      expect(message).toHaveAttribute('id', 'custom-dialog-description')
-    })
-
-    it('should use default id when not provided', () => {
-      renderWithI18n(<ConfirmDialog {...defaultProps} />)
-
-      const title = screen.getByTestId('confirm-dialog-title')
-      expect(title).toHaveAttribute('id', 'confirm-dialog-title')
-
-      const message = screen.getByTestId('confirm-dialog-message')
-      expect(message).toHaveAttribute('id', 'confirm-dialog-description')
+      const dialog = screen.getByTestId('confirm-dialog')
+      expect(dialog).toHaveAttribute('id', 'custom-dialog')
     })
   })
 })

--- a/kelta-ui/app/src/components/ConfirmDialog/ConfirmDialog.tsx
+++ b/kelta-ui/app/src/components/ConfirmDialog/ConfirmDialog.tsx
@@ -106,11 +106,6 @@ export function ConfirmDialog({
   const resolvedConfirmLabel = confirmLabel ?? t('common.confirm')
   const resolvedCancelLabel = cancelLabel ?? t('common.cancel')
 
-  // Generate unique IDs for accessibility
-  const dialogId = id ?? 'confirm-dialog'
-  const titleId = `${dialogId}-title`
-  const descriptionId = `${dialogId}-description`
-
   const handleOpenChange = (isOpen: boolean) => {
     if (!isOpen && closeOnOverlayClick) {
       onCancel()
@@ -126,20 +121,23 @@ export function ConfirmDialog({
   return (
     <AlertDialog open={open} onOpenChange={handleOpenChange}>
       <AlertDialogContent
+        id={id}
         data-testid="confirm-dialog"
         data-variant={variant}
         className={cn('max-w-md', variant === 'danger' && 'border-destructive/20')}
         onEscapeKeyDown={handleEscapeKeyDown}
       >
         <AlertDialogHeader>
+          {/* Title/Description ids stay Radix-managed so the content's
+              aria-labelledby/aria-describedby wiring (and its dev-mode
+              accessibility checks) keep working. */}
           <AlertDialogTitle
-            id={titleId}
             data-testid="confirm-dialog-title"
             className={cn(variant === 'danger' && 'text-destructive')}
           >
             {title}
           </AlertDialogTitle>
-          <AlertDialogDescription id={descriptionId} data-testid="confirm-dialog-message">
+          <AlertDialogDescription data-testid="confirm-dialog-message">
             {message}
           </AlertDialogDescription>
         </AlertDialogHeader>


### PR DESCRIPTION
## Summary
- `ConfirmDialog` overrode the Radix-generated `id` on `AlertDialogTitle`/`AlertDialogDescription`, breaking the content's `aria-labelledby`/`aria-describedby` wiring and firing "`AlertDialogContent` requires a Title/Description" console warnings in every consumer (visible in AiAgentsPage's delete-confirmation test)
- Radix now manages the title/description ids; the optional `id` prop applies to the dialog content element instead

## Changes
- `kelta-ui/app/src/components/ConfirmDialog/ConfirmDialog.tsx` — removed id overrides, moved `id` prop to `AlertDialogContent`
- `kelta-ui/app/src/components/ConfirmDialog/ConfirmDialog.test.tsx` — assert aria-labelledby/aria-describedby wiring + no Radix a11y warnings instead of hardcoded id attributes

## Testing
- `/verify` green: runtime modules build, gateway + worker tests (1565), kelta-web lint/typecheck/format/coverage, kelta-ui lint/format + 2245 unit tests
- Radix accessibility warnings no longer appear in AiAgentsPage or ConfirmDialog test output

🤖 Generated with [Claude Code](https://claude.com/claude-code)