### PR TITLE
fix(mcp): kebab-case route leftovers in update_layout/delete_layout/list_approvals

### DIFF
--- a/.claude/docs/concerns.md
+++ b/.claude/docs/concerns.md
@@ -252,6 +252,10 @@ create and fail their own type validation — all converted to JSON values, and
 error envelopes rendered as `{"errors":[{}]}` (bean members dropped at serialization on the
 deployed worker); `GlobalExceptionHandler` now emits plain maps (`JsonApiError.toMap()`), which
 serialize reliably under any mapper config — never build error bodies from the bean directly.
+*(Follow-up fix/mcp-kebab-leftovers, 2026-07-10: the batch missed three more camelCase paths —
+`update_layout`/`delete_layout` (`/api/pageLayouts/{id}`) and `list_approvals`
+(`/api/approvalInstances`) — all 404'd against the kebab routes; found when `delete_layout`
+failed during tenant layout setup. New MCP tools MUST use kebab-case system-collection routes.)*
 
 **FIXED (fix/hyphen-collection-refresh) — kebab-case collection names broke generated SQL identifier names.**
 `PhysicalTableStorageAdapter.sanitizeIdentifier` (strict `[a-zA-Z0-9_]`) was fed raw

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/DeleteLayoutTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/DeleteLayoutTool.java
@@ -34,7 +34,7 @@ public class DeleteLayoutTool implements AdminTool {
         Tool tool = Tool.builder()
                 .name("delete_layout")
                 .title("Delete Layout")
-                .description("Delete a page layout and (cascade) its sections and field assignments. Wraps DELETE /api/pageLayouts/{id}. Does NOT delete the underlying field definitions on the collection.")
+                .description("Delete a page layout and (cascade) its sections and field assignments. Wraps DELETE /api/page-layouts/{id}. Does NOT delete the underlying field definitions on the collection.")
                 .inputSchema(Schemas.object(properties, List.of("id")))
                 .annotations(ToolHints.write(true, true))
                 .build();
@@ -51,7 +51,7 @@ public class DeleteLayoutTool implements AdminTool {
                                 .content(List.of(new TextContent("Argument \"id\" is required.")))
                                 .build();
                     }
-                    String path = "/api/pageLayouts/" + URLEncoder.encode(id.toString(), StandardCharsets.UTF_8);
+                    String path = "/api/page-layouts/" + URLEncoder.encode(id.toString(), StandardCharsets.UTF_8);
                     try {
                         GatewayHttpClient.Response response = gateway.delete(path);
                         if (response.isSuccess()) {

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/UpdateLayoutTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/UpdateLayoutTool.java
@@ -37,7 +37,7 @@ public class UpdateLayoutTool implements AdminTool {
         Tool tool = Tool.builder()
                 .name("update_layout")
                 .title("Update Layout")
-                .description("Update a page layout's metadata (name, default flag, record type). PATCHes /api/pageLayouts/{id}. To restructure sections or fields, use delete_layout + create_layout — full section replacement isn't supported in a single tool call.")
+                .description("Update a page layout's metadata (name, default flag, record type). PATCHes /api/page-layouts/{id}. To restructure sections or fields, use delete_layout + create_layout — full section replacement isn't supported in a single tool call.")
                 .inputSchema(Schemas.object(properties, List.of("id")))
                 .annotations(ToolHints.write(true, true))
                 .build();
@@ -62,7 +62,7 @@ public class UpdateLayoutTool implements AdminTool {
                             "type", "pageLayouts",
                             "id", id.toString(),
                             "attributes", attrs));
-                    String path = "/api/pageLayouts/" + URLEncoder.encode(id.toString(), StandardCharsets.UTF_8);
+                    String path = "/api/page-layouts/" + URLEncoder.encode(id.toString(), StandardCharsets.UTF_8);
                     try {
                         return McpErrorMapper.toResult(gateway.patch(path, body));
                     } catch (RuntimeException e) {

--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/ListApprovalsTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/ListApprovalsTool.java
@@ -64,7 +64,7 @@ public class ListApprovalsTool implements UserTool {
                                 pageNumber.toString(), StandardCharsets.UTF_8));
                     }
 
-                    String path = "/api/approvalInstances"
+                    String path = "/api/approval-instances"
                             + (parts.isEmpty() ? "" : "?" + String.join("&", parts));
                     try {
                         return McpErrorMapper.toResult(gateway.get(path));

--- a/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/ListApprovalsToolTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/ListApprovalsToolTest.java
@@ -41,30 +41,30 @@ class ListApprovalsToolTest {
 
     @Test
     void defaultsToPendingFilter() {
-        wm.stubFor(get(urlEqualTo("/api/approvalInstances?filter[status][EQ]=PENDING"))
+        wm.stubFor(get(urlEqualTo("/api/approval-instances?filter[status][EQ]=PENDING"))
                 .willReturn(aResponse().withStatus(200).withBody("{\"data\":[]}")));
 
         tool.toSpecification().callHandler().apply(
                 null, new CallToolRequest("list_approvals", Map.of(), null));
 
         wm.verify(WireMock.getRequestedFor(
-                urlEqualTo("/api/approvalInstances?filter[status][EQ]=PENDING")));
+                urlEqualTo("/api/approval-instances?filter[status][EQ]=PENDING")));
     }
 
     @Test
     void allStatusOmitsTheFilter() {
-        wm.stubFor(get(urlEqualTo("/api/approvalInstances"))
+        wm.stubFor(get(urlEqualTo("/api/approval-instances"))
                 .willReturn(aResponse().withStatus(200).withBody("{\"data\":[]}")));
 
         tool.toSpecification().callHandler().apply(
                 null, new CallToolRequest("list_approvals", Map.of("status", "all"), null));
 
-        wm.verify(WireMock.getRequestedFor(urlEqualTo("/api/approvalInstances")));
+        wm.verify(WireMock.getRequestedFor(urlEqualTo("/api/approval-instances")));
     }
 
     @Test
     void appendsPagingParams() {
-        wm.stubFor(get(urlEqualTo("/api/approvalInstances?filter[status][EQ]=APPROVED&page[size]=50&page[number]=2"))
+        wm.stubFor(get(urlEqualTo("/api/approval-instances?filter[status][EQ]=APPROVED&page[size]=50&page[number]=2"))
                 .willReturn(aResponse().withStatus(200).withBody("{\"data\":[]}")));
 
         tool.toSpecification().callHandler().apply(
@@ -74,6 +74,6 @@ class ListApprovalsToolTest {
                         "pageNumber", 2), null));
 
         wm.verify(WireMock.getRequestedFor(
-                urlEqualTo("/api/approvalInstances?filter[status][EQ]=APPROVED&page[size]=50&page[number]=2")));
+                urlEqualTo("/api/approval-instances?filter[status][EQ]=APPROVED&page[size]=50&page[number]=2")));
     }
 }


### PR DESCRIPTION
## Summary
- #1222 fixed the create-side camelCase 404s but missed three tools: `update_layout` + `delete_layout` (`/api/pageLayouts/{id}`) and `list_approvals` (`/api/approvalInstances`). All 404 against the real kebab routes — hit live today when `delete_layout` failed during tenant layout setup.
- Paths + tool descriptions + WireMock stubs corrected.

## Testing
- kelta-mcp: 216/216.

🤖 Generated with [Claude Code](https://claude.com/claude-code)