### PR TITLE
fix(runtime): migrate unique constraints on flag toggles + name real fields in violation errors

### DIFF
--- a/.claude/docs/concerns.md
+++ b/.claude/docs/concerns.md
@@ -190,6 +190,26 @@ an audit feed.
 
 (No open bugs from the original audit. See Resolved → Bugs.)
 
+**FIXED (fix/unique-constraint-migration) — field `unique` flag toggles never reached the
+physical schema, and unique-violation 409s named the wrong field (found 2026-07-10 operating
+the student-incentives tenant).** (1) `SchemaMigrationEngine.migrateSchema` diffed added/
+removed/type-changed fields but never the `unique` flag, so PATCHing `unique=false` updated
+metadata while the Postgres constraint (default-named `<table>_<column>_key` from the inline
+`CREATE TABLE ... UNIQUE`) kept rejecting inserts — cross-tenant-invisible and only fixable via
+psql. Now a toggle resolves the actual single-column UNIQUE constraint name(s) from
+`information_schema` (legacy default names included) and drops them (true→false) or adds a
+hyphen-safe `uniq_<table>_<column>` constraint (false→true, idempotent under NATS event
+redelivery, skipped when any constraint already covers the column). Composite `uniq_*`
+*indexes* (CompositeUniqueConstraintService) and the EXTERNAL_ID unique index are untouched —
+the catalog lookup matches single-column constraints only. History rows recorded as
+`ALTER_UNIQUE`. (2) `detectUniqueViolationField` reported the *index name* for composite
+violations and probed only fields still flagged `unique` (a stale physical index therefore
+reported `unknown`); it now parses the Postgres error detail (`Key (country, slug)=(…)`) and
+maps physical columns back to field names, falling back to the old name/probe paths for
+drivers without that detail (H2). Tests: `SchemaMigrationEngineTest$UniqueFlagToggleTests`
+(H2 toggle both ways, idempotence, composite-index survival) +
+`PhysicalTableStorageAdapterTest$UniqueViolationColumnExtraction`.
+
 **FIXED (fix/cerbos-batch-chunking) — list pages over 50 rows silently emptied by the Cerbos
 batch limit (found 2026-07-10, in production).** The Cerbos server rejects CheckResources
 requests over 50 resources (`INVALID_ARGUMENT: number of resources in batch (N) exceeds

--- a/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/storage/PhysicalTableStorageAdapter.java
+++ b/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/storage/PhysicalTableStorageAdapter.java
@@ -27,6 +27,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -1519,6 +1520,23 @@ public class PhysicalTableStorageAdapter implements StorageAdapter {
      */
     private String detectUniqueViolationField(CollectionDefinition definition, Map<String, Object> data,
             DuplicateKeyException e) {
+        // Best source: the Postgres error detail names the violated columns exactly —
+        // "Key (country, slug)=(..., erasmus-plus) already exists." Map the physical
+        // columns back to field names so the client learns the real field set, for
+        // composite constraints and for single columns alike (including stale indexes
+        // whose field no longer carries unique=true in metadata).
+        List<String> violatedColumns = extractViolatedColumns(e);
+        if (!violatedColumns.isEmpty()) {
+            Map<String, String> fieldByColumn = new LinkedHashMap<>();
+            for (FieldDefinition field : definition.fields()) {
+                fieldByColumn.put(getColumnName(definition, field), field.name());
+            }
+            fieldByColumn.putIfAbsent("id", "id");
+            return violatedColumns.stream()
+                    .map(column -> fieldByColumn.getOrDefault(column, column))
+                    .collect(Collectors.joining(", "));
+        }
+
         // Composite unique indexes created by CompositeUniqueConstraintService use the
         // "uniq_<table>_<col1>_<col2>" naming convention — surface that instead of
         // pretending the duplicate belongs to a single field.
@@ -1542,6 +1560,42 @@ public class PhysicalTableStorageAdapter implements StorageAdapter {
         }
 
         return "unknown";
+    }
+
+    private static final java.util.regex.Pattern DUPLICATE_KEY_DETAIL =
+            java.util.regex.Pattern.compile("Key \\((.+?)\\)=");
+
+    /**
+     * Pulls the violated column list out of a Postgres duplicate-key error detail
+     * ({@code Key (col1, col2)=(v1, v2) already exists.}). Returns an empty list when
+     * the driver message carries no such detail (e.g. H2's message format), in which
+     * case callers fall back to name- and probe-based detection.
+     */
+    static List<String> extractViolatedColumns(DuplicateKeyException e) {
+        Throwable cause = e;
+        while (cause != null) {
+            String msg = cause.getMessage();
+            if (msg != null) {
+                var matcher = DUPLICATE_KEY_DETAIL.matcher(msg);
+                if (matcher.find()) {
+                    List<String> columns = new ArrayList<>();
+                    for (String part : matcher.group(1).split(",")) {
+                        String column = part.trim();
+                        if (column.length() > 1 && column.startsWith("\"") && column.endsWith("\"")) {
+                            column = column.substring(1, column.length() - 1);
+                        }
+                        if (!column.isEmpty()) {
+                            columns.add(column);
+                        }
+                    }
+                    if (!columns.isEmpty()) {
+                        return columns;
+                    }
+                }
+            }
+            cause = cause.getCause();
+        }
+        return List.of();
     }
 
     /**

--- a/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/storage/SchemaMigrationEngine.java
+++ b/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/storage/SchemaMigrationEngine.java
@@ -6,6 +6,7 @@ import io.kelta.runtime.model.FieldType;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.dao.DataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
 
@@ -71,7 +72,8 @@ public class SchemaMigrationEngine {
         ADD_COLUMN,
         DEPRECATE_COLUMN,
         ALTER_COLUMN_TYPE,
-        DROP_COLUMN
+        DROP_COLUMN,
+        ALTER_UNIQUE
     }
     
     private static final String MIGRATIONS_TABLE = "kelta_migrations";
@@ -282,8 +284,112 @@ public class SchemaMigrationEngine {
             executeMigration(migration);
         }
 
+        // Detect unique-flag toggles. These need a live constraint-catalog lookup
+        // (legacy constraints carry Postgres default names like <table>_<column>_key),
+        // so they are applied directly rather than as precomputed MigrationActions —
+        // and after the loop above, so a just-added or just-retyped column exists.
+        int uniqueToggles = 0;
+        for (FieldDefinition newField : newDefinition.fields()) {
+            FieldDefinition oldField = oldDefinition.getField(newField.name());
+            if (oldField == null || !newField.type().hasPhysicalColumn()) {
+                continue;
+            }
+            if (oldField.unique() != newField.unique()) {
+                applyUniqueToggle(newDefinition, newField, tableRef, newField.unique());
+                uniqueToggles++;
+            }
+        }
+
         log.info("Schema migration completed for collection '{}': {} changes applied",
-            newDefinition.name(), migrations.size());
+            newDefinition.name(), migrations.size() + uniqueToggles);
+    }
+
+    /**
+     * Adds or drops the single-column UNIQUE constraint backing a field's
+     * {@code unique} flag.
+     *
+     * <p>Dropping resolves the actual constraint name(s) from the catalog instead of
+     * guessing: constraints created inline by {@code CREATE TABLE ... UNIQUE} carry the
+     * Postgres default name ({@code <table>_<column>_key}), while ones added by this
+     * method are named {@code uniq_<table>_<column>}. Only single-column UNIQUE
+     * constraints on exactly this column are touched — composite uniques (which are
+     * separate {@code uniq_*} <em>indexes</em> managed by
+     * {@code CompositeUniqueConstraintService}) and the {@code EXTERNAL_ID} unique
+     * index are unaffected. Adding is idempotent: if any single-column UNIQUE
+     * constraint already covers the column (including a legacy-named one), nothing
+     * is done — NATS collection-changed events may reach a pod more than once.
+     */
+    private void applyUniqueToggle(CollectionDefinition definition, FieldDefinition field,
+                                    TableRef tableRef, boolean makeUnique) {
+        String columnName = sanitizeIdentifier(resolvePhysicalColumnName(definition, field));
+        List<String> existing = findSingleColumnUniqueConstraints(tableRef, columnName);
+
+        if (makeUnique) {
+            if (!existing.isEmpty()) {
+                log.info("Unique constraint already present for '{}.{}' ({}), skipping add",
+                    definition.name(), field.name(), existing);
+                return;
+            }
+            String sql = "ALTER TABLE " + tableRef.toSql()
+                + " ADD CONSTRAINT " + uniqueConstraintName(tableRef.tableName(), columnName)
+                + " UNIQUE (" + columnName + ")";
+            try {
+                jdbcTemplate.execute(sql);
+            } catch (DataAccessException e) {
+                throw new StorageException("Failed to add unique constraint for field '"
+                    + field.name() + "' on collection '" + definition.name()
+                    + "' (existing duplicate values block the constraint?)", e);
+            }
+            recordMigration(definition.name(), MigrationType.ALTER_UNIQUE, sql);
+            log.info("Added unique constraint on '{}.{}'", definition.name(), field.name());
+            return;
+        }
+
+        if (existing.isEmpty()) {
+            log.info("No single-column unique constraint found for '{}.{}', nothing to drop",
+                definition.name(), field.name());
+            return;
+        }
+        for (String constraintName : existing) {
+            String sql = "ALTER TABLE " + tableRef.toSql()
+                + " DROP CONSTRAINT \"" + constraintName + "\"";
+            try {
+                jdbcTemplate.execute(sql);
+            } catch (DataAccessException e) {
+                throw new StorageException("Failed to drop unique constraint '" + constraintName
+                    + "' for field '" + field.name() + "' on collection '" + definition.name() + "'", e);
+            }
+            recordMigration(definition.name(), MigrationType.ALTER_UNIQUE, sql);
+        }
+        log.info("Dropped unique constraint(s) {} on '{}.{}'", existing, definition.name(), field.name());
+    }
+
+    /**
+     * Returns the names of UNIQUE constraints that cover exactly (and only) the given
+     * column. {@code LOWER(...)} on both sides keeps the lookup portable between
+     * Postgres (unquoted identifiers fold to lowercase) and H2 (fold to uppercase).
+     */
+    private List<String> findSingleColumnUniqueConstraints(TableRef tableRef, String columnName) {
+        String sql = """
+                SELECT tc.constraint_name
+                FROM information_schema.table_constraints tc
+                JOIN information_schema.constraint_column_usage ccu
+                  ON ccu.constraint_name = tc.constraint_name
+                 AND ccu.constraint_schema = tc.constraint_schema
+                WHERE tc.constraint_type = 'UNIQUE'
+                  AND LOWER(tc.table_schema) = LOWER(?)
+                  AND LOWER(tc.table_name) = LOWER(?)
+                GROUP BY tc.constraint_name
+                HAVING COUNT(*) = 1 AND LOWER(MIN(ccu.column_name)) = LOWER(?)
+                """;
+        return jdbcTemplate.queryForList(sql, String.class,
+            tableRef.schema(), tableRef.tableName(), columnName);
+    }
+
+    /** {@code uniq_<table>_<column>}, hyphen-safe and bounded to Postgres's 63-char limit. */
+    private String uniqueConstraintName(String tableName, String columnName) {
+        String name = "uniq_" + PhysicalTableStorageAdapter.identifierPart(tableName) + "_" + columnName;
+        return name.length() > 63 ? name.substring(0, 63) : name;
     }
     
     /**

--- a/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/storage/PhysicalTableStorageAdapterTest.java
+++ b/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/storage/PhysicalTableStorageAdapterTest.java
@@ -1013,4 +1013,51 @@ class PhysicalTableStorageAdapterTest {
             });
         }
     }
+
+    @Nested
+    @DisplayName("Unique-violation column extraction")
+    class UniqueViolationColumnExtraction {
+
+        private org.springframework.dao.DuplicateKeyException pgStyle(String detail) {
+            // The Postgres driver surfaces the detail inside the nested SQLException
+            // message; Spring wraps it in DuplicateKeyException.
+            return new org.springframework.dao.DuplicateKeyException("duplicate key",
+                new java.sql.SQLException("ERROR: duplicate key value violates unique constraint "
+                    + "\"uniq_incentive_programs_country_slug\"\n  Detail: " + detail));
+        }
+
+        @Test
+        @DisplayName("parses a composite key detail into its column list")
+        void parsesCompositeColumns() {
+            List<String> columns = PhysicalTableStorageAdapter.extractViolatedColumns(
+                pgStyle("Key (country, slug)=(25c26833, erasmus-plus) already exists."));
+            assertEquals(List.of("country", "slug"), columns);
+        }
+
+        @Test
+        @DisplayName("parses a single-column key detail")
+        void parsesSingleColumn() {
+            List<String> columns = PhysicalTableStorageAdapter.extractViolatedColumns(
+                pgStyle("Key (slug)=(erasmus-plus) already exists."));
+            assertEquals(List.of("slug"), columns);
+        }
+
+        @Test
+        @DisplayName("unquotes quoted column identifiers")
+        void unquotesQuotedColumns() {
+            List<String> columns = PhysicalTableStorageAdapter.extractViolatedColumns(
+                pgStyle("Key (\"userId\", \"tenantId\")=(u1, t1) already exists."));
+            assertEquals(List.of("userId", "tenantId"), columns);
+        }
+
+        @Test
+        @DisplayName("returns empty for messages without a Key detail (H2 format)")
+        void emptyWithoutDetail() {
+            org.springframework.dao.DuplicateKeyException h2Style =
+                new org.springframework.dao.DuplicateKeyException("duplicate key",
+                    new java.sql.SQLException("Unique index or primary key violation: "
+                        + "\"PUBLIC.CONSTRAINT_INDEX_4 ON PUBLIC.T(SLUG) VALUES ('x')\""));
+            assertTrue(PhysicalTableStorageAdapter.extractViolatedColumns(h2Style).isEmpty());
+        }
+    }
 }

--- a/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/storage/SchemaMigrationEngineTest.java
+++ b/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/storage/SchemaMigrationEngineTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
@@ -994,6 +995,100 @@ class SchemaMigrationEngineTest {
             assertThrows(IncompatibleSchemaChangeException.class, () ->
                     migrationEngine.migrateSchemaDestructive(
                             oldDef, newDef, TableRef.publicSchema("toggles"), false));
+        }
+    }
+
+    @Nested
+    @DisplayName("Unique flag toggle migrations")
+    class UniqueFlagToggleTests {
+
+        private static final String TABLE = "unique_toggle_items";
+
+        private CollectionDefinition withUnique(boolean unique) {
+            return createCollection(TABLE, List.of(
+                new FieldDefinition("slug", FieldType.STRING, true, false, unique,
+                    null, null, null, null, null),
+                new FieldDefinition("country", FieldType.STRING, true, false, false,
+                    null, null, null, null, null)));
+        }
+
+        private void insertRow(String id, String country, String slug) {
+            jdbcTemplate.update("INSERT INTO " + TABLE
+                + " (id, created_at, updated_at, country, slug) VALUES (?, NOW(), NOW(), ?, ?)",
+                id, country, slug);
+        }
+
+        private int alterUniqueHistoryCount() {
+            Integer count = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM kelta_migrations WHERE collection_name = '" + TABLE
+                    + "' AND migration_type = 'ALTER_UNIQUE'", Integer.class);
+            return count == null ? 0 : count;
+        }
+
+        @BeforeEach
+        void createTable() {
+            // Column-level UNIQUE mirrors what initializeCollection emits — the
+            // database-default-named constraint shape the drop path must resolve
+            // from the catalog (it cannot guess the name).
+            jdbcTemplate.execute("DROP TABLE IF EXISTS " + TABLE);
+            jdbcTemplate.execute("CREATE TABLE " + TABLE + " ("
+                + "id VARCHAR(36) PRIMARY KEY, "
+                + "created_at TIMESTAMP NOT NULL, "
+                + "updated_at TIMESTAMP NOT NULL, "
+                + "country TEXT, "
+                + "slug TEXT UNIQUE)");
+            insertRow("a", "nl", "erasmus-plus");
+        }
+
+        @Test
+        @DisplayName("unique true -> false drops the default-named constraint; duplicates then insert")
+        void dropUniqueAllowsDuplicates() {
+            assertThrows(DataAccessException.class, () -> insertRow("b", "de", "erasmus-plus"));
+
+            migrationEngine.migrateSchema(withUnique(true), withUnique(false));
+
+            insertRow("b", "de", "erasmus-plus");
+            Integer rows = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM " + TABLE + " WHERE slug = 'erasmus-plus'", Integer.class);
+            assertEquals(2, rows);
+            assertEquals(1, alterUniqueHistoryCount());
+        }
+
+        @Test
+        @DisplayName("unique false -> true re-adds a uniq_-named constraint that rejects duplicates")
+        void addUniqueRejectsDuplicates() {
+            migrationEngine.migrateSchema(withUnique(true), withUnique(false));
+            migrationEngine.migrateSchema(withUnique(false), withUnique(true));
+
+            assertThrows(DataAccessException.class, () -> insertRow("b", "de", "erasmus-plus"));
+            assertEquals(2, alterUniqueHistoryCount());
+        }
+
+        @Test
+        @DisplayName("adding when a constraint already covers the column is a no-op (event redelivery)")
+        void addIsIdempotent() {
+            // The CREATE TABLE constraint is still in place; a false -> true toggle
+            // must detect it (whatever its name) and skip the ADD.
+            migrationEngine.migrateSchema(withUnique(false), withUnique(true));
+
+            assertEquals(0, alterUniqueHistoryCount());
+            assertThrows(DataAccessException.class, () -> insertRow("b", "de", "erasmus-plus"));
+        }
+
+        @Test
+        @DisplayName("composite uniq_ indexes on the same column survive a single-column drop")
+        void compositeIndexUntouched() {
+            // The production scenario: single-column unique OFF, composite
+            // (country, slug) uniqueness stays enforced by its separate index.
+            jdbcTemplate.execute("CREATE UNIQUE INDEX uniq_unique_toggle_items_country_slug ON "
+                + TABLE + " (country, slug)");
+
+            migrationEngine.migrateSchema(withUnique(true), withUnique(false));
+
+            // Same slug in another country: now allowed.
+            insertRow("b", "de", "erasmus-plus");
+            // Same (country, slug) pair: still rejected by the composite index.
+            assertThrows(DataAccessException.class, () -> insertRow("c", "de", "erasmus-plus"));
         }
     }
 }


### PR DESCRIPTION
## Summary
- `SchemaMigrationEngine.migrateSchema` diffed added/removed/type-changed fields but never the `unique` flag: PATCHing `attributes.unique=false` updated the field row while the physical Postgres constraint kept rejecting inserts (hit operating the student-incentives tenant — `incentive-programs_slug_key` had to be dropped via psql).
- Toggles now resolve the *actual* single-column UNIQUE constraint name(s) from `information_schema` — legacy Postgres default names (`<table>_<column>_key`) included — and drop them on true→false or add a hyphen-safe `uniq_<table>_<column>` on false→true. Adding is idempotent (skipped when any constraint already covers the column) so NATS event redelivery is safe. Composite `uniq_*` *indexes* (`CompositeUniqueConstraintService`) and the EXTERNAL_ID unique index are untouched; history rows recorded as `ALTER_UNIQUE`.
- Unique-violation 409s now parse the Postgres error detail (`Key (country, slug)=(…) already exists`) and map physical columns back to **field names** — previously composite violations surfaced the raw index name and stale-constraint violations surfaced `unknown`. Falls back to the old name/probe paths for drivers without the detail (H2).

## Changes
- `runtime-core/.../storage/SchemaMigrationEngine.java` — unique-toggle detection + `applyUniqueToggle` + catalog lookup + `ALTER_UNIQUE` history type
- `runtime-core/.../storage/PhysicalTableStorageAdapter.java` — `extractViolatedColumns` + column→field mapping in `detectUniqueViolationField`
- Tests: `SchemaMigrationEngineTest$UniqueFlagToggleTests` (H2: drop-then-duplicate-inserts, re-add-rejects, idempotent add, composite-index survival — the exact production scenario) + `PhysicalTableStorageAdapterTest$UniqueViolationColumnExtraction`
- `.claude/docs/concerns.md` — Known Bugs entry

## Testing
- /verify green: runtime-core 1432, gateway 479, worker 1919, kelta-web lint/typecheck/format/coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)