### PR TITLE
fix(worker): chunk Cerbos batch checks at the server's 50-resource limit

### DIFF
--- a/.claude/docs/concerns.md
+++ b/.claude/docs/concerns.md
@@ -190,6 +190,23 @@ an audit feed.
 
 (No open bugs from the original audit. See Resolved → Bugs.)
 
+**FIXED (fix/cerbos-batch-chunking) — list pages over 50 rows silently emptied by the Cerbos
+batch limit (found 2026-07-10, in production).** The Cerbos server rejects CheckResources
+requests over 50 resources (`INVALID_ARGUMENT: number of resources in batch (N) exceeds
+configured limit (50)`). `CerbosAuthorizationService.batchCheckRecordAccess` sent the whole
+page in one call, so any authenticated list read with `page[size] > 50` on a 51+-row collection
+failed the check, fail-closed stripped **every** row, and the response went out as HTTP 200 with
+`data: []` and a correct `totalCount` — indistinguishable from an empty collection. Three such
+pages also tripped the Cerbos circuit breaker, denying ALL field+record access pod-wide for 10s
+(one over-sized client query = tenant-wide authz brownout). Previously misdiagnosed as an MCP
+`ResponseShaper` bug; MCP `query_collection` and REST both die on it because it lives in the
+worker. `batchCheckFieldAccess` had the same unbounded batch (collections with >50 fields).
+Both now split into ≤50-resource sequential Cerbos calls (`MAX_RESOURCES_PER_CHECK`): record
+chunks fail closed independently (a bad chunk denies only its own records), field chunks deny
+everything and skip the cache write on any failure (a partial allow-set under the full asked-set
+would persist phantom denials). Regression tests in `CerbosAuthorizationServiceTest` (chunk
+fan-out, partial-failure semantics, cache integrity).
+
 **FIXED (fix/mcp-admin-tooling-gaps) — kelta-mcp admin tooling batch (7 defects found building a tenant end-to-end over MCP, 2026-07-10).**
 (1) `FieldBodyBuilder.extractFirstId` substring-scanned for the first `"id"` after `"data"` and
 returned `relationships.createdBy.data.id` — the acting *user's* UUID — because worker responses

--- a/kelta-worker/src/main/java/io/kelta/worker/service/CerbosAuthorizationService.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/service/CerbosAuthorizationService.java
@@ -49,6 +49,16 @@ public class CerbosAuthorizationService {
     /** Maximum time (seconds) to wait for a single Cerbos gRPC call. */
     private static final long CERBOS_TIMEOUT_SECONDS = 2;
 
+    /**
+     * Maximum resources per CheckResources call. The Cerbos server rejects larger
+     * batches with INVALID_ARGUMENT ("number of resources in batch (N) exceeds
+     * configured limit (50)" — its default {@code requestLimits.maxActionsPerResource}
+     * companion limit). Larger inputs are transparently split into sequential calls;
+     * without this, any list page over 50 rows came back fully stripped (fail-closed)
+     * and three such pages opened the circuit breaker for the whole pod.
+     */
+    private static final int MAX_RESOURCES_PER_CHECK = 50;
+
     // Circuit breaker thresholds — configurable via kelta.worker.cerbos-cb-threshold
     // and kelta.worker.cerbos-cb-cooldown-seconds (see WorkerProperties).
 
@@ -304,57 +314,69 @@ public class CerbosAuthorizationService {
             toQuery.addAll(cached.asked());
         }
 
-        Future<Set<String>> future = cerbosExecutor.submit(() -> {
-            Principal principal = buildPrincipal(email, profileId, tenantId);
-
-            var batchRequest = cerbosClient.batch(principal);
-            for (String fieldId : toQuery) {
-                Resource resource = Resource.newInstance("field", fieldId)
-                        .withAttribute("collectionId", AttributeValue.stringValue(collectionId))
-                        .withAttribute("fieldId", AttributeValue.stringValue(fieldId))
-                        .withScope(tenantId);
-                batchRequest.addResourceAndActions(resource, action);
+        // All chunks must succeed before the cache is written: a partial allow-set
+        // stored under the full asked-set would persist denials for fields Cerbos
+        // never answered about. Any chunk failure → deny everything, no cache write.
+        Set<String> allowed = new HashSet<>();
+        for (List<String> chunk : partition(List.copyOf(toQuery), MAX_RESOURCES_PER_CHECK)) {
+            if (isCircuitOpen()) {
+                log.warn("Cerbos circuit open — denying all field access (fail-closed): user={} collection={}",
+                        email, collectionId);
+                return List.of();
             }
+            Future<Set<String>> future = cerbosExecutor.submit(() -> {
+                Principal principal = buildPrincipal(email, profileId, tenantId);
 
-            CheckResourcesResult result = batchRequest.check();
-            Set<String> allowed = new HashSet<>();
-            for (String fieldId : toQuery) {
-                result.find(fieldId).ifPresentOrElse(
-                        checkResult -> {
-                            if (checkResult.isAllowed(action)) {
-                                allowed.add(fieldId);
-                            }
-                        },
-                        () -> log.warn("Cerbos batch field check: field not found in result (fail-closed): field={}", fieldId)
-                );
+                var batchRequest = cerbosClient.batch(principal);
+                for (String fieldId : chunk) {
+                    Resource resource = Resource.newInstance("field", fieldId)
+                            .withAttribute("collectionId", AttributeValue.stringValue(collectionId))
+                            .withAttribute("fieldId", AttributeValue.stringValue(fieldId))
+                            .withScope(tenantId);
+                    batchRequest.addResourceAndActions(resource, action);
+                }
+
+                CheckResourcesResult result = batchRequest.check();
+                Set<String> chunkAllowed = new HashSet<>();
+                for (String fieldId : chunk) {
+                    result.find(fieldId).ifPresentOrElse(
+                            checkResult -> {
+                                if (checkResult.isAllowed(action)) {
+                                    chunkAllowed.add(fieldId);
+                                }
+                            },
+                            () -> log.warn("Cerbos batch field check: field not found in result (fail-closed): field={}", fieldId)
+                    );
+                }
+                return chunkAllowed;
+            });
+
+            try {
+                allowed.addAll(future.get(CERBOS_TIMEOUT_SECONDS, TimeUnit.SECONDS));
+                recordSuccess();
+            } catch (TimeoutException e) {
+                future.cancel(true);
+                recordFailure();
+                log.error("Cerbos batch field check timed out (fail-closed): user={} collection={} fields={}",
+                        email, collectionId, fieldIds.size());
+                return List.of();
+            } catch (Exception e) {
+                future.cancel(true);
+                recordFailure();
+                log.error("Cerbos batch field check failed (fail-closed): user={} collection={} error={}",
+                        email, collectionId, e.getMessage());
+                return List.of();
             }
-            return allowed;
-        });
-
-        try {
-            Set<String> allowed = future.get(CERBOS_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-            recordSuccess();
-            fieldAccessCache.put(cacheKey,
-                    new FieldAccessEntry(Set.copyOf(toQuery), Set.copyOf(allowed)));
-            List<String> result = fieldIds.stream()
-                    .filter(allowed::contains)
-                    .toList();
-            log.debug("Cerbos batch field check: user={} collection={} fields={} allowed={}",
-                    email, collectionId, fieldIds.size(), result.size());
-            return result;
-        } catch (TimeoutException e) {
-            future.cancel(true);
-            recordFailure();
-            log.error("Cerbos batch field check timed out (fail-closed): user={} collection={} fields={}",
-                    email, collectionId, fieldIds.size());
-            return List.of();
-        } catch (Exception e) {
-            future.cancel(true);
-            recordFailure();
-            log.error("Cerbos batch field check failed (fail-closed): user={} collection={} error={}",
-                    email, collectionId, e.getMessage());
-            return List.of();
         }
+
+        fieldAccessCache.put(cacheKey,
+                new FieldAccessEntry(Set.copyOf(toQuery), Set.copyOf(allowed)));
+        List<String> result = fieldIds.stream()
+                .filter(allowed::contains)
+                .toList();
+        log.debug("Cerbos batch field check: user={} collection={} fields={} allowed={}",
+                email, collectionId, fieldIds.size(), result.size());
+        return result;
     }
 
     /**
@@ -373,69 +395,88 @@ public class CerbosAuthorizationService {
             return Set.of();
         }
 
-        Future<Set<String>> future = cerbosExecutor.submit(() -> {
-            Principal principal = buildPrincipal(email, profileId, tenantId);
+        // Chunks are independent: a failed chunk denies only its own records
+        // (fail-closed) while the rest of the page stays authorized, so one bad
+        // gRPC call degrades a page instead of blanking it.
+        Set<String> allowed = new HashSet<>();
+        for (List<Map<String, Object>> chunk : partition(records, MAX_RESOURCES_PER_CHECK)) {
+            if (isCircuitOpen()) {
+                log.warn("Cerbos circuit open — denying remaining record access (fail-closed): user={} collection={}",
+                        email, collectionId);
+                break;
+            }
+            Future<Set<String>> future = cerbosExecutor.submit(() -> {
+                Principal principal = buildPrincipal(email, profileId, tenantId);
 
-            var batchRequest = cerbosClient.batch(principal);
-            for (Map<String, Object> record : records) {
-                String recordId = (String) record.get("id");
-                if (recordId == null) continue;
+                var batchRequest = cerbosClient.batch(principal);
+                for (Map<String, Object> record : chunk) {
+                    String recordId = (String) record.get("id");
+                    if (recordId == null) continue;
 
-                Resource resource = Resource.newInstance("record", recordId)
-                        .withAttribute("collectionId", AttributeValue.stringValue(collectionId))
-                        .withAttribute("tenantId", stringAttr(tenantId));
+                    Resource resource = Resource.newInstance("record", recordId)
+                            .withAttribute("collectionId", AttributeValue.stringValue(collectionId))
+                            .withAttribute("tenantId", stringAttr(tenantId));
 
-                @SuppressWarnings("unchecked")
-                Map<String, Object> attrs = (Map<String, Object>) record.get("attributes");
-                if (attrs != null) {
-                    for (Map.Entry<String, Object> entry : attrs.entrySet()) {
-                        if (entry.getValue() != null) {
-                            resource = resource.withAttribute(entry.getKey(), toAttributeValue(entry.getValue()));
+                    @SuppressWarnings("unchecked")
+                    Map<String, Object> attrs = (Map<String, Object>) record.get("attributes");
+                    if (attrs != null) {
+                        for (Map.Entry<String, Object> entry : attrs.entrySet()) {
+                            if (entry.getValue() != null) {
+                                resource = resource.withAttribute(entry.getKey(), toAttributeValue(entry.getValue()));
+                            }
                         }
                     }
+                    resource = resource.withScope(tenantId);
+                    batchRequest.addResourceAndActions(resource, action);
                 }
-                resource = resource.withScope(tenantId);
-                batchRequest.addResourceAndActions(resource, action);
-            }
 
-            CheckResourcesResult result = batchRequest.check();
-            Set<String> allowed = new java.util.HashSet<>();
-            for (Map<String, Object> record : records) {
-                String recordId = (String) record.get("id");
-                if (recordId == null) {
-                    continue;
+                CheckResourcesResult result = batchRequest.check();
+                Set<String> chunkAllowed = new HashSet<>();
+                for (Map<String, Object> record : chunk) {
+                    String recordId = (String) record.get("id");
+                    if (recordId == null) {
+                        continue;
+                    }
+                    result.find(recordId).ifPresentOrElse(
+                            checkResult -> {
+                                if (checkResult.isAllowed(action)) {
+                                    chunkAllowed.add(recordId);
+                                }
+                            },
+                            () -> log.warn("Cerbos batch record check: record not found in result (fail-closed): record={}", recordId)
+                    );
                 }
-                result.find(recordId).ifPresentOrElse(
-                        checkResult -> {
-                            if (checkResult.isAllowed(action)) {
-                                allowed.add(recordId);
-                            }
-                        },
-                        () -> log.warn("Cerbos batch record check: record not found in result (fail-closed): record={}", recordId)
-                );
-            }
-            return allowed;
-        });
+                return chunkAllowed;
+            });
 
-        try {
-            Set<String> allowed = future.get(CERBOS_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-            recordSuccess();
-            log.debug("Cerbos batch record check: user={} collection={} records={} allowed={}",
-                    email, collectionId, records.size(), allowed.size());
-            return allowed;
-        } catch (TimeoutException e) {
-            future.cancel(true);
-            recordFailure();
-            log.error("Cerbos batch record check timed out (fail-closed): user={} collection={} records={}",
-                    email, collectionId, records.size());
-            return Set.of();
-        } catch (Exception e) {
-            future.cancel(true);
-            recordFailure();
-            log.error("Cerbos batch record check failed (fail-closed): user={} collection={} error={}",
-                    email, collectionId, e.getMessage());
-            return Set.of();
+            try {
+                allowed.addAll(future.get(CERBOS_TIMEOUT_SECONDS, TimeUnit.SECONDS));
+                recordSuccess();
+            } catch (TimeoutException e) {
+                future.cancel(true);
+                recordFailure();
+                log.error("Cerbos batch record check timed out (chunk denied, fail-closed): user={} collection={} chunk={}",
+                        email, collectionId, chunk.size());
+            } catch (Exception e) {
+                future.cancel(true);
+                recordFailure();
+                log.error("Cerbos batch record check failed (chunk denied, fail-closed): user={} collection={} error={}",
+                        email, collectionId, e.getMessage());
+            }
         }
+
+        log.debug("Cerbos batch record check: user={} collection={} records={} allowed={}",
+                email, collectionId, records.size(), allowed.size());
+        return allowed;
+    }
+
+    /** Splits {@code items} into consecutive sublists of at most {@code size} elements. */
+    private static <T> List<List<T>> partition(List<T> items, int size) {
+        List<List<T>> chunks = new java.util.ArrayList<>();
+        for (int i = 0; i < items.size(); i += size) {
+            chunks.add(items.subList(i, Math.min(i + size, items.size())));
+        }
+        return chunks;
     }
 
     /**

--- a/kelta-worker/src/test/java/io/kelta/worker/service/CerbosAuthorizationServiceTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/service/CerbosAuthorizationServiceTest.java
@@ -21,6 +21,7 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
@@ -316,6 +317,105 @@ class CerbosAuthorizationServiceTest {
                     "user@test.com", "profile-1", "tenant-1", "col-1", List.of(), "read");
             assertThat(result).isEmpty();
             verifyNoInteractions(cerbosClient);
+        }
+    }
+
+    @Nested
+    @DisplayName("Batch chunking (Cerbos 50-resource request limit)")
+    class BatchChunking {
+
+        private List<java.util.Map<String, Object>> records(int count) {
+            List<java.util.Map<String, Object>> records = new java.util.ArrayList<>();
+            for (int i = 0; i < count; i++) {
+                records.add(java.util.Map.of("id", "rec-" + i, "attributes", java.util.Map.of()));
+            }
+            return records;
+        }
+
+        @Test
+        @DisplayName("record check over 50 records splits into multiple Cerbos calls and allows all")
+        void recordCheckChunksLargePages() {
+            when(cerbosClient.batch(any(Principal.class))).thenReturn(batchRequest);
+            when(batchRequest.check()).thenReturn(batchResult);
+            when(batchResult.find(anyString())).thenReturn(Optional.of(fieldCheckResult));
+            when(fieldCheckResult.isAllowed("read")).thenReturn(true);
+
+            java.util.Set<String> allowed = service.batchCheckRecordAccess(
+                    "user@test.com", "profile-1", "tenant-1", "col-1", records(82), "read");
+
+            // 82 records → 50 + 32; a single 82-resource call is rejected by the
+            // Cerbos server (INVALID_ARGUMENT over its 50-resource request limit).
+            assertThat(allowed).hasSize(82);
+            verify(cerbosClient, times(2)).batch(any());
+        }
+
+        @Test
+        @DisplayName("a failed record chunk is denied without blanking the other chunks")
+        void failedRecordChunkDegradesPartially() {
+            when(cerbosClient.batch(any(Principal.class))).thenReturn(batchRequest);
+            when(batchRequest.check())
+                    .thenReturn(batchResult)
+                    .thenThrow(new RuntimeException("cerbos unavailable"));
+            when(batchResult.find(anyString())).thenReturn(Optional.of(fieldCheckResult));
+            when(fieldCheckResult.isAllowed("read")).thenReturn(true);
+
+            java.util.Set<String> allowed = service.batchCheckRecordAccess(
+                    "user@test.com", "profile-1", "tenant-1", "col-1", records(82), "read");
+
+            // First chunk (records 0-49) allowed; failed second chunk fail-closed.
+            assertThat(allowed).hasSize(50);
+            assertThat(allowed).contains("rec-0", "rec-49").doesNotContain("rec-50", "rec-81");
+        }
+
+        @Test
+        @DisplayName("field check over 50 fields splits into multiple Cerbos calls and caches the union")
+        void fieldCheckChunksLargeFieldSets() {
+            when(cerbosClient.batch(any(Principal.class))).thenReturn(batchRequest);
+            when(batchRequest.check()).thenReturn(batchResult);
+            when(batchResult.find(anyString())).thenReturn(Optional.of(fieldCheckResult));
+            when(fieldCheckResult.isAllowed("read")).thenReturn(true);
+
+            List<String> fields = new java.util.ArrayList<>();
+            for (int i = 0; i < 120; i++) {
+                fields.add("field-" + i);
+            }
+
+            List<String> result = service.batchCheckFieldAccess(
+                    "user@test.com", "profile-1", "tenant-1", "col-1", fields, "read");
+            assertThat(result).hasSize(120);
+            verify(cerbosClient, times(3)).batch(any());
+
+            // Second call is fully served from the cache — no further Cerbos calls.
+            List<String> cached = service.batchCheckFieldAccess(
+                    "user@test.com", "profile-1", "tenant-1", "col-1", fields, "read");
+            assertThat(cached).hasSize(120);
+            verify(cerbosClient, times(3)).batch(any());
+        }
+
+        @Test
+        @DisplayName("a failed field chunk denies everything and skips the cache write")
+        void failedFieldChunkDeniesAllAndDoesNotCache() {
+            when(cerbosClient.batch(any(Principal.class))).thenReturn(batchRequest);
+            when(batchRequest.check()).thenThrow(new RuntimeException("cerbos unavailable"));
+
+            List<String> fields = new java.util.ArrayList<>();
+            for (int i = 0; i < 60; i++) {
+                fields.add("field-" + i);
+            }
+
+            List<String> result = service.batchCheckFieldAccess(
+                    "user@test.com", "profile-1", "tenant-1", "col-1", fields, "read");
+            assertThat(result).isEmpty();
+
+            // No cache entry was written: the retry goes back to Cerbos.
+            // doReturn: re-stubbing check() via when() would invoke the throwing stub.
+            doReturn(batchResult).when(batchRequest).check();
+            when(batchResult.find(anyString())).thenReturn(Optional.of(fieldCheckResult));
+            when(fieldCheckResult.isAllowed("read")).thenReturn(true);
+
+            List<String> retry = service.batchCheckFieldAccess(
+                    "user@test.com", "profile-1", "tenant-1", "col-1", fields, "read");
+            assertThat(retry).hasSize(60);
         }
     }
 


### PR DESCRIPTION
## Summary
- Any authenticated list read with `page[size] > 50` on a 51+-row collection sent one oversized CheckResources call; the Cerbos server rejects >50 resources (`INVALID_ARGUMENT`), the fail-closed handler stripped **every** row, and the response went out **HTTP 200 with `data: []` and a correct `totalCount`** — indistinguishable from an empty collection.
- Three such pages tripped the Cerbos circuit breaker → **all** field+record authz denied pod-wide for 10s (one oversized client query = tenant-wide authz brownout).
- Hit in production today by the student-incentives site build (82 `program-translations` at `page[size]=200`) — the live site rendered "0 programs". Previously misdiagnosed as an MCP `ResponseShaper` bug; REST and MCP both flow through this worker path.
- `batchCheckRecordAccess` and `batchCheckFieldAccess` now split into ≤50-resource sequential Cerbos calls (`MAX_RESOURCES_PER_CHECK = 50`).

## Semantics (fail-closed preserved)
- **Record chunks fail independently**: a failed chunk denies only its own records — a bad gRPC call degrades a page instead of blanking it.
- **Field chunks fail atomically**: any failure denies everything and skips the cache write — a partial allow-set cached under the full asked-set would persist phantom denials.
- Circuit breaker unchanged; per-chunk breaker check stops mid-loop when open.

## Changes
- `kelta-worker/.../service/CerbosAuthorizationService.java` — chunking in both batch methods + `partition` helper
- `kelta-worker/.../service/CerbosAuthorizationServiceTest.java` — 4 new tests: chunk fan-out (records + fields), partial-failure record semantics, field cache-integrity on failure
- `.claude/docs/concerns.md` — Known Bugs entry

## Testing
- `CerbosAuthorizationServiceTest`: 17/17
- Full worker suite: 1919 tests, 0 failures

## Security note
Touches the Cerbos authz path — **no auto-merge** per SECURITY.md; needs a human merge. Deny-by-default is preserved in every failure mode; this only removes the false-deny on oversized batches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)