### PR TITLE
fix(security): record Cerbos policy keyed on collection name, not UUID

### DIFF
--- a/.claude/docs/architecture.md
+++ b/.claude/docs/architecture.md
@@ -75,6 +75,19 @@ Cerbos enforcement is **collection/record-scoped, not blanket**. Concretely:
 - **Collection API routes** (`/{tenant}/{collection}`): the gateway `RouteAuthorizationFilter`
   (order 0) runs the per-resource Cerbos object check, and the worker
   `CerbosRecordAuthorizationAdvice` + FLS advices add record/field checks.
+  - **Cerbos `collectionId` keying (important).** The `collection` policy CEL (gateway) and
+    the `record`/`field` policies (worker advices) key `R.attr.collectionId` on **different
+    identifiers**, because their checkers pass different values. The gateway's
+    `RouteAuthorizationFilter.checkObjectPermission` passes `route.getId()` = the bootstrap
+    `collection.id` (a **UUID**), so `CerbosPolicyGenerator.generateCollectionPolicy` keys the
+    collection CEL on the UUID. The worker `CerbosRecordAuthorizationAdvice` and
+    `CerbosFieldSecurityAdvice` take `collectionId` from the **URL path segment** (the collection
+    **name**), and record-share widening joins by name — so `generateRecordPolicy` and
+    `generateFieldPolicy` key their CEL on the **name**. `generateRecordPolicy` therefore takes a
+    `collectionIdToName` map and translates the per-collection + custom-rule CEL literals to names
+    while still looking up object permissions by the stored UUID. Get this wrong in one direction
+    and per-collection allow rules silently never match: a UUID-keyed record CEL denies every
+    record to non-`VIEW_ALL_DATA` profiles (they'd see empty lists everywhere).
 - **Static routes** (`/api/admin/**`, `/api/me/**`, `/api/_search/**`, `/api/metrics/**`):
   `RouteAuthorizationFilter` **skips** ids starting `static-` — they get only the blanket
   `API_ACCESS` system-permission check. The worker advices **exclude** `/api/admin/`. So a new

--- a/.claude/docs/concerns.md
+++ b/.claude/docs/concerns.md
@@ -84,14 +84,20 @@ route.
 
 (No open bugs from the original audit. See Resolved → Bugs.)
 
-**Cerbos object/record policies are likely generated from collection UUIDs but checked
-against collection names (under investigation).** `profile_object_permission.collection_id`
-and `loadCollectionIdsForTenant` feed collection UUIDs into the collection/record policy
-CEL, while the gateway/worker advices pass the URL-path collection *name* — if confirmed,
-per-collection CRUD grants for non-admin profiles never match and only the unconditional
-`VIEW_ALL_DATA`/`MODIFY_ALL_DATA` rules take effect. The equivalent field-permission
-mismatch was real and is fixed (BootstrapRepository COALESCE-join translation, data-masking
-PR); a spawned task covers verifying + fixing the object/record side the same way.
+**FIXED (PR #1174) — record-policy `collectionId` was UUID-keyed but checked by name.**
+`CerbosPolicyGenerator.generateRecordPolicy` emitted `R.attr.collectionId == "<UUID>"` (from
+`profile_object_permission.collection_id` + `collection.id`, both UUIDs), but
+`CerbosRecordAuthorizationAdvice` sets `R.attr.collectionId` from the URL path **name**. With
+`permissions-enabled=true` (default) and real Cerbos policies, per-collection record allow rules
+never matched, so any profile lacking `VIEW_ALL_DATA` (e.g. the seeded **Standard User**) had
+**every record filtered out** of reads and denied on writes — except explicitly record-shared
+rows. The harness runs Cerbos in allow-all mode and e2e runs as admin, so neither caught it (same
+blind spot as the field-permission bug, per `feedback_db-constraint-test-gap`). Fix: the record
+policy CEL (and its custom-rule CEL) now key on the collection **name** via a `collectionIdToName`
+map; the **collection** policy stays UUID-keyed because the gateway's `checkObjectPermission`
+passes the UUID (`route.getId()`). See `architecture.md` → Cerbos `collectionId` keying.
+**Pre-merge gate: verify on a live stack** (`make up`, log in as a non-admin profile, toggle
+per-collection object permissions) — the allow-all harness Cerbos cannot exercise real deny.
 
 ## Tech Debt
 

--- a/kelta-worker/src/main/java/io/kelta/worker/service/CerbosPolicyGenerator.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/service/CerbosPolicyGenerator.java
@@ -232,16 +232,30 @@ public class CerbosPolicyGenerator {
 
     /**
      * Generates the record resource policy for a tenant (base CRUD + custom ABAC rules).
+     *
+     * <p><strong>Record CEL keys on the collection NAME, not the UUID.</strong> The
+     * worker's {@code CerbosRecordAuthorizationAdvice} sets {@code R.attr.collectionId}
+     * from the request URL segment (the collection API name), and record-share widening
+     * joins by collection name too — so the per-collection record rules must match on the
+     * name. Object permissions are still <em>looked up</em> by the collection UUID (the id
+     * stored in {@code profile_object_permission}); only the emitted CEL literal is the
+     * name, resolved via {@code collectionIdToName}. This differs from
+     * {@link #generateCollectionPolicy}, whose CEL stays UUID-keyed because the gateway's
+     * route-level {@code checkObjectPermission} passes the collection UUID
+     * ({@code route.getId()} = bootstrap {@code collection.id}). A map miss falls back to
+     * the id (tolerant of any collection lacking a name entry).
      */
     public Map<String, Object> generateRecordPolicy(String tenantId,
                                                       List<ProfileData> profiles,
                                                       List<String> collectionIds,
-                                                      List<CustomRule> customRules) {
+                                                      List<CustomRule> customRules,
+                                                      Map<String, String> collectionIdToName) {
         // Start with same collection-level CRUD rules applied to records
         List<Map<String, Object>> rules = new ArrayList<>();
 
         // Per-collection CRUD (same as collection policy)
         for (String collectionId : collectionIds) {
+            String collectionRef = resolveCollectionRef(collectionIdToName, collectionId);
             for (String action : List.of("create", "read", "edit", "delete")) {
                 List<String> allowedRoles = new ArrayList<>();
                 for (ProfileData profile : profiles) {
@@ -256,7 +270,7 @@ public class CerbosPolicyGenerator {
                     rule.put("effect", "EFFECT_ALLOW");
                     rule.put("derivedRoles", allowedRoles);
                     Map<String, Object> condition = new LinkedHashMap<>();
-                    condition.put("match", Map.of("expr", "R.attr.collectionId == \"" + collectionId + "\""));
+                    condition.put("match", Map.of("expr", "R.attr.collectionId == \"" + collectionRef + "\""));
                     rule.put("condition", condition);
                     rules.add(rule);
                 }
@@ -301,7 +315,8 @@ public class CerbosPolicyGenerator {
                     ? "EFFECT_DENY" : "EFFECT_ALLOW");
             rule.put("derivedRoles", List.of("profile_" + customRule.profileId()));
 
-            String collExpr = "R.attr.collectionId == \"" + customRule.collectionId() + "\"";
+            String collExpr = "R.attr.collectionId == \""
+                    + resolveCollectionRef(collectionIdToName, customRule.collectionId()) + "\"";
             String celExpr = customRule.celExpression();
             String combinedExpr = celExpr != null && !celExpr.isBlank()
                     ? collExpr + " && " + celExpr
@@ -315,6 +330,17 @@ public class CerbosPolicyGenerator {
         }
 
         return buildResourcePolicy("record", tenantId, rules);
+    }
+
+    /**
+     * Resolves a collection UUID to the API name used in record CEL, falling back to the
+     * id itself when the map is null or has no entry (so an unmapped collection still emits
+     * a well-formed, if id-keyed, rule rather than a {@code null} literal).
+     */
+    private static String resolveCollectionRef(Map<String, String> collectionIdToName, String collectionId) {
+        return collectionIdToName != null
+                ? collectionIdToName.getOrDefault(collectionId, collectionId)
+                : collectionId;
     }
 
     private Map<String, Object> buildResourcePolicy(String resource, String tenantId,

--- a/kelta-worker/src/main/java/io/kelta/worker/service/CerbosPolicySyncService.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/service/CerbosPolicySyncService.java
@@ -86,7 +86,22 @@ public class CerbosPolicySyncService {
                 log.info("No profiles found for tenant {} — skipping Cerbos policy sync", tenantId);
                 return;
             }
-            List<String> collectionIds = loadCollectionIdsForTenant(tenantId);
+            List<Map<String, Object>> activeCollections = bootstrapRepository.findActiveCollections();
+            List<String> collectionIds = activeCollections.stream()
+                    .map(row -> (String) row.get("id"))
+                    .filter(Objects::nonNull)
+                    .toList();
+            // id -> API name, so the record policy CEL can key on the collection name the
+            // worker record advice passes (the collection policy stays UUID-keyed for the
+            // gateway). See generateRecordPolicy.
+            Map<String, String> collectionIdToName = new LinkedHashMap<>();
+            for (Map<String, Object> row : activeCollections) {
+                String id = (String) row.get("id");
+                String name = (String) row.get("name");
+                if (id != null && name != null) {
+                    collectionIdToName.put(id, name);
+                }
+            }
             List<CerbosPolicyGenerator.CustomRule> customRules = loadCustomRulesForTenant(tenantId);
 
             // Generate policies
@@ -94,7 +109,8 @@ public class CerbosPolicySyncService {
             Map<String, Object> systemPolicy = policyGenerator.generateSystemFeaturePolicy(tenantId, profiles);
             Map<String, Object> collectionPolicy = policyGenerator.generateCollectionPolicy(tenantId, profiles, collectionIds);
             Map<String, Object> fieldPolicy = policyGenerator.generateFieldPolicy(tenantId, profiles);
-            Map<String, Object> recordPolicy = policyGenerator.generateRecordPolicy(tenantId, profiles, collectionIds, customRules);
+            Map<String, Object> recordPolicy = policyGenerator.generateRecordPolicy(
+                    tenantId, profiles, collectionIds, customRules, collectionIdToName);
 
             // Push to Cerbos Admin API
             pushPolicy(derivedRoles);
@@ -232,14 +248,6 @@ public class CerbosPolicySyncService {
                     .put(fieldId, visibility);
         }
         return perms;
-    }
-
-    private List<String> loadCollectionIdsForTenant(String tenantId) {
-        List<Map<String, Object>> collections = bootstrapRepository.findActiveCollections();
-        return collections.stream()
-                .map(row -> (String) row.get("id"))
-                .filter(Objects::nonNull)
-                .toList();
     }
 
     private List<CerbosPolicyGenerator.CustomRule> loadCustomRulesForTenant(String tenantId) {

--- a/kelta-worker/src/test/java/io/kelta/worker/service/CerbosPolicyGeneratorTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/service/CerbosPolicyGeneratorTest.java
@@ -367,7 +367,8 @@ class CerbosPolicyGeneratorTest {
                     "R.attr.status == \"locked\"", true);
 
             Map<String, Object> policy = generator.generateRecordPolicy(
-                    TENANT_ID, List.of(adminProfile()), List.of("col-1"), List.of(customRule));
+                    TENANT_ID, List.of(adminProfile()), List.of("col-1"), List.of(customRule),
+                    Map.of("col-1", "col-1"));
 
             Map<String, Object> resourcePolicy = (Map<String, Object>) policy.get("resourcePolicy");
             List<Map<String, Object>> rules = (List<Map<String, Object>>) resourcePolicy.get("rules");
@@ -386,6 +387,65 @@ class CerbosPolicyGeneratorTest {
         }
 
         @Test
+        @DisplayName("record CRUD CEL keys on the collection NAME, while collection policy stays UUID-keyed")
+        @SuppressWarnings("unchecked")
+        void recordCelUsesCollectionName() {
+            // A profile that can read collection UUID "col-uuid-1" (name "contacts").
+            ProfileData reader = new ProfileData(
+                    "reader-profile", "Reader",
+                    Map.of(),
+                    Map.of("col-uuid-1", Map.of("canRead", true)),
+                    Map.of());
+            List<String> collectionIds = List.of("col-uuid-1");
+            Map<String, String> idToName = Map.of("col-uuid-1", "contacts");
+
+            Map<String, Object> recordPolicy = generator.generateRecordPolicy(
+                    TENANT_ID, List.of(reader), collectionIds, List.of(), idToName);
+            Map<String, Object> collectionPolicy = generator.generateCollectionPolicy(
+                    TENANT_ID, List.of(reader), collectionIds);
+
+            // Record read rule matches on the NAME (what CerbosRecordAuthorizationAdvice passes).
+            assertThat(readRuleExpr(recordPolicy, "read"))
+                    .contains("R.attr.collectionId == \"contacts\"")
+                    .doesNotContain("col-uuid-1");
+            // Collection read rule still matches on the UUID (what the gateway passes).
+            assertThat(readRuleExpr(collectionPolicy, "read"))
+                    .contains("R.attr.collectionId == \"col-uuid-1\"")
+                    .doesNotContain("contacts");
+        }
+
+        @Test
+        @DisplayName("record CEL falls back to the id when no name mapping exists")
+        @SuppressWarnings("unchecked")
+        void recordCelFallsBackToId() {
+            ProfileData reader = new ProfileData(
+                    "reader-profile", "Reader",
+                    Map.of(), Map.of("col-uuid-9", Map.of("canRead", true)), Map.of());
+
+            Map<String, Object> policy = generator.generateRecordPolicy(
+                    TENANT_ID, List.of(reader), List.of("col-uuid-9"), List.of(), Map.of());
+
+            assertThat(readRuleExpr(policy, "read")).contains("R.attr.collectionId == \"col-uuid-9\"");
+        }
+
+        @SuppressWarnings("unchecked")
+        private String readRuleExpr(Map<String, Object> policy, String action) {
+            Map<String, Object> resourcePolicy = (Map<String, Object>) policy.get("resourcePolicy");
+            List<Map<String, Object>> rules = (List<Map<String, Object>>) resourcePolicy.get("rules");
+            return rules.stream()
+                    .filter(rule -> "EFFECT_ALLOW".equals(rule.get("effect")))
+                    .filter(rule -> ((List<String>) rule.get("actions")).contains(action))
+                    .filter(rule -> rule.get("condition") != null)
+                    .map(rule -> {
+                        Map<String, Object> condition = (Map<String, Object>) rule.get("condition");
+                        Map<String, Object> match = (Map<String, Object>) condition.get("match");
+                        return (String) match.get("expr");
+                    })
+                    .findFirst()
+                    .orElse("");
+        }
+
+        @Test
         @DisplayName("should skip disabled custom rules")
         @SuppressWarnings("unchecked")
         void skipsDisabledCustomRules() {
@@ -394,7 +454,7 @@ class CerbosPolicyGeneratorTest {
                     "delete", "EFFECT_DENY", "true", false);
 
             Map<String, Object> policy = generator.generateRecordPolicy(
-                    TENANT_ID, List.of(), List.of(), List.of(disabledRule));
+                    TENANT_ID, List.of(), List.of(), List.of(disabledRule), Map.of());
 
             Map<String, Object> resourcePolicy = (Map<String, Object>) policy.get("resourcePolicy");
             List<Map<String, Object>> rules = (List<Map<String, Object>>) resourcePolicy.get("rules");


### PR DESCRIPTION
## Verified bug

`CerbosPolicyGenerator.generateRecordPolicy` emits per-collection CRUD rules with CEL `R.attr.collectionId == "<collectionId>"`, where `collectionId` comes from `profile_object_permission.collection_id` / `collection.id` — both **UUIDs** (`SystemCollectionSeeder` uses `UUID.randomUUID()`; V55 seeds object perms with `c.id`; user-collection rows also get a UUID id via `DefaultQueryEngine.create`).

But `CerbosRecordAuthorizationAdvice.extractCollectionId` sets `R.attr.collectionId` to the **URL path segment = collection name**, and `RecordShareAccessService` joins by collection name. So the record CEL compares **name vs UUID** and never matches.

Impact (traced end-to-end): with `permissions-enabled=true` (default) and real Cerbos policies, any profile without the `VIEW_ALL_DATA` system permission — including the seeded **Standard User** (`API_ACCESS` + `MANAGE_LISTVIEWS` only) — has **every record filtered out** of list/detail reads and **denied** on writes, except records explicitly shared with them. The gateway's collection-level check is unaffected and still gates access; this is the separate worker record layer silently denying everything.

Why it was never caught: the kelta-test-harness runs Cerbos in **allow-all** mode (per `RecordShareWideningScenarioTest`) and e2e runs as **admin** — the same blind spot that hid the field-permission bug (`feedback_db-constraint-test-gap`).

## Fix

The record policy CEL (per-collection CRUD **and** custom ABAC rules) now keys on the collection **name** via a `collectionIdToName` map passed into `generateRecordPolicy`; object permissions are still *looked up* by the stored UUID (only the emitted CEL literal changes). A map miss falls back to the id.

**The collection policy stays UUID-keyed on purpose.** The gateway's `RouteAuthorizationFilter.checkObjectPermission` passes `route.getId()` = bootstrap `collection.id` (UUID), so `generateCollectionPolicy` must keep matching on the UUID. Translating *both* (as first suspected) would have broken the working gateway collection check. This aligns the record policy with how the field policy already keys on the collection name — worker advices use names, only the gateway uses the UUID.

## Tests
- `CerbosPolicyGeneratorTest`: new cases lock both directions — record CRUD CEL emits the **name** while the collection CEL still emits the **UUID** for the same input, plus id-fallback when unmapped. Worker suite green (1581).
- The allow-all harness Cerbos can't exercise real deny, so no harness scenario is added.

## Pre-merge gate
**Verify on a live stack** (`make up`, log in as a non-admin profile e.g. Standard User, read a collection's records, toggle per-collection object permissions) before merging — this is the only environment with real per-tenant Cerbos policies.

## Docs
`architecture.md` (Cerbos `collectionId` keying: collection=UUID/gateway vs record+field=name/worker), `concerns.md` (Known Bugs → fixed, with the live-stack gate).

Security-typed → **not auto-merged**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)