### PR TITLE
fix(ui): show image avatar when avatarFrom points at an image-URL field

### DIFF
--- a/kelta-ui/app/src/pages/PageLayoutsPage/components/DetailExtrasPanel.tsx
+++ b/kelta-ui/app/src/pages/PageLayoutsPage/components/DetailExtrasPanel.tsx
@@ -29,6 +29,7 @@ import { RailBlocksEditor } from './RailBlocksEditor'
 
 interface MultiSelectFieldPickerProps {
   label: string
+  hint?: string
   values: string[]
   availableFieldNames: string[]
   onChange: (next: string[]) => void
@@ -36,6 +37,7 @@ interface MultiSelectFieldPickerProps {
 
 function MultiSelectFieldPicker({
   label,
+  hint,
   values,
   availableFieldNames,
   onChange,
@@ -54,6 +56,7 @@ function MultiSelectFieldPicker({
       <Label className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
         {label}
       </Label>
+      {hint && <p className="text-[11px] leading-snug text-muted-foreground">{hint}</p>}
       <div className="flex flex-wrap gap-1.5">
         {values.length === 0 && (
           <span className="text-xs text-muted-foreground">None — leave empty to auto-derive.</span>
@@ -239,6 +242,7 @@ export function DetailExtrasPanel(): React.ReactElement | null {
 
         <MultiSelectFieldPicker
           label="Avatar from"
+          hint="An image-URL field shows as the avatar picture; text fields contribute their first letters as initials."
           values={avatarFrom}
           availableFieldNames={availableFieldNames}
           onChange={(next) => updateHeader({ avatarFrom: next })}

--- a/kelta-ui/app/src/styles/kelta-design.css
+++ b/kelta-ui/app/src/styles/kelta-design.css
@@ -151,6 +151,17 @@ body {
     inset 0 1px 0 rgba(255, 255, 255, 0.2);
 }
 
+/* Image avatar — fills the hero box when headerConfig.avatarFrom points at an
+   image-URL field. Absolute so the presence dot keeps its -2px overhang. */
+.kelta-hero-avatar-img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: inherit;
+}
+
 /* Online presence dot — bottom-right, 3px ring of page bg */
 .kelta-presence-dot {
   position: absolute;

--- a/kelta-web/packages/components/src/detail/RecordHeader.test.tsx
+++ b/kelta-web/packages/components/src/detail/RecordHeader.test.tsx
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { RecordHeader } from './RecordHeader';
+
+const baseProps = {
+  recordId: 'rec-1',
+  collectionLabel: 'Titles',
+  fallbackTitle: 'Tell Me What You Want',
+};
+
+function avatarBox(container: HTMLElement): HTMLElement {
+  const el = container.querySelector('.kelta-hero-avatar');
+  if (!(el instanceof HTMLElement)) throw new Error('avatar box not rendered');
+  return el;
+}
+
+describe('RecordHeader avatar', () => {
+  it('derives initials from the fallback title when no avatarFrom is configured', () => {
+    const { container } = render(<RecordHeader {...baseProps} record={{}} />);
+    expect(avatarBox(container).textContent).toBe('TM');
+  });
+
+  it('derives initials from configured text fields', () => {
+    const { container } = render(
+      <RecordHeader
+        {...baseProps}
+        record={{ firstName: 'ada', lastName: 'lovelace' }}
+        config={{ avatarFrom: ['firstName', 'lastName'] }}
+      />
+    );
+    expect(avatarBox(container).textContent).toBe('AL');
+  });
+
+  it('renders an image when the avatarFrom field holds an http(s) URL', () => {
+    const { container } = render(
+      <RecordHeader
+        {...baseProps}
+        record={{ posterUrl: 'https://cdn.example.com/poster.jpg' }}
+        config={{ avatarFrom: ['posterUrl'] }}
+      />
+    );
+    const img = avatarBox(container).querySelector('img');
+    expect(img).not.toBeNull();
+    expect(img).toHaveAttribute('src', 'https://cdn.example.com/poster.jpg');
+    // No "H"-from-"https" initials next to the image
+    expect(avatarBox(container).textContent).toBe('');
+  });
+
+  it('renders an image for data:image URIs', () => {
+    const uri = 'data:image/png;base64,iVBORw0KGgo=';
+    const { container } = render(
+      <RecordHeader {...baseProps} record={{ poster: uri }} config={{ avatarFrom: ['poster'] }} />
+    );
+    expect(avatarBox(container).querySelector('img')).toHaveAttribute('src', uri);
+  });
+
+  it('falls back to title initials when the image fails to load', () => {
+    const { container } = render(
+      <RecordHeader
+        {...baseProps}
+        record={{ posterUrl: 'https://cdn.example.com/broken.jpg' }}
+        config={{ avatarFrom: ['posterUrl'] }}
+      />
+    );
+    const img = avatarBox(container).querySelector('img');
+    expect(img).not.toBeNull();
+    fireEvent.error(img as HTMLImageElement);
+    expect(avatarBox(container).querySelector('img')).toBeNull();
+    // URL value is skipped as an initials source — use the fallback title
+    expect(avatarBox(container).textContent).toBe('TM');
+  });
+
+  it('uses the first image URL when avatarFrom mixes text and URL fields', () => {
+    const { container } = render(
+      <RecordHeader
+        {...baseProps}
+        record={{ name: 'Widget', posterUrl: 'https://cdn.example.com/p.jpg' }}
+        config={{ avatarFrom: ['name', 'posterUrl'] }}
+      />
+    );
+    expect(avatarBox(container).querySelector('img')).toHaveAttribute(
+      'src',
+      'https://cdn.example.com/p.jpg'
+    );
+  });
+
+  it('keeps the presence dot when showing an image avatar', () => {
+    const { container } = render(
+      <RecordHeader
+        {...baseProps}
+        record={{ posterUrl: 'https://cdn.example.com/p.jpg' }}
+        config={{ avatarFrom: ['posterUrl'] }}
+        showPresence
+      />
+    );
+    expect(avatarBox(container).querySelector('.kelta-presence-dot')).not.toBeNull();
+    expect(avatarBox(container).querySelector('img')).not.toBeNull();
+  });
+
+  it('renders the title from the record when titleFields is set', () => {
+    render(
+      <RecordHeader
+        {...baseProps}
+        record={{ title: 'Actual Title' }}
+        config={{ titleFields: ['title'] }}
+      />
+    );
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('Actual Title');
+  });
+});

--- a/kelta-web/packages/components/src/detail/RecordHeader.tsx
+++ b/kelta-web/packages/components/src/detail/RecordHeader.tsx
@@ -49,6 +49,23 @@ export interface RecordHeaderProps {
   showPresence?: boolean;
 }
 
+/** http(s) URLs and data:image URIs are treated as avatar images, not initials sources. */
+function isImageUrl(value: unknown): boolean {
+  return typeof value === 'string' && /^(https?:\/\/|data:image\/)/i.test(value.trim());
+}
+
+function computeAvatarImage(
+  record: Record<string, unknown>,
+  avatarFrom: string[] | undefined
+): string | null {
+  if (!avatarFrom) return null;
+  for (const f of avatarFrom) {
+    const v = record[f];
+    if (typeof v === 'string' && isImageUrl(v)) return v.trim();
+  }
+  return null;
+}
+
 function computeInitials(
   record: Record<string, unknown>,
   avatarFrom: string[] | undefined,
@@ -58,7 +75,9 @@ function computeInitials(
     const chars = avatarFrom
       .map((f) => {
         const v = record[f];
-        return typeof v === 'string' && v.length > 0 ? v.charAt(0).toUpperCase() : '';
+        return typeof v === 'string' && v.length > 0 && !isImageUrl(v)
+          ? v.charAt(0).toUpperCase()
+          : '';
       })
       .filter(Boolean)
       .join('');
@@ -99,11 +118,19 @@ export function RecordHeader({
   showPresence = false,
 }: RecordHeaderProps): React.ReactElement {
   const [copied, setCopied] = useState(false);
+  // Tracks the URL that failed to load so a record/config change retries cleanly.
+  const [failedAvatarUrl, setFailedAvatarUrl] = useState<string | null>(null);
 
   const initials = useMemo(
     () => computeInitials(record, config?.avatarFrom, fallbackTitle),
     [record, config?.avatarFrom, fallbackTitle]
   );
+
+  const avatarUrl = useMemo(
+    () => computeAvatarImage(record, config?.avatarFrom),
+    [record, config?.avatarFrom]
+  );
+  const showAvatarImage = avatarUrl !== null && avatarUrl !== failedAvatarUrl;
 
   const title = useMemo(
     () => computeTitle(record, config?.titleFields, fallbackTitle),
@@ -124,7 +151,16 @@ export function RecordHeader({
     >
       <div className="flex min-w-0 items-start gap-4">
         <div className="kelta-hero-avatar" aria-hidden="true">
-          {initials}
+          {showAvatarImage ? (
+            <img
+              src={avatarUrl}
+              alt=""
+              className="kelta-hero-avatar-img"
+              onError={() => setFailedAvatarUrl(avatarUrl)}
+            />
+          ) : (
+            initials
+          )}
           {showPresence && <span className="kelta-presence-dot" aria-hidden="true" />}
         </div>
 


### PR DESCRIPTION
## Summary
- The record-detail header treated `headerConfig.avatarFrom` purely as an initials source: it took the first character of each configured field's value. Pointing it at an image field like `posterUrl` therefore rendered the letter "H" (from `https://...`) instead of the picture.
- `RecordHeader` (`@kelta/components`) now renders the field value as the avatar image when it is an http(s) URL or `data:image/` URI, filling the 72×72 hero box with `object-fit: cover` and inherited corner radius.
- If the image fails to load, it falls back to initials — and URL values are skipped when deriving initials, so the fallback comes from the record title instead of the URL scheme.
- Text-field initials behavior is unchanged; the presence dot keeps its overhang (image is styled inside the box, no `overflow: hidden`).
- The layout editor's "Avatar from" picker now has a hint explaining image-URL vs initials behavior.

## Changes
- `kelta-web/packages/components/src/detail/RecordHeader.tsx` — image-URL detection, `<img>` rendering with error fallback, URL-skipping in `computeInitials`
- `kelta-web/packages/components/src/detail/RecordHeader.test.tsx` — new unit tests (8) covering initials, http/data URLs, load-failure fallback, mixed fields, presence dot
- `kelta-ui/app/src/styles/kelta-design.css` — `.kelta-hero-avatar-img` rule
- `kelta-ui/app/src/pages/PageLayoutsPage/components/DetailExtrasPanel.tsx` — hint text under the Avatar-from picker

## Testing
- `/verify` fully green: runtime modules build, gateway + worker tests (1915), kelta-web lint/typecheck/format/coverage (965 tests), kelta-ui lint/format/tests (2518 tests)
- New RecordHeader unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)