### PR TITLE
test(harness): flow wait-resume + record-share widening scenarios

### DIFF
--- a/.claude/docs/testing.md
+++ b/.claude/docs/testing.md
@@ -7,7 +7,7 @@
 - **AssertJ** fluent assertions
 - **Mockito** 5.21.0
 - **jqwik** 1.8.2 — property-based testing
-- **Testcontainers** 1.20.4 — Docker-based integration tests
+- **Testcontainers** 1.21.3 in `kelta-test-harness` (1.20.4 elsewhere via `kelta-platform`) — Docker-based integration tests. 1.21.x is required on hosts running Docker Engine 29+ (min API 1.44; older docker-java pings `/v1.32` and gets a 400 → "Could not find a valid Docker environment").
 - **MockWebServer** — HTTP service mocks
 - **Awaitility** — async assertions
 
@@ -16,6 +16,8 @@
 Boots a full mini-stack (Postgres, Redis, NATS, Cerbos, worker, auth, gateway) via Testcontainers and runs `*ScenarioTest.java` against it under the `integration-tests` profile.
 
 **Database selection**: `KeltaStack` reads `CI_DB_JDBC_URL` at startup. When set (CI), it skips the Testcontainers PG and points worker + auth at the shared `kelta-ci-db` pool — the URL emitted by `scripts/ci/checkout-db.sh` already pins `currentSchema=ci_<run-tag>` for per-run isolation. When unset (local dev), it falls back to a Testcontainers PG on the docker network alias `postgres`. The Testcontainers dependency stays in `pom.xml` either way.
+
+**Direct DB assertions**: `ScenarioBase.openDbConnection()` opens a JDBC connection from the test JVM (via `KeltaStack.dbJdbcUrl()`, which maps the local container port / passes the CI URL through) for asserting table state the API doesn't expose — e.g. `flow_pending_resume` in `FlowWaitResumeScenarioTest`. Caveat: the harness DB user is the image's bootstrap superuser and **bypasses RLS even on FORCE'd tables**; RLS assertions must run as a non-superuser probe role created by the test (`openDbConnection(user, password)` + `set_config('app.current_tenant_id', …)`) — see `RecordShareWideningScenarioTest`. Also note V77's RLS loop only matches tables in the `public` schema, so on CI (`ci_*` schemas) only migrations that `ALTER TABLE` directly (e.g. V150 `record_share`) have RLS — don't write harness RLS assertions against V77-listed tables.
 
 ### Organization
 - Unit tests: `src/test/java/io/kelta/...Test.java`

--- a/kelta-test-harness/pom.xml
+++ b/kelta-test-harness/pom.xml
@@ -31,7 +31,10 @@
 
     <properties>
         <java.version>25</java.version>
-        <testcontainers.version>1.20.4</testcontainers.version>
+        <!-- 1.21.x bundles docker-java 3.5+, required for Docker Engine 29 (min API 1.44 —
+             older clients get 400 on their /v1.32 ping and Testcontainers reports
+             "Could not find a valid Docker environment"). -->
+        <testcontainers.version>1.21.3</testcontainers.version>
         <skipITs>true</skipITs>
         <!-- Maven resource filtering injects these into harness.properties -->
         <harness.basedir>${project.basedir}</harness.basedir>
@@ -78,6 +81,13 @@
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- Direct JDBC access for scenarios that assert DB state the API doesn't
+             expose (flow_pending_resume, record_share RLS) — version from the Boot parent. -->
+        <dependency>
+            <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <scope>test</scope>
         </dependency>

--- a/kelta-test-harness/src/test/java/io/kelta/testharness/KeltaStack.java
+++ b/kelta-test-harness/src/test/java/io/kelta/testharness/KeltaStack.java
@@ -206,6 +206,25 @@ public final class KeltaStack {
         return "http://" + GATEWAY.getHost() + ":" + GATEWAY.getMappedPort(8080);
     }
 
+    /**
+     * JDBC URL for the harness database, reachable from the <em>test JVM</em>
+     * (not the docker network). External CI URLs are host-reachable as-is; the
+     * local Testcontainers PG needs its mapped-port URL. For CI, the URL keeps
+     * its {@code currentSchema=ci_<run-tag>} pin so direct connections land in
+     * the same isolated schema the services use.
+     */
+    public static String dbJdbcUrl() {
+        return DB_CONFIG.external() ? DB_CONFIG.jdbcUrl() : POSTGRES.getJdbcUrl();
+    }
+
+    public static String dbUsername() {
+        return DB_CONFIG.username();
+    }
+
+    public static String dbPassword() {
+        return DB_CONFIG.password();
+    }
+
     // ── Startup ──────────────────────────────────────────────────────────────
 
     /**

--- a/kelta-test-harness/src/test/java/io/kelta/testharness/ScenarioBase.java
+++ b/kelta-test-harness/src/test/java/io/kelta/testharness/ScenarioBase.java
@@ -7,6 +7,10 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.web.client.RestClient;
 
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+
 /**
  * Base class for cross-service scenario tests.
  *
@@ -37,6 +41,29 @@ public abstract class ScenarioBase {
                 .baseUrl(KeltaStack.gatewayBaseUrl())
                 .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                 .build();
+    }
+
+    /**
+     * Opens a direct JDBC connection to the harness database as the service DB
+     * user, for asserting DB state the API doesn't expose. Caller closes it.
+     *
+     * <p>Note: this user is typically a Postgres superuser (both the local
+     * Testcontainers PG and the CI pool use the image's bootstrap user), so it
+     * <em>bypasses RLS</em> even on FORCE'd tables. Assertions about RLS must
+     * connect as a non-superuser role instead — see
+     * {@link #openDbConnection(String, String)}.
+     */
+    protected Connection openDbConnection() throws SQLException {
+        return DriverManager.getConnection(
+                KeltaStack.dbJdbcUrl(), KeltaStack.dbUsername(), KeltaStack.dbPassword());
+    }
+
+    /**
+     * Opens a direct JDBC connection as an arbitrary role (e.g. a non-superuser
+     * probe role created by the test to observe RLS). Caller closes it.
+     */
+    protected Connection openDbConnection(String username, String password) throws SQLException {
+        return DriverManager.getConnection(KeltaStack.dbJdbcUrl(), username, password);
     }
 
     /**

--- a/kelta-test-harness/src/test/java/io/kelta/testharness/scenarios/FlowWaitResumeScenarioTest.java
+++ b/kelta-test-harness/src/test/java/io/kelta/testharness/scenarios/FlowWaitResumeScenarioTest.java
@@ -1,0 +1,188 @@
+package io.kelta.testharness.scenarios;
+
+import io.kelta.testharness.ScenarioBase;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Flow Wait-state park + scheduled resume through the real stack (gateway → worker →
+ * FlowEngine → JdbcFlowStore → Postgres), against {@code flow_execution} and
+ * {@code flow_pending_resume} (V71).
+ *
+ * <p>Regression guard for the persistence path Mockito worker tests can't reach: a Wait
+ * with {@code Seconds} above the 10s inline threshold must park the execution WAITING and
+ * write a real {@code flow_pending_resume} row with {@code resume_at ≈ now + seconds};
+ * {@code FlowResumePollerConfig} (10s poll) must then claim it via
+ * {@code JdbcFlowStore.claimPendingResumes} ({@code UPDATE … FOR UPDATE SKIP LOCKED
+ * RETURNING}) and {@code FlowEngine.resumeExecution} must delete the row and complete the
+ * flow. (See the DB-constraint-test-gap lesson — a mocked JdbcTemplate would pass even if
+ * the claim SQL or the FK to flow_execution were broken.)
+ */
+@DisplayName("Flow Wait Resume Scenario")
+class FlowWaitResumeScenarioTest extends ScenarioBase {
+
+    private static final long WAITING_TIMEOUT_MS  = 15_000;
+    /** 11s wait + up to 10s poller interval + resume execution, with CI headroom. */
+    private static final long COMPLETED_TIMEOUT_MS = 60_000;
+
+    @Test
+    @DisplayName("parks a Seconds=11 Wait as WAITING with a pending-resume row, then the poller claims it once and completes the flow")
+    @SuppressWarnings("unchecked")
+    void parksWaitingAndResumesViaPoller() throws Exception {
+        String token = auth.loginAsAdmin();
+        String tenantId = auth.extractTenantId(token);
+        String slug = tenants.slugForTenantId(tenantId);
+
+        waitForStatus(gatewayClientWithToken(token), "/" + slug + "/api/flows", HttpStatus.OK, 20);
+
+        // A minimal AUTOLAUNCHED flow: Wait 11s (> the 10s inline-sleep threshold, so the
+        // engine must persist and park) → Succeed.
+        String suffix = Long.toHexString(System.nanoTime());
+        Map<String, Object> definition = Map.of(
+                "Comment", "Harness wait-resume scenario",
+                "StartAt", "WaitEleven",
+                "States", Map.of(
+                        "WaitEleven", Map.of("Type", "Wait", "Seconds", 11, "Next", "Finish"),
+                        "Finish", Map.of("Type", "Succeed")));
+        Map<String, Object> payload = Map.of(
+                "data", Map.of(
+                        "type", "flows",
+                        "attributes", Map.of(
+                                "name", "wait-resume-harness-" + suffix,
+                                "flowType", "AUTOLAUNCHED",
+                                "active", true,
+                                "definition", definition)));
+
+        ResponseEntity<Map> created = gatewayClientWithToken(token)
+                .post().uri("/" + slug + "/api/flows")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(payload)
+                .retrieve().toEntity(Map.class);
+        assertThat(created.getStatusCode().is2xxSuccessful())
+                .as("flow create should succeed").isTrue();
+        String flowId = (String) ((Map<String, Object>) created.getBody().get("data")).get("id");
+        assertThat(flowId).isNotBlank();
+
+        // Manual invocation — the response returns immediately because an >10s Wait parks
+        // instead of sleeping inline.
+        ResponseEntity<Map> executed = gatewayClientWithToken(token)
+                .post().uri("/" + slug + "/api/flows/" + flowId + "/execute")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(Map.of("input", Map.of()))
+                .retrieve().toEntity(Map.class);
+        assertThat(executed.getStatusCode().is2xxSuccessful())
+                .as("flow execute should be accepted").isTrue();
+        String executionId = (String) ((Map<String, Object>) executed.getBody().get("data")).get("id");
+        assertThat(executionId).isNotBlank();
+
+        // The execution parks WAITING at the Wait state.
+        String status = pollStatusUntil(token, slug, executionId, "WAITING", WAITING_TIMEOUT_MS);
+        assertThat(status).as("execution parks WAITING at the Wait state").isEqualTo("WAITING");
+
+        // A real flow_pending_resume row exists: time-based (no resume_event), unclaimed,
+        // due ~11s after creation. Compare resume_at against the row's own created_at so
+        // the assertion is immune to clock skew between the test JVM and the DB. The row is
+        // inserted right after the WAITING status update, so retry briefly to close the gap.
+        try (Connection db = openDbConnection();
+             PreparedStatement ps = db.prepareStatement("""
+                     SELECT claimed_by, resume_event, tenant_id,
+                            EXTRACT(EPOCH FROM (resume_at - created_at)) AS delay_seconds
+                     FROM flow_pending_resume
+                     WHERE execution_id = ?
+                     """)) {
+            ps.setString(1, executionId);
+            waitForPendingResumeRow(ps);
+            try (ResultSet rs = ps.executeQuery()) {
+                assertThat(rs.next())
+                        .as("a flow_pending_resume row was written for the parked execution").isTrue();
+                assertThat(rs.getString("resume_event"))
+                        .as("a Seconds wait is time-based, not event-based").isNull();
+                assertThat(rs.getString("claimed_by"))
+                        .as("the row is unclaimed until resume_at is due").isNull();
+                assertThat(rs.getString("tenant_id")).isEqualTo(tenantId);
+                assertThat(rs.getDouble("delay_seconds"))
+                        .as("resume_at is ~11s after the row was created")
+                        .isBetween(9.0, 13.0);
+                assertThat(rs.next())
+                        .as("exactly one pending-resume row per parked execution").isFalse();
+            }
+        }
+
+        // The poller claims the due row (SELECT FOR UPDATE SKIP LOCKED → exactly one
+        // claimant) and resumeExecution completes the flow.
+        status = pollStatusUntil(token, slug, executionId, "COMPLETED", COMPLETED_TIMEOUT_MS);
+        assertThat(status)
+                .as("the resume poller claimed the row and completed the flow")
+                .isEqualTo("COMPLETED");
+
+        // resumeExecution deletes the pending-resume row before advancing — a leftover row
+        // would be re-claimed and double-resumed.
+        try (Connection db = openDbConnection();
+             PreparedStatement ps = db.prepareStatement(
+                     "SELECT COUNT(*) FROM flow_pending_resume WHERE execution_id = ?")) {
+            ps.setString(1, executionId);
+            try (ResultSet rs = ps.executeQuery()) {
+                rs.next();
+                assertThat(rs.getInt(1))
+                        .as("the claimed pending-resume row is deleted on resume").isZero();
+            }
+        }
+    }
+
+    /**
+     * Re-runs the prepared pending-resume query until it returns a row (max ~5s).
+     * The row lands milliseconds after the WAITING status update; this only guards
+     * against observing the tiny gap between the two writes on a slow CI runner.
+     */
+    private void waitForPendingResumeRow(PreparedStatement ps) throws Exception {
+        for (int i = 0; i < 10; i++) {
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    return;
+                }
+            }
+            Thread.sleep(500);
+        }
+        // Fall through — the assertion on the next executeQuery() reports the failure.
+    }
+
+    /**
+     * Polls the execution until it reaches {@code targetStatus} or a terminal status,
+     * returning the last observed status.
+     */
+    @SuppressWarnings("unchecked")
+    private String pollStatusUntil(String token, String slug, String executionId,
+                                   String targetStatus, long timeoutMs) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        String status = null;
+        while (System.currentTimeMillis() < deadline) {
+            ResponseEntity<Map> resp = gatewayClientWithToken(token)
+                    .get().uri("/" + slug + "/api/flows/executions/" + executionId)
+                    .retrieve().toEntity(Map.class);
+            Map<String, Object> data = (Map<String, Object>) resp.getBody().get("data");
+            Map<String, Object> attrs = (Map<String, Object>) data.get("attributes");
+            status = (String) attrs.get("status");
+            if (targetStatus.equals(status)) {
+                return status;
+            }
+            // FAILED / CANCELLED will never transition further — bail out with the evidence.
+            if ("FAILED".equals(status) || "CANCELLED".equals(status)) {
+                throw new AssertionError("Execution " + executionId + " reached terminal status "
+                        + status + " while waiting for " + targetStatus
+                        + " (error: " + attrs.get("errorMessage") + ")");
+            }
+            Thread.sleep(500);
+        }
+        return status;
+    }
+}

--- a/kelta-test-harness/src/test/java/io/kelta/testharness/scenarios/RecordShareWideningScenarioTest.java
+++ b/kelta-test-harness/src/test/java/io/kelta/testharness/scenarios/RecordShareWideningScenarioTest.java
@@ -1,0 +1,259 @@
+package io.kelta.testharness.scenarios;
+
+import io.kelta.testharness.ScenarioBase;
+import io.kelta.testharness.fixtures.TenantFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Record-share <em>widening lookup</em> semantics against real RLS-enabled Postgres —
+ * the query behind {@code RecordShareRepository.findSharesForPrincipal} (kelta-worker):
+ * join {@code record_share → collection} by collection <em>name</em>, USER-direct +
+ * GROUP-membership grants via IN-lists, scoped to the current tenant by the V150
+ * {@code tenant_isolation} RLS policy.
+ *
+ * <p>The harness Cerbos policies are dev allow-all, so the widen path
+ * ({@code CerbosRecordAuthorizationAdvice} → {@code RecordShareAccessService}) never
+ * fires end-to-end here — no record is ever denied. This scenario instead runs the
+ * repository's exact SQL over real share rows, which is precisely what Mockito worker
+ * tests can't verify (see the DB-constraint-test-gap lesson): the join column names,
+ * the IN-list matching, and the RLS policy itself.
+ *
+ * <p><b>RLS needs a non-superuser:</b> the harness DB user is the image's bootstrap
+ * (super)user and bypasses RLS even on FORCE'd tables, so the SELECTs run as a dedicated
+ * probe role created by the test. The SQL below mirrors
+ * {@code RecordShareRepository.findSharesForPrincipal} — keep them in sync.
+ */
+@DisplayName("Record Share Widening Scenario")
+class RecordShareWideningScenarioTest extends ScenarioBase {
+
+    private static final String PROBE_ROLE     = "kelta_harness_rls_probe";
+    private static final String PROBE_PASSWORD = "kelta-harness-rls-probe";
+
+    /** Mirror of RecordShareRepository.findSharesForPrincipal with 5 record + 2 group slots. */
+    private static final String WIDENING_SQL = """
+            SELECT rs.record_id, rs.access_level
+            FROM record_share rs
+            JOIN collection c ON c.id = rs.collection_id
+            WHERE c.name = ?
+              AND rs.record_id IN (?,?,?,?,?)
+              AND (
+                (rs.shared_with_type = 'USER' AND rs.shared_with_id = ?)
+                OR (rs.shared_with_type = 'GROUP' AND rs.shared_with_id IN (?,?))
+              )
+            """;
+
+    /** The repository's groupIds-empty branch emits no GROUP clause at all. */
+    private static final String WIDENING_SQL_USER_ONLY = """
+            SELECT rs.record_id, rs.access_level
+            FROM record_share rs
+            JOIN collection c ON c.id = rs.collection_id
+            WHERE c.name = ?
+              AND rs.record_id IN (?,?,?,?,?)
+              AND (
+                (rs.shared_with_type = 'USER' AND rs.shared_with_id = ?)
+              )
+            """;
+
+    @Test
+    @DisplayName("returns USER + GROUP grants for the principal, excludes other principals, and RLS scopes rows by tenant")
+    void widensByUserAndGroupUnderRls() throws Exception {
+        // Tenant A: the seeded ecommerce tenant (it has real collections to join against).
+        String token = auth.loginAsAdmin(TenantFixture.ECOMMERCE_SLUG);
+        String tenantA = auth.extractTenantId(token);
+        // Tenant B: the seeded default tenant — used to prove cross-tenant invisibility.
+        String tenantB = tenants.tenantIdForSlug(TenantFixture.DEFAULT_SLUG);
+        assertThat(tenantB).isNotBlank().isNotEqualTo(tenantA);
+
+        // A real collection row (id + name) so the join-by-name has something to hit. It must
+        // be a collection row *owned by tenant A* — system collections belong to the platform
+        // sentinel tenant, and the V77 tenant_isolation policy on `collection` would hide them
+        // from the tenant-scoped probe, silently emptying the join.
+        String collectionId;
+        String collectionName;
+        try (Connection admin = openDbConnection();
+             PreparedStatement ps = admin.prepareStatement(
+                     "SELECT id, name FROM collection WHERE tenant_id = ? LIMIT 1")) {
+            ps.setString(1, tenantA);
+            try (ResultSet rs = ps.executeQuery()) {
+                assertThat(rs.next()).as("ecommerce tenant has a seeded collection").isTrue();
+                collectionId = rs.getString("id");
+                collectionName = rs.getString("name");
+            }
+        }
+        assertThat(collectionId).isNotBlank();
+        assertThat(collectionName).isNotBlank();
+
+        String suffix = Long.toHexString(System.nanoTime());
+        String recUser       = "wid-" + suffix + "-user-rec";
+        String recGroup      = "wid-" + suffix + "-group-rec";
+        String recOtherUser  = "wid-" + suffix + "-other-user-rec";
+        String recOtherGroup = "wid-" + suffix + "-other-group-rec";
+        String recAbsent     = "wid-" + suffix + "-absent-rec";
+
+        String userId     = "wid-user-" + suffix;
+        String groupOne   = "wid-grp1-" + suffix;
+        String groupTwo   = "wid-grp2-" + suffix;
+        String otherUser  = "wid-other-user-" + suffix;
+        String otherGroup = "wid-other-grp-" + suffix;
+
+        try (Connection admin = openDbConnection()) {
+            ensureProbeRole(admin);
+
+            // Seed share rows with explicit tenant ids (the admin connection bypasses RLS,
+            // exactly like Flyway seeds do). Row 5 is the RLS canary: same record + same
+            // user as row 1 but in tenant B — if the policy leaked, the tenant-A query
+            // would return recUser twice with two access levels.
+            insertShare(admin, tenantA, collectionId, recUser,       userId,     "USER",  "READ");
+            insertShare(admin, tenantA, collectionId, recGroup,      groupOne,   "GROUP", "EDIT");
+            insertShare(admin, tenantA, collectionId, recOtherUser,  otherUser,  "USER",  "READ");
+            insertShare(admin, tenantA, collectionId, recOtherGroup, otherGroup, "GROUP", "EDIT");
+            insertShare(admin, tenantB, collectionId, recUser,       userId,     "USER",  "EDIT");
+
+            try (Connection probe = openDbConnection(PROBE_ROLE, PROBE_PASSWORD)) {
+                // ── Tenant A ────────────────────────────────────────────────────────
+                setTenant(probe, tenantA);
+
+                // USER-direct + GROUP grants, decoy principals excluded, absent record ignored.
+                Map<String, String> grants = queryWidening(probe, WIDENING_SQL, collectionName,
+                        List.of(recUser, recGroup, recOtherUser, recOtherGroup, recAbsent),
+                        userId, List.of(groupTwo, groupOne));
+                assertThat(grants)
+                        .as("user-direct + group grants, nothing from other principals or tenants")
+                        .containsOnly(
+                                Map.entry(recUser, "READ"),
+                                Map.entry(recGroup, "EDIT"));
+
+                // Empty-groups branch: no GROUP clause — the group-shared record drops out.
+                Map<String, String> userOnly = queryWidening(probe, WIDENING_SQL_USER_ONLY, collectionName,
+                        List.of(recUser, recGroup, recOtherUser, recOtherGroup, recAbsent),
+                        userId, List.of());
+                assertThat(userOnly)
+                        .as("without group ids only the user-direct share matches")
+                        .containsOnly(Map.entry(recUser, "READ"));
+
+                // Join is by collection *name* — a wrong name must match nothing even
+                // though the share rows reference a valid collection id.
+                Map<String, String> wrongName = queryWidening(probe, WIDENING_SQL,
+                        "no_such_collection_" + suffix,
+                        List.of(recUser, recGroup, recOtherUser, recOtherGroup, recAbsent),
+                        userId, List.of(groupTwo, groupOne));
+                assertThat(wrongName).as("join by collection name misses on a wrong name").isEmpty();
+
+                // ── Tenant B ────────────────────────────────────────────────────────
+                setTenant(probe, tenantB);
+
+                // RLS row visibility: tenant B sees only its own share on recUser, with
+                // its own access level — none of tenant A's four rows.
+                try (PreparedStatement ps = probe.prepareStatement(
+                        "SELECT record_id, access_level FROM record_share WHERE record_id LIKE ?")) {
+                    ps.setString(1, "wid-" + suffix + "-%");
+                    Map<String, String> visible = new HashMap<>();
+                    try (ResultSet rs = ps.executeQuery()) {
+                        while (rs.next()) {
+                            visible.put(rs.getString("record_id"), rs.getString("access_level"));
+                        }
+                    }
+                    assertThat(visible)
+                            .as("RLS: tenant B sees only its own share row")
+                            .containsOnly(Map.entry(recUser, "EDIT"));
+                }
+            }
+        } finally {
+            try (Connection admin = openDbConnection();
+                 PreparedStatement ps = admin.prepareStatement(
+                         "DELETE FROM record_share WHERE record_id LIKE ?")) {
+                ps.setString(1, "wid-" + suffix + "-%");
+                ps.executeUpdate();
+            }
+        }
+    }
+
+    /**
+     * Creates the non-superuser probe role (idempotent — roles are cluster-wide and the
+     * CI DB pool is shared across runs) and grants it read access to the two tables in
+     * the harness schema. {@code current_schema()} honours the CI URL's
+     * {@code currentSchema=ci_<run-tag>} pin, so grants land on this run's schema.
+     */
+    private void ensureProbeRole(Connection admin) throws Exception {
+        try (Statement st = admin.createStatement()) {
+            st.execute("""
+                    DO $$ BEGIN
+                        CREATE ROLE %s LOGIN PASSWORD '%s';
+                    EXCEPTION WHEN duplicate_object THEN NULL;
+                    END $$
+                    """.formatted(PROBE_ROLE, PROBE_PASSWORD));
+            String schema;
+            try (ResultSet rs = st.executeQuery("SELECT current_schema()")) {
+                rs.next();
+                schema = rs.getString(1);
+            }
+            st.execute("GRANT USAGE ON SCHEMA \"" + schema + "\" TO " + PROBE_ROLE);
+            st.execute("GRANT SELECT ON \"" + schema + "\".record_share, \""
+                    + schema + "\".collection TO " + PROBE_ROLE);
+        }
+    }
+
+    private void insertShare(Connection conn, String tenantId, String collectionId,
+                             String recordId, String sharedWithId, String sharedWithType,
+                             String accessLevel) throws Exception {
+        try (PreparedStatement ps = conn.prepareStatement("""
+                INSERT INTO record_share
+                    (id, tenant_id, collection_id, record_id, shared_with_id, shared_with_type, access_level)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """)) {
+            ps.setString(1, UUID.randomUUID().toString());
+            ps.setString(2, tenantId);
+            ps.setString(3, collectionId);
+            ps.setString(4, recordId);
+            ps.setString(5, sharedWithId);
+            ps.setString(6, sharedWithType);
+            ps.setString(7, accessLevel);
+            ps.executeUpdate();
+        }
+    }
+
+    /** Session-scoped tenant binding — same setting the worker's RLS relies on. */
+    private void setTenant(Connection conn, String tenantId) throws Exception {
+        try (PreparedStatement ps = conn.prepareStatement(
+                "SELECT set_config('app.current_tenant_id', ?, false)")) {
+            ps.setString(1, tenantId);
+            ps.execute();
+        }
+    }
+
+    /** Runs a widening query and returns {@code recordId → accessLevel}. */
+    private Map<String, String> queryWidening(Connection conn, String sql, String collectionName,
+                                              List<String> recordIds, String userId,
+                                              List<String> groupIds) throws Exception {
+        try (PreparedStatement ps = conn.prepareStatement(sql)) {
+            int i = 1;
+            ps.setString(i++, collectionName);
+            for (String recordId : recordIds) {
+                ps.setString(i++, recordId);
+            }
+            ps.setString(i++, userId);
+            for (String groupId : groupIds) {
+                ps.setString(i++, groupId);
+            }
+            Map<String, String> result = new HashMap<>();
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    result.put(rs.getString("record_id"), rs.getString("access_level"));
+                }
+            }
+            return result;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds the two missing real-Postgres kelta-test-harness scenarios for features that shipped with unit tests only (per the DB-constraint-test-gap policy): flow Wait-state park/resume and record-share widening SQL.
- **FlowWaitResumeScenarioTest** — creates an AUTOLAUNCHED flow with `Wait Seconds=11` (above the 10s inline threshold), executes it via the gateway, and proves against real Postgres: the execution parks `WAITING`, exactly one `flow_pending_resume` row exists (time-based, unclaimed, `resume_at ≈ created_at + 11s`), the resume poller claims it (`JdbcFlowStore.claimPendingResumes`, `FOR UPDATE SKIP LOCKED`), and `FlowEngine.resumeExecution` deletes the row and completes the flow.
- **RecordShareWideningScenarioTest** — runs the exact `RecordShareRepository.findSharesForPrincipal` SQL over real `record_share` rows: USER-direct + GROUP IN-list grants match, decoy principals are excluded, the join is by collection *name*, and the V150 RLS `tenant_isolation` policy scopes rows per tenant. Runs as a non-superuser probe role because the harness DB user is a superuser and bypasses RLS; the widen path can't be reached end-to-end since harness Cerbos policies are dev allow-all.

## Changes
- `kelta-test-harness/.../scenarios/FlowWaitResumeScenarioTest.java` (new)
- `kelta-test-harness/.../scenarios/RecordShareWideningScenarioTest.java` (new)
- `kelta-test-harness/.../KeltaStack.java` — `dbJdbcUrl()/dbUsername()/dbPassword()` accessors (host-reachable URL locally, CI URL passed through with its `currentSchema` pin)
- `kelta-test-harness/.../ScenarioBase.java` — `openDbConnection()` helpers for direct-JDBC assertions
- `kelta-test-harness/pom.xml` — org.postgresql driver (test scope); Testcontainers 1.20.4 → 1.21.3 (Docker Engine 29 drops API < 1.40; older docker-java pings `/v1.32` and container discovery fails)
- `.claude/docs/testing.md` — direct-DB assertion pattern, RLS superuser caveat, V77 public-schema-only RLS gotcha for CI schemas

## Testing
- Full harness suite green locally: `mvn verify -f kelta-test-harness/pom.xml -Pintegration-tests` — all 16 scenario classes pass including the two new ones
- `/verify` green: runtime modules built, gateway 457 tests, worker 1565 tests, kelta-web lint/typecheck/format/coverage (no kelta-ui changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)