### PR TITLE
perf(worker): record-invariant short-circuit for Cerbos record checks

### DIFF
--- a/.claude/docs/concerns.md
+++ b/.claude/docs/concerns.md
@@ -190,6 +190,27 @@ an audit feed.
 
 (No open bugs from the original audit. See Resolved → Bugs.)
 
+**FIXED (fix/cerbos-record-check-shortcircuit) — per-record Cerbos batch checks ran (with
+full record payloads) even for collections with no record-level rules; a read burst could
+open the circuit breaker (found 2026-07-10, in production, after #1223).** The generated
+`record` policy has only three rule kinds (`CerbosPolicyGenerator#generateRecordPolicy`):
+per-collection CRUD mirrors of object permissions, VIEW_ALL/MODIFY_ALL overrides, and custom
+rules — only custom rules can reference record data. Yet `CerbosRecordAuthorizationAdvice`
+batch-checked every page with every record attribute (rich-text HTML included); on the
+homelab PDP each 50-resource CheckResources took 0.5–1.4s, so 7 concurrent collection reads
+(a static-site build) queued past the 2s timeout → chunks failed closed → 3 misses opened the
+breaker → 10s of tenant-wide empty pages. Now: `RecordRuleIndex` (new, cached per tenant,
+NATS policy-changed eviction alongside the field cache) reports whether a collection has ANY
+enabled custom rule (conservative: CEL-bearing or not, unresolvable collection refs mark ALL
+collections variant, lookup failure falls back to the batch); without variant rules the
+advice replaces the batch with ONE `checkCollectionWideRecordAccess` sentinel check whose
+ALLOW is cached per (tenant, profile, collection, action) — DENY is never cached because it
+may be a fail-closed timeout/breaker artifact. Record-share widening unchanged. Caveat (same
+as #1179): the harness Cerbos is allow-all, so real deny behavior is only verifiable on a
+live stack — unit tests cover the path selection, caching, eviction and conservatism.
+Deferred follow-ups: attribute slimming for the remaining batch path (send only CEL-referenced
+attrs) and breaker tuning (client-load timeouts vs connectivity errors).
+
 **FIXED (fix/unique-constraint-migration) — field `unique` flag toggles never reached the
 physical schema, and unique-violation 409s named the wrong field (found 2026-07-10 operating
 the student-incentives tenant).** (1) `SchemaMigrationEngine.migrateSchema` diffed added/

--- a/kelta-worker/src/main/java/io/kelta/worker/interceptor/CerbosRecordAuthorizationAdvice.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/interceptor/CerbosRecordAuthorizationAdvice.java
@@ -2,6 +2,7 @@ package io.kelta.worker.interceptor;
 
 import io.kelta.worker.service.CerbosAuthorizationService;
 import io.kelta.worker.service.CerbosPermissionResolver;
+import io.kelta.worker.service.RecordRuleIndex;
 import io.kelta.worker.service.RecordShareAccessService;
 import jakarta.servlet.http.HttpServletRequest;
 import org.slf4j.Logger;
@@ -37,16 +38,19 @@ public class CerbosRecordAuthorizationAdvice implements ResponseBodyAdvice<Objec
     private final CerbosAuthorizationService authzService;
     private final CerbosPermissionResolver permissionResolver;
     private final RecordShareAccessService recordShareAccessService;
+    private final RecordRuleIndex recordRuleIndex;
     private final boolean permissionsEnabled;
 
     public CerbosRecordAuthorizationAdvice(
             CerbosAuthorizationService authzService,
             CerbosPermissionResolver permissionResolver,
             RecordShareAccessService recordShareAccessService,
+            RecordRuleIndex recordRuleIndex,
             @Value("${kelta.gateway.security.permissions-enabled:true}") boolean permissionsEnabled) {
         this.authzService = authzService;
         this.permissionResolver = permissionResolver;
         this.recordShareAccessService = recordShareAccessService;
+        this.recordRuleIndex = recordRuleIndex;
         this.permissionsEnabled = permissionsEnabled;
     }
 
@@ -102,8 +106,25 @@ public class CerbosRecordAuthorizationAdvice implements ResponseBodyAdvice<Objec
                 }
             }
 
-            Set<String> allowedIds = new HashSet<>(authzService.batchCheckRecordAccess(
-                    email, profileId, tenantId, collectionId, typedRecords, action));
+            Set<String> allowedIds;
+            if (recordRuleIndex.hasRecordVariantRules(tenantId, collectionId)) {
+                allowedIds = new HashSet<>(authzService.batchCheckRecordAccess(
+                        email, profileId, tenantId, collectionId, typedRecords, action));
+            } else {
+                // No record-variant rules: the record policy decides identically for
+                // every record, so one cached collection-wide check covers the page
+                // and Cerbos never sees the record payloads.
+                allowedIds = new HashSet<>();
+                if (authzService.checkCollectionWideRecordAccess(
+                        email, profileId, tenantId, collectionId, action)) {
+                    for (Map<String, Object> record : typedRecords) {
+                        String id = (String) record.get("id");
+                        if (id != null) {
+                            allowedIds.add(id);
+                        }
+                    }
+                }
+            }
 
             // Manual record shares may widen access to records the profile denied
             Set<String> deniedIds = typedRecords.stream()
@@ -150,6 +171,16 @@ public class CerbosRecordAuthorizationAdvice implements ResponseBodyAdvice<Objec
         String recordId = (String) record.get("id");
         if (recordId == null) {
             return true;
+        }
+
+        if (!recordRuleIndex.hasRecordVariantRules(tenantId, collectionId)) {
+            if (authzService.checkCollectionWideRecordAccess(
+                    email, profileId, tenantId, collectionId, action)) {
+                return true;
+            }
+            return !recordShareAccessService
+                    .widen(email, collectionId, Set.of(recordId), action)
+                    .isEmpty();
         }
 
         Map<String, Object> attributes = new LinkedHashMap<>();

--- a/kelta-worker/src/main/java/io/kelta/worker/listener/CerbosCacheInvalidationListener.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/listener/CerbosCacheInvalidationListener.java
@@ -2,6 +2,7 @@ package io.kelta.worker.listener;
 
 import tools.jackson.databind.ObjectMapper;
 import io.kelta.worker.service.CerbosAuthorizationService;
+import io.kelta.worker.service.RecordRuleIndex;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -9,8 +10,9 @@ import org.springframework.stereotype.Component;
 import java.util.Map;
 
 /**
- * NATS listener that invalidates the worker's Cerbos field access cache
- * when policies are re-synced for a tenant.
+ * NATS listener that invalidates the worker's Cerbos authorization caches
+ * (field access, collection-wide record decisions, custom-rule index) when
+ * policies are re-synced for a tenant.
  *
  * <p>Listens to {@code kelta.cerbos.policies.changed} events published by
  * {@code CerbosPolicySyncService} after pushing updated policies to Cerbos.
@@ -21,11 +23,14 @@ public class CerbosCacheInvalidationListener {
     private static final Logger log = LoggerFactory.getLogger(CerbosCacheInvalidationListener.class);
 
     private final CerbosAuthorizationService authzService;
+    private final RecordRuleIndex recordRuleIndex;
     private final ObjectMapper objectMapper;
 
     public CerbosCacheInvalidationListener(CerbosAuthorizationService authzService,
+                                            RecordRuleIndex recordRuleIndex,
                                             ObjectMapper objectMapper) {
         this.authzService = authzService;
+        this.recordRuleIndex = recordRuleIndex;
         this.objectMapper = objectMapper;
     }
 
@@ -40,8 +45,9 @@ public class CerbosCacheInvalidationListener {
                 return;
             }
 
-            log.info("Cerbos policies changed for tenant {} — evicting worker field cache", tenantId);
+            log.info("Cerbos policies changed for tenant {} — evicting worker authz caches", tenantId);
             authzService.evictForTenant(tenantId);
+            recordRuleIndex.evictTenant(tenantId);
         } catch (Exception e) {
             log.error("Failed to process policy changed event: {}", e.getMessage(), e);
         }

--- a/kelta-worker/src/main/java/io/kelta/worker/service/CerbosAuthorizationService.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/service/CerbosAuthorizationService.java
@@ -91,6 +91,12 @@ public class CerbosAuthorizationService {
     // unmask but allows read.
     private final Cache<String, FieldAccessEntry> fieldAccessCache;
 
+    // Collection-wide record decisions: key = "tenantId:profileId:collectionRef:action".
+    // Only consulted for collections WITHOUT record-variant custom rules (RecordRuleIndex),
+    // where the record policy's outcome is identical for every record. ALLOW only — a deny
+    // is never cached because it may be a fail-closed artifact (timeout/breaker).
+    private final Cache<String, Boolean> collectionRecordAccessCache;
+
     // Metrics
     private final Counter cacheHits;
     private final Counter cacheMisses;
@@ -115,6 +121,11 @@ public class CerbosAuthorizationService {
                 .maximumSize(CACHE_MAX_SIZE)
                 .expireAfterWrite(CACHE_TTL)
                 .recordStats()
+                .build();
+
+        this.collectionRecordAccessCache = Caffeine.newBuilder()
+                .maximumSize(CACHE_MAX_SIZE)
+                .expireAfterWrite(CACHE_TTL)
                 .build();
 
         this.cacheHits = Counter.builder("cerbos.cache.hits")
@@ -380,6 +391,32 @@ public class CerbosAuthorizationService {
     }
 
     /**
+     * Collection-wide record decision for collections whose record policy is
+     * record-invariant (no enabled custom rules — see {@link RecordRuleIndex}).
+     * One sentinel Cerbos check stands in for the whole page; ALLOW results are
+     * cached per (tenant, profile, collection, action) until the policy-changed
+     * event evicts them. DENY is returned but never cached — it may be a
+     * fail-closed artifact of a timeout or an open circuit breaker, and a real
+     * deny re-checks in one cheap call per page.
+     */
+    public boolean checkCollectionWideRecordAccess(String email, String profileId, String tenantId,
+                                                    String collectionRef, String action) {
+        String cacheKey = tenantId + ":" + profileId + ":" + collectionRef + ":" + action;
+        Boolean cached = collectionRecordAccessCache.getIfPresent(cacheKey);
+        if (cached != null) {
+            cacheHits.increment();
+            return cached;
+        }
+        cacheMisses.increment();
+        boolean allowed = checkRecordAccess(email, profileId, tenantId,
+                collectionRef, "__collection_wide__", Map.of(), action);
+        if (allowed) {
+            collectionRecordAccessCache.put(cacheKey, Boolean.TRUE);
+        }
+        return allowed;
+    }
+
+    /**
      * Batch-checks record access for multiple records in a single Cerbos gRPC call.
      * NOT cached because record checks depend on record attributes (ABAC/CEL rules).
      *
@@ -488,9 +525,14 @@ public class CerbosAuthorizationService {
                 .filter(key -> key.startsWith(tenantId + ":"))
                 .peek(fieldAccessCache::invalidate)
                 .count();
-        if (evicted > 0) {
-            cacheEvictions.increment(evicted);
-            log.info("Evicted {} cached field access entries for tenant {}", evicted, tenantId);
+        long recordEvicted = collectionRecordAccessCache.asMap().keySet().stream()
+                .filter(key -> key.startsWith(tenantId + ":"))
+                .peek(collectionRecordAccessCache::invalidate)
+                .count();
+        if (evicted + recordEvicted > 0) {
+            cacheEvictions.increment(evicted + recordEvicted);
+            log.info("Evicted {} field + {} collection-wide record cache entries for tenant {}",
+                    evicted, recordEvicted, tenantId);
         }
     }
 
@@ -509,22 +551,27 @@ public class CerbosAuthorizationService {
             return;
         }
         String prefix = tenantId + ":";
+        java.util.function.Predicate<String> matchesCollection = key -> {
+            if (!key.startsWith(prefix)) {
+                return false;
+            }
+            // key = tenantId:profileId:collectionRef:action — match the collection
+            // segment positionally so every action's entry is evicted.
+            String[] parts = key.split(":", -1);
+            return parts.length >= 4 && parts[2].equals(collectionId);
+        };
         long evicted = fieldAccessCache.asMap().keySet().stream()
-                .filter(key -> {
-                    if (!key.startsWith(prefix)) {
-                        return false;
-                    }
-                    // key = tenantId:profileId:collectionId:action — match the collection
-                    // segment positionally so every action's entry is evicted.
-                    String[] parts = key.split(":", -1);
-                    return parts.length >= 4 && parts[2].equals(collectionId);
-                })
+                .filter(matchesCollection)
                 .peek(fieldAccessCache::invalidate)
                 .count();
-        if (evicted > 0) {
-            cacheEvictions.increment(evicted);
-            log.info("Evicted {} cached field access entries for tenant={} collection={}",
-                    evicted, tenantId, collectionId);
+        long recordEvicted = collectionRecordAccessCache.asMap().keySet().stream()
+                .filter(matchesCollection)
+                .peek(collectionRecordAccessCache::invalidate)
+                .count();
+        if (evicted + recordEvicted > 0) {
+            cacheEvictions.increment(evicted + recordEvicted);
+            log.info("Evicted {} field + {} collection-wide record cache entries for tenant={} collection={}",
+                    evicted, recordEvicted, tenantId, collectionId);
         }
     }
 

--- a/kelta-worker/src/main/java/io/kelta/worker/service/RecordRuleIndex.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/service/RecordRuleIndex.java
@@ -1,0 +1,117 @@
+package io.kelta.worker.service;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Answers "can this collection's record-level Cerbos outcome vary per record?"
+ *
+ * <p>The generated {@code record} resource policy contains only three kinds of rules
+ * (see {@code CerbosPolicyGenerator#generateRecordPolicy}): per-collection CRUD mirrors
+ * of the object permissions, VIEW_ALL/MODIFY_ALL overrides, and admin-authored custom
+ * rules. Only the custom rules can reference record data — without them the decision is
+ * identical for every record of the collection, so the per-record batch check (which
+ * ships full record payloads to Cerbos, rich text included) can be replaced by a single
+ * cached collection-wide check. That batch was expensive enough that a parallel read
+ * burst could push checks past their timeout and open the circuit breaker (2026-07-10).
+ *
+ * <p>Conservative on purpose: <em>any</em> enabled custom rule on the collection —
+ * CEL-bearing or not — reinstates the full batch path, and any failure to load or map
+ * the rules reports "variant" so authorization never gets weaker than the batch check.
+ *
+ * <p>The per-tenant rule set is cached (short TTL as a safety net) and evicted by
+ * {@code CerbosCacheInvalidationListener} on the same policy-changed NATS event that
+ * evicts the field-access cache, so custom-rule edits propagate to every pod.
+ */
+@Service
+public class RecordRuleIndex {
+
+    private static final Logger log = LoggerFactory.getLogger(RecordRuleIndex.class);
+
+    private static final Duration CACHE_TTL = Duration.ofMinutes(10);
+    private static final int CACHE_MAX_SIZE = 1_000;
+
+    /** Marks a tenant whose rules could not be safely mapped — everything is variant. */
+    static final String ALL_COLLECTIONS = "*";
+
+    private final JdbcTemplate jdbcTemplate;
+
+    // tenantId -> collection refs (raw collection_id values AND resolved API names)
+    // that carry at least one enabled custom rule.
+    private final Cache<String, Set<String>> variantCollectionsByTenant;
+
+    public RecordRuleIndex(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+        this.variantCollectionsByTenant = Caffeine.newBuilder()
+                .maximumSize(CACHE_MAX_SIZE)
+                .expireAfterWrite(CACHE_TTL)
+                .build();
+    }
+
+    /**
+     * True when record-level decisions for this collection can differ per record —
+     * i.e. the caller must run the full per-record batch check. {@code collectionRef}
+     * accepts either the collection API name (what the advice extracts from the URL)
+     * or the collection UUID.
+     */
+    public boolean hasRecordVariantRules(String tenantId, String collectionRef) {
+        if (tenantId == null || collectionRef == null) {
+            return true;
+        }
+        Set<String> variant = variantCollectionsByTenant.get(tenantId, this::loadVariantCollections);
+        if (variant == null) {
+            return true;
+        }
+        return variant.contains(ALL_COLLECTIONS) || variant.contains(collectionRef);
+    }
+
+    /** Evicts the tenant's entry — called on the policy-changed NATS event. */
+    public void evictTenant(String tenantId) {
+        if (tenantId != null) {
+            variantCollectionsByTenant.invalidate(tenantId);
+        }
+    }
+
+    private Set<String> loadVariantCollections(String tenantId) {
+        try {
+            // ANSI CAST (not ::) so the lookup also runs on H2 in tests.
+            String sql = """
+                    SELECT pcr.collection_id, c.name
+                    FROM profile_custom_rules pcr
+                    LEFT JOIN collection c ON CAST(c.id AS VARCHAR(36)) = pcr.collection_id
+                    WHERE pcr.tenant_id = ? AND pcr.enabled = true
+                    """;
+            Set<String> refs = new HashSet<>();
+            jdbcTemplate.query(sql, rs -> {
+                String collectionId = rs.getString(1);
+                String name = rs.getString(2);
+                if (collectionId != null) {
+                    refs.add(collectionId);
+                }
+                if (name != null) {
+                    refs.add(name);
+                } else if (collectionId != null) {
+                    // A rule whose collection we cannot resolve by name might still be
+                    // matched by the advice under a name we don't know — treat every
+                    // collection as variant rather than risk skipping a real rule.
+                    refs.add(ALL_COLLECTIONS);
+                }
+            }, tenantId);
+            return refs;
+        } catch (Exception e) {
+            // Fail towards the full batch check (never weaker authorization). Not
+            // cached: Caffeine treats a null load as absent, so the next call retries.
+            log.warn("Could not load custom-rule index for tenant {} — keeping per-record checks: {}",
+                    tenantId, e.getMessage());
+            return null;
+        }
+    }
+}

--- a/kelta-worker/src/test/java/io/kelta/worker/interceptor/CerbosRecordAuthorizationAdviceTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/interceptor/CerbosRecordAuthorizationAdviceTest.java
@@ -24,13 +24,17 @@ class CerbosRecordAuthorizationAdviceTest {
     @Mock private CerbosAuthorizationService authzService;
     @Mock private CerbosPermissionResolver permissionResolver;
     @Mock private RecordShareAccessService recordShareAccessService;
+    @Mock private io.kelta.worker.service.RecordRuleIndex recordRuleIndex;
 
     private CerbosRecordAuthorizationAdvice advice;
 
     @BeforeEach
     void setUp() {
+        // Default: collection has record-variant rules → the batch path (the
+        // pre-short-circuit behavior every existing test was written against).
+        lenient().when(recordRuleIndex.hasRecordVariantRules(any(), any())).thenReturn(true);
         advice = new CerbosRecordAuthorizationAdvice(
-                authzService, permissionResolver, recordShareAccessService, true);
+                authzService, permissionResolver, recordShareAccessService, recordRuleIndex, true);
     }
 
     private ServletServerHttpRequest createRequest(String path) {
@@ -310,8 +314,50 @@ class CerbosRecordAuthorizationAdviceTest {
     @DisplayName("Should skip when permissions disabled")
     void shouldDoNothingWhenDisabled() {
         var disabledAdvice = new CerbosRecordAuthorizationAdvice(
-                authzService, permissionResolver, recordShareAccessService, false);
+                authzService, permissionResolver, recordShareAccessService, recordRuleIndex, false);
         assertThat(disabledAdvice.supports(null, null)).isFalse();
+    }
+
+    @Test
+    @DisplayName("collections without record-variant rules use one collection-wide check, not the batch")
+    void shortCircuitsWithoutVariantRules() {
+        var request = createRequest("/api/contacts");
+        when(recordRuleIndex.hasRecordVariantRules("tenant-1", "contacts")).thenReturn(false);
+        when(authzService.checkCollectionWideRecordAccess(
+                "user@example.com", "profile-1", "tenant-1", "contacts", "read")).thenReturn(true);
+
+        Map<String, Object> body = Map.of("data", List.of(
+                Map.of("id", "1"), Map.of("id", "2"), Map.of("id", "3")));
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> result = (Map<String, Object>) advice.beforeBodyWrite(
+                body, null, MediaType.APPLICATION_JSON, null, request, null);
+
+        assertThat((List<?>) result.get("data")).hasSize(3);
+        verify(authzService, never()).batchCheckRecordAccess(any(), any(), any(), any(), anyList(), any());
+    }
+
+    @Test
+    @DisplayName("collection-wide deny filters everything but record shares still widen")
+    void shortCircuitDenyStillWidensViaShares() {
+        var request = createRequest("/api/contacts");
+        when(recordRuleIndex.hasRecordVariantRules("tenant-1", "contacts")).thenReturn(false);
+        when(authzService.checkCollectionWideRecordAccess(
+                "user@example.com", "profile-1", "tenant-1", "contacts", "read")).thenReturn(false);
+        when(recordShareAccessService.widen(eq("user@example.com"), eq("contacts"), anySet(), eq("read")))
+                .thenReturn(Set.of("2"));
+
+        Map<String, Object> body = Map.of("data", List.of(
+                Map.of("id", "1"), Map.of("id", "2")));
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> result = (Map<String, Object>) advice.beforeBodyWrite(
+                body, null, MediaType.APPLICATION_JSON, null, request, null);
+
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> data = (List<Map<String, Object>>) result.get("data");
+        assertThat(data).extracting(r -> r.get("id")).containsExactly("2");
+        verify(authzService, never()).batchCheckRecordAccess(any(), any(), any(), any(), anyList(), any());
     }
 
     @Test

--- a/kelta-worker/src/test/java/io/kelta/worker/listener/CerbosCacheInvalidationListenerTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/listener/CerbosCacheInvalidationListenerTest.java
@@ -2,6 +2,7 @@ package io.kelta.worker.listener;
 
 import tools.jackson.databind.ObjectMapper;
 import io.kelta.worker.service.CerbosAuthorizationService;
+import io.kelta.worker.service.RecordRuleIndex;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -18,19 +19,23 @@ class CerbosCacheInvalidationListenerTest {
     @Mock
     private CerbosAuthorizationService authzService;
 
+    @Mock
+    private RecordRuleIndex recordRuleIndex;
+
     private CerbosCacheInvalidationListener listener;
 
     @BeforeEach
     void setUp() {
-        listener = new CerbosCacheInvalidationListener(authzService, new ObjectMapper());
+        listener = new CerbosCacheInvalidationListener(authzService, recordRuleIndex, new ObjectMapper());
     }
 
     @Test
-    @DisplayName("Should evict field cache for tenant on policy changed event")
+    @DisplayName("Should evict authz caches and rule index for tenant on policy changed event")
     void evictsOnPolicyChange() {
         String message = "{\"tenantId\":\"tenant-1\",\"syncedAt\":\"2026-03-22T10:00:00Z\"}";
         listener.handlePolicyChanged(message);
         verify(authzService).evictForTenant("tenant-1");
+        verify(recordRuleIndex).evictTenant("tenant-1");
     }
 
     @Test
@@ -39,6 +44,7 @@ class CerbosCacheInvalidationListenerTest {
         String message = "{\"syncedAt\":\"2026-03-22T10:00:00Z\"}";
         listener.handlePolicyChanged(message);
         verify(authzService, never()).evictForTenant(any());
+        verify(recordRuleIndex, never()).evictTenant(any());
     }
 
     @Test
@@ -46,5 +52,6 @@ class CerbosCacheInvalidationListenerTest {
     void handlesMalformedJson() {
         listener.handlePolicyChanged("not json");
         verify(authzService, never()).evictForTenant(any());
+        verify(recordRuleIndex, never()).evictTenant(any());
     }
 }

--- a/kelta-worker/src/test/java/io/kelta/worker/service/CerbosAuthorizationServiceTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/service/CerbosAuthorizationServiceTest.java
@@ -420,6 +420,57 @@ class CerbosAuthorizationServiceTest {
     }
 
     @Nested
+    @DisplayName("Collection-wide record access (record-invariant short-circuit)")
+    class CollectionWideRecordAccess {
+
+        @Test
+        @DisplayName("ALLOW is cached per (tenant, profile, collection, action)")
+        void allowIsCached() {
+            when(cerbosClient.check(any(Principal.class), any(Resource.class), eq("read")))
+                    .thenReturn(fieldCheckResult);
+            when(fieldCheckResult.isAllowed("read")).thenReturn(true);
+
+            assertThat(service.checkCollectionWideRecordAccess(
+                    "user@test.com", "profile-1", "tenant-1", "contacts", "read")).isTrue();
+            assertThat(service.checkCollectionWideRecordAccess(
+                    "user@test.com", "profile-1", "tenant-1", "contacts", "read")).isTrue();
+
+            verify(cerbosClient, times(1)).check(any(), any(), eq("read"));
+        }
+
+        @Test
+        @DisplayName("DENY is returned but never cached (could be a fail-closed artifact)")
+        void denyIsNotCached() {
+            when(cerbosClient.check(any(Principal.class), any(Resource.class), eq("read")))
+                    .thenReturn(fieldCheckResult);
+            when(fieldCheckResult.isAllowed("read")).thenReturn(false);
+
+            assertThat(service.checkCollectionWideRecordAccess(
+                    "user@test.com", "profile-1", "tenant-1", "contacts", "read")).isFalse();
+            assertThat(service.checkCollectionWideRecordAccess(
+                    "user@test.com", "profile-1", "tenant-1", "contacts", "read")).isFalse();
+
+            verify(cerbosClient, times(2)).check(any(), any(), eq("read"));
+        }
+
+        @Test
+        @DisplayName("evictForTenant clears the cached collection-wide decisions")
+        void evictionClearsCache() {
+            when(cerbosClient.check(any(Principal.class), any(Resource.class), eq("read")))
+                    .thenReturn(fieldCheckResult);
+            when(fieldCheckResult.isAllowed("read")).thenReturn(true);
+
+            service.checkCollectionWideRecordAccess(
+                    "user@test.com", "profile-1", "tenant-1", "contacts", "read");
+            service.evictForTenant("tenant-1");
+            service.checkCollectionWideRecordAccess(
+                    "user@test.com", "profile-1", "tenant-1", "contacts", "read");
+
+            verify(cerbosClient, times(2)).check(any(), any(), eq("read"));
+        }
+    }
+
+    @Nested
     @DisplayName("Collection (object-level) access")
     class CollectionAccess {
 

--- a/kelta-worker/src/test/java/io/kelta/worker/service/RecordRuleIndexTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/service/RecordRuleIndexTest.java
@@ -1,0 +1,112 @@
+package io.kelta.worker.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("RecordRuleIndex")
+class RecordRuleIndexTest {
+
+    private static final String TENANT = "tenant-1";
+    private static final String COLLECTION_ID = "11111111-1111-1111-1111-111111111111";
+
+    private JdbcTemplate jdbcTemplate;
+    private RecordRuleIndex index;
+
+    @BeforeEach
+    void setUp() {
+        jdbcTemplate = new JdbcTemplate(new EmbeddedDatabaseBuilder()
+                .setType(EmbeddedDatabaseType.H2)
+                .generateUniqueName(true)
+                .build());
+        jdbcTemplate.execute("""
+                CREATE TABLE profile_custom_rules (
+                    id VARCHAR(36) PRIMARY KEY,
+                    tenant_id VARCHAR(36) NOT NULL,
+                    profile_id VARCHAR(36),
+                    collection_id VARCHAR(36),
+                    action VARCHAR(32),
+                    effect VARCHAR(32),
+                    condition_json VARCHAR(4000),
+                    enabled BOOLEAN NOT NULL
+                )""");
+        jdbcTemplate.execute("""
+                CREATE TABLE collection (
+                    id UUID PRIMARY KEY,
+                    name VARCHAR(255)
+                )""");
+        index = new RecordRuleIndex(jdbcTemplate);
+    }
+
+    private void insertRule(String id, String collectionId, boolean enabled) {
+        jdbcTemplate.update(
+                "INSERT INTO profile_custom_rules (id, tenant_id, profile_id, collection_id, action, effect, condition_json, enabled) "
+                        + "VALUES (?, ?, 'profile-1', ?, 'read', 'EFFECT_DENY', '{}', ?)",
+                id, TENANT, collectionId, enabled);
+    }
+
+    @Test
+    @DisplayName("no custom rules → nothing is record-variant")
+    void noRules() {
+        assertThat(index.hasRecordVariantRules(TENANT, "contacts")).isFalse();
+        assertThat(index.hasRecordVariantRules(TENANT, COLLECTION_ID)).isFalse();
+    }
+
+    @Test
+    @DisplayName("an enabled rule marks the collection variant by UUID and by name")
+    void enabledRuleMatchesIdAndName() {
+        jdbcTemplate.update("INSERT INTO collection (id, name) VALUES (CAST(? AS UUID), 'contacts')",
+                COLLECTION_ID);
+        insertRule("r1", COLLECTION_ID, true);
+
+        assertThat(index.hasRecordVariantRules(TENANT, COLLECTION_ID)).isTrue();
+        assertThat(index.hasRecordVariantRules(TENANT, "contacts")).isTrue();
+        assertThat(index.hasRecordVariantRules(TENANT, "other-collection")).isFalse();
+    }
+
+    @Test
+    @DisplayName("disabled rules do not count")
+    void disabledRuleIgnored() {
+        insertRule("r1", COLLECTION_ID, false);
+        assertThat(index.hasRecordVariantRules(TENANT, COLLECTION_ID)).isFalse();
+    }
+
+    @Test
+    @DisplayName("a rule whose collection name cannot be resolved marks everything variant")
+    void unresolvableCollectionIsConservative() {
+        insertRule("r1", "99999999-9999-9999-9999-999999999999", true);
+        assertThat(index.hasRecordVariantRules(TENANT, "anything-at-all")).isTrue();
+    }
+
+    @Test
+    @DisplayName("eviction picks up rule changes; cached result served until then")
+    void evictionRefreshes() {
+        assertThat(index.hasRecordVariantRules(TENANT, COLLECTION_ID)).isFalse();
+
+        insertRule("r1", COLLECTION_ID, true);
+        // Still the cached answer until the policy-changed event evicts.
+        assertThat(index.hasRecordVariantRules(TENANT, COLLECTION_ID)).isFalse();
+
+        index.evictTenant(TENANT);
+        assertThat(index.hasRecordVariantRules(TENANT, COLLECTION_ID)).isTrue();
+    }
+
+    @Test
+    @DisplayName("a lookup failure fails towards 'variant' (full batch check)")
+    void lookupFailureIsConservative() {
+        jdbcTemplate.execute("DROP TABLE profile_custom_rules");
+        assertThat(index.hasRecordVariantRules(TENANT, "contacts")).isTrue();
+    }
+
+    @Test
+    @DisplayName("null tenant or collection falls back to the batch path")
+    void nullArgumentsAreConservative() {
+        assertThat(index.hasRecordVariantRules(null, "contacts")).isTrue();
+        assertThat(index.hasRecordVariantRules(TENANT, null)).isTrue();
+    }
+}


### PR DESCRIPTION
## Summary
- After #1223's chunking, the per-record Cerbos batch check remained the bottleneck: it ships **every record attribute** (multi-KB rich text included) per 50-row page, at 0.5–1.4s per CheckResources on the homelab PDP. A 7-collection parallel read burst (static-site build) queued past the 2s timeout → chunks failed closed → 3 misses opened the circuit breaker → **10s of tenant-wide empty pages** (emf-worker logs 2026-07-10T13:11:49Z).
- The generated `record` policy (`CerbosPolicyGenerator#generateRecordPolicy`) can only vary per record through **custom rules** — its other rules (object-permission CRUD mirrors, VIEW_ALL/MODIFY_ALL) decide identically for every record of a collection.
- New `RecordRuleIndex`: per-tenant cache of which collections carry **any enabled custom rule** (by UUID and API name), evicted by the existing `kelta.cerbos.policies.changed` NATS event alongside the field cache. Collections without variant rules skip the batch: `CerbosRecordAuthorizationAdvice` runs one `checkCollectionWideRecordAccess` sentinel check whose **ALLOW** is cached per (tenant, profile, collection, action); **DENY is never cached** (it may be a fail-closed timeout/breaker artifact). Applies to both the list and single-record paths; record-share widening unchanged.

## Conservatism (never weaker than the batch)
- Any enabled custom rule — CEL-bearing or not — keeps the full batch path.
- A rule whose collection name can't be resolved marks **all** collections variant.
- Index lookup failure or null tenant/collection falls back to the batch path.
- Cache eviction rides the same policy-changed event as the field-access cache; 10-minute TTL as a safety net.

## Changes
- `kelta-worker/.../service/RecordRuleIndex.java` (new)
- `kelta-worker/.../service/CerbosAuthorizationService.java` — `checkCollectionWideRecordAccess` + allow-only cache + eviction sweeps
- `kelta-worker/.../interceptor/CerbosRecordAuthorizationAdvice.java` — path selection (list + single record)
- `kelta-worker/.../listener/CerbosCacheInvalidationListener.java` — evicts the rule index too
- Tests: `RecordRuleIndexTest` (H2: id/name matching, disabled rules, conservative fallbacks, eviction), service cache tests (allow cached / deny not / eviction), advice short-circuit tests (batch never called; shares still widen a deny)
- `.claude/docs/concerns.md`

## Testing
- /verify green: gateway 479, worker **1931** (12 new), kelta-web checks
- Live-stack caveat (same as #1179): the harness Cerbos is allow-all, so real deny behavior is only verifiable on a live stack; unit tests cover path selection, caching, eviction, conservatism.

## Security note
Authz-path change — **no auto-merge** per SECURITY.md; needs a human merge. Deferred follow-ups (documented in concerns.md): attribute slimming for the remaining batch path, breaker tuning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)