### PR TITLE
fix(i18n): use double-brace placeholders in restrictedValues key

### DIFF
--- a/kelta-ui/app/src/i18n/translations/ar.json
+++ b/kelta-ui/app/src/i18n/translations/ar.json
@@ -133,7 +133,7 @@
     "picklistOverrides": "تجاوزات قائمة الاختيار",
     "noPicklistFields": "لا توجد حقول قائمة اختيار في هذه المجموعة للتكوين.",
     "allValuesAvailable": "جميع القيم متاحة",
-    "restrictedValues": "{count} من {total} قيم متاحة",
+    "restrictedValues": "{{count}} من {{total}} قيم متاحة",
     "defaultValue": "القيمة الافتراضية",
     "noDefault": "بدون افتراضي",
     "overrideSaved": "تم حفظ تجاوزات قائمة الاختيار بنجاح",

--- a/kelta-ui/app/src/i18n/translations/de.json
+++ b/kelta-ui/app/src/i18n/translations/de.json
@@ -159,7 +159,7 @@
     "picklistOverrides": "Auswahllisten-Überschreibungen",
     "noPicklistFields": "Diese Sammlung hat keine Auswahllistenfelder zur Konfiguration.",
     "allValuesAvailable": "Alle Werte verfügbar",
-    "restrictedValues": "{count} von {total} Werten verfügbar",
+    "restrictedValues": "{{count}} von {{total}} Werten verfügbar",
     "defaultValue": "Standardwert",
     "noDefault": "Kein Standard",
     "overrideSaved": "Auswahllisten-Überschreibungen erfolgreich gespeichert",

--- a/kelta-ui/app/src/i18n/translations/en.json
+++ b/kelta-ui/app/src/i18n/translations/en.json
@@ -165,7 +165,7 @@
     "picklistOverrides": "Picklist Overrides",
     "noPicklistFields": "This collection has no picklist fields to configure.",
     "allValuesAvailable": "All values available",
-    "restrictedValues": "{count} of {total} values available",
+    "restrictedValues": "{{count}} of {{total}} values available",
     "defaultValue": "Default Value",
     "noDefault": "No default",
     "overrideSaved": "Picklist overrides saved successfully",

--- a/kelta-ui/app/src/i18n/translations/es.json
+++ b/kelta-ui/app/src/i18n/translations/es.json
@@ -159,7 +159,7 @@
     "picklistOverrides": "Anulaciones de lista de seleccion",
     "noPicklistFields": "Esta coleccion no tiene campos de lista de seleccion para configurar.",
     "allValuesAvailable": "Todos los valores disponibles",
-    "restrictedValues": "{count} de {total} valores disponibles",
+    "restrictedValues": "{{count}} de {{total}} valores disponibles",
     "defaultValue": "Valor predeterminado",
     "noDefault": "Sin predeterminado",
     "overrideSaved": "Anulaciones de lista de seleccion guardadas correctamente",

--- a/kelta-ui/app/src/i18n/translations/fr.json
+++ b/kelta-ui/app/src/i18n/translations/fr.json
@@ -159,7 +159,7 @@
     "picklistOverrides": "Substitutions de listes de choix",
     "noPicklistFields": "Cette collection n'a pas de champs de liste de choix à configurer.",
     "allValuesAvailable": "Toutes les valeurs disponibles",
-    "restrictedValues": "{count} sur {total} valeurs disponibles",
+    "restrictedValues": "{{count}} sur {{total}} valeurs disponibles",
     "defaultValue": "Valeur par défaut",
     "noDefault": "Aucune valeur par défaut",
     "overrideSaved": "Substitutions de listes de choix enregistrées avec succès",

--- a/kelta-ui/app/src/i18n/translations/pt.json
+++ b/kelta-ui/app/src/i18n/translations/pt.json
@@ -159,7 +159,7 @@
     "picklistOverrides": "Substituicoes de Lista de Opcoes",
     "noPicklistFields": "Esta colecao nao tem campos de lista de opcoes para configurar.",
     "allValuesAvailable": "Todos os valores disponiveis",
-    "restrictedValues": "{count} de {total} valores disponiveis",
+    "restrictedValues": "{{count}} de {{total}} valores disponiveis",
     "defaultValue": "Valor Padrao",
     "noDefault": "Sem padrao",
     "overrideSaved": "Substituicoes de lista de opcoes salvas com sucesso",


### PR DESCRIPTION
## Summary
- `recordTypes.restrictedValues` used single-brace `{count}`/`{total}` placeholders, but `I18nContext.interpolate()` only substitutes double-brace `{{param}}` — the string rendered literally with braces at runtime
- Fixed in all six locale bundles (en, es, de, fr, pt, ar); a repo-wide scan confirmed no other key has single-brace placeholders

## Changes
- `kelta-ui/app/src/i18n/translations/{en,es,de,fr,pt,ar}.json` — `{count}`/`{total}` → `{{count}}`/`{{total}}`

## Testing
- `npm run test:run -- RecordTypePicklistEditor` — 17/17 passed (test mocks `t()` with its own interpolation, so no assertion changes needed; caller already passes `{count, total}` params)

🤖 Generated with [Claude Code](https://claude.com/claude-code)