### PR TITLE
fix(mcp): repair admin tooling — id parsing, type aliases, UI config dialects, endpoint paths, error envelopes

### DIFF
--- a/.claude/docs/concerns.md
+++ b/.claude/docs/concerns.md
@@ -190,6 +190,32 @@ an audit feed.
 
 (No open bugs from the original audit. See Resolved → Bugs.)
 
+**FIXED (fix/mcp-admin-tooling-gaps) — kelta-mcp admin tooling batch (7 defects found building a tenant end-to-end over MCP, 2026-07-10).**
+(1) `FieldBodyBuilder.extractFirstId` substring-scanned for the first `"id"` after `"data"` and
+returned `relationships.createdBy.data.id` — the acting *user's* UUID — because worker responses
+serialize `relationships` before the record's `id`; every `add_field`-by-name and
+`create_collection` inline field posted `collectionId=<user-uuid>` → 400 (collections silently
+created with ZERO fields). Now Jackson-parsed in `AdminLookups`.
+(2) `resolveNativeType` rejected most `FieldType` values (TEXT, CURRENCY, URL, EMAIL, PHONE, …);
+now every enum name passes verbatim + friendly aliases added.
+(3) MCP wrote `fieldTypeConfig.picklistSourceId` but the admin UI resolves
+`fieldTypeConfig.globalPicklistId` (`usePicklistOptions`), and never set `referenceTarget` on
+lookups — MCP-created fields showed no picklist binding / no target collection in the UI. The
+canonical shape is the UI's; the builder now writes `globalPicklistId` + `referenceTarget`.
+(4)–(6) `create_validation_rule` / `create_listview` / `create_layout` posted camelCase paths
+(`/api/validationRules`, `/api/listViews`, `/api/pageLayouts|layoutSections|layoutFields`) that
+404 against the kebab-case system-collection routes, with attribute shapes the worker never
+understood; `create_validation_rule` also documented INVERTED semantics (worker field is
+`errorConditionFormula` — record rejected when TRUE; legacy `expression` args are negated).
+`update_collection` gained `displayFieldName`→`displayFieldId` resolution.
+(7) Worker: JSON-typed system-field defaults declared as strings (`list-views.filters "[]"`,
+`dashboard-components.config "{}"`, `flow-executions.variables "{}"`) are injected verbatim on
+create and fail their own type validation — all converted to JSON values, and
+`SystemCollectionJsonDefaultsTest` now rejects any new string default on a JSON field. Validation
+error envelopes rendered as `{"errors":[{}]}` (bean members dropped at serialization on the
+deployed worker); `GlobalExceptionHandler` now emits plain maps (`JsonApiError.toMap()`), which
+serialize reliably under any mapper config — never build error bodies from the bean directly.
+
 **FIXED (PR #1174) — record-policy `collectionId` was UUID-keyed but checked by name.**
 `CerbosPolicyGenerator.generateRecordPolicy` emitted `R.attr.collectionId == "<UUID>"` (from
 `profile_object_permission.collection_id` + `collection.id`, both UUIDs), but

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/AddFieldTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/AddFieldTool.java
@@ -40,7 +40,11 @@ public class AddFieldTool implements AdminTool {
                 + "text|string→STRING, longText→STRING, number|integer→INTEGER, decimal|double→DOUBLE, "
                 + "long→LONG, boolean→BOOLEAN, date→DATE, datetime→DATETIME, "
                 + "picklist→PICKLIST, multiPicklist→MULTI_PICKLIST, "
-                + "reference|lookup→LOOKUP, json→JSON. Uppercase enum values are also accepted."));
+                + "reference|lookup→LOOKUP, masterDetail→MASTER_DETAIL, json→JSON, "
+                + "currency→CURRENCY, percent→PERCENT, url→URL, email→EMAIL, phone→PHONE, "
+                + "autoNumber→AUTO_NUMBER, externalId→EXTERNAL_ID, encrypted→ENCRYPTED, "
+                + "geolocation→GEOLOCATION, array→ARRAY, richText→RICH_TEXT, vector→VECTOR. "
+                + "Every uppercase FieldType enum name is also accepted verbatim."));
         properties.put("required", Schemas.bool("Whether the field is required (default false).", false));
         properties.put("unique", Schemas.bool("Whether values must be unique (default false). Sent as uniqueConstraint.", false));
         properties.put("indexed", Schemas.bool("Whether the column has a database index (default false).", false));

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/AdminLookups.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/AdminLookups.java
@@ -1,0 +1,114 @@
+package io.kelta.mcp.tool.admin;
+
+import io.kelta.mcp.client.GatewayHttpClient;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Gateway-backed name/id resolution shared by the admin tools.
+ *
+ * <p>All parsing is done with Jackson on the JSON:API envelope. The old
+ * substring scan ("first {@code "id"} after {@code "data"}") returned the
+ * {@code relationships.createdBy.data.id} — the acting <em>user's</em> UUID —
+ * because the worker serializes {@code relationships} before the record's own
+ * {@code id}. Every helper here reads {@code data[0].id} / {@code data.id}
+ * explicitly so response key order can never matter again.
+ */
+final class AdminLookups {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private final GatewayHttpClient gateway;
+
+    AdminLookups(GatewayHttpClient gateway) {
+        this.gateway = gateway;
+    }
+
+    /**
+     * The id of the first resource in a JSON:API body: {@code data.id} for a
+     * single-resource document, {@code data[0].id} for a list document.
+     * Returns null when the body has no resource.
+     */
+    static String firstResourceId(String json) {
+        JsonNode data = dataNode(json);
+        if (data == null) return null;
+        JsonNode id = data.path("id");
+        return id.isMissingNode() || id.isNull() || id.asString().isBlank() ? null : id.asString();
+    }
+
+    /** A string attribute of the first resource in a JSON:API body, or null. */
+    static String firstResourceAttribute(String json, String attribute) {
+        JsonNode data = dataNode(json);
+        if (data == null) return null;
+        JsonNode value = data.path("attributes").path(attribute);
+        return value.isMissingNode() || value.isNull() ? null : value.asString();
+    }
+
+    private static JsonNode dataNode(String json) {
+        if (json == null || json.isBlank()) return null;
+        try {
+            JsonNode root = MAPPER.readTree(json);
+            JsonNode data = root.path("data");
+            if (data.isArray()) {
+                return data.isEmpty() ? null : data.get(0);
+            }
+            return data.isObject() ? data : null;
+        } catch (RuntimeException e) {
+            return null;
+        }
+    }
+
+    /** Resolves a collection name to its UUID, or null when not found. */
+    String collectionIdByName(String collectionName) {
+        String path = "/api/collections?filter[name][eq]="
+                + URLEncoder.encode(collectionName, StandardCharsets.UTF_8);
+        GatewayHttpClient.Response res = gateway.get(path);
+        if (!res.isSuccess() || res.body() == null) {
+            return null;
+        }
+        return firstResourceId(res.body());
+    }
+
+    /** Resolves a collection UUID to its name, or null when not found. */
+    String collectionNameById(String collectionId) {
+        String path = "/api/collections/" + URLEncoder.encode(collectionId, StandardCharsets.UTF_8);
+        GatewayHttpClient.Response res = gateway.get(path);
+        if (!res.isSuccess() || res.body() == null) {
+            return null;
+        }
+        return firstResourceAttribute(res.body(), "name");
+    }
+
+    /**
+     * All fields of a collection as {@code fieldName -> fieldId}. Used to
+     * resolve layout field references and {@code displayFieldName}.
+     */
+    Map<String, String> fieldIdsByName(String collectionId) {
+        String path = "/api/fields?filter[collectionId][EQ]="
+                + URLEncoder.encode(collectionId, StandardCharsets.UTF_8)
+                + "&page[size]=200";
+        GatewayHttpClient.Response res = gateway.get(path);
+        Map<String, String> out = new LinkedHashMap<>();
+        if (!res.isSuccess() || res.body() == null) {
+            return out;
+        }
+        try {
+            JsonNode root = MAPPER.readTree(res.body());
+            for (JsonNode item : root.path("data")) {
+                String name = item.path("attributes").path("name").asString();
+                String id = item.path("id").asString();
+                if (!name.isBlank() && !id.isBlank()) {
+                    out.put(name, id);
+                }
+            }
+        } catch (RuntimeException e) {
+            return out;
+        }
+        return out;
+    }
+}

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/CreateLayoutTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/CreateLayoutTool.java
@@ -10,8 +10,6 @@ import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
 import org.springframework.stereotype.Component;
-import tools.jackson.databind.JsonNode;
-import tools.jackson.databind.ObjectMapper;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -19,14 +17,18 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Composite admin tool: build a complete page layout (pageLayout +
- * sections + per-section fields) in a single Claude tool call.
+ * Composite admin tool: build a complete page layout (page-layout +
+ * layout-sections + per-section layout-fields) in a single Claude tool call.
  *
- * <p>Wraps three underlying endpoints:
+ * <p>Wraps three system-collection endpoints with the worker's actual
+ * attribute shapes (kebab-case routes, {@code collectionId}/{@code layoutId}/
+ * {@code sectionId} parents, {@code heading} for the section title, and
+ * {@code fieldId} — resolved from each entry's {@code fieldName} — for layout
+ * fields):
  * <ol>
- *   <li>POST /api/pageLayouts — layout container</li>
- *   <li>POST /api/layoutSections — one per section, child of the layout</li>
- *   <li>POST /api/layoutFields — one per field, child of its section</li>
+ *   <li>POST /api/page-layouts — layout container</li>
+ *   <li>POST /api/layout-sections — one per section, child of the layout</li>
+ *   <li>POST /api/layout-fields — one per field, child of its section</li>
  * </ol>
  *
  * <p>The layout is created first; if it fails, no children are
@@ -37,12 +39,12 @@ import java.util.Map;
 @Component
 public class CreateLayoutTool implements AdminTool {
 
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-
     private final GatewayHttpClient gateway;
+    private final AdminLookups lookups;
 
     public CreateLayoutTool(GatewayHttpClient gateway) {
         this.gateway = gateway;
+        this.lookups = new AdminLookups(gateway);
     }
 
     @Override
@@ -50,8 +52,8 @@ public class CreateLayoutTool implements AdminTool {
         Map<String, Object> sectionFieldItem = new LinkedHashMap<>();
         sectionFieldItem.put("type", "object");
         sectionFieldItem.put("description",
-                "{\"fieldName\":\"...\",\"sortOrder\":number,\"width\":\"full|half|third\","
-                + "\"readOnly\":bool,\"required\":bool}");
+                "{\"fieldName\":\"...\",\"sortOrder\":number,\"columnNumber\":1|2|3,"
+                + "\"columnSpan\":number,\"readOnly\":bool,\"required\":bool,\"labelOverride\":\"...\"}");
         sectionFieldItem.put("additionalProperties", true);
 
         Map<String, Object> sectionFieldsArr = new LinkedHashMap<>();
@@ -80,15 +82,13 @@ public class CreateLayoutTool implements AdminTool {
         Map<String, Object> properties = new LinkedHashMap<>();
         properties.put("name", Schemas.string("Layout name (unique within collection)."));
         properties.put("collectionName", Schemas.string("Collection this layout displays."));
-        properties.put("recordTypeName", Schemas.string(
-                "Optional record type the layout applies to (omit for collection-wide)."));
         properties.put("isDefault", Schemas.bool("Whether this is the default layout for the collection.", false));
         properties.put("sections", sectionsArr);
 
         Tool tool = Tool.builder()
                 .name("create_layout")
                 .title("Create Layout")
-                .description("Build a complete page layout in one call: layout + sections + fields per section. The layout is created first; sections and their fields follow. Returns a summary of what was created and any per-piece failures.")
+                .description("Build a complete page layout in one call: layout + sections + fields per section. Field entries reference fields by fieldName (resolved to ids). The layout is created first; sections and their fields follow. Returns a summary of what was created and any per-piece failures.")
                 .inputSchema(Schemas.object(properties, List.of("name", "collectionName", "sections")))
                 .annotations(ToolHints.write(false, false))
                 .build();
@@ -109,31 +109,36 @@ public class CreateLayoutTool implements AdminTool {
                         return error("Argument \"sections\" must be an array.");
                     }
 
+                    String collectionId = lookups.collectionIdByName(cn.toString());
+                    if (collectionId == null) {
+                        return error("Collection \"" + cn + "\" not found.");
+                    }
+                    Map<String, String> fieldIds = lookups.fieldIdsByName(collectionId);
+
                     Map<String, Object> layoutAttrs = new LinkedHashMap<>();
+                    layoutAttrs.put("collectionId", collectionId);
                     layoutAttrs.put("name", n.toString());
-                    layoutAttrs.put("collectionName", cn.toString());
-                    if (args.get("recordTypeName") instanceof String r && !r.isBlank()) layoutAttrs.put("recordTypeName", r);
+                    layoutAttrs.put("layoutType", "DETAIL");
                     if (args.get("isDefault") instanceof Boolean b) layoutAttrs.put("isDefault", b);
 
                     Map<String, Object> layoutBody = Map.of("data", Map.of(
-                            "type", "pageLayouts",
+                            "type", "page-layouts",
                             "attributes", layoutAttrs));
 
                     GatewayHttpClient.Response layoutRes;
                     try {
-                        layoutRes = gateway.post("/api/pageLayouts", layoutBody);
+                        layoutRes = gateway.post("/api/page-layouts", layoutBody);
                     } catch (RuntimeException e) {
                         return McpErrorMapper.fromException(e);
                     }
                     if (!layoutRes.isSuccess()) {
                         return McpErrorMapper.toResult(layoutRes);
                     }
-                    String layoutId = extractId(layoutRes.body());
+                    String layoutId = AdminLookups.firstResourceId(layoutRes.body());
 
                     List<Map<String, Object>> sectionResults = new ArrayList<>();
                     for (int i = 0; i < sections.size(); i++) {
-                        Map<String, Object> sectionResult = createSection(layoutId, i, sections.get(i));
-                        sectionResults.add(sectionResult);
+                        sectionResults.add(createSection(layoutId, i, sections.get(i), fieldIds));
                     }
 
                     String summary = "{\n  \"layout\": " + layoutRes.body()
@@ -146,86 +151,90 @@ public class CreateLayoutTool implements AdminTool {
                 .build();
     }
 
-    private Map<String, Object> createSection(String layoutId, int index, Object sectionRaw) {
+    private Map<String, Object> createSection(String layoutId, int index, Object sectionRaw,
+                                              Map<String, String> fieldIds) {
         if (!(sectionRaw instanceof Map<?, ?> sectionMap)) {
             return Map.of("index", index, "error", "section entry must be an object");
         }
+        Object heading = sectionMap.get("sectionName");
         Map<String, Object> sectionAttrs = new LinkedHashMap<>();
-        for (Map.Entry<?, ?> e : sectionMap.entrySet()) {
-            String key = String.valueOf(e.getKey());
-            if (!"fields".equals(key)) sectionAttrs.put(key, e.getValue());
-        }
-        if (layoutId != null) sectionAttrs.put("pageLayoutId", layoutId);
-        sectionAttrs.putIfAbsent("sortOrder", index);
+        if (layoutId != null) sectionAttrs.put("layoutId", layoutId);
+        sectionAttrs.put("heading", heading != null ? heading.toString() : "Section " + (index + 1));
+        sectionAttrs.put("columns", sectionMap.get("columns") instanceof Number c ? c.intValue() : 2);
+        sectionAttrs.put("sortOrder", sectionMap.get("sortOrder") instanceof Number so ? so.intValue() : index);
+        sectionAttrs.put("sectionType", "STANDARD");
 
         Map<String, Object> sectionBody = Map.of("data", Map.of(
-                "type", "layoutSections",
+                "type", "layout-sections",
                 "attributes", sectionAttrs));
         GatewayHttpClient.Response sectionRes;
         try {
-            sectionRes = gateway.post("/api/layoutSections", sectionBody);
+            sectionRes = gateway.post("/api/layout-sections", sectionBody);
         } catch (RuntimeException e) {
             return Map.of("index", index, "error", e.getClass().getSimpleName() + ": " + e.getMessage());
         }
         if (!sectionRes.isSuccess()) {
             return Map.of(
                     "index", index,
-                    "sectionName", sectionAttrs.getOrDefault("sectionName", "?"),
+                    "sectionName", sectionAttrs.get("heading"),
                     "status", sectionRes.status() == null ? 0 : sectionRes.status().value(),
                     "body", sectionRes.body());
         }
 
-        String sectionId = extractId(sectionRes.body());
+        String sectionId = AdminLookups.firstResourceId(sectionRes.body());
         Object fieldsRaw = sectionMap.get("fields");
         List<Map<String, Object>> fieldResults = new ArrayList<>();
         if (fieldsRaw instanceof List<?> fields) {
+            int columns = (int) sectionAttrs.get("columns");
             for (int j = 0; j < fields.size(); j++) {
-                fieldResults.add(createLayoutField(sectionId, j, fields.get(j)));
+                fieldResults.add(createLayoutField(sectionId, j, columns, fields.get(j), fieldIds));
             }
         }
         return Map.of(
                 "index", index,
-                "sectionName", sectionAttrs.getOrDefault("sectionName", "?"),
+                "sectionName", sectionAttrs.get("heading"),
                 "status", sectionRes.status() == null ? 0 : sectionRes.status().value(),
                 "fields", fieldResults);
     }
 
-    private Map<String, Object> createLayoutField(String sectionId, int index, Object fieldRaw) {
+    private Map<String, Object> createLayoutField(String sectionId, int index, int columns,
+                                                  Object fieldRaw, Map<String, String> fieldIds) {
         if (!(fieldRaw instanceof Map<?, ?> fieldMap)) {
             return Map.of("index", index, "error", "field entry must be an object");
         }
-        Map<String, Object> fieldAttrs = new LinkedHashMap<>();
-        for (Map.Entry<?, ?> e : fieldMap.entrySet()) {
-            fieldAttrs.put(String.valueOf(e.getKey()), e.getValue());
+        Object fieldName = fieldMap.get("fieldName");
+        String fieldId = fieldName != null ? fieldIds.get(fieldName.toString()) : null;
+        if (fieldId == null) {
+            return Map.of("index", index,
+                    "fieldName", fieldName == null ? "?" : fieldName.toString(),
+                    "error", "field not found on collection");
         }
-        if (sectionId != null) fieldAttrs.put("layoutSectionId", sectionId);
-        fieldAttrs.putIfAbsent("sortOrder", index);
+
+        Map<String, Object> fieldAttrs = new LinkedHashMap<>();
+        if (sectionId != null) fieldAttrs.put("sectionId", sectionId);
+        fieldAttrs.put("fieldId", fieldId);
+        fieldAttrs.put("sortOrder", fieldMap.get("sortOrder") instanceof Number so ? so.intValue() : index);
+        fieldAttrs.put("columnNumber", fieldMap.get("columnNumber") instanceof Number c
+                ? c.intValue() : (index % Math.max(columns, 1)) + 1);
+        if (fieldMap.get("columnSpan") instanceof Number cs) fieldAttrs.put("columnSpan", cs.intValue());
+        if (fieldMap.get("required") instanceof Boolean b) fieldAttrs.put("isRequiredOnLayout", b);
+        if (fieldMap.get("readOnly") instanceof Boolean b) fieldAttrs.put("isReadOnlyOnLayout", b);
+        if (fieldMap.get("labelOverride") instanceof String lo && !lo.isBlank()) fieldAttrs.put("labelOverride", lo);
 
         Map<String, Object> body = Map.of("data", Map.of(
-                "type", "layoutFields",
+                "type", "layout-fields",
                 "attributes", fieldAttrs));
         GatewayHttpClient.Response fr;
         try {
-            fr = gateway.post("/api/layoutFields", body);
+            fr = gateway.post("/api/layout-fields", body);
         } catch (RuntimeException e) {
             return Map.of("index", index, "error", e.getClass().getSimpleName());
         }
         return Map.of(
                 "index", index,
-                "fieldName", fieldAttrs.getOrDefault("fieldName", "?"),
+                "fieldName", fieldName.toString(),
                 "status", fr.status() == null ? 0 : fr.status().value(),
                 "body", fr.isSuccess() ? "ok" : fr.body());
-    }
-
-    private static String extractId(String body) {
-        if (body == null) return null;
-        try {
-            JsonNode n = OBJECT_MAPPER.readTree(body);
-            JsonNode id = n.path("data").path("id");
-            return id.isMissingNode() || id.isNull() ? null : id.asString();
-        } catch (RuntimeException e) {
-            return null;
-        }
     }
 
     private static CallToolResult error(String message) {

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/CreateListViewTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/CreateListViewTool.java
@@ -11,17 +11,32 @@ import io.modelcontextprotocol.spec.McpSchema.TextContent;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Creates a record in the {@code list-views} system collection.
+ *
+ * <p>Maps the friendly args onto the worker's actual shape: {@code columns}
+ * is a JSON array (from the {@code displayedFields} CSV), the filter object
+ * becomes the {@code filters} array, and {@code filters} is ALWAYS sent —
+ * the system collection's declared default is unusable (string {@code "[]"}
+ * on a JSON field), so omitting it fails validation. (This tool previously
+ * posted to a non-existent {@code /api/listViews} path with pass-through
+ * attribute names the worker never understood.)
+ */
 @Component
 public class CreateListViewTool implements AdminTool {
 
     private final GatewayHttpClient gateway;
+    private final AdminLookups lookups;
 
     public CreateListViewTool(GatewayHttpClient gateway) {
         this.gateway = gateway;
+        this.lookups = new AdminLookups(gateway);
     }
 
     @Override
@@ -33,13 +48,14 @@ public class CreateListViewTool implements AdminTool {
                 "Comma-separated field names to show as columns, in display order."));
         properties.put("filter", Schemas.freeObject(
                 "Optional saved-filter expression in JSON:API filter shape, e.g. {\"status\":{\"EQ\":\"OPEN\"}}."));
-        properties.put("sort", Schemas.string("Default sort, e.g. \"-createdAt\"."));
+        properties.put("sort", Schemas.string("Default sort field, '-' prefix for descending, e.g. \"-createdAt\"."));
         properties.put("isDefault", Schemas.bool("Whether this is the default list view.", false));
+        properties.put("visibility", Schemas.string("PRIVATE (default) or PUBLIC."));
 
         Tool tool = Tool.builder()
                 .name("create_listview")
                 .title("Create List View")
-                .description("Create a saved list view (column set + filter + sort) for a collection. Wraps POST /api/listViews.")
+                .description("Create a saved list view (column set + filter + sort) for a collection. Wraps POST /api/list-views.")
                 .inputSchema(Schemas.object(properties, List.of("collectionName", "name", "displayedFields")))
                 .annotations(ToolHints.write(false, false))
                 .build();
@@ -55,30 +71,72 @@ public class CreateListViewTool implements AdminTool {
                     if (cn == null || cn.toString().isBlank()
                             || name == null || name.toString().isBlank()
                             || df == null || df.toString().isBlank()) {
-                        return CallToolResult.builder()
-                                .isError(true)
-                                .content(List.of(new TextContent(
-                                        "Arguments \"collectionName\", \"name\", and \"displayedFields\" are required.")))
-                                .build();
+                        return error("Arguments \"collectionName\", \"name\", and \"displayedFields\" are required.");
                     }
 
+                    String collectionId = lookups.collectionIdByName(cn.toString());
+                    if (collectionId == null) {
+                        return error("Collection \"" + cn + "\" not found.");
+                    }
+
+                    List<String> columns = Arrays.stream(df.toString().split(","))
+                            .map(String::trim)
+                            .filter(s -> !s.isEmpty())
+                            .toList();
+
                     Map<String, Object> attrs = new LinkedHashMap<>();
-                    attrs.put("collectionName", cn.toString());
+                    attrs.put("collectionId", collectionId);
                     attrs.put("name", name.toString());
-                    attrs.put("displayedFields", df.toString());
-                    if (args.get("filter") instanceof Map<?, ?> f) attrs.put("filter", f);
-                    if (args.get("sort") instanceof String s && !s.isBlank()) attrs.put("sort", s);
-                    if (args.get("isDefault") instanceof Boolean b) attrs.put("isDefault", b);
+                    attrs.put("columns", columns);
+                    attrs.put("isDefault", args.get("isDefault") instanceof Boolean b ? b : Boolean.FALSE);
+                    // Always sent: the declared default ("[]" as a STRING on a JSON
+                    // field) fails the worker's own type validation when omitted.
+                    attrs.put("filters", toFilters(args.get("filter")));
+                    if (args.get("visibility") instanceof String v && !v.isBlank()) {
+                        attrs.put("visibility", v);
+                    }
+                    if (args.get("sort") instanceof String s && !s.isBlank()) {
+                        String first = s.split(",")[0].trim();
+                        boolean desc = first.startsWith("-");
+                        attrs.put("sortField", desc ? first.substring(1) : first);
+                        attrs.put("sortDirection", desc ? "DESC" : "ASC");
+                    }
 
                     Map<String, Object> body = Map.of("data", Map.of(
-                            "type", "listViews",
+                            "type", "list-views",
                             "attributes", attrs));
                     try {
-                        return McpErrorMapper.toResult(gateway.post("/api/listViews", body));
+                        return McpErrorMapper.toResult(gateway.post("/api/list-views", body));
                     } catch (RuntimeException e) {
                         return McpErrorMapper.fromException(e);
                     }
                 })
+                .build();
+    }
+
+    /** {"status":{"EQ":"OPEN"}} → [{"field":"status","operator":"EQ","value":"OPEN"}]. */
+    private static List<Map<String, Object>> toFilters(Object filterArg) {
+        List<Map<String, Object>> filters = new ArrayList<>();
+        if (filterArg instanceof Map<?, ?> filterMap) {
+            for (Map.Entry<?, ?> fieldEntry : filterMap.entrySet()) {
+                if (fieldEntry.getValue() instanceof Map<?, ?> ops) {
+                    for (Map.Entry<?, ?> op : ops.entrySet()) {
+                        Map<String, Object> filter = new LinkedHashMap<>();
+                        filter.put("field", String.valueOf(fieldEntry.getKey()));
+                        filter.put("operator", String.valueOf(op.getKey()));
+                        filter.put("value", op.getValue());
+                        filters.add(filter);
+                    }
+                }
+            }
+        }
+        return filters;
+    }
+
+    private static CallToolResult error(String message) {
+        return CallToolResult.builder()
+                .isError(true)
+                .content(List.of(new TextContent(message)))
                 .build();
     }
 }

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/CreateValidationRuleTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/CreateValidationRuleTool.java
@@ -15,13 +15,25 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Creates a record in the {@code validation-rules} system collection.
+ *
+ * <p>The worker's semantics are an <em>error condition</em>: the record is
+ * REJECTED when {@code errorConditionFormula} evaluates to true. (This tool
+ * previously documented the opposite — "expression must evaluate true" — and
+ * posted to a non-existent {@code /api/validationRules} path; both are fixed.
+ * A legacy {@code expression} argument is still accepted and is negated into
+ * {@code NOT(...)} to preserve its documented must-hold meaning.)
+ */
 @Component
 public class CreateValidationRuleTool implements AdminTool {
 
     private final GatewayHttpClient gateway;
+    private final AdminLookups lookups;
 
     public CreateValidationRuleTool(GatewayHttpClient gateway) {
         this.gateway = gateway;
+        this.lookups = new AdminLookups(gateway);
     }
 
     @Override
@@ -29,18 +41,27 @@ public class CreateValidationRuleTool implements AdminTool {
         Map<String, Object> properties = new LinkedHashMap<>();
         properties.put("collectionName", Schemas.string("Collection the rule applies to."));
         properties.put("name", Schemas.string("Rule name (unique within collection)."));
+        properties.put("errorConditionFormula", Schemas.string(
+                "Formula describing the ERROR condition: the record is REJECTED when this evaluates true. "
+                + "Reference fields by attribute name; functions like AND(), OR(), NOT(), ISBLANK() are available. "
+                + "Example: AND(NOT(ISBLANK(amountMin)), NOT(ISBLANK(amountMax)), amountMax < amountMin)."));
         properties.put("expression", Schemas.string(
-                "Boolean expression that must evaluate true. Failure triggers the rule. "
-                + "Reference fields with their attribute names (e.g. \"amount > 0\")."));
+                "(Deprecated) Boolean expression that must hold for the record to be valid. "
+                + "Wrapped as NOT(expression) into errorConditionFormula. Prefer errorConditionFormula."));
         properties.put("errorMessage", Schemas.string(
-                "Error message shown to the user when the rule fails."));
+                "Error message shown to the user when the rule rejects the record."));
+        properties.put("errorField", Schemas.string(
+                "Optional field name the error is attributed to in API responses and forms."));
+        properties.put("evaluateOn", Schemas.string(
+                "When the rule runs: CREATE, UPDATE, or CREATE_AND_UPDATE (default)."));
+        properties.put("severity", Schemas.string("ERROR (default, blocks the save) or WARNING."));
         properties.put("active", Schemas.bool("Whether the rule is active (default true).", true));
 
         Tool tool = Tool.builder()
                 .name("create_validation_rule")
                 .title("Create Validation Rule")
-                .description("Create a validation rule on a collection. Records that fail the expression are rejected at create/update time.")
-                .inputSchema(Schemas.object(properties, List.of("collectionName", "name", "expression", "errorMessage")))
+                .description("Create a validation rule on a collection. The record is rejected at create/update time when errorConditionFormula evaluates TRUE. Wraps POST /api/validation-rules.")
+                .inputSchema(Schemas.object(properties, List.of("collectionName", "name", "errorMessage")))
                 .annotations(ToolHints.write(false, false))
                 .build();
 
@@ -51,36 +72,59 @@ public class CreateValidationRuleTool implements AdminTool {
                     if (args == null) args = Map.of();
                     Object cn = args.get("collectionName");
                     Object name = args.get("name");
-                    Object expr = args.get("expression");
                     Object msg = args.get("errorMessage");
                     if (cn == null || cn.toString().isBlank()
                             || name == null || name.toString().isBlank()
-                            || expr == null || expr.toString().isBlank()
                             || msg == null || msg.toString().isBlank()) {
-                        return CallToolResult.builder()
-                                .isError(true)
-                                .content(List.of(new TextContent(
-                                        "Arguments \"collectionName\", \"name\", \"expression\", and \"errorMessage\" are required.")))
-                                .build();
+                        return error("Arguments \"collectionName\", \"name\", and \"errorMessage\" are required.");
+                    }
+
+                    String formula = null;
+                    if (args.get("errorConditionFormula") instanceof String f && !f.isBlank()) {
+                        formula = f;
+                    } else if (args.get("expression") instanceof String legacy && !legacy.isBlank()) {
+                        // Legacy semantics: expression must hold → error when it does not.
+                        formula = "NOT(" + legacy + ")";
+                    }
+                    if (formula == null) {
+                        return error("Provide \"errorConditionFormula\" (or the deprecated \"expression\").");
+                    }
+
+                    String collectionId = lookups.collectionIdByName(cn.toString());
+                    if (collectionId == null) {
+                        return error("Collection \"" + cn + "\" not found.");
                     }
 
                     Map<String, Object> attrs = new LinkedHashMap<>();
-                    attrs.put("collectionName", cn.toString());
+                    attrs.put("collectionId", collectionId);
                     attrs.put("name", name.toString());
-                    attrs.put("expression", expr.toString());
+                    attrs.put("errorConditionFormula", formula);
                     attrs.put("errorMessage", msg.toString());
-                    if (args.get("active") instanceof Boolean b) attrs.put("active", b);
-                    else attrs.put("active", true);
+                    attrs.put("active", args.get("active") instanceof Boolean b ? b : Boolean.TRUE);
+                    attrs.put("evaluateOn", args.get("evaluateOn") instanceof String ev && !ev.isBlank()
+                            ? ev : "CREATE_AND_UPDATE");
+                    attrs.put("severity", args.get("severity") instanceof String sv && !sv.isBlank()
+                            ? sv : "ERROR");
+                    if (args.get("errorField") instanceof String ef && !ef.isBlank()) {
+                        attrs.put("errorField", ef);
+                    }
 
                     Map<String, Object> body = Map.of("data", Map.of(
-                            "type", "validationRules",
+                            "type", "validation-rules",
                             "attributes", attrs));
                     try {
-                        return McpErrorMapper.toResult(gateway.post("/api/validationRules", body));
+                        return McpErrorMapper.toResult(gateway.post("/api/validation-rules", body));
                     } catch (RuntimeException e) {
                         return McpErrorMapper.fromException(e);
                     }
                 })
+                .build();
+    }
+
+    private static CallToolResult error(String message) {
+        return CallToolResult.builder()
+                .isError(true)
+                .content(List.of(new TextContent(message)))
                 .build();
     }
 }

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/FieldBodyBuilder.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/FieldBodyBuilder.java
@@ -1,9 +1,8 @@
 package io.kelta.mcp.tool.admin;
 
 import io.kelta.mcp.client.GatewayHttpClient;
+import io.kelta.runtime.model.FieldType;
 
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -14,16 +13,23 @@ import java.util.regex.Pattern;
  * worker's {@code POST /api/fields} endpoint expects. Shared by {@link AddFieldTool}
  * and {@link CreateCollectionTool} so both go through the same alias mapping
  * and per-type payload assembly.
+ *
+ * <p>Field-type config is written in the shape the admin UI reads
+ * ({@code fieldTypeConfig.globalPicklistId} — see kelta-ui's
+ * {@code usePicklistOptions.resolvePicklistSource}), and lookup fields carry a
+ * {@code referenceTarget} attribute (target collection <em>name</em>) alongside
+ * the {@code referenceCollectionId} relationship, because the UI displays the
+ * name, not the relationship.
  */
 final class FieldBodyBuilder {
 
     static final Pattern UUID_PATTERN = Pattern.compile(
             "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$");
 
-    private final GatewayHttpClient gateway;
+    private final AdminLookups lookups;
 
     FieldBodyBuilder(GatewayHttpClient gateway) {
-        this.gateway = gateway;
+        this.lookups = new AdminLookups(gateway);
     }
 
     /** Builds the body, or returns a {@link Result} carrying a user-readable error. */
@@ -94,33 +100,17 @@ final class FieldBodyBuilder {
             if (UUID_PATTERN.matcher(cn).matches()) {
                 return cn;
             }
-            return lookupCollectionIdByName(cn);
+            return lookups.collectionIdByName(cn);
         }
         return null;
     }
 
-    String lookupCollectionIdByName(String collectionName) {
-        String path = "/api/collections?filter[name][eq]="
-                + URLEncoder.encode(collectionName, StandardCharsets.UTF_8);
-        GatewayHttpClient.Response res = gateway.get(path);
-        if (!res.isSuccess() || res.body() == null) {
-            return null;
-        }
-        return extractFirstId(res.body());
-    }
-
+    /**
+     * The id of the first resource in a JSON:API body. Kept as the shared
+     * entry point for tools that parse create/list responses.
+     */
     static String extractFirstId(String json) {
-        if (json == null) return null;
-        int dataIdx = json.indexOf("\"data\"");
-        if (dataIdx < 0) return null;
-        int idIdx = json.indexOf("\"id\"", dataIdx);
-        if (idIdx < 0) return null;
-        int openQuote = json.indexOf('"', idIdx + 4);
-        if (openQuote < 0) return null;
-        int closeQuote = json.indexOf('"', openQuote + 1);
-        if (closeQuote < 0) return null;
-        String value = json.substring(openQuote + 1, closeQuote);
-        return value.isBlank() ? null : value;
+        return AdminLookups.firstResourceId(json);
     }
 
     private String applyPicklistConfig(Map<String, Object> args, Map<String, Object> attrs) {
@@ -134,7 +124,13 @@ final class FieldBodyBuilder {
         }
         Map<String, Object> config = new LinkedHashMap<>();
         config.put("picklistSourceType", sourceType);
-        config.put("picklistSourceId", picklistSourceId);
+        if ("GLOBAL".equals(sourceType)) {
+            // Canonical key the admin UI resolves (usePicklistOptions): a field
+            // written without it renders with NO picklist binding in the UI.
+            config.put("globalPicklistId", picklistSourceId);
+        } else {
+            config.put("picklistSourceId", picklistSourceId);
+        }
         attrs.put("fieldTypeConfig", config);
         return null;
     }
@@ -210,13 +206,27 @@ final class FieldBodyBuilder {
                                               Map<String, Object> attrs,
                                               Map<String, Object> relationships) {
         String targetId = null;
+        String targetName = null;
         if (args.get("referenceCollectionId") instanceof String s && !s.isBlank()) {
             targetId = s;
         } else if (args.get("referenceCollection") instanceof String s && !s.isBlank()) {
-            targetId = UUID_PATTERN.matcher(s).matches() ? s : lookupCollectionIdByName(s);
+            if (UUID_PATTERN.matcher(s).matches()) {
+                targetId = s;
+            } else {
+                targetName = s;
+                targetId = lookups.collectionIdByName(s);
+            }
         }
         if (targetId == null) {
             return "reference/lookup fields require \"referenceCollectionId\" (UUID of the target collection) or a resolvable \"referenceCollection\" name.";
+        }
+        if (targetName == null) {
+            targetName = lookups.collectionNameById(targetId);
+        }
+        if (targetName != null && !targetName.isBlank()) {
+            // The admin UI displays referenceTarget (the collection NAME) on
+            // relationship fields; without it the field shows no target.
+            attrs.put("referenceTarget", targetName);
         }
 
         if (args.get("relationshipName") instanceof String rn && !rn.isBlank()) {
@@ -241,13 +251,21 @@ final class FieldBodyBuilder {
 
     /**
      * Maps an MCP-friendly type alias to the native uppercase {@code FieldType}
-     * enum value the worker accepts. Returns null for unknown aliases.
+     * enum value the worker accepts. Any exact enum name (e.g. {@code CURRENCY},
+     * {@code TEXT}, {@code GEOLOCATION}) passes through verbatim; friendly
+     * camelCase/lowercase aliases cover the common types. Returns null for
+     * unknown inputs.
+     *
+     * <p>Note: {@code text}/{@code longText} intentionally map to {@code STRING}
+     * — the admin UI has no renderer for the {@code TEXT} type, and both map to
+     * the same Postgres column type. Pass {@code TEXT} explicitly if you really
+     * want the native type.
      */
     static String resolveNativeType(String alias) {
         if (alias == null) return null;
         String trimmed = alias.trim();
         if (trimmed.isEmpty()) return null;
-        return switch (trimmed) {
+        String mapped = switch (trimmed) {
             case "text", "string", "String", "STRING" -> "STRING";
             case "longText", "longtext", "long_text" -> "STRING";
             case "number", "integer", "Integer", "INTEGER" -> "INTEGER";
@@ -264,8 +282,27 @@ final class FieldBodyBuilder {
             case "json", "Json", "JSON" -> "JSON";
             case "richText", "rich_text", "RichText", "RICH_TEXT" -> "RICH_TEXT";
             case "vector", "Vector", "VECTOR" -> "VECTOR";
+            case "currency", "Currency" -> "CURRENCY";
+            case "percent", "Percent" -> "PERCENT";
+            case "url", "Url" -> "URL";
+            case "email", "Email" -> "EMAIL";
+            case "phone", "Phone" -> "PHONE";
+            case "autoNumber", "auto_number", "autonumber" -> "AUTO_NUMBER";
+            case "externalId", "external_id" -> "EXTERNAL_ID";
+            case "encrypted", "Encrypted" -> "ENCRYPTED";
+            case "geolocation", "Geolocation" -> "GEOLOCATION";
+            case "array", "Array" -> "ARRAY";
             default -> null;
         };
+        if (mapped != null) {
+            return mapped;
+        }
+        // Any exact FieldType enum name passes through (CURRENCY, TEXT, PERCENT, ...).
+        try {
+            return FieldType.valueOf(trimmed).name();
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
     }
 
     record Result(Map<String, Object> body, String errorMessage) {

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/UpdateCollectionTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/UpdateCollectionTool.java
@@ -21,9 +21,11 @@ import java.util.Map;
 public class UpdateCollectionTool implements AdminTool {
 
     private final GatewayHttpClient gateway;
+    private final AdminLookups lookups;
 
     public UpdateCollectionTool(GatewayHttpClient gateway) {
         this.gateway = gateway;
+        this.lookups = new AdminLookups(gateway);
     }
 
     @Override
@@ -50,14 +52,30 @@ public class UpdateCollectionTool implements AdminTool {
                 .callHandler((context, request) -> {
                     Map<String, Object> args = request.arguments();
                     if (args == null) args = Map.of();
-                    Object id = args.get("id");
-                    if (id == null || id.toString().isBlank()) {
+                    Object idArg = args.get("id");
+                    if (idArg == null || idArg.toString().isBlank()) {
                         return error("Argument \"id\" is required.");
+                    }
+                    String id = idArg.toString();
+                    if (!FieldBodyBuilder.UUID_PATTERN.matcher(id).matches()) {
+                        String resolved = lookups.collectionIdByName(id);
+                        if (resolved == null) {
+                            return error("Collection \"" + id + "\" not found.");
+                        }
+                        id = resolved;
                     }
 
                     Map<String, Object> attrs = new LinkedHashMap<>();
                     if (args.get("displayName") instanceof String s && !s.isBlank()) attrs.put("displayName", s);
-                    if (args.get("displayFieldName") instanceof String s && !s.isBlank()) attrs.put("displayFieldName", s);
+                    if (args.get("displayFieldName") instanceof String s && !s.isBlank()) {
+                        // The worker stores displayFieldId (a field UUID) — a
+                        // displayFieldName attribute would be silently ignored.
+                        String fieldId = lookups.fieldIdsByName(id).get(s);
+                        if (fieldId == null) {
+                            return error("Field \"" + s + "\" not found on the collection.");
+                        }
+                        attrs.put("displayFieldId", fieldId);
+                    }
                     if (args.get("description") instanceof String s) attrs.put("description", s);
                     if (args.get("tenantScoped") instanceof Boolean b) attrs.put("tenantScoped", b);
                     if (attrs.isEmpty()) {
@@ -66,9 +84,9 @@ public class UpdateCollectionTool implements AdminTool {
 
                     Map<String, Object> body = Map.of("data", Map.of(
                             "type", "collections",
-                            "id", id.toString(),
+                            "id", id,
                             "attributes", attrs));
-                    String path = "/api/collections/" + URLEncoder.encode(id.toString(), StandardCharsets.UTF_8);
+                    String path = "/api/collections/" + URLEncoder.encode(id, StandardCharsets.UTF_8);
                     try {
                         return McpErrorMapper.toResult(gateway.patch(path, body));
                     } catch (RuntimeException e) {

--- a/kelta-mcp/src/test/java/io/kelta/mcp/tool/admin/AddFieldToolTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/tool/admin/AddFieldToolTest.java
@@ -167,7 +167,9 @@ class AddFieldToolTest {
         wm.verify(WireMock.postRequestedFor(urlEqualTo("/api/fields"))
                 .withRequestBody(matchingJsonPath("$.data.attributes.type", equalTo("PICKLIST")))
                 .withRequestBody(matchingJsonPath("$.data.attributes.fieldTypeConfig.picklistSourceType", equalTo("GLOBAL")))
-                .withRequestBody(matchingJsonPath("$.data.attributes.fieldTypeConfig.picklistSourceId", equalTo(picklistId))));
+                // canonical key the admin UI resolves — a field written without it
+                // renders with no picklist binding in the field editor
+                .withRequestBody(matchingJsonPath("$.data.attributes.fieldTypeConfig.globalPicklistId", equalTo(picklistId))));
     }
 
     @Test
@@ -382,5 +384,90 @@ class AddFieldToolTest {
 
         wm.verify(WireMock.postRequestedFor(urlEqualTo("/api/fields"))
                 .withRequestBody(matchingJsonPath("$.data.attributes.type", equalTo("STRING"))));
+    }
+
+    @Test
+    void resolvesCollectionIdFromRealisticLookupResponse() {
+        // Regression: worker responses serialize relationships (whose
+        // createdBy/updatedBy carry the USER's UUID) before the record's own
+        // id. The old substring scan grabbed that user id, so every
+        // add_field-by-name posted collectionId=<user-uuid> and got a 400.
+        wm.stubFor(get(urlEqualTo("/api/collections?filter[name][eq]=projects"))
+                .willReturn(aResponse().withStatus(200).withBody(
+                        "{\"metadata\":{\"totalCount\":1},\"data\":[{"
+                        + "\"relationships\":{\"updatedBy\":{\"data\":{\"id\":\"99999999-9999-9999-9999-999999999999\",\"type\":\"users\"}},"
+                        + "\"createdBy\":{\"data\":{\"id\":\"99999999-9999-9999-9999-999999999999\",\"type\":\"users\"}}},"
+                        + "\"attributes\":{\"name\":\"projects\"},"
+                        + "\"id\":\"" + COLLECTION_ID + "\",\"type\":\"collections\"}]}")));
+        wm.stubFor(post(urlEqualTo("/api/fields"))
+                .willReturn(aResponse().withStatus(201).withBody("{}")));
+
+        tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("add_field", Map.of(
+                        "collectionName", "projects",
+                        "fieldName", "summary",
+                        "type", "string"), null));
+
+        wm.verify(WireMock.postRequestedFor(urlEqualTo("/api/fields"))
+                .withRequestBody(matchingJsonPath("$.data.attributes.collectionId", equalTo(COLLECTION_ID))));
+    }
+
+    @Test
+    void mapsExpandedAliasesAndPassesEnumNamesVerbatim() {
+        stubCollectionLookup();
+        wm.stubFor(post(urlEqualTo("/api/fields"))
+                .willReturn(aResponse().withStatus(201).withBody("{}")));
+
+        tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("add_field", Map.of(
+                        "collectionName", "projects",
+                        "fieldName", "budget",
+                        "type", "currency"), null));
+        wm.verify(WireMock.postRequestedFor(urlEqualTo("/api/fields"))
+                .withRequestBody(matchingJsonPath("$.data.attributes.type", equalTo("CURRENCY"))));
+
+        tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("add_field", Map.of(
+                        "collectionName", "projects",
+                        "fieldName", "homepage",
+                        "type", "url"), null));
+        wm.verify(WireMock.postRequestedFor(urlEqualTo("/api/fields"))
+                .withRequestBody(matchingJsonPath("$.data.attributes.type", equalTo("URL"))));
+
+        // exact enum names pass through verbatim (previously rejected)
+        tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("add_field", Map.of(
+                        "collectionName", "projects",
+                        "fieldName", "notes",
+                        "type", "TEXT"), null));
+        wm.verify(WireMock.postRequestedFor(urlEqualTo("/api/fields"))
+                .withRequestBody(matchingJsonPath("$.data.attributes.name", equalTo("notes")))
+                .withRequestBody(matchingJsonPath("$.data.attributes.type", equalTo("TEXT"))));
+    }
+
+    @Test
+    void referenceSetsReferenceTargetFromResolvedName() {
+        stubCollectionLookup();
+        String targetId = "33333333-3333-3333-3333-333333333333";
+        wm.stubFor(get(urlEqualTo("/api/collections/" + targetId))
+                .willReturn(aResponse().withStatus(200).withBody(
+                        "{\"data\":{\"relationships\":{\"updatedBy\":{\"data\":{\"id\":\"u1\",\"type\":\"users\"}}},"
+                        + "\"attributes\":{\"name\":\"accounts\"},"
+                        + "\"id\":\"" + targetId + "\",\"type\":\"collections\"}}")));
+        wm.stubFor(post(urlEqualTo("/api/fields"))
+                .willReturn(aResponse().withStatus(201).withBody("{}")));
+
+        tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("add_field", Map.of(
+                        "collectionName", "projects",
+                        "fieldName", "account",
+                        "type", "lookup",
+                        "referenceCollectionId", targetId), null));
+
+        // The admin UI displays referenceTarget — without it a relationship
+        // field shows no target collection.
+        wm.verify(WireMock.postRequestedFor(urlEqualTo("/api/fields"))
+                .withRequestBody(matchingJsonPath("$.data.attributes.referenceTarget", equalTo("accounts")))
+                .withRequestBody(matchingJsonPath("$.data.relationships.referenceCollectionId.data.id", equalTo(targetId))));
     }
 }

--- a/kelta-mcp/src/test/java/io/kelta/mcp/tool/admin/CreateLayoutToolTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/tool/admin/CreateLayoutToolTest.java
@@ -17,12 +17,22 @@ import java.util.Map;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static org.assertj.core.api.Assertions.assertThat;
 
+/**
+ * The tool targets the worker's kebab-case system-collection routes with the
+ * real attribute shapes: page-layouts get a resolved {@code collectionId},
+ * layout-sections a {@code layoutId} + {@code heading}, and layout-fields a
+ * {@code sectionId} + {@code fieldId} resolved from the entry's fieldName.
+ * (The previous camelCase paths — /api/pageLayouts etc. — 404 on the worker.)
+ */
 class CreateLayoutToolTest {
+
+    private static final String COLLECTION_ID = "11111111-1111-1111-1111-111111111111";
 
     private WireMockServer wm;
     private CreateLayoutTool tool;
@@ -44,6 +54,19 @@ class CreateLayoutToolTest {
         wm.stop();
     }
 
+    private void stubCollectionAndFields() {
+        wm.stubFor(get(urlEqualTo("/api/collections?filter[name][eq]=projects"))
+                .willReturn(aResponse().withStatus(200).withBody(
+                        "{\"data\":[{\"type\":\"collections\",\"id\":\"" + COLLECTION_ID + "\"}]}")));
+        wm.stubFor(get(urlEqualTo("/api/fields?filter[collectionId][EQ]=" + COLLECTION_ID + "&page[size]=200"))
+                .willReturn(aResponse().withStatus(200).withBody(
+                        "{\"data\":["
+                        + "{\"id\":\"fid-name\",\"type\":\"fields\",\"attributes\":{\"name\":\"name\"}},"
+                        + "{\"id\":\"fid-owner\",\"type\":\"fields\",\"attributes\":{\"name\":\"owner\"}},"
+                        + "{\"id\":\"fid-stage\",\"type\":\"fields\",\"attributes\":{\"name\":\"stage\"}}"
+                        + "]}")));
+    }
+
     @Test
     void rejectsWithoutNameOrCollection() {
         CallToolResult r1 = tool.toSpecification().callHandler().apply(
@@ -61,13 +84,14 @@ class CreateLayoutToolTest {
 
     @Test
     void createsLayoutSectionsAndFieldsInOrder() {
-        wm.stubFor(post(urlEqualTo("/api/pageLayouts"))
+        stubCollectionAndFields();
+        wm.stubFor(post(urlEqualTo("/api/page-layouts"))
                 .willReturn(aResponse().withStatus(201).withBody(
-                        "{\"data\":{\"id\":\"L1\",\"type\":\"pageLayouts\"}}")));
-        wm.stubFor(post(urlEqualTo("/api/layoutSections"))
+                        "{\"data\":{\"id\":\"L1\",\"type\":\"page-layouts\"}}")));
+        wm.stubFor(post(urlEqualTo("/api/layout-sections"))
                 .willReturn(aResponse().withStatus(201).withBody(
-                        "{\"data\":{\"id\":\"S1\",\"type\":\"layoutSections\"}}")));
-        wm.stubFor(post(urlEqualTo("/api/layoutFields"))
+                        "{\"data\":{\"id\":\"S1\",\"type\":\"layout-sections\"}}")));
+        wm.stubFor(post(urlEqualTo("/api/layout-fields"))
                 .willReturn(aResponse().withStatus(201).withBody(
                         "{\"data\":{\"id\":\"F1\"}}")));
 
@@ -84,23 +108,51 @@ class CreateLayoutToolTest {
                                         "fields", List.of(Map.of("fieldName", "stage"))))), null));
 
         assertThat(result.isError()).isNotEqualTo(Boolean.TRUE);
-        wm.verify(WireMock.postRequestedFor(urlEqualTo("/api/pageLayouts"))
+        wm.verify(WireMock.postRequestedFor(urlEqualTo("/api/page-layouts"))
                 .withHeader("Authorization", equalTo("Bearer klt_layout_test"))
+                .withRequestBody(matchingJsonPath("$.data.type", equalTo("page-layouts")))
                 .withRequestBody(matchingJsonPath("$.data.attributes.name", equalTo("ProjectsMain")))
-                .withRequestBody(matchingJsonPath("$.data.attributes.collectionName", equalTo("projects"))));
-        wm.verify(2, WireMock.postRequestedFor(urlEqualTo("/api/layoutSections")));
-        wm.verify(3, WireMock.postRequestedFor(urlEqualTo("/api/layoutFields")));
-        // sortOrder defaulting + child references
-        wm.verify(WireMock.postRequestedFor(urlEqualTo("/api/layoutSections"))
-                .withRequestBody(matchingJsonPath("$.data.attributes.sectionName", equalTo("Status")))
+                .withRequestBody(matchingJsonPath("$.data.attributes.collectionId", equalTo(COLLECTION_ID)))
+                .withRequestBody(matchingJsonPath("$.data.attributes.layoutType", equalTo("DETAIL"))));
+        wm.verify(2, WireMock.postRequestedFor(urlEqualTo("/api/layout-sections")));
+        wm.verify(3, WireMock.postRequestedFor(urlEqualTo("/api/layout-fields")));
+        // sortOrder defaulting, heading mapping + child references
+        wm.verify(WireMock.postRequestedFor(urlEqualTo("/api/layout-sections"))
+                .withRequestBody(matchingJsonPath("$.data.attributes.layoutId", equalTo("L1")))
+                .withRequestBody(matchingJsonPath("$.data.attributes.heading", equalTo("Status")))
                 .withRequestBody(matchingJsonPath("$.data.attributes.sortOrder", equalTo("1"))));
-        wm.verify(WireMock.postRequestedFor(urlEqualTo("/api/layoutFields"))
-                .withRequestBody(matchingJsonPath("$.data.attributes.layoutSectionId", equalTo("S1"))));
+        wm.verify(WireMock.postRequestedFor(urlEqualTo("/api/layout-fields"))
+                .withRequestBody(matchingJsonPath("$.data.attributes.sectionId", equalTo("S1")))
+                .withRequestBody(matchingJsonPath("$.data.attributes.fieldId", equalTo("fid-stage"))));
+    }
+
+    @Test
+    void reportsUnknownFieldNamesInsteadOfPosting() {
+        stubCollectionAndFields();
+        wm.stubFor(post(urlEqualTo("/api/page-layouts"))
+                .willReturn(aResponse().withStatus(201).withBody(
+                        "{\"data\":{\"id\":\"L1\"}}")));
+        wm.stubFor(post(urlEqualTo("/api/layout-sections"))
+                .willReturn(aResponse().withStatus(201).withBody(
+                        "{\"data\":{\"id\":\"S1\"}}")));
+
+        CallToolResult result = tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("create_layout", Map.of(
+                        "name", "L",
+                        "collectionName", "projects",
+                        "sections", List.of(Map.of("sectionName", "S",
+                                "fields", List.of(Map.of("fieldName", "doesNotExist"))))), null));
+
+        assertThat(result.isError()).isNotEqualTo(Boolean.TRUE);
+        assertThat(((io.modelcontextprotocol.spec.McpSchema.TextContent) result.content().get(0)).text())
+                .contains("field not found on collection");
+        wm.verify(0, WireMock.postRequestedFor(urlEqualTo("/api/layout-fields")));
     }
 
     @Test
     void shortCircuitsWhenLayoutCreationFails() {
-        wm.stubFor(post(urlEqualTo("/api/pageLayouts"))
+        stubCollectionAndFields();
+        wm.stubFor(post(urlEqualTo("/api/page-layouts"))
                 .willReturn(aResponse().withStatus(409).withBody("{}")));
 
         CallToolResult result = tool.toSpecification().callHandler().apply(
@@ -108,10 +160,10 @@ class CreateLayoutToolTest {
                         "name", "L",
                         "collectionName", "projects",
                         "sections", List.of(Map.of("sectionName", "S",
-                                "fields", List.of(Map.of("fieldName", "x"))))), null));
+                                "fields", List.of(Map.of("fieldName", "name"))))), null));
 
         assertThat(result.isError()).isEqualTo(Boolean.TRUE);
-        wm.verify(0, WireMock.postRequestedFor(urlEqualTo("/api/layoutSections")));
-        wm.verify(0, WireMock.postRequestedFor(urlEqualTo("/api/layoutFields")));
+        wm.verify(0, WireMock.postRequestedFor(urlEqualTo("/api/layout-sections")));
+        wm.verify(0, WireMock.postRequestedFor(urlEqualTo("/api/layout-fields")));
     }
 }

--- a/kelta-mcp/src/test/java/io/kelta/mcp/tool/admin/CreateListViewToolTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/tool/admin/CreateListViewToolTest.java
@@ -1,0 +1,116 @@
+package io.kelta.mcp.tool.admin;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import io.kelta.mcp.auth.RequestPatHolder;
+import io.kelta.mcp.client.GatewayHttpClient;
+import io.kelta.mcp.config.McpProperties;
+import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestClient;
+
+import java.util.Map;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * List views are records of the {@code list-views} system collection with a
+ * {@code columns} JSON array and a {@code filters} array that must ALWAYS be
+ * sent — the declared default is a string {@code "[]"} that fails the field's
+ * own JSON type validation. (The tool previously posted to a non-existent
+ * {@code /api/listViews} path with pass-through attribute names.)
+ */
+class CreateListViewToolTest {
+
+    private static final String COLLECTION_ID = "11111111-1111-1111-1111-111111111111";
+
+    private WireMockServer wm;
+    private CreateListViewTool tool;
+
+    @BeforeEach
+    void setUp() {
+        wm = new WireMockServer(0);
+        wm.start();
+        GatewayHttpClient client = new GatewayHttpClient(
+                RestClient.builder(),
+                new McpProperties("http://localhost:" + wm.port(), 30, 60_000, null));
+        tool = new CreateListViewTool(client);
+        RequestPatHolder.set("klt_listview_test");
+        wm.stubFor(get(urlEqualTo("/api/collections?filter[name][eq]=projects"))
+                .willReturn(aResponse().withStatus(200).withBody(
+                        "{\"data\":[{\"type\":\"collections\",\"id\":\"" + COLLECTION_ID + "\"}]}")));
+    }
+
+    @AfterEach
+    void tearDown() {
+        RequestPatHolder.clear();
+        wm.stop();
+    }
+
+    @Test
+    void postsColumnsAndAlwaysSendsFilters() {
+        wm.stubFor(post(urlEqualTo("/api/list-views"))
+                .willReturn(aResponse().withStatus(201).withBody("{\"data\":{\"id\":\"lv1\"}}")));
+
+        CallToolResult result = tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("create_listview", Map.of(
+                        "collectionName", "projects",
+                        "name", "All projects",
+                        "displayedFields", "name, owner ,stage",
+                        "sort", "-createdAt"), null));
+
+        assertThat(result.isError()).isNotEqualTo(Boolean.TRUE);
+        wm.verify(WireMock.postRequestedFor(urlEqualTo("/api/list-views"))
+                .withRequestBody(matchingJsonPath("$.data.type", equalTo("list-views")))
+                .withRequestBody(matchingJsonPath("$.data.attributes.collectionId", equalTo(COLLECTION_ID)))
+                .withRequestBody(matchingJsonPath("$.data.attributes.columns[0]", equalTo("name")))
+                .withRequestBody(matchingJsonPath("$.data.attributes.columns[1]", equalTo("owner")))
+                .withRequestBody(matchingJsonPath("$.data.attributes.columns[2]", equalTo("stage")))
+                // filters must ALWAYS be present, even when no filter was given
+                // (empty JSON arrays don't match a JsonPath presence check)
+                .withRequestBody(WireMock.containing("\"filters\":[]"))
+                .withRequestBody(matchingJsonPath("$.data.attributes.sortField", equalTo("createdAt")))
+                .withRequestBody(matchingJsonPath("$.data.attributes.sortDirection", equalTo("DESC"))));
+    }
+
+    @Test
+    void mapsFilterObjectToFiltersArray() {
+        wm.stubFor(post(urlEqualTo("/api/list-views"))
+                .willReturn(aResponse().withStatus(201).withBody("{\"data\":{\"id\":\"lv1\"}}")));
+
+        tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("create_listview", Map.of(
+                        "collectionName", "projects",
+                        "name", "Open",
+                        "displayedFields", "name",
+                        "filter", Map.of("status", Map.of("EQ", "OPEN"))), null));
+
+        wm.verify(WireMock.postRequestedFor(urlEqualTo("/api/list-views"))
+                .withRequestBody(matchingJsonPath("$.data.attributes.filters[0].field", equalTo("status")))
+                .withRequestBody(matchingJsonPath("$.data.attributes.filters[0].operator", equalTo("EQ")))
+                .withRequestBody(matchingJsonPath("$.data.attributes.filters[0].value", equalTo("OPEN"))));
+    }
+
+    @Test
+    void failsWhenCollectionUnknown() {
+        wm.stubFor(get(urlEqualTo("/api/collections?filter[name][eq]=nope"))
+                .willReturn(aResponse().withStatus(200).withBody("{\"data\":[]}")));
+
+        CallToolResult result = tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("create_listview", Map.of(
+                        "collectionName", "nope",
+                        "name", "x",
+                        "displayedFields", "a"), null));
+
+        assertThat(result.isError()).isEqualTo(Boolean.TRUE);
+    }
+}

--- a/kelta-mcp/src/test/java/io/kelta/mcp/tool/admin/CreateValidationRuleToolTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/tool/admin/CreateValidationRuleToolTest.java
@@ -1,0 +1,110 @@
+package io.kelta.mcp.tool.admin;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import io.kelta.mcp.auth.RequestPatHolder;
+import io.kelta.mcp.client.GatewayHttpClient;
+import io.kelta.mcp.config.McpProperties;
+import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestClient;
+
+import java.util.Map;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Validation rules are records of the {@code validation-rules} system
+ * collection: the record is REJECTED when {@code errorConditionFormula}
+ * evaluates true. (The tool previously posted to a non-existent
+ * {@code /api/validationRules} path and documented inverted semantics.)
+ */
+class CreateValidationRuleToolTest {
+
+    private static final String COLLECTION_ID = "11111111-1111-1111-1111-111111111111";
+
+    private WireMockServer wm;
+    private CreateValidationRuleTool tool;
+
+    @BeforeEach
+    void setUp() {
+        wm = new WireMockServer(0);
+        wm.start();
+        GatewayHttpClient client = new GatewayHttpClient(
+                RestClient.builder(),
+                new McpProperties("http://localhost:" + wm.port(), 30, 60_000, null));
+        tool = new CreateValidationRuleTool(client);
+        RequestPatHolder.set("klt_rule_test");
+        wm.stubFor(get(urlEqualTo("/api/collections?filter[name][eq]=projects"))
+                .willReturn(aResponse().withStatus(200).withBody(
+                        "{\"data\":[{\"type\":\"collections\",\"id\":\"" + COLLECTION_ID + "\"}]}")));
+    }
+
+    @AfterEach
+    void tearDown() {
+        RequestPatHolder.clear();
+        wm.stop();
+    }
+
+    @Test
+    void postsErrorConditionFormulaToKebabRoute() {
+        wm.stubFor(post(urlEqualTo("/api/validation-rules"))
+                .willReturn(aResponse().withStatus(201).withBody("{\"data\":{\"id\":\"r1\"}}")));
+
+        CallToolResult result = tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("create_validation_rule", Map.of(
+                        "collectionName", "projects",
+                        "name", "amount-range",
+                        "errorConditionFormula", "amountMax < amountMin",
+                        "errorMessage", "amountMax must be >= amountMin"), null));
+
+        assertThat(result.isError()).isNotEqualTo(Boolean.TRUE);
+        wm.verify(WireMock.postRequestedFor(urlEqualTo("/api/validation-rules"))
+                .withRequestBody(matchingJsonPath("$.data.type", equalTo("validation-rules")))
+                .withRequestBody(matchingJsonPath("$.data.attributes.collectionId", equalTo(COLLECTION_ID)))
+                .withRequestBody(matchingJsonPath("$.data.attributes.errorConditionFormula", equalTo("amountMax < amountMin")))
+                .withRequestBody(matchingJsonPath("$.data.attributes.errorMessage", equalTo("amountMax must be >= amountMin")))
+                .withRequestBody(matchingJsonPath("$.data.attributes.evaluateOn", equalTo("CREATE_AND_UPDATE")))
+                .withRequestBody(matchingJsonPath("$.data.attributes.severity", equalTo("ERROR")))
+                .withRequestBody(matchingJsonPath("$.data.attributes.active", equalTo("true"))));
+    }
+
+    @Test
+    void negatesLegacyExpressionIntoErrorCondition() {
+        wm.stubFor(post(urlEqualTo("/api/validation-rules"))
+                .willReturn(aResponse().withStatus(201).withBody("{\"data\":{\"id\":\"r1\"}}")));
+
+        tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("create_validation_rule", Map.of(
+                        "collectionName", "projects",
+                        "name", "amount-positive",
+                        "expression", "amount > 0",
+                        "errorMessage", "amount must be positive"), null));
+
+        // Legacy semantics were "expression must hold" — the error condition is
+        // its negation.
+        wm.verify(WireMock.postRequestedFor(urlEqualTo("/api/validation-rules"))
+                .withRequestBody(matchingJsonPath("$.data.attributes.errorConditionFormula",
+                        equalTo("NOT(amount > 0)"))));
+    }
+
+    @Test
+    void requiresAFormula() {
+        CallToolResult result = tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("create_validation_rule", Map.of(
+                        "collectionName", "projects",
+                        "name", "r",
+                        "errorMessage", "m"), null));
+
+        assertThat(result.isError()).isEqualTo(Boolean.TRUE);
+    }
+}

--- a/kelta-mcp/src/test/java/io/kelta/mcp/tool/admin/UpdateCollectionToolTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/tool/admin/UpdateCollectionToolTest.java
@@ -1,0 +1,102 @@
+package io.kelta.mcp.tool.admin;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import io.kelta.mcp.auth.RequestPatHolder;
+import io.kelta.mcp.client.GatewayHttpClient;
+import io.kelta.mcp.config.McpProperties;
+import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestClient;
+
+import java.util.Map;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
+import static com.github.tomakehurst.wiremock.client.WireMock.patch;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * {@code displayFieldName} resolves to the field's UUID and PATCHes
+ * {@code displayFieldId} — the worker has no displayFieldName attribute, so
+ * the previous pass-through was silently ignored.
+ */
+class UpdateCollectionToolTest {
+
+    private static final String COLLECTION_ID = "11111111-1111-1111-1111-111111111111";
+
+    private WireMockServer wm;
+    private UpdateCollectionTool tool;
+
+    @BeforeEach
+    void setUp() {
+        wm = new WireMockServer(0);
+        wm.start();
+        GatewayHttpClient client = new GatewayHttpClient(
+                RestClient.builder(),
+                new McpProperties("http://localhost:" + wm.port(), 30, 60_000, null));
+        tool = new UpdateCollectionTool(client);
+        RequestPatHolder.set("klt_update_test");
+    }
+
+    @AfterEach
+    void tearDown() {
+        RequestPatHolder.clear();
+        wm.stop();
+    }
+
+    @Test
+    void resolvesDisplayFieldNameToDisplayFieldId() {
+        wm.stubFor(get(urlEqualTo("/api/fields?filter[collectionId][EQ]=" + COLLECTION_ID + "&page[size]=200"))
+                .willReturn(aResponse().withStatus(200).withBody(
+                        "{\"data\":[{\"id\":\"fid-name\",\"type\":\"fields\",\"attributes\":{\"name\":\"nameEn\"}}]}")));
+        wm.stubFor(patch(urlEqualTo("/api/collections/" + COLLECTION_ID))
+                .willReturn(aResponse().withStatus(200).withBody("{\"data\":{\"id\":\"" + COLLECTION_ID + "\"}}")));
+
+        CallToolResult result = tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("update_collection", Map.of(
+                        "id", COLLECTION_ID,
+                        "displayFieldName", "nameEn"), null));
+
+        assertThat(result.isError()).isNotEqualTo(Boolean.TRUE);
+        wm.verify(WireMock.patchRequestedFor(urlEqualTo("/api/collections/" + COLLECTION_ID))
+                .withRequestBody(matchingJsonPath("$.data.attributes.displayFieldId", equalTo("fid-name"))));
+    }
+
+    @Test
+    void acceptsCollectionNameAsId() {
+        wm.stubFor(get(urlEqualTo("/api/collections?filter[name][eq]=projects"))
+                .willReturn(aResponse().withStatus(200).withBody(
+                        "{\"data\":[{\"type\":\"collections\",\"id\":\"" + COLLECTION_ID + "\"}]}")));
+        wm.stubFor(patch(urlEqualTo("/api/collections/" + COLLECTION_ID))
+                .willReturn(aResponse().withStatus(200).withBody("{}")));
+
+        CallToolResult result = tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("update_collection", Map.of(
+                        "id", "projects",
+                        "displayName", "Projects"), null));
+
+        assertThat(result.isError()).isNotEqualTo(Boolean.TRUE);
+        wm.verify(WireMock.patchRequestedFor(urlEqualTo("/api/collections/" + COLLECTION_ID))
+                .withRequestBody(matchingJsonPath("$.data.attributes.displayName", equalTo("Projects"))));
+    }
+
+    @Test
+    void errorsWhenDisplayFieldMissing() {
+        wm.stubFor(get(urlEqualTo("/api/fields?filter[collectionId][EQ]=" + COLLECTION_ID + "&page[size]=200"))
+                .willReturn(aResponse().withStatus(200).withBody("{\"data\":[]}")));
+
+        CallToolResult result = tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("update_collection", Map.of(
+                        "id", COLLECTION_ID,
+                        "displayFieldName", "ghost"), null));
+
+        assertThat(result.isError()).isEqualTo(Boolean.TRUE);
+    }
+}

--- a/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/model/system/SystemCollectionDefinitions.java
+++ b/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/model/system/SystemCollectionDefinitions.java
@@ -326,7 +326,10 @@ public final class SystemCollectionDefinitions {
             .addField(FieldDefinition.bool("isDefault").withColumnName("is_default"))
             .addField(FieldDefinition.requiredJson("columns"))
             .addField(FieldDefinition.string("filterLogic").withColumnName("filter_logic"))
-            .addField(FieldDefinition.json("filters").withDefault("[]"))
+            // JSON-typed defaults must be JSON values, not strings — a String
+            // default is injected verbatim on create and then fails the field's
+            // own type validation ("filters: Invalid type, expected JSON").
+            .addField(FieldDefinition.json("filters").withDefault(List.of()))
             .addField(FieldDefinition.string("sortField").withColumnName("sort_field"))
             .addField(FieldDefinition.string("sortDirection", 4).withColumnName("sort_direction")
                 .withDefault("ASC"))
@@ -1572,7 +1575,7 @@ public final class SystemCollectionDefinitions {
                 .withColumnName("column_span").withDefault(1))
             .addField(FieldDefinition.integer("rowSpan")
                 .withColumnName("row_span").withDefault(1))
-            .addField(FieldDefinition.json("config").withDefault("{}"))
+            .addField(FieldDefinition.json("config").withDefault(Map.of()))
             .addField(FieldDefinition.requiredInteger("sortOrder")
                 .withColumnName("sort_order"))
             .build();
@@ -1627,7 +1630,7 @@ public final class SystemCollectionDefinitions {
                 .withColumnName("started_by"))
             .addField(FieldDefinition.string("triggerRecordId", 36)
                 .withColumnName("trigger_record_id"))
-            .addField(FieldDefinition.json("variables").withDefault("{}"))
+            .addField(FieldDefinition.json("variables").withDefault(Map.of()))
             .addField(FieldDefinition.string("currentNodeId", 100)
                 .withColumnName("current_node_id"))
             .addField(FieldDefinition.text("errorMessage")

--- a/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/router/GlobalExceptionHandler.java
+++ b/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/router/GlobalExceptionHandler.java
@@ -85,7 +85,7 @@ public class GlobalExceptionHandler {
             errors.add(error);
         }
 
-        return ResponseEntity.badRequest().body(Map.of("errors", errors));
+        return ResponseEntity.badRequest().body(errorBody(errors));
     }
 
     /**
@@ -112,7 +112,7 @@ public class GlobalExceptionHandler {
         }
 
         return ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY)
-                .body(Map.of("errors", errors));
+                .body(errorBody(errors));
     }
 
     /**
@@ -142,7 +142,7 @@ public class GlobalExceptionHandler {
             errors.add(error);
         }
 
-        return ResponseEntity.badRequest().body(Map.of("errors", errors));
+        return ResponseEntity.badRequest().body(errorBody(errors));
     }
 
     /**
@@ -162,7 +162,7 @@ public class GlobalExceptionHandler {
         error.setSource(Map.of("pointer", "/data/attributes/" + ex.getFieldName()));
         error.setMeta(Map.of("requestId", requestId));
 
-        return ResponseEntity.status(HttpStatus.CONFLICT).body(Map.of("errors", List.of(error)));
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(errorBody(error));
     }
 
     /**
@@ -181,7 +181,7 @@ public class GlobalExceptionHandler {
             "This record was modified since you opened it. Reload the latest version and try again.");
         error.setMeta(Map.of("requestId", requestId, "path", request.getRequestURI()));
 
-        return ResponseEntity.status(HttpStatus.CONFLICT).body(Map.of("errors", List.of(error)));
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(errorBody(error));
     }
 
     /**
@@ -201,7 +201,7 @@ public class GlobalExceptionHandler {
         error.setMeta(Map.of("requestId", requestId, "path", request.getRequestURI()));
 
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-            .body(Map.of("errors", List.of(error)));
+            .body(errorBody(error));
     }
 
     /**
@@ -231,7 +231,7 @@ public class GlobalExceptionHandler {
             errors.add(error);
         }
 
-        return ResponseEntity.badRequest().body(Map.of("errors", errors));
+        return ResponseEntity.badRequest().body(errorBody(errors));
     }
 
     /**
@@ -264,7 +264,7 @@ public class GlobalExceptionHandler {
             errors.add(error);
         }
 
-        return ResponseEntity.badRequest().body(Map.of("errors", errors));
+        return ResponseEntity.badRequest().body(errorBody(errors));
     }
 
     /**
@@ -283,7 +283,7 @@ public class GlobalExceptionHandler {
             "Request body is missing or could not be parsed as JSON");
         error.setMeta(Map.of("requestId", requestId, "path", request.getRequestURI()));
 
-        return ResponseEntity.badRequest().body(Map.of("errors", List.of(error)));
+        return ResponseEntity.badRequest().body(errorBody(error));
     }
 
     /**
@@ -303,7 +303,7 @@ public class GlobalExceptionHandler {
         error.setSource(Map.of("parameter", ex.getParameterName()));
         error.setMeta(Map.of("requestId", requestId, "path", request.getRequestURI()));
 
-        return ResponseEntity.badRequest().body(Map.of("errors", List.of(error)));
+        return ResponseEntity.badRequest().body(errorBody(error));
     }
 
     /**
@@ -324,7 +324,7 @@ public class GlobalExceptionHandler {
         error.setSource(Map.of("parameter", ex.getName()));
         error.setMeta(Map.of("requestId", requestId, "path", request.getRequestURI()));
 
-        return ResponseEntity.badRequest().body(Map.of("errors", List.of(error)));
+        return ResponseEntity.badRequest().body(errorBody(error));
     }
 
     /**
@@ -345,7 +345,7 @@ public class GlobalExceptionHandler {
             "No handler for " + request.getMethod() + " " + path);
         error.setMeta(Map.of("requestId", requestId, "path", path));
 
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Map.of("errors", List.of(error)));
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(errorBody(error));
     }
 
     /**
@@ -365,7 +365,7 @@ public class GlobalExceptionHandler {
         error.setMeta(Map.of("requestId", requestId, "path", request.getRequestURI()));
 
         return ResponseEntity.status(HttpStatus.METHOD_NOT_ALLOWED)
-            .body(Map.of("errors", List.of(error)));
+            .body(errorBody(error));
     }
 
     /**
@@ -387,7 +387,7 @@ public class GlobalExceptionHandler {
         error.setMeta(Map.of("requestId", requestId, "path", request.getRequestURI()));
 
         return ResponseEntity.status(HttpStatus.UNSUPPORTED_MEDIA_TYPE)
-            .body(Map.of("errors", List.of(error)));
+            .body(errorBody(error));
     }
 
     /**
@@ -412,7 +412,7 @@ public class GlobalExceptionHandler {
             String.valueOf(status.value()), code, status.getReasonPhrase(), detail);
         error.setMeta(Map.of("requestId", requestId, "path", request.getRequestURI()));
 
-        return ResponseEntity.status(status).body(Map.of("errors", List.of(error)));
+        return ResponseEntity.status(status).body(errorBody(error));
     }
 
     /**
@@ -431,7 +431,7 @@ public class GlobalExceptionHandler {
         error.setMeta(Map.of("requestId", requestId, "path", request.getRequestURI()));
 
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-            .body(Map.of("errors", List.of(error)));
+            .body(errorBody(error));
     }
 
     /**
@@ -439,5 +439,23 @@ public class GlobalExceptionHandler {
      */
     private String generateRequestId() {
         return UUID.randomUUID().toString().substring(0, 8);
+    }
+
+    /**
+     * Builds the JSON:API error envelope from plain maps ({@link JsonApiError#toMap()}).
+     * Maps serialize identically under every converter configuration; serializing the
+     * bean itself has been observed to produce {@code {"errors":[{}]}} on the deployed
+     * worker, hiding the failure reason from API clients.
+     */
+    private static Map<String, Object> errorBody(List<JsonApiError> errors) {
+        List<Map<String, Object>> mapped = new ArrayList<>(errors.size());
+        for (JsonApiError error : errors) {
+            mapped.add(error.toMap());
+        }
+        return Map.of("errors", mapped);
+    }
+
+    private static Map<String, Object> errorBody(JsonApiError error) {
+        return errorBody(List.of(error));
     }
 }

--- a/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/model/system/SystemCollectionJsonDefaultsTest.java
+++ b/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/model/system/SystemCollectionJsonDefaultsTest.java
@@ -1,0 +1,51 @@
+package io.kelta.runtime.model.system;
+
+import io.kelta.runtime.model.CollectionDefinition;
+import io.kelta.runtime.model.FieldDefinition;
+import io.kelta.runtime.model.FieldType;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Declared defaults on JSON-typed system fields must be JSON values (maps or
+ * lists), never strings. {@code DefaultQueryEngine} injects the declared
+ * default verbatim when the attribute is missing on create, and the field's
+ * own type validation then runs on it — a String default like {@code "[]"}
+ * makes every create that omits the field fail with
+ * "Invalid type, expected JSON" (this is exactly what broke creating a
+ * list view without explicit {@code filters}).
+ */
+class SystemCollectionJsonDefaultsTest {
+
+    @Test
+    void jsonTypedDefaultsAreJsonValues() {
+        for (CollectionDefinition definition : SystemCollectionDefinitions.all()) {
+            for (FieldDefinition field : definition.fields()) {
+                if (field.defaultValue() == null) {
+                    continue;
+                }
+                if (field.type() == FieldType.JSON || field.type() == FieldType.ARRAY) {
+                    assertThat(field.defaultValue())
+                            .as("%s.%s declares a %s default — JSON-typed defaults must be a Map or List, not %s",
+                                    definition.name(), field.name(), field.type(),
+                                    field.defaultValue().getClass().getSimpleName())
+                            .matches(v -> v instanceof Map || v instanceof List);
+                }
+            }
+        }
+    }
+
+    @Test
+    void listViewFiltersDefaultsToEmptyJsonArray() {
+        CollectionDefinition listViews = SystemCollectionDefinitions.listViews();
+        FieldDefinition filters = listViews.fields().stream()
+                .filter(f -> "filters".equals(f.name()))
+                .findFirst()
+                .orElseThrow();
+        assertThat(filters.defaultValue()).isEqualTo(List.of());
+    }
+}

--- a/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/router/GlobalExceptionHandlerTest.java
+++ b/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/router/GlobalExceptionHandlerTest.java
@@ -1,6 +1,5 @@
 package io.kelta.runtime.router;
 
-import io.kelta.jsonapi.JsonApiError;
 import io.kelta.runtime.query.InvalidQueryException;
 import io.kelta.runtime.storage.UniqueConstraintViolationException;
 import io.kelta.runtime.validation.RecordValidationException;
@@ -44,6 +43,11 @@ import static org.mockito.Mockito.when;
  * Verifies the JSON:API 4xx error envelope: every response body has a non-empty
  * {@code errors[]} array, and each error object carries {@code status}, {@code code},
  * and {@code detail} so clients can distinguish failure classes without trial-and-error.
+ *
+ * <p>Error objects are plain maps ({@code JsonApiError.toMap()}), asserted here as maps
+ * — the same shape that goes over the wire. Bean-typed bodies serialized to
+ * {@code {"errors":[{}]}} on the deployed worker, so the envelope's serialized form is
+ * itself under test (see {@link #errorEnvelope_serializesWithAllMembers()}).
  */
 @SuppressWarnings("unchecked")
 class GlobalExceptionHandlerTest {
@@ -55,6 +59,26 @@ class GlobalExceptionHandlerTest {
     void setUp() {
         handler = new GlobalExceptionHandler();
         request = new MockHttpServletRequest("POST", "/api/widgets");
+    }
+
+    private static List<Map<String, Object>> errors(ResponseEntity<Map<String, Object>> response) {
+        return (List<Map<String, Object>>) response.getBody().get("errors");
+    }
+
+    private static Map<String, Object> firstError(ResponseEntity<Map<String, Object>> response) {
+        return errors(response).get(0);
+    }
+
+    private static String str(Map<String, Object> error, String member) {
+        return (String) error.get(member);
+    }
+
+    private static Map<String, Object> source(Map<String, Object> error) {
+        return (Map<String, Object>) error.get("source");
+    }
+
+    private static Map<String, Object> meta(Map<String, Object> error) {
+        return (Map<String, Object>) error.get("meta");
     }
 
     @Test
@@ -73,16 +97,16 @@ class GlobalExceptionHandlerTest {
         ResponseEntity<Map<String, Object>> response = handler.handleMethodArgumentNotValid(ex, request);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
-        List<JsonApiError> errors = (List<JsonApiError>) response.getBody().get("errors");
+        List<Map<String, Object>> errors = errors(response);
         assertThat(errors).hasSize(2);
-        for (JsonApiError e : errors) {
-            assertThat(e.getStatus()).isEqualTo("400");
-            assertThat(e.getCode()).isEqualTo("VALIDATION_FAILED");
-            assertThat(e.getDetail()).isNotBlank();
-            assertThat(e.getSource()).containsKey("pointer");
+        for (Map<String, Object> e : errors) {
+            assertThat(str(e, "status")).isEqualTo("400");
+            assertThat(str(e, "code")).isEqualTo("VALIDATION_FAILED");
+            assertThat(str(e, "detail")).isNotBlank();
+            assertThat(source(e)).containsKey("pointer");
         }
-        assertThat(errors.get(0).getSource().get("pointer")).isEqualTo("/data/attributes/name");
-        assertThat(errors.get(1).getSource().get("pointer")).isEqualTo("/data/attributes/size");
+        assertThat(source(errors.get(0)).get("pointer")).isEqualTo("/data/attributes/name");
+        assertThat(source(errors.get(1)).get("pointer")).isEqualTo("/data/attributes/size");
     }
 
     @Test
@@ -100,13 +124,13 @@ class GlobalExceptionHandlerTest {
         ResponseEntity<Map<String, Object>> response = handler.handleConstraintViolation(ex, request);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
-        List<JsonApiError> errors = (List<JsonApiError>) response.getBody().get("errors");
+        List<Map<String, Object>> errors = errors(response);
         assertThat(errors).hasSize(1);
-        JsonApiError e = errors.get(0);
-        assertThat(e.getStatus()).isEqualTo("400");
-        assertThat(e.getCode()).isEqualTo("VALIDATION_FAILED");
-        assertThat(e.getDetail()).isEqualTo("must be greater than 0");
-        assertThat(e.getSource()).containsEntry("parameter", "limit");
+        Map<String, Object> e = errors.get(0);
+        assertThat(str(e, "status")).isEqualTo("400");
+        assertThat(str(e, "code")).isEqualTo("VALIDATION_FAILED");
+        assertThat(str(e, "detail")).isEqualTo("must be greater than 0");
+        assertThat(source(e)).containsEntry("parameter", "limit");
     }
 
     @Test
@@ -122,14 +146,14 @@ class GlobalExceptionHandlerTest {
         ResponseEntity<Map<String, Object>> response = handler.handleHttpMessageNotReadable(ex, request);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
-        List<JsonApiError> errors = (List<JsonApiError>) response.getBody().get("errors");
+        List<Map<String, Object>> errors = errors(response);
         assertThat(errors).hasSize(1);
-        JsonApiError e = errors.get(0);
-        assertThat(e.getStatus()).isEqualTo("400");
-        assertThat(e.getCode()).isEqualTo("INVALID_PAYLOAD");
-        assertThat(e.getTitle()).isEqualTo("Bad Request");
-        assertThat(e.getDetail()).contains("could not be parsed");
-        assertThat(e.getMeta()).containsEntry("path", "/api/widgets");
+        Map<String, Object> e = errors.get(0);
+        assertThat(str(e, "status")).isEqualTo("400");
+        assertThat(str(e, "code")).isEqualTo("INVALID_PAYLOAD");
+        assertThat(str(e, "title")).isEqualTo("Bad Request");
+        assertThat(str(e, "detail")).contains("could not be parsed");
+        assertThat(meta(e)).containsEntry("path", "/api/widgets");
     }
 
     @Test
@@ -140,11 +164,11 @@ class GlobalExceptionHandlerTest {
         ResponseEntity<Map<String, Object>> response = handler.handleMissingParameter(ex, request);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
-        JsonApiError e = ((List<JsonApiError>) response.getBody().get("errors")).get(0);
-        assertThat(e.getStatus()).isEqualTo("400");
-        assertThat(e.getCode()).isEqualTo("MISSING_PARAMETER");
-        assertThat(e.getDetail()).isEqualTo("Required parameter 'filter' is missing");
-        assertThat(e.getSource()).containsEntry("parameter", "filter");
+        Map<String, Object> e = firstError(response);
+        assertThat(str(e, "status")).isEqualTo("400");
+        assertThat(str(e, "code")).isEqualTo("MISSING_PARAMETER");
+        assertThat(str(e, "detail")).isEqualTo("Required parameter 'filter' is missing");
+        assertThat(source(e)).containsEntry("parameter", "filter");
     }
 
     @Test
@@ -155,11 +179,11 @@ class GlobalExceptionHandlerTest {
         ResponseEntity<Map<String, Object>> response = handler.handleTypeMismatch(ex, request);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
-        JsonApiError e = ((List<JsonApiError>) response.getBody().get("errors")).get(0);
-        assertThat(e.getStatus()).isEqualTo("400");
-        assertThat(e.getCode()).isEqualTo("INVALID_PARAMETER");
-        assertThat(e.getDetail()).contains("'id'").contains("Long");
-        assertThat(e.getSource()).containsEntry("parameter", "id");
+        Map<String, Object> e = firstError(response);
+        assertThat(str(e, "status")).isEqualTo("400");
+        assertThat(str(e, "code")).isEqualTo("INVALID_PARAMETER");
+        assertThat(str(e, "detail")).contains("'id'").contains("Long");
+        assertThat(source(e)).containsEntry("parameter", "id");
     }
 
     @Test
@@ -172,11 +196,11 @@ class GlobalExceptionHandlerTest {
         ResponseEntity<Map<String, Object>> response = handler.handleNotFound(ex, request);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
-        JsonApiError e = ((List<JsonApiError>) response.getBody().get("errors")).get(0);
-        assertThat(e.getStatus()).isEqualTo("404");
-        assertThat(e.getCode()).isEqualTo("NOT_FOUND");
-        assertThat(e.getTitle()).isEqualTo("Not Found");
-        assertThat(e.getDetail()).contains("GET").contains("/api/missing");
+        Map<String, Object> e = firstError(response);
+        assertThat(str(e, "status")).isEqualTo("404");
+        assertThat(str(e, "code")).isEqualTo("NOT_FOUND");
+        assertThat(str(e, "title")).isEqualTo("Not Found");
+        assertThat(str(e, "detail")).contains("GET").contains("/api/missing");
     }
 
     @Test
@@ -189,9 +213,9 @@ class GlobalExceptionHandlerTest {
         ResponseEntity<Map<String, Object>> response = handler.handleNotFound(ex, request);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
-        JsonApiError e = ((List<JsonApiError>) response.getBody().get("errors")).get(0);
-        assertThat(e.getStatus()).isEqualTo("404");
-        assertThat(e.getCode()).isEqualTo("NOT_FOUND");
+        Map<String, Object> e = firstError(response);
+        assertThat(str(e, "status")).isEqualTo("404");
+        assertThat(str(e, "code")).isEqualTo("NOT_FOUND");
     }
 
     @Test
@@ -202,10 +226,10 @@ class GlobalExceptionHandlerTest {
         ResponseEntity<Map<String, Object>> response = handler.handleMethodNotAllowed(ex, request);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.METHOD_NOT_ALLOWED);
-        JsonApiError e = ((List<JsonApiError>) response.getBody().get("errors")).get(0);
-        assertThat(e.getStatus()).isEqualTo("405");
-        assertThat(e.getCode()).isEqualTo("METHOD_NOT_ALLOWED");
-        assertThat(e.getDetail()).contains("DELETE");
+        Map<String, Object> e = firstError(response);
+        assertThat(str(e, "status")).isEqualTo("405");
+        assertThat(str(e, "code")).isEqualTo("METHOD_NOT_ALLOWED");
+        assertThat(str(e, "detail")).contains("DELETE");
     }
 
     @Test
@@ -217,10 +241,10 @@ class GlobalExceptionHandlerTest {
         ResponseEntity<Map<String, Object>> response = handler.handleUnsupportedMediaType(ex, request);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNSUPPORTED_MEDIA_TYPE);
-        JsonApiError e = ((List<JsonApiError>) response.getBody().get("errors")).get(0);
-        assertThat(e.getStatus()).isEqualTo("415");
-        assertThat(e.getCode()).isEqualTo("UNSUPPORTED_MEDIA_TYPE");
-        assertThat(e.getDetail()).contains("text/plain");
+        Map<String, Object> e = firstError(response);
+        assertThat(str(e, "status")).isEqualTo("415");
+        assertThat(str(e, "code")).isEqualTo("UNSUPPORTED_MEDIA_TYPE");
+        assertThat(str(e, "detail")).contains("text/plain");
     }
 
     @Test
@@ -230,10 +254,10 @@ class GlobalExceptionHandlerTest {
         ResponseEntity<Map<String, Object>> response = handler.handleResponseStatus(ex, request);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
-        JsonApiError e = ((List<JsonApiError>) response.getBody().get("errors")).get(0);
-        assertThat(e.getStatus()).isEqualTo("409");
-        assertThat(e.getCode()).isEqualTo("CONFLICT");
-        assertThat(e.getDetail()).isEqualTo("Widget already exists");
+        Map<String, Object> e = firstError(response);
+        assertThat(str(e, "status")).isEqualTo("409");
+        assertThat(str(e, "code")).isEqualTo("CONFLICT");
+        assertThat(str(e, "detail")).isEqualTo("Widget already exists");
     }
 
     @Test
@@ -246,17 +270,17 @@ class GlobalExceptionHandlerTest {
                 handler.handleValidationException(new ValidationException(result), request);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
-        List<JsonApiError> errors = (List<JsonApiError>) response.getBody().get("errors");
+        List<Map<String, Object>> errors = errors(response);
         assertThat(errors).hasSize(2);
-        for (JsonApiError e : errors) {
-            assertThat(e.getStatus()).isEqualTo("400");
-            assertThat(e.getCode()).isNotBlank();
-            assertThat(e.getDetail()).isNotBlank();
-            assertThat(e.getSource()).containsKey("pointer");
+        for (Map<String, Object> e : errors) {
+            assertThat(str(e, "status")).isEqualTo("400");
+            assertThat(str(e, "code")).isNotBlank();
+            assertThat(str(e, "detail")).isNotBlank();
+            assertThat(source(e)).containsKey("pointer");
         }
-        assertThat(errors.get(0).getSource().get("pointer")).isEqualTo("/data/attributes/email");
-        assertThat(errors.get(0).getCode()).isEqualTo("PATTERN");
-        assertThat(errors.get(1).getCode()).isEqualTo("nullable");
+        assertThat(source(errors.get(0)).get("pointer")).isEqualTo("/data/attributes/email");
+        assertThat(str(errors.get(0), "code")).isEqualTo("PATTERN");
+        assertThat(str(errors.get(1), "code")).isEqualTo("nullable");
     }
 
     @Test
@@ -269,13 +293,13 @@ class GlobalExceptionHandlerTest {
                 handler.handleRecordValidationException(ex, request);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY);
-        List<JsonApiError> errors = (List<JsonApiError>) response.getBody().get("errors");
+        List<Map<String, Object>> errors = errors(response);
         assertThat(errors).hasSize(1);
-        JsonApiError e = errors.get(0);
-        assertThat(e.getStatus()).isEqualTo("422");
-        assertThat(e.getCode()).isEqualTo("VALIDATION_RULE_FAILED");
-        assertThat(e.getDetail()).isEqualTo("Year must be between 1888 and 2031");
-        assertThat(e.getSource()).containsEntry("pointer", "/data/attributes/year");
+        Map<String, Object> e = errors.get(0);
+        assertThat(str(e, "status")).isEqualTo("422");
+        assertThat(str(e, "code")).isEqualTo("VALIDATION_RULE_FAILED");
+        assertThat(str(e, "detail")).isEqualTo("Year must be between 1888 and 2031");
+        assertThat(source(e)).containsEntry("pointer", "/data/attributes/year");
     }
 
     @Test
@@ -287,8 +311,8 @@ class GlobalExceptionHandlerTest {
                 handler.handleRecordValidationException(ex, request);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY);
-        JsonApiError e = ((List<JsonApiError>) response.getBody().get("errors")).get(0);
-        assertThat(e.getSource()).containsEntry("pointer", "/data/attributes/cross_field_rule");
+        Map<String, Object> e = firstError(response);
+        assertThat(source(e)).containsEntry("pointer", "/data/attributes/cross_field_rule");
     }
 
     @Test
@@ -299,11 +323,11 @@ class GlobalExceptionHandlerTest {
                 handler.handleInvalidQueryException(ex, request);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
-        JsonApiError e = ((List<JsonApiError>) response.getBody().get("errors")).get(0);
-        assertThat(e.getStatus()).isEqualTo("400");
-        assertThat(e.getCode()).isEqualTo("INVALID_QUERY");
-        assertThat(e.getDetail()).isEqualTo("unknown sort field");
-        assertThat(e.getSource()).containsEntry("pointer", "/data/attributes/sort");
+        Map<String, Object> e = firstError(response);
+        assertThat(str(e, "status")).isEqualTo("400");
+        assertThat(str(e, "code")).isEqualTo("INVALID_QUERY");
+        assertThat(str(e, "detail")).isEqualTo("unknown sort field");
+        assertThat(source(e)).containsEntry("pointer", "/data/attributes/sort");
     }
 
     @Test
@@ -315,11 +339,11 @@ class GlobalExceptionHandlerTest {
                 handler.handleUniqueConstraintViolation(ex, request);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
-        JsonApiError e = ((List<JsonApiError>) response.getBody().get("errors")).get(0);
-        assertThat(e.getStatus()).isEqualTo("409");
-        assertThat(e.getCode()).isEqualTo("UNIQUE_VIOLATION");
-        assertThat(e.getDetail()).isNotBlank();
-        assertThat(e.getSource()).containsEntry("pointer", "/data/attributes/name");
+        Map<String, Object> e = firstError(response);
+        assertThat(str(e, "status")).isEqualTo("409");
+        assertThat(str(e, "code")).isEqualTo("UNIQUE_VIOLATION");
+        assertThat(str(e, "detail")).isNotBlank();
+        assertThat(source(e)).containsEntry("pointer", "/data/attributes/name");
     }
 
     @Test
@@ -328,11 +352,31 @@ class GlobalExceptionHandlerTest {
                 handler.handleGenericException(new RuntimeException("secret stack trace"), request);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
-        JsonApiError e = ((List<JsonApiError>) response.getBody().get("errors")).get(0);
-        assertThat(e.getStatus()).isEqualTo("500");
-        assertThat(e.getCode()).isEqualTo("INTERNAL_ERROR");
+        Map<String, Object> e = firstError(response);
+        assertThat(str(e, "status")).isEqualTo("500");
+        assertThat(str(e, "code")).isEqualTo("INTERNAL_ERROR");
         // detail must not leak the original exception message
-        assertThat(e.getDetail()).doesNotContain("secret stack trace");
+        assertThat(str(e, "detail")).doesNotContain("secret stack trace");
+    }
+
+    @Test
+    void errorEnvelope_serializesWithAllMembers() {
+        // Regression: the deployed worker returned {"errors":[{}]} — the bean
+        // members were dropped at serialization time. The envelope is maps now,
+        // so any mapper must produce the full JSON:API error object.
+        ValidationResult result = ValidationResult.failure(List.of(
+                new io.kelta.runtime.validation.FieldError("filters", "Invalid type, expected JSON", "type")));
+
+        ResponseEntity<Map<String, Object>> response =
+                handler.handleValidationException(new ValidationException(result), request);
+
+        String json = new tools.jackson.databind.ObjectMapper().writeValueAsString(response.getBody());
+        assertThat(json)
+                .contains("\"status\":\"400\"")
+                .contains("\"code\":\"type\"")
+                .contains("\"detail\":\"Invalid type, expected JSON\"")
+                .contains("\"pointer\":\"/data/attributes/filters\"")
+                .doesNotContain("{}");
     }
 
     static class Sample {

--- a/kelta-platform/runtime/runtime-jsonapi/src/main/java/io/kelta/jsonapi/JsonApiError.java
+++ b/kelta-platform/runtime/runtime-jsonapi/src/main/java/io/kelta/jsonapi/JsonApiError.java
@@ -80,6 +80,27 @@ public class JsonApiError {
         this.meta = meta;
     }
 
+    /**
+     * The error as a plain map (nulls omitted), in JSON:API member order.
+     *
+     * <p>Response bodies are built from these maps rather than the bean itself:
+     * plain maps serialize identically under every converter/mapper
+     * configuration, whereas bean serialization has been observed to drop all
+     * members on the deployed worker ({@code {"errors":[{}]}}), leaving the
+     * real failure reason only in the logs.
+     */
+    public Map<String, Object> toMap() {
+        Map<String, Object> map = new java.util.LinkedHashMap<>();
+        if (id != null) map.put("id", id);
+        if (status != null) map.put("status", status);
+        if (code != null) map.put("code", code);
+        if (title != null) map.put("title", title);
+        if (detail != null) map.put("detail", detail);
+        if (source != null) map.put("source", source);
+        if (meta != null) map.put("meta", meta);
+        return map;
+    }
+
     @Override
     public String toString() {
         return "JsonApiError{" +

--- a/kelta-platform/runtime/runtime-jsonapi/src/test/java/io/kelta/jsonapi/JsonApiErrorToMapTest.java
+++ b/kelta-platform/runtime/runtime-jsonapi/src/test/java/io/kelta/jsonapi/JsonApiErrorToMapTest.java
@@ -1,0 +1,48 @@
+package io.kelta.jsonapi;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * {@link JsonApiError#toMap()} is what response bodies are built from —
+ * plain maps serialize identically under every mapper configuration, unlike
+ * the bean itself (observed as {@code {"errors":[{}]}} on the deployed worker).
+ */
+class JsonApiErrorToMapTest {
+
+    @Test
+    void toMapCarriesAllSetMembersAndOmitsNulls() {
+        JsonApiError error = new JsonApiError("422", "VALIDATION_RULE_FAILED",
+                "Validation Error", "amountMax must be >= amountMin");
+        error.setSource(Map.of("pointer", "/data/attributes/amountMax"));
+        error.setMeta(Map.of("requestId", "abc12345"));
+
+        Map<String, Object> map = error.toMap();
+
+        assertEquals("422", map.get("status"));
+        assertEquals("VALIDATION_RULE_FAILED", map.get("code"));
+        assertEquals("Validation Error", map.get("title"));
+        assertEquals("amountMax must be >= amountMin", map.get("detail"));
+        assertEquals(Map.of("pointer", "/data/attributes/amountMax"), map.get("source"));
+        assertEquals(Map.of("requestId", "abc12345"), map.get("meta"));
+        assertFalse(map.containsKey("id"), "unset members must be omitted");
+    }
+
+    @Test
+    void envelopeOfMapsSerializesWithMembers() {
+        JsonApiError error = new JsonApiError("400", "VALIDATION_FAILED", "Validation Error", "name is required");
+
+        String json = new tools.jackson.databind.ObjectMapper()
+                .writeValueAsString(Map.of("errors", List.of(error.toMap())));
+
+        assertTrue(json.contains("\"detail\":\"name is required\""), json);
+        assertTrue(json.contains("\"code\":\"VALIDATION_FAILED\""), json);
+        assertFalse(json.contains("{}"), json);
+    }
+}


### PR DESCRIPTION
## Summary
Seven confirmed defects in the MCP admin tooling (and two worker-side issues they exposed), all found 2026-07-10 while building the `student-incentives` tenant end-to-end over `/mcp/admin`. Companion to #1221 (hyphen-name refresh regression) — this PR is everything else from that investigation.

1. **Wrong-id JSON parsing** — `FieldBodyBuilder.extractFirstId` took the first `"id"` after `"data"`, which is `relationships.createdBy.data.id` (the acting **user's** UUID) because the worker serializes `relationships` before the record `id`. Every `add_field` by collectionName and every `create_collection` inline field posted `collectionId=<user-uuid>` → 400; collections were silently created with **zero fields**. Replaced with Jackson parsing in a new shared `AdminLookups` (list → `data[0].id`, single → `data.id`), with a realistic relationships-first regression test.
2. **Type alias map completed** — `TEXT`, `CURRENCY`, `PERCENT`, `URL`, `EMAIL`, `PHONE`, `AUTO_NUMBER`, `EXTERNAL_ID`, `ENCRYPTED`, `GEOLOCATION`, `ARRAY` were rejected outright. Every `FieldType` enum name now passes verbatim + friendly aliases. (`text`/`longText` still map to STRING — the admin UI has no `text` renderer; same Postgres column type.)
3. **UI config dialects** — the field editor resolves picklists via `fieldTypeConfig.globalPicklistId` and displays `referenceTarget` on relationship fields; the builder wrote `picklistSourceId` and never set `referenceTarget`, so MCP-created fields showed **no picklist binding and no target collection** in the UI. Canonical shape is now the UI's.
4. **create_validation_rule** — posted `/api/validationRules` (404) and documented inverted semantics. Now posts `/api/validation-rules` with `errorConditionFormula` (record REJECTED when TRUE), `evaluateOn`/`severity`/`errorField` args, and negates legacy `expression` args (`NOT(...)`) to preserve their documented must-hold meaning.
5. **create_listview** — posted `/api/listViews` (404) with pass-through attrs. Now `/api/list-views` with resolved `collectionId`, `columns` array, sort mapping, and **always sends `filters`** (see 7).
6. **create_layout / update_collection** — layout tool posted `/api/pageLayouts|layoutSections|layoutFields` (404) with attrs the worker never understood; now kebab routes with `collectionId`/`layoutId`+`heading`/`sectionId`+`fieldId` (resolved from fieldName, unknown names reported per-entry). `update_collection` gained `displayFieldName` → `displayFieldId` resolution and accepts a collection name as `id`.
7. **Worker: string defaults on JSON fields** — `list-views.filters "[]"`, `dashboard-components.config "{}"`, `flow-executions.variables "{}"` are injected verbatim on create and fail their own type validation ("Invalid type, expected JSON"). All now JSON values; `SystemCollectionJsonDefaultsTest` guards every system collection against recurrence.
8. **Worker: empty error envelopes** — validation failures returned `{"errors":[{}]}` with the real message only in pod logs (bean members dropped at serialization on the deployed worker). `GlobalExceptionHandler` now builds bodies from `JsonApiError.toMap()` — plain maps serialize identically under every mapper configuration (the record pipeline is map-based and never had this problem). Envelope shape on the wire is unchanged, just no longer empty; wire-shape regression test included.

## Changes
- `kelta-mcp/.../admin/AdminLookups.java` (new) — Jackson-based name/id resolution shared by admin tools
- `kelta-mcp/.../admin/{FieldBodyBuilder, AddFieldTool, CreateValidationRuleTool, CreateListViewTool, CreateLayoutTool, UpdateCollectionTool}.java`
- `runtime-core/.../SystemCollectionDefinitions.java` — 3 JSON defaults fixed
- `runtime-core/.../GlobalExceptionHandler.java` + `runtime-jsonapi/.../JsonApiError.java` (`toMap()`)
- Tests: new `CreateValidationRuleToolTest`, `CreateListViewToolTest`, `UpdateCollectionToolTest`, `SystemCollectionJsonDefaultsTest`, `JsonApiErrorToMapTest`; `AddFieldToolTest`/`CreateLayoutToolTest`/`GlobalExceptionHandlerTest` updated (incl. serialized wire-shape assertions)
- `.claude/docs/concerns.md` — batch documented with the never-again rules

## Testing
- kelta-mcp: 216/216 ✅ · runtime-core + runtime-jsonapi targeted suites ✅
- Full verify: runtime build ✅, gateway `mvn verify` ✅, worker `mvn verify` ✅, kelta-web lint/typecheck/format/965 tests ✅ (kelta-ui untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)