### PR TITLE
docs(specs): telehealth slice 7 — archival & retention for chats and video calls

### DIFF
--- a/.claude/docs/specs/telehealth/2-chat-backend.md
+++ b/.claude/docs/specs/telehealth/2-chat-backend.md
@@ -39,8 +39,9 @@ WS   recv {"event":"chat.message","conversationId":"…","messageId":"…","send
 Collection shapes (system collections; JSON:API names as listed):
 
 - `chat-queues`: name, description, active.
-- `chat-conversations`: queueId (lookup), subject, status `OPEN|ASSIGNED|CLOSED`, origin
-  `PORTAL|INTERNAL`, assignedTo (user), contextRecordId?, lastMessageAt, closedAt.
+- `chat-conversations`: queueId (lookup), subject, status `OPEN|ASSIGNED|CLOSED|ARCHIVED`
+  (ARCHIVED transitions + read-only guard land in slice 7), origin `PORTAL|INTERNAL`,
+  assignedTo (user), contextRecordId?, lastMessageAt, closedAt.
 - `chat-messages`: conversationId (master-detail), senderId, senderType `INTERNAL|PORTAL`,
   kind `TEXT|SYSTEM|ATTACHMENT`, body (rich text), sentAt. Excluded from full-text/embedding
   indexes; excluded from generic realtime `data` push.
@@ -94,9 +95,10 @@ TODO); `status.md` row update.
 
 ## 8. Risks & open questions
 
-- **Message-table growth** in the shared public schema — indexes above + a retention policy
-  (per-tenant `chatRetentionDays`, scheduled purge job) tracked in `concerns.md`; partition
-  only if real volume demands it.
+- **Message-table growth** in the shared public schema — indexes above; the durable
+  mitigation is slice 7's archive-then-purge (live message rows purged only after the
+  encounter is archived — never a bare retention delete). Tracked in `concerns.md`;
+  partition only if real volume demands it.
 - Membership cache (30s) means a just-removed participant may receive id-only events briefly
   — acceptable (no bodies on the wire); document it.
 - `MANAGE_CHAT` naming vs a finer `chat-agent` concept: v1 keeps profile-based simplicity

--- a/.claude/docs/specs/telehealth/5-video-backend.md
+++ b/.claude/docs/specs/telehealth/5-video-backend.md
@@ -27,7 +27,9 @@ Delivers video-session lifecycle on self-hosted LiveKit:
   no-show detection), and emit audit events.
 - **Recording (optional)**: per-tenant flag + per-visit consent (captured in slice 6); room
   composite egress → tenant-prefixed S3 → `egress_ended` webhook attaches the file as an
-  attachment record on the appointment; retention via the attachment lifecycle.
+  attachment record on the appointment; retention/purge of recordings is governed by the
+  slice-7 encounter archive (`retentionUntil`/`legalHold`), and session `ENDED` also
+  triggers the slice-7 session-summary archive once that slice lands.
 - Sessions auto-created for CONFIRMED appointments at booking or first-join (implementation
   decides; spec default: lazily at first token request).
 

--- a/.claude/docs/specs/telehealth/7-archival-retention.md
+++ b/.claude/docs/specs/telehealth/7-archival-retention.md
@@ -1,0 +1,138 @@
+# [Slice 7] — Archival & Retention (Chats + Video Calls)
+
+> Child spec of [Telehealth parent](./README.md), to be refined with the implementation.
+> Conforms to parent §Key architecture decisions, §Security. Depends on slice 2 (chat) and
+> slice 5 (video sessions); its UI touches land in the slice 3 console and the slice 6
+> appointment/visit surfaces. Backend + FE.
+
+## 1. Goal & scope
+
+Delivers the **encounter record**: closed chats and ended video calls are archived into an
+immutable, retrievable artifact with tenant-controlled retention — archive-then-purge, never
+delete-first. This is the compliance backbone for telemedicine (visit documentation) and
+simultaneously the growth mitigation for the live chat tables flagged in slice 2.
+
+- **`telehealth-archives` system collection** — one row per archived source:
+  sourceType `CONVERSATION|VIDEO_SESSION`, sourceId, appointmentId?, portalUserId,
+  artifact attachment ids, sha256, archivedAt, archivedBy (user or `system`),
+  retentionUntil, legalHold (boolean), purgedAt?.
+- **Archive artifact** — canonical JSON transcript/summary written to S3 via the existing
+  attachment lifecycle and linked to the archive row (and the appointment record when one
+  exists): for conversations — participants, full ordered messages, attachment manifest
+  (keys + hashes; the attachment objects themselves are retained, not copied), status
+  history; for video sessions — session metadata, participants + join/leave times,
+  duration, consent state, recording key when present. A human-readable **PDF render** of
+  the transcript is produced alongside the JSON (staff/patient download). SHA-256 of the
+  JSON stored on the archive row for tamper evidence.
+- **Lifecycle**: conversations gain an `ARCHIVED` status (CLOSED → ARCHIVED). Manual
+  "Archive now" (staff) + **auto-archive** of CLOSED conversations after
+  `archiveAfterDays` (tenant setting) via the scheduled-job pattern
+  (`ScheduledJobExecutorService`). Video sessions auto-archive on `ENDED` (webhook path,
+  slice 5). ARCHIVED conversations are read-only — the message hook rejects new messages.
+- **Retention & purge**: `retentionYears` (tenant setting; telemedicine default **7
+  years**, opinionated) sets `retentionUntil`. A retention sweep purges *expired* archives
+  (artifact + linked recording objects + archive row marked `purgedAt`) — **skipping any
+  row with `legalHold`**. Live-table cleanup: message rows may be purged
+  `purgeLiveAfterDays` after successful archival (transcript preserved in the artifact) —
+  this replaces the bare "retention purge" note from slice 2.
+- **Access**: staff list/search archives (metadata filters: patient, provider, date range,
+  type) and download artifacts; portal users see **their own** visit/chat history
+  read-only (participant share carries over to the archive row). Every artifact download
+  is audited.
+- **Settings + permissions**: per-tenant retention settings (archiveAfterDays,
+  retentionYears, purgeLiveAfterDays) on the telehealth admin settings surface; changing
+  retention or toggling `legalHold` requires the existing **`MANAGE_DATA`** system
+  permission (no new permission; delegated admins without it cannot shorten retention).
+
+Does NOT deliver: WORM/object-lock storage guarantees (S3 bucket object-lock is an
+operator/infra option, documented not enforced), e-discovery export bundles beyond
+per-encounter download (data-export integration is listed, full legal-export tooling is
+v2), transcript full-text search (metadata search only — PHI stays out of FTS per parent).
+
+## 2. UI samples
+
+Console (slice 3 surface): *Archived* filter tab; archived thread renders read-only with an
+"Archived <date> · retained until <date>" banner and a Download (PDF/JSON) action.
+Appointment record (slice 6 surface): "Encounter record" card — chat transcript + video
+session summary + recording link, with download. Admin: Telehealth settings page section
+"Retention" (three numeric settings + explanation), archive list with legal-hold toggle
+(MANAGE_DATA-gated, confirm dialog).
+
+## 3. Data & API contracts
+
+```
+POST /api/telehealth/archives                       {sourceType, sourceId}          → 201 archive row (manual archive-now; staff, member or MANAGE_CHAT)
+GET  /api/telehealth/archives?filter…               metadata list (staff; portal sees own)
+GET  /api/telehealth/archives/{id}                  detail incl. artifact download URLs (presigned; audited)
+POST /api/telehealth/archives/{id}/legal-hold       {enabled}                       → MANAGE_DATA only
+GET  /api/telehealth/retention-settings | PUT       tenant settings                 → MANAGE_DATA only
+```
+
+- Conversation status enum extends to `OPEN|ASSIGNED|CLOSED|ARCHIVED`; the
+  `kelta.chat.conversation.*` event carries the new status (parent contract updated) so
+  flows can trigger on archival.
+- Archive rows ride `kelta.record.changed` like any system collection — no new NATS
+  subject.
+- Artifact JSON schema versioned (`schemaVersion: 1`) — future renders must stay
+  back-readable.
+- Idempotency: one archive row per (sourceType, sourceId) — re-archive requests return the
+  existing row.
+
+## 4. DB migrations
+
+One migration (verify head): `telehealth-archives` table + RLS + indexes
+(`(tenant_id, portal_user_id)`, `(tenant_id, retention_until) WHERE purged_at IS NULL AND NOT legal_hold`),
+tenant retention-settings storage (tenant `limits`/settings JSON — no new table if the
+existing settings pattern fits), `ARCHIVED` status check-constraint update on
+chat-conversations.
+
+## 5. File-by-file code changes (sketch)
+
+| Area | Files |
+|------|-------|
+| runtime-core | `SystemCollectionDefinitions` +`telehealth-archives`; conversation status enum |
+| kelta-worker | `ArchiveService` (transcript assembly, JSON+PDF render, hash, S3 write via attachment lifecycle), `TelehealthArchiveController`, auto-archive + retention-sweep scheduled jobs (`SELECT FOR UPDATE SKIP LOCKED` claim pattern), message-hook read-only guard for ARCHIVED, video `ENDED` → archive wiring (slice 5 webhook path), retention-settings endpoints, audit events (`ARCHIVE_CREATED`, `ARCHIVE_ACCESSED`, `ARCHIVE_PURGED`, `LEGAL_HOLD_CHANGED`, `RETENTION_SETTINGS_CHANGED`) |
+| kelta-ui | Console Archived tab + read-only thread state; encounter-record card on appointment detail; admin Retention settings + legal-hold UI; portal history list (own archives) |
+| i18n | `telehealth.archive.*` |
+
+PDF render: reuse whatever the report PDF-export path uses (`ReportExecutionController`
+export) — do not introduce a second PDF library.
+
+## 6. Test plan
+
+- Worker unit: transcript assembly determinism + sha256 stability, idempotent archive,
+  read-only guard (message POST on ARCHIVED → 409), retention math (`retentionUntil`),
+  sweep skips legalHold, purge removes artifact + recording keys and stamps `purgedAt`,
+  settings permission gates (MANAGE_DATA 200 / others 403).
+- Harness (real Postgres/RLS): cross-tenant archive invisibility; portal user reads own
+  archive + denied on others; live-message purge after archival leaves artifact readable;
+  concurrent sweep claim (SKIP LOCKED) processes each row once.
+- Vitest: archived-thread read-only rendering, settings form validation, legal-hold
+  confirm flow.
+- Playwright (post-deploy, skip-gated): close chat → archive-now → Archived tab shows
+  read-only thread → download PDF; appointment encounter card lists chat + video summary;
+  portal sees own history.
+
+## 7. Docs to update (same PR)
+
+`status.md` (archival noted in the telehealth row); parent README slice table + contracts
+(done when this slice was specced); `integrations.md` (artifact schema + S3 layout);
+`concerns.md` — **close/reword the chat table-growth item** (archival + live purge is the
+mitigation) and add "purge sweep is destructive — verify backup posture" note;
+`architecture.md` (`/api/telehealth/archives` authz rows).
+
+## 8. Risks & open questions
+
+- **Purge is irreversible** — the sweep deletes PHI artifacts on schedule. Guardrails:
+  legalHold check, `purgedAt` stamps (rows kept as tombstones), dry-run mode for the first
+  release, and the operator backup-posture note in `concerns.md`.
+- Retention defaults are jurisdiction-dependent (7 years is a common US medical-records
+  default; EU/member-state rules differ) — tenant-configurable, operator decides; the spec
+  ships a default, not legal advice.
+- PDF rendering of rich-text messages can drift from the console rendering — the JSON
+  artifact is canonical; PDF is a convenience render and says so in its footer.
+- Storage cost: artifacts + retained recordings count against `gov_storage_mb` (existing
+  enforcement) — no new governor key.
+- Attachment objects referenced by archived transcripts must survive live-row purge —
+  the manifest pins them; `AttachmentCleanupHook` cascade rules must be verified against
+  this (the archive row becomes the owning record where needed).

--- a/.claude/docs/specs/telehealth/README.md
+++ b/.claude/docs/specs/telehealth/README.md
@@ -31,10 +31,12 @@ Read this parent first; every child references it.
 | 4 — Scheduling & visit links | `4-scheduling.md` | backend + FE (appointments, slots, reminders) |
 | 5 — Video backend (LiveKit) | `5-video-backend.md` | **backend + infra, security** |
 | 6 — Video UI & visit experience | `6-video-ui.md` | FE (join, waiting room, consent) |
+| 7 — Archival & retention (chats + calls) | `7-archival-retention.md` | backend + FE (encounter record, retention/purge) |
 
-**Dependency order (hard edges): 1 → 2 → 3, and 1 → 4 → 5 → 6.** Chat (2–3) and scheduling
-(4) are independent tracks after slice 1. Slice 6 also consumes the chat widget from 3 for
-in-call chat, but degrades gracefully without it.
+**Dependency order (hard edges): 1 → 2 → 3, and 1 → 4 → 5 → 6; 7 follows 2 and 5.** Chat
+(2–3) and scheduling (4) are independent tracks after slice 1. Slice 6 also consumes the
+chat widget from 3 for in-call chat, but degrades gracefully without it. Slice 7's UI
+touches (Archived tab, encounter-record card) land on the slice 3/6 surfaces.
 
 ## Context
 
@@ -115,6 +117,13 @@ tenant isolation, auditability, and deny-by-default portal access preserved thro
   mirrors the `ai-tokens-monthly` Redis pattern) and `maxPortalUsers` (enforced at
   invite/create — closing the known "gov_users tracked but not enforced" gap for the portal
   population).
+- **Archive-then-purge, never delete-first.** Every closed chat and ended video call
+  becomes an immutable **encounter record** (slice 7): a versioned, hashed JSON transcript
+  /session-summary artifact (+ PDF render) in S3, indexed by a `telehealth-archives`
+  system collection row carrying `retentionUntil` + `legalHold`. Tenant-configured
+  retention (telemedicine default 7 years) drives a purge sweep that skips legal holds;
+  live chat rows may be purged only *after* archival — which is also the growth mitigation
+  for the shared message tables. ARCHIVED conversations are read-only.
 - **Compliance posture for telemedicine.** Every conversation/session access emits
   `SecurityAuditLogger` events (OpenSearch); recording is **off by default**, per-tenant
   opt-in, with explicit in-call consent capture stored on the session record; media is
@@ -158,7 +167,7 @@ Use these — do not rebuild.
 
 ```
 kelta.chat.message.<tenantId>.<conversationId>       chat message created (ids + sender + kind; NO body text)
-kelta.chat.conversation.<tenantId>.<conversationId>  conversation lifecycle (OPENED|ASSIGNED|CLOSED)
+kelta.chat.conversation.<tenantId>.<conversationId>  conversation lifecycle (OPENED|ASSIGNED|CLOSED|ARCHIVED)
 kelta.video.session.<tenantId>.<sessionId>           video session lifecycle (CREATED|ACTIVE|ENDED|RECORDING_READY)
 ```
 
@@ -173,7 +182,7 @@ send  {"action":"chat.leave","conversationId":"<uuid>"}
 recv  {"action":"chat.joined","conversationId":"…"} | {"action":"error","message":"…"}
 recv  {"event":"chat.message","conversationId":"…","messageId":"…","senderId":"…",
        "kind":"TEXT|SYSTEM|ATTACHMENT","timestamp":"…"}            (no body — invalidation signal)
-recv  {"event":"chat.conversation","conversationId":"…","status":"OPEN|ASSIGNED|CLOSED",…}
+recv  {"event":"chat.conversation","conversationId":"…","status":"OPEN|ASSIGNED|CLOSED|ARCHIVED",…}
 ```
 
 Presence reuses the existing `presence.join` with resource conventions
@@ -193,6 +202,10 @@ POST /api/telehealth/sessions/{id}/token           mint LiveKit access token (me
 GET  /api/telehealth/visits/{signedToken}          visit-link landing (public path, HMAC)
 POST /api/telehealth/webhooks/livekit              LiveKit webhook (public path, signature-verified)
 POST /api/auth/portal/request-link | /exchange     magic-link login (kelta-auth, rate-limited)
+POST /api/telehealth/archives                      archive-now {sourceType, sourceId} (staff)
+GET  /api/telehealth/archives[/{id}]               encounter records (staff; portal sees own; downloads audited)
+POST /api/telehealth/archives/{id}/legal-hold      MANAGE_DATA only
+GET|PUT /api/telehealth/retention-settings         MANAGE_DATA only
 ```
 
 Generic JSON:API on the chat/telehealth system collections remains available to staff
@@ -234,7 +247,9 @@ issuers already supported by `DynamicReactiveJwtDecoder`).
   full-text/embedding indexes by default.
 - **Audit.** New `SecurityAuditLogger` event types: `PORTAL_LINK_REQUESTED`, `PORTAL_LOGIN`,
   `CHAT_CONVERSATION_OPENED/ASSIGNED/CLOSED`, `CHAT_ACCESS_DENIED`,
-  `VIDEO_TOKEN_ISSUED`, `VIDEO_SESSION_STARTED/ENDED`, `RECORDING_CONSENT_CAPTURED`.
+  `VIDEO_TOKEN_ISSUED`, `VIDEO_SESSION_STARTED/ENDED`, `RECORDING_CONSENT_CAPTURED`,
+  `ARCHIVE_CREATED`, `ARCHIVE_ACCESSED`, `ARCHIVE_PURGED`, `LEGAL_HOLD_CHANGED`,
+  `RETENTION_SETTINGS_CHANGED`.
 - **JWT on the WS query param** (existing design) applies to portal sockets too — never log
   upgrade URLs.
 

--- a/.claude/docs/status.md
+++ b/.claude/docs/status.md
@@ -89,7 +89,7 @@ HA/failover docs (RTO/RPO) · scheduled *backup* (data export itself ships — s
 
 | Capability | Notes |
 |------------|-------|
-| Telehealth: chat + video + scheduling + portal users | Parent spec `specs/telehealth/README.md` (2026-07-10), slices 1–6: portal identity (magic-link login, `user_type`, participant `record_share` grants) → chat (system collections + conversation-scoped WS routing on the existing `/ws/realtime` socket) → chat console/widget → scheduling (slots, reminders via `DelayActionHandler`, signed visit links) → self-hosted LiveKit video (token mint, webhooks, governor `videoMinutesPerMonth`) → visit UX. Nothing implemented yet — no chat/video code exists in the repo. |
+| Telehealth: chat + video + scheduling + portal users + archival | Parent spec `specs/telehealth/README.md` (2026-07-10), slices 1–7: portal identity (magic-link login, `user_type`, participant `record_share` grants) → chat (system collections + conversation-scoped WS routing on the existing `/ws/realtime` socket) → chat console/widget → scheduling (slots, reminders via `DelayActionHandler`, signed visit links) → self-hosted LiveKit video (token mint, webhooks, governor `videoMinutesPerMonth`) → visit UX → archival & retention (immutable encounter records for chats + calls, `telehealth-archives`, retention/legal-hold, archive-then-purge). Nothing implemented yet — no chat/video code exists in the repo. |
 
 *(Data masking: PR 1 backend core + PR 2 egress/UI/MCP shipped — see the 🟡 Partial table; only v2 contexts [dashboards, system-tier flow/webhook] + post-deploy e2e remain.)*
 *(Delegated administration moved to 🟡 2026-07-05 — scoped user management ships; see the Partial table.)*


### PR DESCRIPTION
## Summary

Extends the telehealth plan (#1229) with **archival of chats and video calls** — the compliance encounter record.

- New child spec `.claude/docs/specs/telehealth/7-archival-retention.md`:
  - **Archive-then-purge, never delete-first.** Immutable encounter artifact per closed chat / ended call: versioned canonical JSON transcript/session summary (+ PDF render) in S3 via the existing attachment lifecycle, SHA-256 recorded for tamper evidence, indexed by a new `telehealth-archives` system collection.
  - Conversation lifecycle gains **ARCHIVED** (read-only, hook-enforced); auto-archive of CLOSED chats after `archiveAfterDays`; video sessions archive on `ENDED`.
  - **Retention**: tenant-configurable `retentionYears` (7-year telemedicine default) + `legalHold` override; purge sweep skips holds, stamps tombstones; retention/legal-hold changes gated on existing `MANAGE_DATA`.
  - Live chat rows purged only **after** archival — this becomes the slice-2 message-table growth mitigation.
  - Staff archive search/download (audited), portal users read their own visit history.
- Parent README: slice table + dependency edges, archive-then-purge decision, `/api/telehealth/archives` contracts, ARCHIVED in the WS/NATS status enums, new audit event types.
- Slices 2/5 consistency edits (retention deferred to slice 7); `status.md` telehealth row now 1–7.

Docs-only PR — no code changes, full `/verify` build not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)