### PR TITLE
fix(worker): cross-pod system-collection cache eviction on record change

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -212,7 +212,7 @@ Each maps to a real mistake an agent has made here. Violating one usually compil
 | `kelta.config.tenant.ip-allowlist.changed.<tenantId>` | Tenant IP allowlist (network access) changed |
 | `kelta.config.environment.changed.<tenantId>.<envId>` | Sandbox environment created/cloned/refreshed/archived |
 | `kelta.config.promotion.executed.<tenantId>.<promotionId>` | Metadata promotion executed/failed/rolled back |
-| `kelta.record.changed.<tenantId>.<collection>` | Record CRUD (flows, search index, webhooks, realtime). Payload `containsMaskedFields=true` ⇒ realtime bridge omits record data |
+| `kelta.record.changed.<tenantId>.<collection>` | Record CRUD (flows, search index, webhooks, realtime, cross-pod system-collection cache eviction). Payload `containsMaskedFields=true` ⇒ realtime bridge omits record data |
 | `kelta.trigger.<tenantId>.<topic>` | External flow trigger — starts active `NATS_TRIGGERED` flows whose trigger-config `topic` matches (KELTA_TRIGGERS stream, queue-group consumed; body = arbitrary JSON, not a `PlatformEvent`) |
 
 Envelope: `PlatformEvent<T>` (`eventId`, `eventType`, `tenantId`, `correlationId`, `userId`,

--- a/kelta-worker/src/main/java/io/kelta/worker/config/NatsSubscriptionConfig.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/config/NatsSubscriptionConfig.java
@@ -15,6 +15,7 @@ import io.kelta.worker.listener.RecordWebhookPublisher;
 import io.kelta.worker.listener.SvixWebhookPublisher;
 import io.kelta.worker.listener.MenuCacheInvalidationListener;
 import io.kelta.worker.listener.SystemFeatureCacheInvalidationListener;
+import io.kelta.worker.listener.SystemCollectionCacheInvalidationListener;
 import io.kelta.worker.listener.TranslationCacheInvalidationListener;
 import io.kelta.worker.listener.TenantEmailCacheInvalidationListener;
 import io.kelta.worker.module.ModuleEventListener;
@@ -52,6 +53,7 @@ public class NatsSubscriptionConfig {
     private final LayoutCacheInvalidationListener layoutCacheInvalidationListener;
     private final MenuCacheInvalidationListener menuCacheInvalidationListener;
     private final TranslationCacheInvalidationListener translationCacheInvalidationListener;
+    private final SystemCollectionCacheInvalidationListener systemCollectionCacheInvalidationListener;
 
     @Autowired(required = false)
     private CredentialCacheInvalidationListener credentialCacheInvalidationListener;
@@ -79,7 +81,8 @@ public class NatsSubscriptionConfig {
                                    SystemFeatureCacheInvalidationListener systemFeatureCacheInvalidationListener,
                                    LayoutCacheInvalidationListener layoutCacheInvalidationListener,
                                    MenuCacheInvalidationListener menuCacheInvalidationListener,
-                                   TranslationCacheInvalidationListener translationCacheInvalidationListener) {
+                                   TranslationCacheInvalidationListener translationCacheInvalidationListener,
+                                   SystemCollectionCacheInvalidationListener systemCollectionCacheInvalidationListener) {
         this.subscriptionManager = subscriptionManager;
         this.flowEventListener = flowEventListener;
         this.natsTriggerFlowListener = natsTriggerFlowListener;
@@ -92,6 +95,7 @@ public class NatsSubscriptionConfig {
         this.layoutCacheInvalidationListener = layoutCacheInvalidationListener;
         this.menuCacheInvalidationListener = menuCacheInvalidationListener;
         this.translationCacheInvalidationListener = translationCacheInvalidationListener;
+        this.systemCollectionCacheInvalidationListener = systemCollectionCacheInvalidationListener;
     }
 
     @PostConstruct
@@ -165,6 +169,15 @@ public class NatsSubscriptionConfig {
         subscriptionManager.register(EventSubscription.broadcast(
                 "worker-layout-cache", "kelta.config.layout.changed.*",
                 layoutCacheInvalidationListener::handleLayoutChanged));
+
+        // System-collection response cache invalidation — every pod evicts its
+        // cached JSON:API responses for a system collection when one of its rows
+        // changes anywhere in the fleet. Without this, DynamicCollectionRouter's
+        // same-pod eviction left the other replicas serving stale field/collection
+        // config until the 10-minute TTL.
+        subscriptionManager.register(EventSubscription.broadcast(
+                "worker-system-collection-cache", "kelta.record.changed.>",
+                systemCollectionCacheInvalidationListener::handleRecordChanged));
 
         // Menu/app config invalidation (apps/nav v2) — every pod evicts its cached
         // ui-menus / ui-menu-items responses when navigation config changes anywhere.

--- a/kelta-worker/src/main/java/io/kelta/worker/listener/SystemCollectionCacheInvalidationListener.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/listener/SystemCollectionCacheInvalidationListener.java
@@ -1,0 +1,80 @@
+package io.kelta.worker.listener;
+
+import io.kelta.runtime.model.system.SystemCollectionDefinitions;
+import io.kelta.runtime.router.SystemCollectionCache;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+import java.util.Set;
+
+/**
+ * Subscribes to {@code kelta.record.changed.>} (broadcast) and evicts the changed
+ * system collection's response entries from the {@link SystemCollectionCache} on
+ * every pod.
+ *
+ * <p>Without this, a system-collection write only evicted the cache on the pod
+ * that handled the request ({@code DynamicCollectionRouter}'s same-pod eviction)
+ * — the other replicas kept serving the stale cached JSON:API response until the
+ * 10-minute TTL, and the gateway would then re-cache that stale body for another
+ * 10 minutes. User-visible as field config (e.g. a picklist binding) not showing
+ * up in the admin UI until ~20 minutes after the change.
+ *
+ * <p>User-collection record events vastly outnumber system ones on this subject,
+ * so events are filtered against the static system-collection name set before
+ * touching the cache.
+ */
+@Component
+public class SystemCollectionCacheInvalidationListener {
+
+    private static final Logger log = LoggerFactory.getLogger(SystemCollectionCacheInvalidationListener.class);
+
+    private static final Set<String> SYSTEM_COLLECTION_NAMES =
+            SystemCollectionDefinitions.byName().keySet();
+
+    private final SystemCollectionCache systemCollectionCache;
+    private final ObjectMapper objectMapper;
+
+    public SystemCollectionCacheInvalidationListener(SystemCollectionCache systemCollectionCache,
+                                                     ObjectMapper objectMapper) {
+        this.systemCollectionCache = systemCollectionCache;
+        this.objectMapper = objectMapper;
+    }
+
+    public void handleRecordChanged(String message) {
+        try {
+            JsonNode root = objectMapper.readTree(message);
+            JsonNode payload = root.has("payload") ? root.get("payload") : root;
+
+            String collectionName = textOrNull(payload.get("collectionName"));
+            if (collectionName == null || !SYSTEM_COLLECTION_NAMES.contains(collectionName)) {
+                return;
+            }
+
+            String tenantId = textOrNull(root.get("tenantId"));
+            if (tenantId == null) {
+                tenantId = textOrNull(payload.get("tenantId"));
+            }
+
+            log.info("System collection '{}' changed (tenant {}) — evicting cached responses",
+                    collectionName, tenantId);
+            systemCollectionCache.evict(tenantId, collectionName);
+            if (tenantId != null) {
+                // Non-tenant-scoped reads cache under the "_" key — evict those too.
+                systemCollectionCache.evict(null, collectionName);
+            }
+        } catch (Exception e) {
+            log.error("Failed to process record changed event for cache eviction: {}", e.getMessage(), e);
+        }
+    }
+
+    private static String textOrNull(JsonNode node) {
+        if (node == null || node.isNull() || !node.isTextual()) {
+            return null;
+        }
+        String value = node.stringValue();
+        return value.isBlank() ? null : value;
+    }
+}

--- a/kelta-worker/src/test/java/io/kelta/worker/config/NatsSubscriptionConfigTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/config/NatsSubscriptionConfigTest.java
@@ -9,6 +9,7 @@ import io.kelta.worker.listener.CustomDomainCacheInvalidationListener;
 import io.kelta.worker.listener.FlowEventListener;
 import io.kelta.worker.listener.LayoutCacheInvalidationListener;
 import io.kelta.worker.listener.MenuCacheInvalidationListener;
+import io.kelta.worker.listener.SystemCollectionCacheInvalidationListener;
 import io.kelta.worker.listener.TranslationCacheInvalidationListener;
 import io.kelta.worker.listener.NatsTriggerFlowListener;
 import io.kelta.worker.listener.SearchIndexListener;
@@ -45,7 +46,8 @@ class NatsSubscriptionConfigTest {
                 mock(SystemFeatureCacheInvalidationListener.class),
                 mock(LayoutCacheInvalidationListener.class),
                 mock(MenuCacheInvalidationListener.class),
-                mock(TranslationCacheInvalidationListener.class));
+                mock(TranslationCacheInvalidationListener.class),
+                mock(SystemCollectionCacheInvalidationListener.class));
     }
 
     @Test
@@ -55,11 +57,13 @@ class NatsSubscriptionConfigTest {
         // when kelta.encryption.key is not configured.
         config.registerSubscriptions();
 
-        // Eleven always-on subscriptions: worker-flows, worker-nats-trigger,
+        // Fourteen always-on subscriptions: worker-flows, worker-nats-trigger,
         // worker-search-index, worker-schema, worker-modules, worker-cerbos,
         // worker-flow-cache, worker-nats-trigger-cache, worker-domain-cache,
-        // worker-feature-cache, worker-layout-cache. Credential/Superset/Svix are conditional.
-        verify(subscriptionManager, times(13)).register(any(EventSubscription.class));
+        // worker-feature-cache, worker-layout-cache, worker-menu-cache,
+        // worker-translation-cache, worker-system-collection-cache.
+        // Credential/Superset/Svix are conditional.
+        verify(subscriptionManager, times(14)).register(any(EventSubscription.class));
     }
 
     @Test
@@ -70,6 +74,6 @@ class NatsSubscriptionConfigTest {
 
         config.registerSubscriptions();
 
-        verify(subscriptionManager, times(14)).register(any(EventSubscription.class));
+        verify(subscriptionManager, times(15)).register(any(EventSubscription.class));
     }
 }

--- a/kelta-worker/src/test/java/io/kelta/worker/listener/SystemCollectionCacheInvalidationListenerTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/listener/SystemCollectionCacheInvalidationListenerTest.java
@@ -1,0 +1,66 @@
+package io.kelta.worker.listener;
+
+import io.kelta.runtime.router.SystemCollectionCache;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@DisplayName("SystemCollectionCacheInvalidationListener")
+class SystemCollectionCacheInvalidationListenerTest {
+
+    private static final String TENANT = "11111111-1111-1111-1111-111111111111";
+
+    private SystemCollectionCache cache;
+    private SystemCollectionCacheInvalidationListener listener;
+
+    @BeforeEach
+    void setUp() {
+        cache = mock(SystemCollectionCache.class);
+        listener = new SystemCollectionCacheInvalidationListener(cache, new ObjectMapper());
+    }
+
+    @Test
+    @DisplayName("evicts tenant and '_' entries when a system collection row changes")
+    void evictsOnSystemCollectionChange() {
+        listener.handleRecordChanged("""
+                {"tenantId":"%s","payload":{"collectionName":"fields","recordId":"f1","changeType":"UPDATED"}}
+                """.formatted(TENANT));
+
+        verify(cache).evict(TENANT, "fields");
+        verify(cache).evict(null, "fields");
+    }
+
+    @Test
+    @DisplayName("ignores user-collection record events")
+    void ignoresUserCollectionEvents() {
+        listener.handleRecordChanged("""
+                {"tenantId":"%s","payload":{"collectionName":"customers","recordId":"c1","changeType":"CREATED"}}
+                """.formatted(TENANT));
+
+        verifyNoInteractions(cache);
+    }
+
+    @Test
+    @DisplayName("reads tenantId from the payload when the envelope lacks it")
+    void fallsBackToPayloadTenantId() {
+        listener.handleRecordChanged("""
+                {"payload":{"tenantId":"%s","collectionName":"global-picklists","recordId":"p1","changeType":"UPDATED"}}
+                """.formatted(TENANT));
+
+        verify(cache).evict(TENANT, "global-picklists");
+        verify(cache).evict(null, "global-picklists");
+    }
+
+    @Test
+    @DisplayName("malformed events are swallowed, not thrown")
+    void malformedEventDoesNotThrow() {
+        listener.handleRecordChanged("not json");
+
+        verifyNoInteractions(cache);
+    }
+}


### PR DESCRIPTION
## Summary
- System-collection writes evicted the worker's cached JSON:API responses on the handling pod only; the other replicas (3 in prod) served stale config until the 10-minute TTL, and the gateway re-cached the stale body for up to 10 more minutes. Reported symptom: a field's global-picklist binding set in the DB not showing in the Edit Field UI until ~20 minutes later, varying by which pod answered.
- New `worker-system-collection-cache` BROADCAST subscription on `kelta.record.changed.>`: every pod evicts its `SystemCollectionCache` entries for the changed collection. Filtered against `SystemCollectionDefinitions.byName()` so user-record events (the vast majority on this subject) are ignored; evicts both the tenant-scoped and `_` key prefixes.
- Closes the hole for `fields`, `collections`, `global-picklists`, `picklist-values`, `list-views`, `profiles`, layouts, etc. — previously only `ui-menus` (#1207) and `ui-translations` (#1212) had per-collection listeners.

## Changes
- `kelta-worker/.../listener/SystemCollectionCacheInvalidationListener.java` — new listener
- `kelta-worker/.../config/NatsSubscriptionConfig.java` — broadcast registration
- `kelta-worker/.../config/NatsSubscriptionConfigTest.java` — counts 13→14 / 14→15
- `kelta-worker/.../listener/SystemCollectionCacheInvalidationListenerTest.java` — 4 tests
- `CLAUDE.md` — `kelta.record.changed` row mentions cache eviction

## Testing
- Full `kelta-worker` suite: 1912/1912 green (4 new listener tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)