### PR TITLE
docs(specs): telehealth chat + video plan — parent spec + 6 slices

### DIFF
--- a/.claude/docs/specs/telehealth/1-portal-identity.md
+++ b/.claude/docs/specs/telehealth/1-portal-identity.md
@@ -1,0 +1,102 @@
+# [Slice 1] — Portal Identity & Record Access
+
+> Child spec of [Telehealth parent](./README.md), to be refined with the implementation.
+> Conforms to parent §Key architecture decisions, §Security. **Security-typed PR — never
+> auto-merged.** Backend + auth; small admin-UI surface.
+
+## 1. Goal & scope
+
+Delivers the **external user** foundation every other slice depends on:
+
+- `user_type ∈ {INTERNAL, PORTAL}` on `platform_user`, surfaced as a JWT claim and forwarded
+  identity attribute.
+- A seeded **Portal User** profile (API_ACCESS only; no collection CRUD, no setup
+  permissions) provisioned for new tenants and backfilled for existing ones.
+- **Passwordless magic-link login** for portal users (email one-time link/OTP), issued by
+  kelta-auth; portal invites through the existing invite pipeline.
+- A reusable **participant-share hook utility**: system collections can declare "creating a
+  participant row grants the named user a `record_share` on the parent record" — the
+  mechanism later slices use to scope patients to their own conversations/appointments.
+- `maxPortalUsers` governor key, enforced at portal-user create/invite (staff `gov_users`
+  stays tracked-only; changing that is out of scope).
+
+Does NOT deliver: any chat/scheduling/video surface; self-service open registration
+(portal users exist by invite, booking flow, or tenant IdP federation); SMS OTP
+(email only — `SmsProvider` SPI hookup is deferred per parent).
+
+## 2. UI samples
+
+Admin Users page: a *Type* column (Internal/Portal badge) + "Invite portal user" action
+(email + optional name; profile forced to Portal User). Portal login page (served on the
+tenant slug/custom domain): email field → "Check your email" confirmation → link opens an
+authenticated session; uniform response whether or not the email exists.
+
+## 3. Data & API contracts
+
+```
+POST /api/auth/portal/request-link   {email}                    → 202 {status:"sent"} (always, uniform)
+POST /api/auth/portal/exchange       {token}                    → session cookie/JWT redirect (auth-code style)
+POST /api/admin/users/portal-invite  {email, firstName?, lastName?} → 201 user (PENDING_ACTIVATION, PORTAL)
+```
+
+- JWT gains `user_type` claim; gateway forwards `X-User-Type` alongside existing identity
+  headers (header-transform filter).
+- Magic-link token: single-use, ≤15 min expiry, HMAC-signed, bound to
+  `(tenantId, userId, purpose=portal-login)`; storage + verification mirror the existing
+  invite/campaign token patterns; consumed atomically. Request endpoint rate-limited
+  per-email and per-IP.
+- Participant-share utility (worker): `ParticipantShareSupport.grant(collectionId, recordId,
+  userId, accessLevel)` writing `record_share` rows (USER type) — wraps
+  `RecordShareRepository`; idempotent on re-invite.
+- `TenantTierQuotas` gains `maxPortalUsers` (FREE small, ENTERPRISE larger, UNLIMITED ∞);
+  create/invite paths throw the governor-exceeded error (429 envelope) when at cap.
+
+## 4. DB migrations
+
+One migration (**verify directory head first**; V167 at time of writing):
+`ALTER TABLE platform_user ADD COLUMN user_type` (text, NOT NULL default `INTERNAL`, check
+constraint), backfill, index on `(tenant_id, user_type)`; seed Portal User profile per
+existing tenant (mirror the V162 `VIEW_ANALYTICS` per-profile seeding pattern); magic-link
+token table (hashed token, purpose, expires_at, consumed_at, RLS).
+
+## 5. File-by-file code changes (sketch — finalize with implementation)
+
+| Area | Files |
+|------|-------|
+| kelta-auth | `PortalLoginController` (request-link/exchange), token service, `KeltaUserDetails` + JWT customizer for `user_type`, login-page template |
+| kelta-worker | `AdminInviteController` portal path, `UserInviteService` portal branch (Portal User profile, portal email template), `ParticipantShareSupport`, `TenantTierQuotas` + governor enforcement, `TenantProvisioningHook` profile seed |
+| kelta-gateway | header-transform filter forwards `X-User-Type`; no new routes (auth paths already routed) |
+| kelta-ui | Users page type column + portal invite dialog; portal login page (unauthenticated shell) |
+| Cerbos | principal attr `userType` available to future policies |
+
+Email templates: `portal_invite`, `portal_login_link` (system-seeded, tenant-overridable).
+Audit: `PORTAL_LINK_REQUESTED`, `PORTAL_LOGIN`, `PORTAL_USER_INVITED`.
+
+## 6. Test plan
+
+- kelta-auth unit: token single-use/expiry/purpose-binding; uniform not-found response;
+  rate limit.
+- Worker unit: portal invite forces profile + type; governor cap rejects at limit;
+  `ParticipantShareSupport` idempotency.
+- Harness (real Postgres/RLS): portal user + share grant reads parent record, non-participant
+  denied; cross-tenant isolation on the token table.
+- Playwright: invite → mailpit link → portal session lands on the tenant app; portal JWT
+  gets 403 on `/api/admin/**` and on an unshared collection read.
+
+## 7. Docs to update (same PR)
+
+`status.md` Telehealth row (⚪ → 🟡 in-flight); `architecture.md` (portal auth flow, new
+identity header); `conventions.md` (portal-endpoint authz idiom); `integrations.md` (magic
+links); `SECURITY.md` review note; CLAUDE.md Messaging table unchanged (no new subjects).
+
+## 8. Risks & open questions
+
+- Magic-link deliverability depends on tenant SMTP health — surface send failures in
+  `email-logs`; consider a resend cooldown UX.
+- `user_type` on the JWT means token re-issue on type change (acceptable: type is immutable
+  after create in v1).
+- Decision taken (opinionated): portal users are **invited, not self-registered** in v1 —
+  self-serve signup would open an enumeration/abuse surface this slice doesn't budget for;
+  the booking flow (slice 4) can auto-invite.
+- Seat semantics: portal seats counted separately from staff (`maxPortalUsers` vs
+  `gov_users`) — pricing implications are an operator decision, keys are independent.

--- a/.claude/docs/specs/telehealth/2-chat-backend.md
+++ b/.claude/docs/specs/telehealth/2-chat-backend.md
@@ -1,0 +1,104 @@
+# [Slice 2] — Chat Backend
+
+> Child spec of [Telehealth parent](./README.md), to be refined with the implementation.
+> Conforms to parent §Shared contracts, §Security. Depends on slice 1 (portal identity +
+> participant shares). Backend: worker + gateway + runtime.
+
+## 1. Goal & scope
+
+Delivers human-to-human chat storage, APIs, and realtime delivery:
+
+- System collections: `chat-queues`, `chat-conversations`, `chat-messages`,
+  `chat-participants` (declared in `SystemCollectionDefinitions`, tables + RLS via Flyway,
+  Cerbos policies for staff profiles).
+- Scoped REST under `/api/chat/**` (gateway static route) with **in-controller participant
+  authz** — the portal access path (parent §Shared contracts lists the endpoints).
+- NATS publishers (BeforeSaveHooks) for `kelta.chat.message.*` / `kelta.chat.conversation.*`
+  (ids only, per Critical Rule 1 — broadcast, never local-only refresh).
+- Gateway: `chat.join`/`chat.leave` socket actions with membership verification, a
+  conversation routing index (mirror of the collection index), and `ChatMessageBridge`
+  fanning chat events to joined sessions only.
+- Attachments on messages via the existing S3 lifecycle; queue + manual-claim assignment;
+  RECORD_TRIGGERED flows fire on conversation/message creates for tenant automations
+  (e.g. notify agents on new conversation).
+
+Does NOT deliver: UI (slice 3), typing indicators (presence `chat:<id>` viewing only),
+auto-routing strategies, server-push message bodies (invalidation-only rule holds).
+
+## 2. Sample payloads
+
+```
+POST /api/chat/conversations {queueId?, subject?, contextRecordId?} → 201 conversation (status OPEN, origin from user_type)
+POST /api/chat/conversations/{id}/messages {body, kind:"TEXT"}      → 201 message; hook publishes chat.message event
+GET  /api/chat/conversations/{id}/messages?after=<messageId>&page[size]=50 → ordered page (participant-only)
+WS   recv {"event":"chat.message","conversationId":"…","messageId":"…","senderId":"…","kind":"TEXT","timestamp":"…"}
+```
+
+## 3. Data & API contracts
+
+Collection shapes (system collections; JSON:API names as listed):
+
+- `chat-queues`: name, description, active.
+- `chat-conversations`: queueId (lookup), subject, status `OPEN|ASSIGNED|CLOSED`, origin
+  `PORTAL|INTERNAL`, assignedTo (user), contextRecordId?, lastMessageAt, closedAt.
+- `chat-messages`: conversationId (master-detail), senderId, senderType `INTERNAL|PORTAL`,
+  kind `TEXT|SYSTEM|ATTACHMENT`, body (rich text), sentAt. Excluded from full-text/embedding
+  indexes; excluded from generic realtime `data` push.
+- `chat-participants`: conversationId (master-detail), userId, role `AGENT|PORTAL`,
+  joinedAt, lastReadAt. Creating a PORTAL participant triggers the slice-1 participant-share
+  grant on the conversation.
+
+Authorization matrix: portal → scoped endpoints only (membership checked in-controller,
+audited denials); staff → scoped endpoints + generic JSON:API per profile grants
+(`view=queue|all` gated on a new `MANAGE_CHAT` system permission for supervisors; agents see
+`mine` + their queues). Sender identity always resolved from forwarded identity headers —
+body-supplied sender ignored (approvals slice-2 precedent).
+
+Gateway membership check: `GET /internal/chat/conversations/{id}/members/{userId}` (worker
+internal API), cached ~30s per (conversation,user); `chat.join` cap 20 per session
+(sits under the existing 50-subscription budget separately tracked).
+
+## 4. DB migrations
+
+One migration (verify head; V167+ depending on slice-1 landing): four tables + RLS policies
++ indexes — `(tenant_id, conversation_id, sent_at)` on messages,
+`(tenant_id, assigned_to, status)` + `(tenant_id, queue_id, status)` on conversations,
+unique `(conversation_id, user_id)` on participants.
+
+## 5. File-by-file code changes (sketch)
+
+| Area | Files |
+|------|-------|
+| runtime-core | `SystemCollectionDefinitions` +4 collections |
+| kelta-worker | `ChatController` (`/api/chat/**`), `ChatService` (membership, assignment, read receipts, JdbcTemplate repos), `ChatMessageHook`/`ChatConversationHook` (validate sender/participants, publish NATS, bump lastMessageAt), internal membership endpoint, `MANAGE_CHAT` permission seed, Cerbos policy generation entries, audit events |
+| kelta-gateway | `SubscriptionManager` conversation index + caps, `RealtimeWebSocketHandler` `chat.join/leave` actions, `ChatMessageBridge`, `NatsSubscriptionConfig` +`kelta.chat.>` broadcast subscription, `RouteConfigService.registerStaticRoutes()` +`/api/chat/**` |
+| runtime-events | `ChatMessagePayload`, `ChatConversationPayload` records |
+
+## 6. Test plan
+
+- Worker unit: membership authz (participant 200 / non-participant 403 / portal vs staff
+  views), sender-identity hardening, hook publishes on create (InOrder with mocked
+  publisher), assignment + close transitions.
+- Gateway unit: join → membership check → routed; deny → error action + audit; bridge fans
+  only to joined sessions; leave/disconnect cleanup.
+- Harness (real Postgres/RLS): cross-tenant conversation invisible; portal share grant
+  gives conversation read but not other conversations; message pagination under RLS.
+- Playwright deferred to slice 3 (needs UI).
+
+## 7. Docs to update (same PR)
+
+CLAUDE.md Messaging table (+2 subject rows); `architecture.md` (chat endpoints authz, WS
+extension); `conventions.md` (conversation-scoped socket rule); `playbooks.md`
+("conversation-scoped realtime event" recipe); `concerns.md` (chat table growth + retention
+TODO); `status.md` row update.
+
+## 8. Risks & open questions
+
+- **Message-table growth** in the shared public schema — indexes above + a retention policy
+  (per-tenant `chatRetentionDays`, scheduled purge job) tracked in `concerns.md`; partition
+  only if real volume demands it.
+- Membership cache (30s) means a just-removed participant may receive id-only events briefly
+  — acceptable (no bodies on the wire); document it.
+- `MANAGE_CHAT` naming vs a finer `chat-agent` concept: v1 keeps profile-based simplicity
+  (agents = users in queue-linked groups or with the permission); revisit if per-queue
+  membership needs first-class modeling.

--- a/.claude/docs/specs/telehealth/3-chat-ui.md
+++ b/.claude/docs/specs/telehealth/3-chat-ui.md
@@ -1,0 +1,87 @@
+# [Slice 3] — Chat UI: Internal Console + Portal Widget
+
+> Child spec of [Telehealth parent](./README.md), to be refined with the implementation.
+> Conforms to parent §Reuse Map, §Security. Depends on slice 2. Frontend-only.
+
+## 1. Goal & scope
+
+Delivers both chat surfaces:
+
+- **Internal console** at `/:tenant/app/chat` (end-user app): inbox with *My conversations*
+  / *Queue* / *All* tabs (the `ApprovalsInboxPage` pattern — filters + tabs + bell), a
+  conversation view (virtualized message list, composer, attachment upload, presence
+  "viewing" chip), claim/close actions, unread badges from `lastReadAt`.
+- **Portal widget** `chat-panel` in the page-builder registry: a tenant drops it on a
+  custom-app page; a portal user sees their conversations, starts one (configured queue),
+  and messages the agent. Props: `queueId`, `welcomeText`, `allowAttachments`.
+- Shared primitives in `@kelta/components`: `MessageList`, `MessageComposer`,
+  `ConversationListItem` (console and widget both consume them — component-reuse rule).
+- Realtime: `RealtimeClient` gains `joinConversation/leaveConversation` + `chat.message`
+  event handling → **invalidate** `['chat-messages', conversationId]` +
+  `['chat-conversations']` (invalidation-only rule holds; no cache writes). Offline sends
+  ride the existing outbox (`SyncEngine`) with pending/failed states in the composer.
+- `TopNavBar` bell aggregates unread chat count alongside approvals; nav menu-item path kind
+  `/chat`.
+
+Does NOT deliver: typing indicators, emoji/reactions, message edit/delete (v2), video
+escalation button (slice 6 adds it into this console).
+
+## 2. UI samples
+
+Console: left rail conversation list (status + unread + last message time), center thread
+(day dividers, sender grouping, attachment chips with presigned download), composer with
+attach + send (Cmd+Enter), header with claim/close + presence chip. Widget: single-thread
+panel sized to its page-builder container, "Start conversation" empty state with
+`welcomeText`.
+
+## 3. Data & API contracts
+
+Consumes slice-2 REST + WS contracts verbatim (parent §Shared contracts). New FE types in
+`kelta-ui/app/src/types/chat.ts` mirroring the collection shapes. Read receipts:
+`POST .../read-receipt` fired on thread focus (debounced). Unread count hook
+`useUnreadChatCount(userId)` = conversations where `lastMessageAt > lastReadAt`, polled +
+realtime-invalidated.
+
+## 4. DB migrations
+
+None.
+
+## 5. File-by-file code changes (sketch)
+
+| Area | Files |
+|------|-------|
+| @kelta/components | `MessageList`, `MessageComposer`, `ConversationListItem` (+ exports, stories/tests) |
+| kelta-ui app | `pages/app/ChatConsolePage/` (inbox + thread), `hooks/useConversations.ts` / `useChatMessages.ts` / `useUnreadChatCount.ts`, `realtime/RealtimeClient.ts` (+chat actions/events), `realtime/invalidation.ts` (+chat keys), `navTabs.ts` `/chat` path kind, `TopNavBar` bell aggregation, App.tsx lazy route |
+| Page builder | `widgets/builtins/engagement.tsx` (`chat-panel` descriptor, registered in `widgets/builtins/index.ts`) |
+| Offline | outbox handling for `POST /api/chat/**` (queue + retry surfaces already generic) |
+| i18n | `chat.*` keys in `en.json` (+ fallbacks) |
+
+All new strings through `useI18n()`; pages `React.lazy`; reuse `Badge`, `Card`,
+`DropdownMenu`, `apiClient`, `usePresence`.
+
+## 6. Test plan
+
+- Vitest: hooks (pagination, unread math, invalidation on chat.message), composer
+  offline-queue state, widget renders from resolved props, RealtimeClient join/leave +
+  resubscribe-on-reconnect (fake WebSocket).
+- Playwright (post-deploy, skip-gated): two-context roundtrip — portal user (widget on a
+  custom page) sends; agent console receives (via invalidation refetch), replies; portal
+  sees reply; attachment upload/download; claim + close flow.
+- Coverage: kelta-web 80% gate applies to the new components.
+
+## 7. Docs to update (same PR)
+
+`status.md` (chat 🟡 → ✅ end-to-end with slice 2); `playbooks.md` widget row if the
+`engagement` category is new; `conventions.md` unchanged (invalidation rule already
+documented in slice 2's update).
+
+## 8. Risks & open questions
+
+- Refetch-per-message latency (~1 RTT after invalidation) is the accepted v1 trade — if UX
+  demands instant echo, local-echo of *own* sends (optimistic append of the POST response)
+  is allowed since it's authorized data, not socket data.
+- Widget inside arbitrary tenant pages must not double-mount the realtime provider —
+  `CustomPage` runs inside `EndUserShell` (provider present); portal shell must too
+  (verify in slice 1's portal landing work).
+- Bell aggregation ordering with approvals count — keep two counters side-by-side rather
+  than a merged number if design review objects.

--- a/.claude/docs/specs/telehealth/4-scheduling.md
+++ b/.claude/docs/specs/telehealth/4-scheduling.md
@@ -1,0 +1,97 @@
+# [Slice 4] — Scheduling & Visit Links
+
+> Child spec of [Telehealth parent](./README.md), to be refined with the implementation.
+> Conforms to parent §Shared contracts, §Security. Depends on slice 1 (portal users book /
+> get invited). Backend + FE.
+
+## 1. Goal & scope
+
+Delivers scheduled visits between a provider (internal) and a portal user:
+
+- System collections: `telehealth-availability` (weekly rules + date exceptions per
+  provider) and `telehealth-appointments` (portalUserId, providerId, scheduledStart/End,
+  status `REQUESTED|CONFIRMED|CANCELLED|COMPLETED|NO_SHOW`, visitType, reason,
+  conversationId?, videoSessionId? — video fields wired in slice 5).
+- **Slot engine**: `GET /api/telehealth/slots?providerId&from&to&duration` computes
+  availability minus booked appointments; `POST /api/telehealth/appointments` books with a
+  conflict check that survives concurrent requests (constraint/locking, not read-then-write).
+- **Booking surfaces**: page-builder widget `appointment-scheduler` (portal picks provider →
+  slot → confirms; auto-creates the participant share via slice 1); staff side books from
+  the appointment collection UI + `CalendarMonthView` on `scheduledStart` (existing saved
+  calendar views).
+- **Reminders & confirmations**: seeded, tenant-editable flow templates — confirmation email
+  on CONFIRMED (with RFC 5545 `.ics` attachment), reminder at T-minus offset via
+  `DelayActionHandler` (`delayUntilField: scheduledStart` minus configured minutes),
+  cancellation notice. Seeded email templates `appointment_confirmed`,
+  `appointment_reminder`, `appointment_cancelled` with a signed **visit link**.
+- **Visit links**: `GET /api/telehealth/visits/{signedToken}` (public path) — HMAC token
+  bound to (tenant, appointment, portal user), valid only in the appointment window ±
+  grace, redirects into the portal app's appointment page (magic-link auth if no session).
+
+Does NOT deliver: recurrence, group visits, external calendar sync (Google/CalDAV — the
+`.ics` attachment is the v1 interop), SMS reminders, video session creation (slice 5).
+
+## 2. UI samples
+
+Widget: 3-step wizard (provider/visit type → date grid with free slots in the portal user's
+timezone → confirm + reason). Staff: appointments list + calendar view; appointment record
+detail shows status timeline, linked conversation, reschedule/cancel actions.
+
+## 3. Data & API contracts
+
+```
+GET  /api/telehealth/slots?providerId&from&to&duration=30 → {slots:[{start,end}]}   (tenant TZ math server-side)
+POST /api/telehealth/appointments {providerId, start, visitType, reason?}           → 201 (portal: self; staff: any portalUserId)
+POST /api/telehealth/appointments/{id}/cancel|reschedule|complete
+GET  /api/telehealth/visits/{token}                                                 → 302 into portal appointment page
+```
+
+Availability shape: weekday, startTime, endTime, timezone, effectiveFrom/To, plus exception
+rows (date, closed|window-override). Slot computation is pure worker logic (unit-testable);
+booking enforces `status IN (REQUESTED, CONFIRMED)` non-overlap per provider. Portal authz:
+own appointments only (participant share on create + in-controller checks on the scoped
+endpoints, same idiom as chat).
+
+## 4. DB migrations
+
+One migration (verify head): two tables + RLS + indexes
+(`(tenant_id, provider_id, scheduled_start)` and an overlap-guard constraint — exclusion
+constraint on tstzrange per provider where status active, or equivalent locking strategy
+decided at implementation).
+
+## 5. File-by-file code changes (sketch)
+
+| Area | Files |
+|------|-------|
+| runtime-core | `SystemCollectionDefinitions` +2 collections |
+| kelta-worker | `TelehealthSchedulingController` + `SlotService` + `AppointmentService` (JdbcTemplate repos, conflict-safe booking), `AppointmentHook` (participant share, NATS via record.changed only — no custom subject needed), `.ics` generator util in the email path, seeded flow + email templates, gateway static route registration `/api/telehealth/**`, visit-token service (HMAC, campaign precedent), audit events |
+| kelta-ui | `appointment-scheduler` widget descriptor; appointments admin/list config; calendar saved-view seed |
+| i18n | `telehealth.scheduling.*` |
+
+## 6. Test plan
+
+- Worker unit: slot math (rules + exceptions + TZ/DST edges), double-book race (constraint
+  path), visit-token window binding + single-use, `.ics` output validity (RFC 5545 lint).
+- Harness: RLS on appointments; portal reads own only; booking conflict under two concurrent
+  transactions (real Postgres).
+- Vitest: widget wizard flow with mocked slots.
+- Playwright (post-deploy, skip-gated): portal books via widget → confirmation email in
+  mailpit with `.ics` + visit link → link lands authenticated on the appointment page;
+  staff sees it on the calendar; reminder flow fires (delay shortened in test config).
+
+## 7. Docs to update (same PR)
+
+`status.md`; `integrations.md` (`.ics` + visit links); `architecture.md`
+(`/api/telehealth/**` authz row + static route); `concerns.md` if the exclusion-constraint
+approach adds operational notes.
+
+## 8. Risks & open questions
+
+- Timezone/DST correctness is the bug farm — all persistence UTC, slot expansion in the
+  provider's zone, rendering in the viewer's; DST-transition tests are mandatory.
+- Overlap enforcement choice (Postgres exclusion constraint vs advisory lock) decided at
+  implementation; the harness race test pins the behavior either way.
+- Reminder flows are tenant-editable seeds — a tenant deleting the flow silently loses
+  reminders; note in the admin UI (badge "reminders disabled") as a stretch.
+- Provider identity = platform user in v1; a separate "provider directory" collection
+  (specialties, display bios for the widget) is deferred unless the widget needs it.

--- a/.claude/docs/specs/telehealth/5-video-backend.md
+++ b/.claude/docs/specs/telehealth/5-video-backend.md
@@ -1,0 +1,102 @@
+# [Slice 5] — Video Backend (LiveKit)
+
+> Child spec of [Telehealth parent](./README.md), to be refined with the implementation.
+> Conforms to parent §Key architecture decisions, §Security, §Deployment. Depends on
+> slice 4 (appointments). **Security-typed PR — never auto-merged.** Backend + infra.
+
+## 1. Goal & scope
+
+Delivers video-session lifecycle on self-hosted LiveKit:
+
+- **Infra**: LiveKit ArgoCD app in `~/GitHub/homelab-argo` (Deployment, Service, Ingress
+  `livekit.rzware.com`/`livekit.kelta.io` for wss signaling, embedded TURN with TLS
+  fallback, node UDP media range; image via Harbor; keys in a Secret). Local dev:
+  `docker-compose.yml` `telehealth` profile + `make up-telehealth`.
+- `video-sessions` system collection: appointmentId?, conversationId? (ad-hoc escalation
+  from chat), roomName (opaque UUID), status `CREATED|ACTIVE|ENDED`, startedAt, endedAt,
+  durationSeconds, recordingConsent, recordingKey?.
+- **Token mint**: `POST /api/telehealth/sessions/{id}/token` — authorizes the caller
+  (appointment provider/portal participant or conversation participant), checks the
+  `telehealth` feature flag + `videoMinutesPerMonth` governor, then mints a short-TTL HS256
+  LiveKit access token (identity = userId, display name, room-scoped join/publish/subscribe
+  grants). Hand-minted JWT with existing libs — no vendor SDK dependency.
+- **Webhooks**: `POST /api/telehealth/webhooks/livekit` (public path, signature-verified,
+  idempotent) — `room_started`/`participant_joined`/`room_finished`/`egress_ended` drive
+  session status, compute minutes into the governor usage counter, publish
+  `kelta.video.session.<tenantId>.<sessionId>` (NATS_TRIGGERED flows: post-visit follow-up,
+  no-show detection), and emit audit events.
+- **Recording (optional)**: per-tenant flag + per-visit consent (captured in slice 6); room
+  composite egress → tenant-prefixed S3 → `egress_ended` webhook attaches the file as an
+  attachment record on the appointment; retention via the attachment lifecycle.
+- Sessions auto-created for CONFIRMED appointments at booking or first-join (implementation
+  decides; spec default: lazily at first token request).
+
+Does NOT deliver: any UI (slice 6), SIP/phone dial-in, live transcription (LiveKit agents —
+possible v2 with kelta-ai), multi-region SFU.
+
+## 2. Sample payloads
+
+```
+POST /api/telehealth/sessions/{id}/token → {url:"wss://livekit.<domain>", token:"<jwt>", expiresAt}
+webhook room_finished → session ENDED, durationSeconds set, usage counter += ceil(minutes), NATS event published
+```
+
+LiveKit grant claims (video): `{roomJoin:true, room:"<roomName>", canPublish:true,
+canSubscribe:true}`; TTL ≈ appointment window + grace.
+
+## 3. Data & API contracts
+
+Parent §Shared contracts lists the endpoints/subject. Governor: `videoMinutesPerMonth` in
+`TenantTierQuotas` + Redis `video-minutes-monthly:<tenantId>:<yyyy-MM>` (the ai-tokens
+pattern); token mint rejects at cap with the 429 governor envelope. Credentials: LiveKit API
+key/secret in the platform credential store (encrypted, `kelta.config.credential.changed`
+invalidation), configured per environment — not per tenant (single shared SFU; rooms are
+tenant-namespaced `t_<tenantId>_<uuid>` and tokens are room-scoped).
+
+## 4. DB migrations
+
+One migration (verify head): `video-sessions` table + RLS + indexes
+(`(tenant_id, appointment_id)`, `(tenant_id, status)`); webhook idempotency table (event id,
+processed_at) or Redis SETNX — decided at implementation.
+
+## 5. File-by-file code changes (sketch)
+
+| Area | Files |
+|------|-------|
+| runtime-core | `SystemCollectionDefinitions` +`video-sessions` |
+| kelta-worker | `VideoSessionController` (token mint), `VideoSessionService`, `LiveKitTokenService` (HS256 mint), `LiveKitWebhookController` + signature verifier + idempotency, governor key + usage counter, egress→attachment wiring, audit events (`VIDEO_TOKEN_ISSUED`, `VIDEO_SESSION_STARTED/ENDED`) |
+| kelta-gateway | public path for the webhook; `/api/telehealth/**` static route already registered (slice 4) |
+| runtime-events | `VideoSessionPayload` |
+| homelab-argo (separate repo PR) | livekit app manifests |
+| repo root | docker-compose `telehealth` profile, Makefile target, README env keys |
+
+## 6. Test plan
+
+- Worker unit: token grants/TTL/room scoping, authz matrix (provider ok, portal participant
+  ok, stranger 403, feature-off 403, governor-cap 429), webhook signature accept/reject +
+  idempotent replay, minutes computation.
+- Harness: session RLS; webhook → status transition → NATS publish (Testcontainers NATS);
+  egress → attachment row.
+- Manual/deploy smoke: two browsers join a dev-stack room (documented in README); Playwright
+  automation lands in slice 6 with fake-media flags.
+- Infra: ArgoCD sync + `livekit-cli` connection test documented in the runbook.
+
+## 7. Docs to update (same PR)
+
+CLAUDE.md Messaging table (+`kelta.video.session.*`); `integrations.md` LiveKit section
+(deploy, token shape, webhooks, recording); `architecture.md` trust boundary; `ci-cd.md` if
+the compose profile touches CI; `README.md` (profile + env); `concerns.md` (SFU ops:
+UDP/TURN reachability, single-node capacity); `status.md`.
+
+## 8. Risks & open questions
+
+- **Patient-network reachability** is the classic failure: corporate/hospital NATs block
+  UDP — TURN-TLS on 443 must be enabled and smoke-tested from a restricted network before
+  calling this shipped.
+- Single shared SFU across tenants is an accepted v1 trade (room-scoped tokens isolate
+  access; media isn't tenant-RLS'd by nature) — document in `concerns.md`; per-tenant
+  keys/instances only if a compliance requirement demands it.
+- Recording consent semantics (both parties? per-tenant policy?) — v1: recording only
+  starts after all participants consent (slice 6 captures it); operators needing
+  one-party-consent rules configure per tenant. Legal posture is the operator's.
+- LiveKit version pinning + upgrade cadence goes in the homelab-argo runbook.

--- a/.claude/docs/specs/telehealth/6-video-ui.md
+++ b/.claude/docs/specs/telehealth/6-video-ui.md
@@ -1,0 +1,86 @@
+# [Slice 6] — Video UI & Visit Experience
+
+> Child spec of [Telehealth parent](./README.md), to be refined with the implementation.
+> Conforms to parent §Reuse Map, §Security. Depends on slice 5 (+ slice 3 for in-call
+> chat). Frontend-only.
+
+## 1. Goal & scope
+
+Delivers the call experience for both personas:
+
+- **Shared `VideoRoom` component** in `@kelta/components` wrapping
+  `@livekit/components-react` + `livekit-client` (Apache-2.0): pre-join device check
+  (cam/mic select, preview, permissions troubleshooting), grid layout, control bar
+  (mute/cam/leave; screen share if free), connection-quality indicator, ended state.
+  Lazy-loaded — the LiveKit bundle never ships in the base app chunk.
+- **Staff side**: "Join visit" on the appointment record (window-gated), "Start video"
+  escalation from a chat conversation (creates an ad-hoc session via slice 5), in-call side
+  panel embedding the slice-3 message thread.
+- **Portal side**: `video-visit` page-builder widget — upcoming visit card, join enabled in
+  the appointment window ± grace, **waiting room** (patient joins presence resource
+  `visit:<appointmentId>`; provider's appointment view shows "patient is waiting" via
+  `usePresence`), consent screen when tenant recording is enabled (consent stored on the
+  session before any egress starts), always-visible recording indicator, post-call summary
+  screen.
+- Visit-link landing (slice 4) resolves into this widget's page.
+
+Does NOT deliver: transcription, backgrounds/blur (LiveKit track processors — v2), kiosk
+mode, provider multi-call juggling.
+
+## 2. UI samples
+
+Pre-join: device selectors + preview + "Join visit" (disabled outside window with
+countdown). In-call: video grid, control bar, chat side panel (staff), recording pill.
+Waiting room (portal): "Dr. K will admit you shortly" + camera preview. Consent modal:
+tenant-configurable text, Accept/Decline (decline → audio-video call proceeds unrecorded or
+join blocked per tenant policy).
+
+## 3. Data & API contracts
+
+Consumes slice-5 token endpoint verbatim. Consent:
+`POST /api/telehealth/sessions/{id}/consent {accepted}` (added here, worker-side trivial,
+stored on `video-sessions.recordingConsent`, audited `RECORDING_CONSENT_CAPTURED`).
+Presence resource convention `visit:<appointmentId>` (parent §Shared contracts). Widget
+props: `showUpcomingList`, `joinGraceMinutes`, `consentTextOverride?`.
+
+## 4. DB migrations
+
+None.
+
+## 5. File-by-file code changes (sketch)
+
+| Area | Files |
+|------|-------|
+| @kelta/components | `VideoRoom/` (pre-join, room, ended states; deps `@livekit/components-react`, `livekit-client`) |
+| kelta-ui app | appointment record "Join visit" action, chat console "Start video" escalation, `pages/app/VisitPage/` (route target for visit links), `widgets/builtins/engagement.tsx` +`video-visit` descriptor, `usePresence` waiting-room wiring |
+| kelta-worker | consent endpoint (small; rides this slice) |
+| i18n | `telehealth.visit.*` |
+
+Bundle rule: `React.lazy` + dynamic import for everything touching livekit-client; verify
+chunk split in the build output.
+
+## 6. Test plan
+
+- Vitest: window-gating logic, consent flow state machine, token-fetch error surfaces
+  (feature off / governor cap → friendly messages), VideoRoom renders with a mocked LiveKit
+  room object.
+- Playwright (post-deploy, skip-gated): two contexts with
+  `--use-fake-device-for-media-stream` / fake UI stream — portal joins waiting room,
+  provider sees presence, both connect to the dev-compose LiveKit, media tracks present,
+  leave → session ENDED; consent modal path when recording enabled.
+- Manual cross-network smoke (TURN path) documented as a release gate with slice 5.
+
+## 7. Docs to update (same PR)
+
+`status.md` (Telehealth → ✅ when this lands); `kelta-ui/DESIGN.md` if the call surface
+introduces new visual tokens; parent README slice table SHIPPED annotations.
+
+## 8. Risks & open questions
+
+- Browser permission UX (blocked camera) is the top support driver — the pre-join
+  troubleshooting states are in-scope, not polish.
+- LiveKit bundle size (~hundreds of KB) — enforced lazy split; measure in CI.
+- Consent-decline policy (proceed unrecorded vs block) — default: proceed unrecorded;
+  per-tenant override flag. Operator decides the legal stance.
+- e2e against a real SFU in CI may be flaky — keep the Playwright spec skip-gated to the
+  deployed dev stack (per repo precedent) rather than fighting CI networking.

--- a/.claude/docs/specs/telehealth/README.md
+++ b/.claude/docs/specs/telehealth/README.md
@@ -1,0 +1,285 @@
+# Telehealth — Chat + Video for Internal and External Users (Parent Spec)
+
+> **Status:** parent planning spec. Authoritative shared contract for adding **human-to-human
+> chat and scheduled video visits** to the platform: an internal user (agent/provider) working
+> from the end-user app answers chats and joins scheduled video calls with **external users
+> (patients/portal users)** who reach the same services through a **tenant custom application**
+> (page-builder pages, optionally on a custom domain). Each slice in the
+> [Slice plan](#slice-plan) is expanded into its own child spec in this directory and
+> **extends, never contradicts** the [Reuse Map](#reuse-map),
+> [shared contracts](#shared-contracts), and [Security](#security) sections below.
+>
+> Source-verified against the codebase on 2026-07-10 (Flyway directory head **V166**
+> — next new migration is **V167**; deployed flyway_schema_history keeps pre-flatten
+> numbering, so always check the directory + deployed history before numbering). If code and
+> this doc disagree, trust the code and fix this doc.
+
+## How to use this document
+
+This parent defines the cross-cutting architecture once. Child specs each cover one PR-sized
+slice with acceptance criteria, UI samples, exact contracts, DB migrations (or "none"),
+file-by-file changes, and a test plan — per the child-spec template in
+`specs/app-surfacing/README.md` (sections 1–8; sections that don't apply state "N/A — reason").
+Read this parent first; every child references it.
+
+| Slice | Child spec | Axis |
+|-------|-----------|------|
+| 0 — This spec + doc wiring | (this file) | foundation (docs) |
+| 1 — Portal identity & record access | `1-portal-identity.md` | **backend + auth, security** |
+| 2 — Chat backend | `2-chat-backend.md` | backend (collections, WS routing, NATS) |
+| 3 — Chat UI (console + widget) | `3-chat-ui.md` | FE (internal console + portal widget) |
+| 4 — Scheduling & visit links | `4-scheduling.md` | backend + FE (appointments, slots, reminders) |
+| 5 — Video backend (LiveKit) | `5-video-backend.md` | **backend + infra, security** |
+| 6 — Video UI & visit experience | `6-video-ui.md` | FE (join, waiting room, consent) |
+
+**Dependency order (hard edges): 1 → 2 → 3, and 1 → 4 → 5 → 6.** Chat (2–3) and scheduling
+(4) are independent tracks after slice 1. Slice 6 also consumes the chat widget from 3 for
+in-call chat, but degrades gracefully without it.
+
+## Context
+
+The platform has no human-to-human communication features. The 2026-07-10 recon confirmed:
+
+1. **Chat is greenfield** — no chat/message/conversation collections, controllers, or event
+   streams exist anywhere (kelta-ai chat is Claude Q&A, not messaging).
+2. **The realtime plumbing is built and extensible** — gateway `/ws/realtime`
+   (`RealtimeWebSocketHandler`, `SubscriptionManager`, `RealtimeBridge`,
+   `PresenceService`) authenticates JWTs, routes per `tenantId:collection`, fans out NATS
+   events, and tracks per-resource presence with heartbeats. The FE `RealtimeClient` +
+   `RealtimeProvider` (invalidation-only) ship in the end-user app.
+3. **External users don't exist as a concept** — every user is a staff-shaped
+   `platform_user`; no `user_type`, no self-serve or passwordless login, no default
+   "own records only" enforcement. But the ingredients do exist: the invite flow +
+   email templates, federated JIT provisioning, the `record_share` table +
+   `RecordShareAccessService` Cerbos widening, and signed-token public endpoints
+   (campaign tracking HMAC links).
+4. **Scheduling primitives mostly exist** — DATE/DATETIME fields, `CalendarMonthView`,
+   SCHEDULED (cron) flows, `DelayActionHandler` (delay-until-field), tenant SMTP email +
+   templates + logs, S3 attachments with presigned URLs, governor limits, per-tenant feature
+   flags, `SecurityAuditLogger`. Missing: availability/slot logic, recurrence, a production
+   `SmsProvider`.
+5. **Video is entirely absent** — no WebRTC/SFU/TURN references in the repo.
+
+**Intended outcome:** a tenant can enable Telehealth, drop a `chat-panel` and
+`appointment-scheduler`/`video-visit` widget onto custom-app pages for portal users, and
+staff get a chat inbox console plus calendar-driven video visits in the end-user app — with
+tenant isolation, auditability, and deny-by-default portal access preserved throughout.
+
+## Key architecture decisions
+
+- **Video = self-hosted LiveKit OSS (Apache-2.0 WebRTC SFU).** Standards-first (WebRTC,
+  DTLS-SRTP media encryption), open source, single-binary server that deploys to the
+  existing K8s cluster via ArgoCD, embedded TURN with TLS fallback, egress service for
+  recording, signed webhooks for room lifecycle, and mature React components
+  (`@livekit/components-react`, Apache-2.0). Access tokens are plain HS256 JWTs with a
+  `video` grant claim — the worker mints them with existing JWT libs; no vendor SDK required.
+  **Media never traverses the gateway**: clients connect to LiveKit's own ingress
+  (`livekit.<domain>`); the platform only authorizes + mints tokens and consumes webhooks.
+  Considered and rejected: Jitsi (multi-service footprint, weaker embed SDK), mediasoup
+  (a library — we'd own SFU orchestration), SaaS video (Twilio/Daily — closed source,
+  per-minute cost, PHI leaves the infrastructure; violates the open-source-only rule).
+- **Chat = platform-native on the existing realtime socket, with conversation-scoped
+  routing.** New `kelta.chat.message.<tenantId>.<conversationId>` NATS family; a
+  `ChatMessageBridge` in the gateway (mirror of `RealtimeBridge`) fans events **only to
+  sessions that joined the conversation and passed a membership check** — NOT the
+  collection-broadcast model, which fans to every tenant subscriber and would leak message
+  metadata across patients. Considered and rejected for v1: Matrix (open standard, but a
+  foreign identity/homeserver model and heavy ops for an embedded tenant chat; revisit if
+  cross-org federation ever matters).
+- **Chat/scheduling data = system collections** (`chat-conversations`, `chat-messages`,
+  `chat-participants`, `chat-queues`, `telehealth-appointments`, `telehealth-availability`,
+  `video-sessions`) — the approvals precedent: platform code and UI rely on a fixed shape,
+  and system collections get JSON:API, RLS, flows (RECORD_TRIGGERED automations), audit,
+  attachments, and realtime for free. Growth risk (shared public-schema tables holding
+  high-volume messages) is mitigated with indexes + a per-tenant retention policy and
+  recorded in `concerns.md`.
+- **External users = first-class platform users with `user_type = PORTAL`** — not anonymous
+  guests. Passwordless magic-link/OTP login (email; SMS later via the existing `SmsProvider`
+  SPI), admin- or flow-initiated invites, optional per-tenant federation (already built).
+  Portal users authenticate exactly like staff (same JWT, same gateway filters, same WS
+  auth); a seeded **Portal User profile** + participant-based `record_share` grants give
+  deny-by-default access to only their own conversations/appointments.
+- **Direct reads stay on the authorized HTTP path; the socket stays an invalidation
+  signal.** The established invalidation-only client rule holds for chat too: a pushed
+  `chat.message` event triggers a refetch of the conversation query — the client never
+  writes pushed `data` into caches. (Join-time membership checks make payload push safe as
+  a v2 latency optimization; not v1.)
+- **Scheduling = availability rules + a slot engine + booked appointments**, with reminder
+  automation built from existing pieces: seeded flow templates using `DelayActionHandler`
+  (delay-until `scheduledStart` minus offset) + tenant email templates + an RFC 5545 `.ics`
+  attachment. Visit-join links in emails are short-lived signed HMAC tokens (the
+  campaign-tracking precedent), never bare record ids.
+- **Feature-gated + governed per tenant.** A `telehealth` feature flag (tier defaults +
+  per-tenant override, invalidated via `kelta.config.feature.changed.<tenantId>`) gates
+  every endpoint and UI surface. New governor keys: `videoMinutesPerMonth` (usage counter
+  mirrors the `ai-tokens-monthly` Redis pattern) and `maxPortalUsers` (enforced at
+  invite/create — closing the known "gov_users tracked but not enforced" gap for the portal
+  population).
+- **Compliance posture for telemedicine.** Every conversation/session access emits
+  `SecurityAuditLogger` events (OpenSearch); recording is **off by default**, per-tenant
+  opt-in, with explicit in-call consent capture stored on the session record; media is
+  DTLS-SRTP, signaling and chat ride wss/TLS; recordings land in the tenant's S3 prefix
+  with a retention policy; NATS subjects and logs carry **ids only, never message bodies or
+  PHI**. Self-hosting keeps PHI inside the operator's infrastructure (no third-party
+  processor). HIPAA formalities (BAA, risk analysis) are an operator concern documented
+  here, not enforced by code.
+
+## Reuse Map
+
+Use these — do not rebuild.
+
+| Need | Reuse | Path |
+|------|-------|------|
+| WS auth + session lifecycle | `RealtimeWebSocketHandler` (JWT query param, 4000/4001 closes) | `kelta-gateway/.../websocket/RealtimeWebSocketHandler.java` |
+| Socket routing + caps | `SubscriptionManager` (50 subs/session, 100 conns/tenant) | `kelta-gateway/.../websocket/SubscriptionManager.java` |
+| NATS→WS fanout pattern | `RealtimeBridge` (copy for `ChatMessageBridge`) | `kelta-gateway/.../listener/RealtimeBridge.java` |
+| Who-is-here / waiting room | `PresenceService` (resource-keyed, 30s heartbeat, 90s expiry) | `kelta-gateway/.../websocket/PresenceService.java` |
+| FE socket client | `RealtimeClient` (backoff, resubscribe, token refresh) + `RealtimeProvider` | `kelta-ui/app/src/realtime/` |
+| Record-level grants | `record_share` table + `RecordShareAccessService` Cerbos widening | `kelta-worker/.../repository/RecordShareRepository.java` |
+| Invite + email delivery | `UserInviteService`, `EmailService` SPI, `email-templates`/`email-logs` | `kelta-worker/.../service/`, `runtime-module-integration/.../spi/EmailService.java` |
+| Passwordless precedent | Signed HMAC public links (campaign tracking) + `PublicPathMatcher` | `kelta-worker/.../controller/CampaignTrackingController.java` |
+| Time-based automation | `DelayActionHandler` (delayUntilField), `ScheduledJobExecutorService` (cron) | `runtime-module-integration/.../handlers/DelayActionHandler.java` |
+| Flow triggers | RECORD_TRIGGERED / NATS_TRIGGERED / SCHEDULED flows | `runtime-core/.../flow/FlowTriggerEvaluator.java` |
+| File attachments | S3 presigned upload/download, `AttachmentCleanupHook`, `AttachmentUrlEnricher` | `kelta-worker/.../service/S3StorageService.java` |
+| Quotas + usage counters | `TenantTierQuotas`, `GovernorLimitsController`, Redis daily/monthly counters | `kelta-worker/.../service/TenantTierQuotas.java` |
+| Per-tenant feature gate | `tenant.limits` + `kelta.config.feature.changed` invalidation | `kelta-worker/.../listener/SystemFeatureEventPublisher.java` |
+| Audit trail | `SecurityAuditLogger` (structured, OpenSearch) | `kelta-worker/.../service/SecurityAuditLogger.java` |
+| Inbox UX pattern | `ApprovalsInboxPage` + `TopNavBar` bell + count hook | `kelta-ui/app/src/pages/app/ApprovalsInboxPage/` |
+| Calendar UI | `CalendarMonthView` (renders any DATE/DATETIME field) | `kelta-ui/app/src/components/CalendarMonthView/` |
+| Custom-app embedding | Page-builder `WidgetDescriptor` registry (palette/inspector/runtime auto-wire) | `kelta-ui/app/src/pages/PageBuilderPage/widgets/` |
+| Offline sends | IndexedDB outbox + `SyncEngine` + `OfflineIndicator` | `kelta-ui/app/src/offline/` |
+| Custom domains + JWT issuers | `CustomDomainFilter`, `DynamicReactiveJwtDecoder` | `kelta-gateway/.../filter/CustomDomainFilter.java` |
+| In-controller permission checks | `requirePermission` pattern | e.g. `kelta-worker/.../controller/EnvironmentController.java` |
+| System-collection change events | BeforeSaveHook + `PlatformEventPublisher` (Critical Rule 1) | `kelta-worker/.../listener/CollectionConfigEventPublisher.java` |
+
+## Shared contracts
+
+### NATS subjects (new — added to the CLAUDE.md Messaging table when each slice ships)
+
+```
+kelta.chat.message.<tenantId>.<conversationId>       chat message created (ids + sender + kind; NO body text)
+kelta.chat.conversation.<tenantId>.<conversationId>  conversation lifecycle (OPENED|ASSIGNED|CLOSED)
+kelta.video.session.<tenantId>.<sessionId>           video session lifecycle (CREATED|ACTIVE|ENDED|RECORDING_READY)
+```
+
+Envelope: standard `PlatformEvent<T>`. Payloads carry ids, actor, timestamps, state — never
+message bodies or PHI (bodies are fetched over the authorized JSON:API/REST path).
+
+### WebSocket protocol extensions (same `/ws/realtime` socket)
+
+```
+send  {"action":"chat.join","conversationId":"<uuid>"}     (membership-checked server-side; max 20 joined/session)
+send  {"action":"chat.leave","conversationId":"<uuid>"}
+recv  {"action":"chat.joined","conversationId":"…"} | {"action":"error","message":"…"}
+recv  {"event":"chat.message","conversationId":"…","messageId":"…","senderId":"…",
+       "kind":"TEXT|SYSTEM|ATTACHMENT","timestamp":"…"}            (no body — invalidation signal)
+recv  {"event":"chat.conversation","conversationId":"…","status":"OPEN|ASSIGNED|CLOSED",…}
+```
+
+Presence reuses the existing `presence.join` with resource conventions
+`chat:<conversationId>` (typing/viewing) and `visit:<appointmentId>` (waiting room).
+
+### REST namespace (gateway static route `/api/telehealth/**` and `/api/chat/**` — Pitfall: register in `RouteConfigService.registerStaticRoutes()`)
+
+```
+POST /api/chat/conversations                       start conversation (portal or staff)
+GET  /api/chat/conversations?view=mine|queue|all   inbox lists (staff views permission-gated)
+GET  /api/chat/conversations/{id}/messages?after=  history (participant-only, in-controller check)
+POST /api/chat/conversations/{id}/messages         send (participant-only)
+POST /api/chat/conversations/{id}/assign|close|read-receipt
+GET  /api/telehealth/slots?providerId&from&to&duration
+POST /api/telehealth/appointments                  book (conflict-checked)
+POST /api/telehealth/sessions/{id}/token           mint LiveKit access token (member-only)
+GET  /api/telehealth/visits/{signedToken}          visit-link landing (public path, HMAC)
+POST /api/telehealth/webhooks/livekit              LiveKit webhook (public path, signature-verified)
+POST /api/auth/portal/request-link | /exchange     magic-link login (kelta-auth, rate-limited)
+```
+
+Generic JSON:API on the chat/telehealth system collections remains available to staff
+profiles; the Portal User profile gets **no** direct collection grants — portal access goes
+through the scoped endpoints above plus `record_share` widening.
+
+### Identity
+
+`platform_user.user_type ∈ {INTERNAL, PORTAL}` (default INTERNAL). The JWT carries a
+`user_type` claim; gateway forwards it like other identity headers. Portal sessions are
+issued by kelta-auth exactly like staff sessions (same issuer/JWKS path, custom-domain
+issuers already supported by `DynamicReactiveJwtDecoder`).
+
+## Security
+
+- **Slices 1 and 5 are security-typed PRs — never auto-merged** (SECURITY.md + standing
+  rule): slice 1 changes authentication (passwordless login, new principal type); slice 5
+  exposes signed public endpoints and mints media-access tokens.
+- **Deny-by-default for portal users.** The seeded Portal User profile grants `API_ACCESS`
+  only — no collection CRUD, no setup permissions. Every portal read/write flows through
+  participant-scoped endpoints (in-controller membership checks) or `record_share` grants
+  written by hooks when the user becomes a participant. A portal JWT hitting `/api/admin/**`
+  or generic collections fails closed.
+- **WS join authz.** `chat.join` verifies conversation membership against the worker
+  (cached, short TTL) before any fanout; presence resources for chat/visits apply the same
+  check. The existing tenant/collection subscribe path is unchanged.
+- **Signed links.** Magic-link + visit tokens: single-use, short expiry (magic link ≤ 15
+  min, visit link scoped to the appointment window), HMAC-signed server secret, bound to
+  tenant + user + purpose, invalidated on use, rate-limited request endpoints with no
+  account enumeration (uniform responses). Follow the campaign-tracking HMAC implementation,
+  not a new scheme.
+- **LiveKit trust boundary.** API key/secret live in the platform credential store (never
+  tenant-visible); tokens are minted server-side per session with room-scoped grants and
+  short TTL; webhook requests are signature-verified (LiveKit signs with the API key) and
+  processed idempotently. Room names are opaque UUIDs, never PHI.
+- **No PHI in transport metadata.** NATS payloads, WS events, audit entries, and logs carry
+  ids only. Message bodies live in the RLS-protected tables and are fetched over the
+  authorized path. Masking interplay: chat/telehealth system collections are excluded from
+  full-text/embedding indexes by default.
+- **Audit.** New `SecurityAuditLogger` event types: `PORTAL_LINK_REQUESTED`, `PORTAL_LOGIN`,
+  `CHAT_CONVERSATION_OPENED/ASSIGNED/CLOSED`, `CHAT_ACCESS_DENIED`,
+  `VIDEO_TOKEN_ISSUED`, `VIDEO_SESSION_STARTED/ENDED`, `RECORDING_CONSENT_CAPTURED`.
+- **JWT on the WS query param** (existing design) applies to portal sockets too — never log
+  upgrade URLs.
+
+## Deployment & infrastructure
+
+- **LiveKit (prod):** new ArgoCD app in `~/GitHub/homelab-argo` — Deployment (single
+  replica to start; Redis only needed multi-node), Service, Ingress `livekit.rzware.com` /
+  `livekit.kelta.io` (wss signaling on 443), UDP media port range on the node (or
+  TURN-TLS 443 fallback for restrictive patient networks — embedded TURN enabled), egress
+  service optional until recording ships. Keys in a K8s Secret; image mirrored through
+  `harbor.rzware.com`.
+- **Local dev:** `docker-compose.yml` gains a `telehealth` profile (`livekit/livekit-server`
+  dev-mode keys) + Makefile `up-telehealth`; mailpit already covers magic-link/reminder
+  email testing.
+- **Rollout:** feature flag off for all tenants until slice 6; enable per tenant via
+  governor limits UI.
+
+## Explicitly deferred (v2+)
+
+- Production `SmsProvider` implementation (SPI exists; needs a provider decision) — email
+  covers v1 notifications.
+- Recurring appointments + multi-provider group visits (LiveKit rooms already support >2
+  participants; the scheduling model is 1:1 for v1).
+- Screen share + in-call file share polish (LiveKit supports screen share nearly free —
+  stretch goal inside slice 6, not a commitment).
+- Server-push message payloads over the socket (needs the per-subscriber authz stance
+  formalized; v1 is invalidation-only).
+- Automatic queue routing/assignment strategies beyond manual claim + flow templates
+  (round-robin/least-busy as flow recipes later).
+- Waiting-room auto-admit, kiosk mode, EHR/FHIR export (HL7 FHIR is the standards path if
+  clinical-system integration is requested).
+- Matrix bridge/federation.
+
+## Docs to update (per CLAUDE.md Rule 6, as slices ship)
+
+- `.claude/docs/status.md` — Telehealth row moves ⚪ → 🟡 → ✅ per slice.
+- `CLAUDE.md` — Messaging table (new subjects, slices 2/5), Module Map only if a new module
+  appears (none planned — code lands in worker/gateway/auth/ui), specs row (slice 0).
+- `.claude/docs/architecture.md` — `/api/chat/**` + `/api/telehealth/**` authorization rows,
+  WS protocol extension, LiveKit trust boundary.
+- `.claude/docs/integrations.md` — LiveKit section (deploy, webhooks, token shape), magic
+  links, `.ics` generation.
+- `.claude/docs/conventions.md` — conversation-scoped socket rule (join-gated fanout, ids
+  only), portal-endpoint authz idiom.
+- `.claude/docs/concerns.md` — chat table growth/retention, LiveKit ops (UDP/TURN), portal
+  enumeration surface.
+- `.claude/docs/playbooks.md` — "add a conversation-scoped realtime event" recipe (slice 2).
+- `README.md` — `telehealth` compose profile + env keys (slice 5).

--- a/.claude/docs/status.md
+++ b/.claude/docs/status.md
@@ -87,6 +87,10 @@ ship a change that moves a row.
 
 HA/failover docs (RTO/RPO) · scheduled *backup* (data export itself ships — see ✅).
 
+| Capability | Notes |
+|------------|-------|
+| Telehealth: chat + video + scheduling + portal users | Parent spec `specs/telehealth/README.md` (2026-07-10), slices 1–6: portal identity (magic-link login, `user_type`, participant `record_share` grants) → chat (system collections + conversation-scoped WS routing on the existing `/ws/realtime` socket) → chat console/widget → scheduling (slots, reminders via `DelayActionHandler`, signed visit links) → self-hosted LiveKit video (token mint, webhooks, governor `videoMinutesPerMonth`) → visit UX. Nothing implemented yet — no chat/video code exists in the repo. |
+
 *(Data masking: PR 1 backend core + PR 2 egress/UI/MCP shipped — see the 🟡 Partial table; only v2 contexts [dashboards, system-tier flow/webhook] + post-deploy e2e remain.)*
 *(Delegated administration moved to 🟡 2026-07-05 — scoped user management ships; see the Partial table.)*
 *(Removed 2026-07-04: sandbox environments + metadata promotion → 🟡 shipped as

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,7 +142,7 @@ visual system.
 | Frontend | React | 19.2 | `kelta-ui/app/package.json` |
 | Frontend build | Vite / Vitest | web 5.1/1.3, ui 7.2/4.0 | package.json (npm, Node 18 in CI) |
 | E2E | Playwright | 1.50 | `e2e-tests/package.json` |
-| Migrations | Flyway | baseline **V1__baseline** (#1189 flatten), next new migration **V162** (deployed history keeps pre-flatten numbering) | `kelta-worker/.../db/migration/` |
+| Migrations | Flyway | baseline **V1__baseline** (#1189 flatten), next new migration **V167** (deployed history keeps pre-flatten numbering) | `kelta-worker/.../db/migration/` |
 
 Check the relevant `pom.xml` / `package.json` for exact current versions before pinning.
 
@@ -252,7 +252,7 @@ Java tests: surefire runs `*Test`/`*Tests`/`*Properties` in parallel; failsafe r
 ## Database Migrations
 
 - Location: `kelta-worker/src/main/resources/db/migration/`
-- Naming: `V<n>__<snake_description>.sql`. **Baseline file is V1__baseline (#1189 flatten); next new migration is V162 — deployed flyway_schema_history retains pre-flatten numbering (entries up to V161), so a lower-numbered migration is silently skipped on existing databases.**
+- Naming: `V<n>__<snake_description>.sql`. **Baseline file is V1__baseline (#1189 flatten); next new migration is V167 (directory head V166) — deployed flyway_schema_history retains pre-flatten numbering, so a lower-numbered migration is silently skipped on existing databases.**
   Check the directory for the true highest number before creating one — never reuse/skip.
 - Flyway runs at worker startup. Migrations execute under the platform sentinel tenant.
 
@@ -325,7 +325,7 @@ are bugs. When in doubt, trust the code and correct the doc to match.
 | `concerns.md` | Known risks, fragile files (don't bloat), tech debt, test gaps, Postgres connection sizing |
 | `ci-cd.md` | GitHub Actions pipeline, Harbor/ArgoCD deploy, smoke/rollback, container builds |
 | `status.md` | **Capability map: what's Complete vs UI-only-stub vs Planned** — check before touching a subsystem |
-| `specs/` | **Forward-looking feature specs** (multi-slice efforts). `specs/page-builder-parity.md` is the parent for the page-builder→OutSystems-parity work (per-slice specs in `specs/page-builder/`); `specs/unified-record/README.md` is the parent for collapsing the two drifted record stacks (admin `/resources` + end-user `/app/o`) into one Record Experience (per-slice specs `specs/unified-record/{1..8}-*.md`); `specs/app-surfacing/README.md` is the parent for surfacing built backends in the end-user app (analytics authz, approvals inbox, native dashboards/reports viewer, realtime client, saved views — per-slice specs `specs/app-surfacing/{1..5}-*.md`). `specs/app-data-entry/README.md` is the parent for the Phase-2 data-entry work (server-persisted user preferences, list power pack, grouping, mass edit, kanban/calendar/gallery views — per-slice specs `specs/app-data-entry/{1..7}-*.md`). `specs/app-platform/README.md` is the parent for the Phase-3 app-platform work (conditional visibility, computed variables, apps/workspaces nav v2, builder undo/redo — per-slice specs `specs/app-platform/{1..4}-*.md`). `specs/app-intelligence/README.md` is the parent for the Phase-4 work (offline outbox UI, AI page generation, presence, tenant i18n authoring — per-slice specs `specs/app-intelligence/{1..4}-*.md`). Read the relevant slice spec before implementing it. |
+| `specs/` | **Forward-looking feature specs** (multi-slice efforts). `specs/page-builder-parity.md` is the parent for the page-builder→OutSystems-parity work (per-slice specs in `specs/page-builder/`); `specs/unified-record/README.md` is the parent for collapsing the two drifted record stacks (admin `/resources` + end-user `/app/o`) into one Record Experience (per-slice specs `specs/unified-record/{1..8}-*.md`); `specs/app-surfacing/README.md` is the parent for surfacing built backends in the end-user app (analytics authz, approvals inbox, native dashboards/reports viewer, realtime client, saved views — per-slice specs `specs/app-surfacing/{1..5}-*.md`). `specs/app-data-entry/README.md` is the parent for the Phase-2 data-entry work (server-persisted user preferences, list power pack, grouping, mass edit, kanban/calendar/gallery views — per-slice specs `specs/app-data-entry/{1..7}-*.md`). `specs/app-platform/README.md` is the parent for the Phase-3 app-platform work (conditional visibility, computed variables, apps/workspaces nav v2, builder undo/redo — per-slice specs `specs/app-platform/{1..4}-*.md`). `specs/app-intelligence/README.md` is the parent for the Phase-4 work (offline outbox UI, AI page generation, presence, tenant i18n authoring — per-slice specs `specs/app-intelligence/{1..4}-*.md`). `specs/telehealth/README.md` is the parent for telehealth chat + video (portal identity/external users, human chat over the realtime socket, scheduling + visit links, self-hosted LiveKit video — per-slice specs `specs/telehealth/{1..6}-*.md`). Read the relevant slice spec before implementing it. |
 
 Module-level: `kelta-{ai,auth,gateway,mcp,worker}/CLAUDE.md`, `kelta-ui/DESIGN.md`.
 Human-facing: `README.md` (local dev, ports, Makefile), `CONTRIBUTING.md`, `SECURITY.md`.


### PR DESCRIPTION
## Summary

Planning spec set for **telehealth (chat + video) on the platform**: an internal user answers chats and joins scheduled video visits with **external portal users** who connect through a tenant custom application (page-builder pages, custom domain).

- `.claude/docs/specs/telehealth/README.md` — parent: architecture decisions (self-hosted **LiveKit** SFU for video, platform-native chat over the existing `/ws/realtime` socket with **conversation-scoped routing**, chat/scheduling data as **system collections**, external users as first-class `user_type=PORTAL` users with magic-link login and `record_share`-based deny-by-default access), reuse map, shared NATS/WS/REST contracts, security model, infra/rollout, deferrals.
- Slices `1..6`: portal identity → chat backend → chat console + `chat-panel` widget → scheduling/slots/reminders/signed visit links → LiveKit video backend (token mint, webhooks, `videoMinutesPerMonth` governor) → visit UX (waiting room via presence, recording consent).
- `status.md`: telehealth row added to ⚪ Planned.
- `CLAUDE.md`: specs-row pointer + fixed stale Flyway-head lines (directory head is **V166**, next **V167**; doc said V162).

Slices 1 and 5 are flagged **security-typed (no auto-merge)** for when they're implemented. Docs-only PR — no code changes, so the full `/verify` build was not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)