### PR TITLE
fix(messaging): provision JetStream streams + native reflection for telehealth events

### DIFF
--- a/.claude/docs/concerns.md
+++ b/.claude/docs/concerns.md
@@ -395,6 +395,25 @@ for removal ("inline the current value"). Findings:
   *before/independent of* the bootstrap fetch), so a future missed DTO degrades (loses only dynamic
   collection routes) instead of taking the entire API offline — but the reflect-config entry is still
   required for the bootstrap to fully load.
+- **The worker is ALSO a GraalVM native image — every `PlatformEvent` payload it serializes to NATS
+  MUST be in `reflect-config.json`, exactly like the gateway bootstrap rule above.** Found 2026-07-11
+  driving a live telehealth video call: the worker published `kelta.video.session.*` with `"payload":{}`
+  (and would do the same for `kelta.chat.*` and `credential/domain/feature.changed`) because
+  `VideoSessionPayload`, `ChatMessagePayload`, `ChatConversationPayload`, `CredentialChangedPayload`,
+  `DomainChangedPayload`, `FeatureChangedPayload` were never added to
+  `kelta-worker/.../META-INF/native-image/io.kelta/kelta-worker/reflect-config.json`. In the JVM/tests
+  this is invisible (reflection is free); the native image can't introspect the getters → Jackson emits
+  an empty bean, so consumers (e.g. NATS_TRIGGERED post-visit flows) get no data. `EventPayloadReflectConfigTest`
+  now fails CI if any `io.kelta.runtime.event.*Payload` is unregistered. **Rule: a new event payload
+  gets a reflect-config entry in BOTH `kelta-worker` and `kelta-gateway` in the same PR.**
+- **Every new `kelta.*` NATS subject namespace needs its own JetStream stream in `JetStreamInitializer`.**
+  `NatsEventPublisher` always JetStream-publishes and awaits an ack; a subject matched by no stream never
+  acks → `CancellationException: response not registered in time` and the event is dropped (publish is
+  best-effort — the error is logged, never thrown). `ensureStream` is add-if-absent — it does **not**
+  `updateStream`, so you cannot bolt a subject onto an existing stream; it needs its own `ensureStream(...)`
+  call. Telehealth slices 2 (chat) + 5 (video) added subjects without streams → chat realtime was fully
+  broken on prod (gateway push consumer looped `[SUB-90007] No matching streams`) and video lifecycle
+  events failed to publish, until `KELTA_CHAT` + `KELTA_VIDEO_SESSION` were added (2026-07-11).
 - Multiple BOM version overrides in worker POM increase transitive conflict risk (`kelta-worker/pom.xml`). Audit on every Spring Boot bump.
 - **pgvector required for VECTOR fields / semantic search.** `PhysicalTableStorageAdapter.initializeCollection` runs `CREATE EXTENSION IF NOT EXISTS vector` lazily — only when a collection actually has a VECTOR field — and throws an actionable `StorageException` if it can't. Local dev + CI use the `pgvector/pgvector:pg15` image (docker-compose + `KeltaStack` Testcontainers). **The standalone prod Postgres at `192.168.0.5` is plain `postgres:15` and must have the pgvector extension installed** (the `.so` available + the worker's DB role allowed to `CREATE EXTENSION`, or an admin pre-creates it) before any tenant defines a VECTOR field; otherwise that collection's table creation fails with the guidance above. Collections without VECTOR fields are unaffected.
 - **Stale `spring-kafka` dependency retired** (Phase 0): `runtime-core/pom.xml` previously declared `spring-kafka`, `spring-kafka-test`, and `testcontainers-kafka` despite the platform using NATS JetStream exclusively. Removed; the misnamed `KafkaRecordEventPublisher` was renamed to `NatsRecordEventPublisher`. The stale event-bus comments and docs that mislabeled NATS as the previous broker have since been corrected to NATS across the codebase.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,6 +189,7 @@ Each maps to a real mistake an agent has made here. Violating one usually compil
 - ❌ Fork a new shared table/filter/form component → ✅ reuse/extend `@kelta/components`.
 - ❌ Read a flow input as `$.<key>` → ✅ `$.input.<key>` (manual/MCP/HTTP double-wraps).
 - ❌ Reintroduce Kafka → messaging is NATS JetStream only.
+- ❌ Add a new `kelta.*` NATS subject without a JetStream stream in `JetStreamInitializer` **and** a native `reflect-config.json` entry for its payload in worker+gateway → ✅ else the publish no-acks (`CancellationException`, event dropped) or the payload serializes `{}` on the native image (`concerns.md` → Dependency Risks).
 - ❌ Leave docs stale → update them in the same PR (Rule 6).
 
 ---
@@ -222,6 +223,14 @@ Each maps to a real mistake an agent has made here. Violating one usually compil
 Envelope: `PlatformEvent<T>` (`eventId`, `eventType`, `tenantId`, `correlationId`, `userId`,
 `timestamp`, `payload`). Subscriptions registered in each service's `NatsSubscriptionConfig`.
 Kafka is fully removed — do not reintroduce.
+
+**JetStream streams** (provisioned in `runtime-messaging-nats/.../JetStreamInitializer.java`, add-if-absent):
+`KELTA_RECORDS` (`kelta.record.changed.>`) · `KELTA_CONFIG` (`kelta.config/cerbos/worker/data.>`) ·
+`KELTA_TRIGGERS` (`kelta.trigger.>`) · `KELTA_PRESENCE` (`kelta.presence.>`) ·
+`KELTA_VIDEO_SESSION` (`kelta.video.session.>`) · `KELTA_CHAT` (`kelta.chat.message/conversation.>`).
+A new subject namespace needs its **own** `ensureStream(...)` (an existing stream's subjects can't be
+extended — it's add-if-absent), and the payload must be in each **native** service's `reflect-config.json`,
+or the publish no-acks and the event is dropped / serializes `{}`. See `concerns.md` → Dependency Risks.
 
 ---
 

--- a/kelta-gateway/src/main/resources/META-INF/native-image/io.kelta/kelta-gateway/reflect-config.json
+++ b/kelta-gateway/src/main/resources/META-INF/native-image/io.kelta/kelta-gateway/reflect-config.json
@@ -76,5 +76,47 @@
     "allDeclaredConstructors": true,
     "allDeclaredMethods": true,
     "allDeclaredFields": true
+  },
+  {
+    "name": "io.kelta.runtime.event.ChatMessagePayload",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "io.kelta.runtime.event.ChatConversationPayload",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "io.kelta.runtime.event.VideoSessionPayload",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "io.kelta.runtime.event.DomainChangedPayload",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "io.kelta.runtime.event.CredentialChangedPayload",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "io.kelta.runtime.event.FeatureChangedPayload",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "io.kelta.runtime.event.FlowChangedPayload",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
   }
 ]

--- a/kelta-platform/runtime/runtime-messaging-nats/src/main/java/io/kelta/runtime/messaging/nats/JetStreamInitializer.java
+++ b/kelta-platform/runtime/runtime-messaging-nats/src/main/java/io/kelta/runtime/messaging/nats/JetStreamInitializer.java
@@ -56,6 +56,20 @@ public class JetStreamInitializer {
             ensureStream(jsm, "KELTA_PRESENCE",
                     List.of("kelta.presence.>"),
                     Duration.ofMinutes(1));
+            // Telehealth video session lifecycle (slice 5): kelta.video.session
+            // .<tenantId>.<sessionId> — ACTIVE/ENDED, fed to NATS_TRIGGERED
+            // post-visit flows. Without this stream the publish gets no ack and
+            // fails (CancellationException) — the subject matched no stream.
+            ensureStream(jsm, "KELTA_VIDEO_SESSION",
+                    List.of("kelta.video.session.>"),
+                    Duration.ofHours(24));
+            // Telehealth chat (slice 2): kelta.chat.message.* and
+            // kelta.chat.conversation.* — realtime fan-out to WebSocket sockets
+            // via the gateway ChatMessageBridge. Same missing-stream gap: the
+            // gateway's push consumer got [SUB-90007] No matching streams.
+            ensureStream(jsm, "KELTA_CHAT",
+                    List.of("kelta.chat.message.>", "kelta.chat.conversation.>"),
+                    Duration.ofHours(24));
         } catch (Exception e) {
             log.error("Failed to initialize JetStream streams: {}", e.getMessage(), e);
         }

--- a/kelta-platform/runtime/runtime-messaging-nats/src/test/java/io/kelta/runtime/messaging/nats/JetStreamInitializerTest.java
+++ b/kelta-platform/runtime/runtime-messaging-nats/src/test/java/io/kelta/runtime/messaging/nats/JetStreamInitializerTest.java
@@ -1,0 +1,52 @@
+package io.kelta.runtime.messaging.nats;
+
+import io.nats.client.JetStreamManagement;
+import io.nats.client.api.StreamConfiguration;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@DisplayName("JetStreamInitializer")
+class JetStreamInitializerTest {
+
+    /**
+     * Regression for the telehealth outage: the video-session and chat subjects
+     * had no stream, so JetStream publishes got no ack and cancelled, and the
+     * gateway's push consumers failed with [SUB-90007] No matching streams.
+     */
+    @Test
+    @DisplayName("provisions the video-session and chat streams when absent")
+    void createsVideoAndChatStreams() throws Exception {
+        NatsConnectionManager connectionManager = mock(NatsConnectionManager.class);
+        JetStreamManagement jsm = mock(JetStreamManagement.class);
+        when(connectionManager.jetStreamManagement()).thenReturn(jsm);
+        // Every stream is absent → getStreamInfo throws → addStream is invoked.
+        when(jsm.getStreamInfo(anyString())).thenThrow(new IOException("stream not found"));
+
+        new JetStreamInitializer(connectionManager).initializeStreams();
+
+        ArgumentCaptor<StreamConfiguration> captor = ArgumentCaptor.forClass(StreamConfiguration.class);
+        verify(jsm, atLeastOnce()).addStream(captor.capture());
+        List<StreamConfiguration> created = captor.getAllValues();
+
+        assertThat(created)
+                .as("KELTA_VIDEO_SESSION stream capturing kelta.video.session.>")
+                .anyMatch(c -> "KELTA_VIDEO_SESSION".equals(c.getName())
+                        && c.getSubjects().contains("kelta.video.session.>"));
+        assertThat(created)
+                .as("KELTA_CHAT stream capturing both chat subjects")
+                .anyMatch(c -> "KELTA_CHAT".equals(c.getName())
+                        && c.getSubjects().containsAll(
+                                List.of("kelta.chat.message.>", "kelta.chat.conversation.>")));
+    }
+}

--- a/kelta-worker/src/main/resources/META-INF/native-image/io.kelta/kelta-worker/reflect-config.json
+++ b/kelta-worker/src/main/resources/META-INF/native-image/io.kelta/kelta-worker/reflect-config.json
@@ -52,5 +52,41 @@
     "allDeclaredConstructors": true,
     "allDeclaredMethods": true,
     "allDeclaredFields": true
+  },
+  {
+    "name": "io.kelta.runtime.event.VideoSessionPayload",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "io.kelta.runtime.event.ChatMessagePayload",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "io.kelta.runtime.event.ChatConversationPayload",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "io.kelta.runtime.event.CredentialChangedPayload",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "io.kelta.runtime.event.DomainChangedPayload",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "io.kelta.runtime.event.FeatureChangedPayload",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
   }
 ]

--- a/kelta-worker/src/test/java/io/kelta/worker/EventPayloadReflectConfigTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/EventPayloadReflectConfigTest.java
@@ -1,0 +1,68 @@
+package io.kelta.worker;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.type.filter.RegexPatternTypeFilter;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Guards against the native-image reflection gap that broke telehealth event
+ * delivery: {@code kelta-worker} is compiled to a GraalVM native image, so a
+ * {@code *Payload} class Jackson serializes must be listed in
+ * {@code reflect-config.json} — otherwise it serializes to {@code {}} at runtime
+ * (a JVM build hides this). Every event payload the worker publishes must be
+ * registered; this test fails CI when a new payload is added without its entry.
+ */
+@DisplayName("event payload native reflection registration")
+class EventPayloadReflectConfigTest {
+
+    private static final String EVENT_PACKAGE = "io.kelta.runtime.event";
+    private static final String REFLECT_CONFIG =
+            "META-INF/native-image/io.kelta/kelta-worker/reflect-config.json";
+
+    @Test
+    @DisplayName("every io.kelta.runtime.event.*Payload is in reflect-config.json")
+    void everyPayloadIsRegistered() throws Exception {
+        // Discover all top-level *Payload classes in the shared event module.
+        ClassPathScanningCandidateComponentProvider scanner =
+                new ClassPathScanningCandidateComponentProvider(false);
+        scanner.addIncludeFilter(new RegexPatternTypeFilter(Pattern.compile(".*Payload")));
+        Set<String> payloads = scanner.findCandidateComponents(EVENT_PACKAGE).stream()
+                .map(bd -> bd.getBeanClassName())
+                .filter(name -> name != null && !name.contains("$")) // top-level only
+                .collect(Collectors.toSet());
+
+        // Sanity: the scanner actually found the known payloads.
+        assertThat(payloads)
+                .contains(EVENT_PACKAGE + ".VideoSessionPayload",
+                        EVENT_PACKAGE + ".ChatMessagePayload",
+                        EVENT_PACKAGE + ".RecordChangedPayload");
+
+        // Collect the class names registered for reflection.
+        Set<String> registered = new HashSet<>();
+        JsonNode config = new ObjectMapper()
+                .readTree(new ClassPathResource(REFLECT_CONFIG).getInputStream());
+        config.forEach(node -> registered.add(node.get("name").asText()));
+
+        List<String> missing = payloads.stream()
+                .filter(p -> !registered.contains(p))
+                .sorted()
+                .toList();
+
+        assertThat(missing)
+                .as("event payloads absent from %s — the native worker will serialize "
+                        + "these to {} at runtime; add an allDeclared* entry", REFLECT_CONFIG)
+                .isEmpty();
+    }
+}


### PR DESCRIPTION
## Summary

A live test video call on the `telehealth` tenant surfaced two prod bugs that silently broke telehealth **video** and **chat** event delivery — both native-image-only, so invisible on the JVM and in tests.

### 1. Missing JetStream streams → publish fails
`NatsEventPublisher` always JetStream-publishes and awaits a `PublishAck`. No stream captured `kelta.video.session.>` or `kelta.chat.*`, so the ack never arrived → `CancellationException: response not registered in time` and the event was dropped (best-effort publish, never thrown).
- **Video**: every lifecycle event (`ACTIVE`/`ENDED`) failed to publish.
- **Chat**: the gateway's push consumers looped `[SUB-90007] No matching streams` — **chat realtime was fully broken on prod**.

Fix: add `KELTA_VIDEO_SESSION` + `KELTA_CHAT` in `JetStreamInitializer`. (`ensureStream` is add-if-absent — a subject can't be bolted onto an existing stream, so each namespace needs its own.)

### 2. Missing native reflection → payload serializes `{}`
`kelta-worker` and `kelta-gateway` are GraalVM native images. Six event payloads were never added to `reflect-config.json`, so native Jackson can't introspect their getters and serializes them to `{}`:
`VideoSessionPayload`, `ChatMessagePayload`, `ChatConversationPayload`, `CredentialChangedPayload`, `DomainChangedPayload`, `FeatureChangedPayload`.
Confirmed live: `kelta.video.session.*` delivered with `"payload":{}`. Registered all six in both services.

## Evidence (live test)
- Worker: `Failed to publish event … to kelta.video.session.…: CancellationException: Future cancelled, response not registered in time`
- Gateway: `Retry failed 'gateway-chat-messages' … [SUB-90007] No matching streams`
- After hot-creating the streams live: gateway `Subscription 'gateway-chat-messages' attached on retry`; a NATS subscriber received the `kelta.video.session` ACTIVE + ENDED events.
- Local serialization repro proved the **source** is fine → isolated the empty payload to the native reflect-config gap (same root class as the 2026-07-02 gateway outage).

## Tests
- `JetStreamInitializerTest` — both new streams created with the right subjects.
- `EventPayloadReflectConfigTest` — scans `io.kelta.runtime.event`, fails CI if any `*Payload` is missing from the worker `reflect-config.json` (prevents recurrence).
- Full `runtime-messaging-nats` suite green (19 tests).

## Deploy note
Prod was **hot-fixed live** (streams created via the `nats` CLI), so chat + video publish work now. The reflect-config registration only takes effect on the **next native rebuild + redeploy** of worker + gateway — the empty-payload half lands with this PR's image build.

## Not auto-merged
Prod-critical messaging infra + needs a coordinated worker/gateway redeploy — leaving the merge to you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
