### PR TITLE
fix(ai): replace retired claude-sonnet-4 fallback model

### DIFF
--- a/kelta-ai/src/main/resources/application.yml
+++ b/kelta-ai/src/main/resources/application.yml
@@ -38,7 +38,7 @@ kelta:
   ai:
     anthropic:
       api-key: ${ANTHROPIC_API_KEY:}
-      default-model: ${AI_DEFAULT_MODEL:claude-sonnet-4-20250514}
+      default-model: ${AI_DEFAULT_MODEL:claude-sonnet-5}
       default-max-tokens: ${AI_DEFAULT_MAX_TOKENS:32768}
       default-temperature: ${AI_DEFAULT_TEMPERATURE:0.7}
     worker-service-url: ${WORKER_SERVICE_URL:http://localhost:8080}


### PR DESCRIPTION
## Summary
- `application.yml` falls back to `claude-sonnet-4-20250514` when `AI_DEFAULT_MODEL` is unset; Anthropic retired that model, so bare deployments 404 on every AI call (hit in prod today — the cluster configmap carried the same value; fixed there in homelab-argo #144).
- Fallback now `claude-sonnet-5`.

## Testing
- Config-only; prod verified separately after the configmap bump (agent run succeeds on sonnet-5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)