### PR TITLE
fix(runtime): stop rejecting kebab-case collection names in generated SQL identifiers

### DIFF
--- a/.claude/docs/concerns.md
+++ b/.claude/docs/concerns.md
@@ -190,6 +190,20 @@ an audit feed.
 
 (No open bugs from the original audit. See Resolved → Bugs.)
 
+**FIXED (fix/hyphen-collection-refresh) — kebab-case collection names broke generated SQL identifier names.**
+`PhysicalTableStorageAdapter.sanitizeIdentifier` (strict `[a-zA-Z0-9_]`) was fed raw
+collection names when building generated index/constraint *names* (`idx_`/`hnsw_`/`fk_` in
+`initializeCollection`, `uniq_` in `CompositeUniqueConstraintService.buildIndexName`) and the
+FK *target table* reference. Collection names are conventionally kebab-case, so on any
+hyphen-named collection: every NATS-triggered `CollectionLifecycleManager.refreshCollection`
+threw `Invalid identifier: <name>` (multi-pod config refresh silently failing — surfaced once
+the #1214–#1216 NATS reliability sweep made event delivery actually work), field DELETE
+returned 500, and composite unique constraints could not be created at all. Fix:
+`identifierPart()` maps hyphens→underscores for generated *names* only; table *references*
+keep the raw name via `TableRef` quoting. Watch-out for future DDL: never pass a collection
+name into `sanitizeIdentifier` directly — names go through `identifierPart`, references
+through `TableRef`.
+
 **FIXED (PR #1174) — record-policy `collectionId` was UUID-keyed but checked by name.**
 `CerbosPolicyGenerator.generateRecordPolicy` emitted `R.attr.collectionId == "<UUID>"` (from
 `profile_object_permission.collection_id` + `collection.id`, both UUIDs), but

--- a/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/storage/CompositeUniqueConstraintService.java
+++ b/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/storage/CompositeUniqueConstraintService.java
@@ -178,7 +178,7 @@ public class CompositeUniqueConstraintService {
         String suffix = String.join("_", columns);
         return PhysicalTableStorageAdapter.buildBoundedIdentifier(
                 INDEX_PREFIX,
-                PhysicalTableStorageAdapter.sanitizeIdentifier(baseTable),
+                PhysicalTableStorageAdapter.identifierPart(baseTable),
                 suffix);
     }
 

--- a/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/storage/PhysicalTableStorageAdapter.java
+++ b/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/storage/PhysicalTableStorageAdapter.java
@@ -183,7 +183,7 @@ public class PhysicalTableStorageAdapter implements StorageAdapter {
             // Unique index for EXTERNAL_ID
             if (field.type() == FieldType.EXTERNAL_ID) {
                 String idxName = buildBoundedIdentifier(
-                        "idx_", sanitizeIdentifier(getBaseTableName(definition)),
+                        "idx_", identifierPart(getBaseTableName(definition)),
                         sanitizeIdentifier(columnName));
                 postCreateStatements.add(
                     "CREATE UNIQUE INDEX IF NOT EXISTS " + idxName
@@ -196,7 +196,7 @@ public class PhysicalTableStorageAdapter implements StorageAdapter {
             // lookup. Idempotent (IF NOT EXISTS), so re-initialization is safe.
             if (field.type() == FieldType.VECTOR) {
                 String idxName = buildBoundedIdentifier(
-                        "hnsw_", sanitizeIdentifier(getBaseTableName(definition)),
+                        "hnsw_", identifierPart(getBaseTableName(definition)),
                         sanitizeIdentifier(columnName));
                 postCreateStatements.add(buildHnswIndexStatement(idxName, qualifiedName, columnName));
             }
@@ -205,14 +205,16 @@ public class PhysicalTableStorageAdapter implements StorageAdapter {
             if ((field.type() == FieldType.LOOKUP || field.type() == FieldType.MASTER_DETAIL)
                     && field.referenceConfig() != null) {
                 String baseName = getBaseTableName(definition);
-                String targetTableName = sanitizeIdentifier(field.referenceConfig().targetCollection());
+                // Raw name: kebab-case targets are legal — TableRef validates and
+                // quotes the reference. Only the generated fk NAME must be strict.
+                String targetTableName = field.referenceConfig().targetCollection();
                 // Target table is in the same schema as the source table
                 TableRef targetRef = tableRef.isPublicSchema()
                         ? TableRef.publicSchema(targetTableName)
                         : TableRef.tenantSchema(tableRef.schema(), targetTableName);
                 String targetCol = sanitizeIdentifier(field.referenceConfig().targetField());
                 String fkName = buildBoundedIdentifier(
-                        "fk_", sanitizeIdentifier(baseName), sanitizeIdentifier(columnName));
+                        "fk_", identifierPart(baseName), sanitizeIdentifier(columnName));
                 String onDelete = field.type() == FieldType.MASTER_DETAIL
                         ? "ON DELETE CASCADE" : "ON DELETE SET NULL";
 
@@ -877,6 +879,21 @@ public class PhysicalTableStorageAdapter implements StorageAdapter {
             throw new IllegalArgumentException("Invalid identifier: " + identifier);
         }
         return identifier;
+    }
+
+    /**
+     * Builds an identifier <em>part</em> for a generated index/constraint name from a
+     * logical name that may legally contain hyphens (kebab-case collection names like
+     * {@code program-translations}). Hyphens become underscores before strict
+     * sanitization — generated names are embedded unquoted in DDL, so they must be
+     * strictly alphanumeric, while the table itself keeps its hyphenated name via
+     * {@link TableRef} quoting. Never use this for a table or column <em>reference</em>.
+     */
+    static String identifierPart(String name) {
+        if (name == null || name.isBlank()) {
+            throw new IllegalArgumentException("Identifier cannot be null or blank");
+        }
+        return sanitizeIdentifier(name.replace('-', '_'));
     }
 
     /** PostgreSQL's identifier length limit. Longer names are silently truncated. */

--- a/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/storage/CompositeUniqueConstraintServiceTest.java
+++ b/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/storage/CompositeUniqueConstraintServiceTest.java
@@ -226,4 +226,20 @@ class CompositeUniqueConstraintServiceTest {
             assertNull(PhysicalTableStorageAdapter.extractCompositeConstraintName(ex));
         }
     }
+
+    @Nested
+    @DisplayName("Kebab-case collection names")
+    class KebabCaseNames {
+
+        @Test
+        @DisplayName("buildIndexName normalizes hyphens instead of throwing")
+        void buildIndexNameNormalizesHyphens() {
+            // Regression: composite unique constraints on kebab-case collections
+            // (program-translations, faq-translations, ...) failed with
+            // "Invalid identifier: program-translations".
+            String name = CompositeUniqueConstraintService.buildIndexName(
+                    "program-translations", List.of("program", "locale"));
+            assertEquals("uniq_program_translations_program_locale", name);
+        }
+    }
 }

--- a/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/storage/PhysicalTableStorageAdapterTest.java
+++ b/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/storage/PhysicalTableStorageAdapterTest.java
@@ -962,4 +962,55 @@ class PhysicalTableStorageAdapterTest {
             assertEquals(4.19, ((Number) result.get("avg_price")).doubleValue(), 0.001);
         }
     }
+
+    @Nested
+    @DisplayName("Kebab-case collection names")
+    class KebabCaseCollectionNames {
+
+        @Test
+        @DisplayName("identifierPart maps hyphens to underscores and stays strict otherwise")
+        void identifierPartMapsHyphens() {
+            assertEquals("program_translations",
+                    PhysicalTableStorageAdapter.identifierPart("program-translations"));
+            assertEquals("plain", PhysicalTableStorageAdapter.identifierPart("plain"));
+            assertThrows(IllegalArgumentException.class,
+                    () -> PhysicalTableStorageAdapter.identifierPart("bad;name"));
+            assertThrows(IllegalArgumentException.class,
+                    () -> PhysicalTableStorageAdapter.identifierPart("  "));
+        }
+
+        @Test
+        @DisplayName("initializeCollection handles a kebab-case tenant collection with a generated index name")
+        void kebabCollectionInitializes() {
+            // Regression: generated index/constraint NAMES used to feed the raw
+            // kebab-case collection name into sanitizeIdentifier and threw
+            // "Invalid identifier: program-translations" on every NATS-triggered
+            // refresh. The EXTERNAL_ID field forces an idx_ name through
+            // identifierPart; the FK path shares the same helper (its DO $$
+            // post-create block is Postgres-only, so it is not executed on H2).
+            List<FieldDefinition> fields = List.of(
+                new FieldDefinition("name", FieldType.STRING, false, false, false, null, null, null, null, null),
+                new FieldDefinition("externalRef", FieldType.EXTERNAL_ID, true, false, false, null, null, null, null, null)
+            );
+            CollectionDefinition kebab = new CollectionDefinition(
+                "program-translations",
+                "Program Translations",
+                "kebab-case regression collection",
+                fields,
+                new StorageConfig("program-translations", Map.of()),
+                null,
+                null,
+                1L,
+                Instant.now(),
+                Instant.now()
+            );
+
+            io.kelta.runtime.context.TenantContext.runWithTenant("tenant-1", "kebab-tenant", () -> {
+                assertDoesNotThrow(() -> adapter.initializeCollection(kebab));
+                Integer count = jdbcTemplate.queryForObject(
+                    "SELECT COUNT(*) FROM \"kebab-tenant\".\"program-translations\"", Integer.class);
+                assertEquals(0, count);
+            });
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Any collection with a hyphen in its name (the platform's own kebab-case convention — `program-translations`, `editorial-list-items`, …) blew up wherever a generated SQL identifier NAME was built from the raw collection name: `PhysicalTableStorageAdapter.sanitizeIdentifier` only allows `[a-zA-Z0-9_]`.
- Blast radius in production (observed 2026-07-10, tenant `student-incentives`, and applies to every hyphen-named collection incl. couchpicks): every NATS-triggered `CollectionLifecycleManager.refreshCollection` threw `Invalid identifier: <name>` — multi-pod config refresh silently failing (this surfaced once the #1214–#1216 NATS reliability sweep made event delivery reliable); `DELETE /api/fields/{id}` returned 500; composite unique constraints could not be created at all (`Invalid identifier: program-translations`).
- Fix: new `identifierPart()` maps hyphens→underscores for generated index/constraint **names** only (`idx_`/`hnsw_`/`fk_`/`uniq_`); table **references** keep the raw name and go through `TableRef`, which validates and quotes them. The FK target-table reference is no longer run through the strict sanitizer.

## Changes
- `runtime-core/.../storage/PhysicalTableStorageAdapter.java` — `identifierPart()` helper; used for `idx_`/`hnsw_`/`fk_` name parts; FK target table passed raw to `TableRef`
- `runtime-core/.../storage/CompositeUniqueConstraintService.java` — `buildIndexName` uses `identifierPart`
- Tests: kebab-case regression coverage in `PhysicalTableStorageAdapterTest` (helper mapping + H2 end-to-end initialize of `program-translations` in a tenant schema with a generated `idx_` name) and `CompositeUniqueConstraintServiceTest` (`uniq_program_translations_program_locale`)
- `.claude/docs/concerns.md` — bug documented with the never-again rule (names via `identifierPart`, references via `TableRef`)

## Testing
- `mvn test -pl runtime/runtime-core -Dtest='PhysicalTableStorageAdapterTest,CompositeUniqueConstraintServiceTest'` — all green incl. 3 new regression tests
- Full verify: runtime modules build, gateway `mvn verify` ✅, worker `mvn verify` ✅, kelta-web lint/typecheck/format/965 tests ✅ (kelta-ui untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)