### PR TITLE
docs: correct post-flatten Flyway numbering (next is V162, not V2)

### DIFF
--- a/.claude/docs/specs/app-surfacing/1-analytics-authz.md
+++ b/.claude/docs/specs/app-surfacing/1-analytics-authz.md
@@ -6,7 +6,7 @@
 > and [Security](./README.md#security) sections.
 >
 > **Security-typed change — never auto-merged** (closes a live authorization gap).
-> Source-verified 2026-07-08 (Flyway head V1__baseline; next V2).
+> Source-verified 2026-07-08 (Flyway head file V1__baseline; next new migration V162 — deployed flyway_schema_history keeps pre-flatten numbering, never number below it).
 
 ## 1. Goal & scope
 
@@ -69,7 +69,7 @@ Reporting**: "View Analytics — Run reports and view dashboards" (rendered by t
 - **Endpoint shapes unchanged.** The gate runs before any service call;
   `MaskingPrincipal` resolution (`principalOf(request)`) is untouched.
 - **Default grants matrix** (new tenants via `TenantProvisioningHook`, existing tenants via
-  V2 — identical outcome):
+  V162 — identical outcome):
 
   | Built-in profile | `VIEW_ANALYTICS` | Rationale |
   |------------------|------------------|-----------|
@@ -91,8 +91,8 @@ Reporting**: "View Analytics — Run reports and view dashboards" (rendered by t
 
 ## 4. DB migrations
 
-**`kelta-worker/src/main/resources/db/migration/V2__seed_view_analytics_permission.sql`**
-(verify head is still V1 before numbering):
+**`kelta-worker/src/main/resources/db/migration/V162__seed_view_analytics_permission.sql`**
+(numbering starts at V162 — deployed environments retain pre-flatten history entries up to V161, so anything lower is silently skipped by Flyway; verify the directory + deployed history before numbering):
 
 ```sql
 -- Backfill VIEW_ANALYTICS for every existing profile, all tenants.
@@ -127,7 +127,7 @@ mixed hook/migration ordering safe.
 
 | File | Change |
 |------|--------|
-| `kelta-worker/src/main/resources/db/migration/V2__seed_view_analytics_permission.sql` | **New** — SQL above. |
+| `kelta-worker/src/main/resources/db/migration/V162__seed_view_analytics_permission.sql` | **New** — SQL above. |
 | `kelta-worker/src/main/java/io/kelta/worker/controller/ReportExecutionController.java` | Add `BootstrapRepository` constructor dep (5th). Add `private void requireAnalyticsAccess(HttpServletRequest request)` — the `EnvironmentController.requirePermission` pattern, accepting `VIEW_ANALYTICS` or `MANAGE_REPORTS` (one permissions fetch, one `anyMatch` over both names). Call it first in `executeReport(...)` (line ~70) and `exportReport(...)` (line ~134), before any service/`principalOf` work. |
 | `kelta-worker/src/main/java/io/kelta/worker/controller/DashboardDataController.java` | Same: `BootstrapRepository` dep + `requireAnalyticsAccess` + call first in `executeDashboard(...)` (~63) and `executeComponent(...)` (~138). (Two private copies mirror the existing per-controller convention — `EnvironmentController`, `DelegatedAdminScopeController` each own theirs; do not invent a shared helper class in this slice.) |
 | `kelta-worker/src/main/java/io/kelta/worker/listener/TenantProvisioningHook.java` | Append `"VIEW_ANALYTICS"` to `ALL_PERMISSIONS` (lines 35-43). Add it to `grantedPermissions` for System Administrator, Solution Manager, Standard User, Read Only, Marketing User, Contract Manager (lines 122-147). Minimum Access unchanged (empty set — the insert loop writes the row with `granted=false`). |
@@ -154,13 +154,13 @@ controller, `TenantContext.set/clear` around each test):** for each of the two c
 **`TenantProvisioningHook` unit:** catalog contains `VIEW_ANALYTICS`; per-profile grant
 matrix matches §3.
 
-**kelta-test-harness (real Postgres + RLS + Flyway V2 — the migration itself is under
+**kelta-test-harness (real Postgres + RLS + Flyway V162 — the migration itself is under
 test):** `AnalyticsAuthzScenarioTest` extends `ScenarioBase`:
 1. `auth.loginAsAdmin()`; create a minimal report via JSON:API `POST /api/reports` (admin
    holds `MANAGE_REPORTS` → passes the gate; proves fallback acceptance live).
 2. Via `openDbConnection()`: `profileIdByName(db, tenantId, "Standard User")` and
    `"Minimum Access"`; `seedActiveUser(...)` one user per profile; `directLogin(...)` each.
-3. Standard User calls `POST /{slug}/api/reports/{id}/execute` → **200** (V2 backfill
+3. Standard User calls `POST /{slug}/api/reports/{id}/execute` → **200** (V162 backfill
    granted it — asserts the migration's grant rule on real data).
 4. Minimum Access user calls the same → **403**.
 5. Same 200/403 pair against `POST /{slug}/api/dashboards/{id}/data` (create a dashboard row
@@ -198,7 +198,7 @@ slice 3's spec (post-deploy, per parent).
   per-request query. If a cache exists by implementation time, reuse its invalidation path —
   do not ship a stale-grant gate.
 - **Ordering — hook vs migration:** new tenants provisioned *after* this deploy get the row
-  from `TenantProvisioningHook`; V2's `NOT EXISTS` guard makes the overlap harmless either
+  from `TenantProvisioningHook`; V162's `NOT EXISTS` guard makes the overlap harmless either
   way.
 - **`Read Only` grant is opinionated** (its seeded permission set is only `VIEW_ALL_DATA`,
   no `API_ACCESS` — such users may not be able to reach the API at all today; the grant is

--- a/.claude/docs/specs/app-surfacing/README.md
+++ b/.claude/docs/specs/app-surfacing/README.md
@@ -8,7 +8,7 @@
 > sections below.
 >
 > Source-verified against the codebase on 2026-07-07 (Flyway head **V1__baseline** after the
-> #1189 flatten — next new migration is **V2**; check the directory before numbering). If code
+> #1189 flatten — next new migration is **V162**: deployed flyway_schema_history keeps pre-flatten numbering (entries up to V161), so lower numbers are silently skipped — check the directory + deployed history before numbering). If code
 > and this doc disagree, trust the code and fix this doc.
 
 ## How to use this document
@@ -203,7 +203,7 @@ helper into `pages/app/ObjectListPage/listUrlState.ts` and both slices use it.
   standing rule). Slice 1 closes the `concerns.md` "reports/dashboards reachable with bare
   `API_ACCESS`" item; update that row in the same PR.
 - **New permission `VIEW_ANALYTICS`** follows the V157 `MANAGE_DELEGATED_ADMINS` pattern
-  (now folded into V1 baseline): **V2 migration** backfills a grant per existing profile
+  (now folded into V1 baseline): **V162 migration** backfills a grant per existing profile
   (granted where the profile already holds `MANAGE_REPORTS`; plus granted to the built-in
   Standard User profile — opinionated default: standard users may *run* analytics, Minimum
   Access may not); `TenantProvisioningHook` seeds it for new tenants; FE
@@ -225,7 +225,7 @@ helper into `pages/app/ObjectListPage/listUrlState.ts` and both slices use it.
 - **Slice 0 — Parent spec + doc wiring** (this file). Author parent + child specs; add the
   specs row to `CLAUDE.md`; fix the stale Flyway-head lines in `CLAUDE.md` (code head is
   **V1__baseline**, doc said V159). No code.
-- **Slice 1 — Analytics authorization** (backend, security). V2 migration seeding
+- **Slice 1 — Analytics authorization** (backend, security). V162 migration seeding
   `VIEW_ANALYTICS`; `TenantProvisioningHook` + FE checklist catalog entries;
   `requirePermission` gates on the four analytics endpoints (accepting
   `VIEW_ANALYTICS` or `MANAGE_REPORTS`); worker unit tests (grant/deny/either-permission) +
@@ -278,7 +278,7 @@ Each `<slice>.md` must include every section (sections that don't apply state "N
 3. **Data & API contracts** — exact TS interfaces / JSON shapes / endpoint signatures;
    versioning + back-compat.
 4. **DB migrations** — exact Flyway `V<n>__*.sql` or "None". Verify head before numbering
-   (head **V1__baseline**, next **V2**).
+   (baseline file **V1__baseline**, next **V162** — deployed history keeps pre-flatten numbering).
 5. **File-by-file code changes** — every file, functions/components, registration/wiring.
 6. **Test plan** — Vitest (FE), worker unit w/ mocked JdbcTemplate/QueryEngine (BE),
    kelta-test-harness scenario (DB/RLS-sensitive), post-deploy Playwright.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,7 +142,7 @@ visual system.
 | Frontend | React | 19.2 | `kelta-ui/app/package.json` |
 | Frontend build | Vite / Vitest | web 5.1/1.3, ui 7.2/4.0 | package.json (npm, Node 18 in CI) |
 | E2E | Playwright | 1.50 | `e2e-tests/package.json` |
-| Migrations | Flyway | head **V1__baseline** (#1189 flatten), next **V2** | `kelta-worker/.../db/migration/` |
+| Migrations | Flyway | baseline **V1__baseline** (#1189 flatten), next new migration **V162** (deployed history keeps pre-flatten numbering) | `kelta-worker/.../db/migration/` |
 
 Check the relevant `pom.xml` / `package.json` for exact current versions before pinning.
 
@@ -249,7 +249,7 @@ Java tests: surefire runs `*Test`/`*Tests`/`*Properties` in parallel; failsafe r
 ## Database Migrations
 
 - Location: `kelta-worker/src/main/resources/db/migration/`
-- Naming: `V<n>__<snake_description>.sql`. **Head is V1__baseline (#1189 flatten); next new migration is V2.**
+- Naming: `V<n>__<snake_description>.sql`. **Baseline file is V1__baseline (#1189 flatten); next new migration is V162 — deployed flyway_schema_history retains pre-flatten numbering (entries up to V161), so a lower-numbered migration is silently skipped on existing databases.**
   Check the directory for the true highest number before creating one — never reuse/skip.
 - Flyway runs at worker startup. Migrations execute under the platform sentinel tenant.
 


### PR DESCRIPTION
## Summary
- Deployed databases keep pre-flatten `flyway_schema_history` entries (up to V161); Flyway skips migrations numbered below the applied head, so a `V2__*.sql` would silently never run on existing environments — only on fresh databases
- Corrects CLAUDE.md (Stack table + Database Migrations section) and the app-surfacing parent + slice 1 child specs: next new migration is **V162**; slice 1's migration becomes `V162__seed_view_analytics_permission.sql`

## Changes
- `CLAUDE.md` — Flyway rows: baseline file V1__baseline, next new migration V162, with the why
- `.claude/docs/specs/app-surfacing/README.md` — header note, security section, slice plan, child-spec template
- `.claude/docs/specs/app-surfacing/1-analytics-authz.md` — migration filename + all V2 references

## Testing
- Docs-only; `grep -rn '\bV2\b'` across the three files returns nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)