### PR TITLE
fix(ui): picklist binding invisible on first Edit Field open

### DIFF
--- a/kelta-ui/app/src/components/FieldEditor/FieldEditor.test.tsx
+++ b/kelta-ui/app/src/components/FieldEditor/FieldEditor.test.tsx
@@ -173,6 +173,28 @@ describe('FieldEditor Component', () => {
       expect(screen.getByTestId('field-default-value-input')).toHaveValue('default')
     })
 
+    it('keeps the stored global picklist selected when the options list arrives after mount', () => {
+      // Regression: the picklists query is enabled on modal open, so on first
+      // open the select mounted before options existed — an uncontrolled select
+      // snapped to the placeholder and never re-applied the stored value.
+      const picklistField: FieldDefinition = {
+        ...mockField,
+        type: 'picklist',
+        fieldTypeConfig: { globalPicklistId: 'gp-late' },
+      }
+      const { rerender } = renderWithProviders(
+        <FieldEditor {...defaultProps} field={picklistField} picklists={[]} />
+      )
+      rerender(
+        <FieldEditor
+          {...defaultProps}
+          field={picklistField}
+          picklists={[{ id: 'gp-late', name: 'Late Picklist' }]}
+        />
+      )
+      expect(screen.getByTestId('field-global-picklist-select')).toHaveValue('gp-late')
+    })
+
     it('should render submit button with "Save" text in edit mode', () => {
       renderWithProviders(<FieldEditor {...defaultProps} field={mockField} />)
 

--- a/kelta-ui/app/src/components/FieldEditor/FieldEditor.tsx
+++ b/kelta-ui/app/src/components/FieldEditor/FieldEditor.tsx
@@ -550,6 +550,10 @@ export function FieldEditor({
   // Watch field type to show/hide reference target and validation rules
   // eslint-disable-next-line react-hooks/incompatible-library
   const watchedType = watch('type')
+  // Controlled value: the picklists prop loads lazily (query enabled on modal
+  // open) — an uncontrolled select mounted before options arrive snaps to the
+  // placeholder and never re-applies the stored value once options render.
+  const watchedGlobalPicklistId = watch('globalPicklistId')
   const watchedRollupChild = watch('rollupChildCollection')
   const watchedRollupFn = watch('rollupFunction')
   const watchedMaskingType = watch('maskingType')
@@ -1068,6 +1072,7 @@ export function FieldEditor({
             }
             data-testid="field-global-picklist-select"
             {...register('globalPicklistId')}
+            value={watchedGlobalPicklistId ?? ''}
           >
             <option value="">{t('fieldEditor.selectPicklist')}</option>
             {picklists.map((picklist) => (
@@ -1075,6 +1080,10 @@ export function FieldEditor({
                 {picklist.name}
               </option>
             ))}
+            {watchedGlobalPicklistId &&
+              !picklists.some((p) => p.id === watchedGlobalPicklistId) && (
+                <option value={watchedGlobalPicklistId}>{t('fieldEditor.loadingPicklist')}</option>
+              )}
           </select>
           {errors.globalPicklistId && (
             <span

--- a/kelta-ui/app/src/hooks/usePicklistOptions.ts
+++ b/kelta-ui/app/src/hooks/usePicklistOptions.ts
@@ -69,7 +69,7 @@ export function usePicklistOptions(
       try {
         const { sourceId, sourceType } = resolvePicklistSource(field)
         const values = await apiClient.getList<PicklistValueDto>(
-          `/api/picklist-values?filter[picklistSourceId][eq]=${encodeURIComponent(sourceId)}&filter[picklistSourceType][eq]=${sourceType}`
+          `/api/picklist-values?filter[picklistSourceId][eq]=${encodeURIComponent(sourceId)}&filter[picklistSourceType][eq]=${sourceType}&page[size]=200`
         )
         return values
           .filter((v) => v.isActive)

--- a/kelta-ui/app/src/i18n/translations/ar.json
+++ b/kelta-ui/app/src/i18n/translations/ar.json
@@ -870,6 +870,7 @@
     "removeRule": "إزالة قاعدة التحقق",
     "globalPicklist": "قائمة الاختيار العامة",
     "selectPicklist": "اختر قائمة اختيار...",
+    "loadingPicklist": "جارٍ تحميل القوائم…",
     "globalPicklistHint": "اختر قائمة الاختيار العامة التي توفر القيم لهذا الحقل.",
     "descriptionPlaceholder": "أدخل وصفاً لهذا الحقل...",
     "trackHistory": "تتبع السجل",

--- a/kelta-ui/app/src/i18n/translations/de.json
+++ b/kelta-ui/app/src/i18n/translations/de.json
@@ -1176,6 +1176,7 @@
     "removeRule": "Validierungsregel entfernen",
     "globalPicklist": "Globale Auswahlliste",
     "selectPicklist": "Auswahlliste auswählen...",
+    "loadingPicklist": "Auswahllisten werden geladen…",
     "globalPicklistHint": "Wählen Sie die globale Auswahlliste, die Werte für dieses Feld bereitstellt.",
     "descriptionPlaceholder": "Geben Sie eine Beschreibung für dieses Feld ein...",
     "trackHistory": "Verlauf verfolgen",

--- a/kelta-ui/app/src/i18n/translations/en.json
+++ b/kelta-ui/app/src/i18n/translations/en.json
@@ -1695,6 +1695,7 @@
     "removeRule": "Remove validation rule",
     "globalPicklist": "Global Picklist",
     "selectPicklist": "Select a picklist...",
+    "loadingPicklist": "Loading picklists…",
     "globalPicklistHint": "Select the global picklist that provides values for this field.",
     "descriptionPlaceholder": "Enter a description for this field...",
     "trackHistory": "Track History",

--- a/kelta-ui/app/src/i18n/translations/es.json
+++ b/kelta-ui/app/src/i18n/translations/es.json
@@ -1176,6 +1176,7 @@
     "removeRule": "Eliminar regla de validacion",
     "globalPicklist": "Lista de seleccion global",
     "selectPicklist": "Seleccionar una lista de seleccion...",
+    "loadingPicklist": "Cargando listas…",
     "globalPicklistHint": "Seleccione la lista de seleccion global que proporciona valores para este campo.",
     "descriptionPlaceholder": "Introduzca una descripcion para este campo...",
     "trackHistory": "Rastrear historial",

--- a/kelta-ui/app/src/i18n/translations/fr.json
+++ b/kelta-ui/app/src/i18n/translations/fr.json
@@ -1176,6 +1176,7 @@
     "removeRule": "Supprimer la règle de validation",
     "globalPicklist": "Liste de choix globale",
     "selectPicklist": "Sélectionner une liste de choix...",
+    "loadingPicklist": "Chargement des listes…",
     "globalPicklistHint": "Sélectionnez la liste de choix globale qui fournit les valeurs pour ce champ.",
     "descriptionPlaceholder": "Entrez une description pour ce champ...",
     "trackHistory": "Suivi de l'historique",

--- a/kelta-ui/app/src/i18n/translations/pt.json
+++ b/kelta-ui/app/src/i18n/translations/pt.json
@@ -1176,6 +1176,7 @@
     "removeRule": "Remover regra de validacao",
     "globalPicklist": "Lista de Opcoes Global",
     "selectPicklist": "Selecione uma lista de opcoes...",
+    "loadingPicklist": "Carregando listas…",
     "globalPicklistHint": "Selecione a lista de opcoes global que fornece valores para este campo.",
     "descriptionPlaceholder": "Insira uma descricao para este campo...",
     "trackHistory": "Rastrear Historico",

--- a/kelta-ui/app/src/pages/CollectionDetailPage/CollectionDetailPage.tsx
+++ b/kelta-ui/app/src/pages/CollectionDetailPage/CollectionDetailPage.tsx
@@ -325,8 +325,10 @@ export function CollectionDetailPage({
   const { data: globalPicklists = [] } = useQuery({
     queryKey: ['global-picklists'],
     queryFn: async () => {
+      // Default page size is 20 — an unpaginated fetch silently dropped any
+      // picklist past the first page, so a field bound to one rendered as unset.
       const response = await apiClient.getList<{ id: string; name: string }>(
-        '/api/global-picklists'
+        '/api/global-picklists?page[size]=200'
       )
       return response
     },

--- a/kelta-web/packages/sdk/src/admin/AdminClient.ts
+++ b/kelta-web/packages/sdk/src/admin/AdminClient.ts
@@ -637,7 +637,7 @@ export class AdminClient {
 
   readonly picklists = {
     listGlobal: async (_tenantId?: string): Promise<GlobalPicklist[]> => {
-      const response = await this.axios.get('/api/global-picklists');
+      const response = await this.axios.get('/api/global-picklists?page[size]=200');
       return unwrapJsonApiList<GlobalPicklist>(response.data);
     },
 


### PR DESCRIPTION
## Summary
- **First-open race**: the Edit Field dialog's Global Picklist select mounted before its options query resolved (`enabled: fieldEditorOpen`) — an uncontrolled `<select>` whose `defaultValue` has no matching option snaps to the placeholder and never re-applies the value when options arrive. A stored picklist binding looked unset on the first open and correct on the second (React Query cache warm). Select value is now controlled via `watch`, with a transient "Loading picklists…" option while the stored id is unresolved.
- **Dropdown truncation**: `/api/global-picklists` fetched with no page size (server default 20) in both `CollectionDetailPage` and the SDK `picklists.listGlobal` — picklists past the first page silently vanished from the dropdown.
- **Value truncation**: `usePicklistOptions` fetched `picklist-values` at the default page size — >20-value picklists truncated in every form dropdown, kanban lane picker, and gallery. Both now `page[size]=200`.

## Changes
- `kelta-ui/app/src/components/FieldEditor/FieldEditor.tsx` — controlled select value + unresolved-id option
- `kelta-ui/app/src/components/FieldEditor/FieldEditor.test.tsx` — late-options regression test (fails on old code)
- `kelta-ui/app/src/pages/CollectionDetailPage/CollectionDetailPage.tsx`, `kelta-web/.../AdminClient.ts`, `kelta-ui/app/src/hooks/usePicklistOptions.ts` — `page[size]=200`
- `kelta-ui/app/src/i18n/translations/*.json` — `fieldEditor.loadingPicklist` (6 locales)

## Testing
- Full FE suite: 203 files, 2513 passed
- Regression test verified red on the old implementation
- lint 0 errors, tsc clean, Prettier clean (both packages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)