### PR TITLE
fix(platform): accept JSON scalar defaults for fields end-to-end

### DIFF
--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/FieldBodyBuilder.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/admin/FieldBodyBuilder.java
@@ -61,7 +61,10 @@ final class FieldBodyBuilder {
         if (args.get("indexed") instanceof Boolean b) attrs.put("indexed", b);
         if (args.get("searchable") instanceof Boolean b) attrs.put("searchable", b);
         if (args.get("description") instanceof String s && !s.isBlank()) attrs.put("description", s);
-        if (args.get("defaultValue") instanceof String s) attrs.put("defaultValue", s);
+        Object dv = args.get("defaultValue");
+        if (dv instanceof String || dv instanceof Boolean || dv instanceof Number) {
+            attrs.put("defaultValue", dv);
+        }
         if (args.get("validation") instanceof Map<?, ?> v) attrs.put("constraints", v);
 
         Map<String, Object> relationships = new LinkedHashMap<>();

--- a/kelta-mcp/src/test/java/io/kelta/mcp/tool/admin/AddFieldToolTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/tool/admin/AddFieldToolTest.java
@@ -95,6 +95,50 @@ class AddFieldToolTest {
     }
 
     @Test
+    void forwardsStringDefaultValue() {
+        stubCollectionLookup();
+        wm.stubFor(post(urlEqualTo("/api/fields"))
+                .willReturn(aResponse().withStatus(201).withBody("{}")));
+
+        tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("add_field", Map.of(
+                        "collectionName", "projects",
+                        "fieldName", "locale",
+                        "type", "text",
+                        "defaultValue", "en"), null));
+
+        wm.verify(WireMock.postRequestedFor(urlEqualTo("/api/fields"))
+                .withRequestBody(matchingJsonPath("$.data.attributes.defaultValue", equalTo("en"))));
+    }
+
+    @Test
+    void forwardsBooleanAndNumericDefaultValues() {
+        stubCollectionLookup();
+        wm.stubFor(post(urlEqualTo("/api/fields"))
+                .willReturn(aResponse().withStatus(201).withBody("{}")));
+
+        tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("add_field", Map.of(
+                        "collectionName", "projects",
+                        "fieldName", "active",
+                        "type", "boolean",
+                        "defaultValue", true), null));
+        tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("add_field", Map.of(
+                        "collectionName", "projects",
+                        "fieldName", "quantity",
+                        "type", "number",
+                        "defaultValue", 30), null));
+
+        wm.verify(WireMock.postRequestedFor(urlEqualTo("/api/fields"))
+                .withRequestBody(matchingJsonPath("$.data.attributes.name", equalTo("active")))
+                .withRequestBody(matchingJsonPath("$.data.attributes.defaultValue", equalTo("true"))));
+        wm.verify(WireMock.postRequestedFor(urlEqualTo("/api/fields"))
+                .withRequestBody(matchingJsonPath("$.data.attributes.name", equalTo("quantity")))
+                .withRequestBody(matchingJsonPath("$.data.attributes.defaultValue", equalTo("30"))));
+    }
+
+    @Test
     void translatesUniqueToUniqueConstraint() {
         stubCollectionLookup();
         wm.stubFor(post(urlEqualTo("/api/fields"))

--- a/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/model/system/SystemCollectionDefinitions.java
+++ b/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/model/system/SystemCollectionDefinitions.java
@@ -523,9 +523,10 @@ public final class SystemCollectionDefinitions {
             .addField(FieldDefinition.bool("isDefault").withColumnName("is_default"))
             .addField(FieldDefinition.requiredJson("columns"))
             .addField(FieldDefinition.string("filterLogic").withColumnName("filter_logic"))
-            // JSON-typed defaults must be JSON values, not strings — a String
-            // default is injected verbatim on create and then fails the field's
-            // own type validation ("filters: Invalid type, expected JSON").
+            // JSON-typed defaults must be JSON containers, not strings — a String
+            // default is injected verbatim on create and stored as a JSON string
+            // ("[]"), not an array, breaking every consumer of the field
+            // (guarded by SystemCollectionJsonDefaultsTest).
             .addField(FieldDefinition.json("filters").withDefault(List.of()))
             .addField(FieldDefinition.string("sortField").withColumnName("sort_field"))
             .addField(FieldDefinition.string("sortDirection", 4).withColumnName("sort_direction")

--- a/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/storage/PhysicalTableStorageAdapter.java
+++ b/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/storage/PhysicalTableStorageAdapter.java
@@ -1221,24 +1221,23 @@ public class PhysicalTableStorageAdapter implements StorageAdapter {
      * @param type the field type
      * @return the converted value
      */
-    private Object convertValueForStorage(Object value, FieldType type) {
+    Object convertValueForStorage(Object value, FieldType type) { // package-private for tests
         if (value == null) {
             return null;
         }
 
         return switch (type) {
             case JSON, ARRAY -> {
-                // Convert Map/List to JSON string for JSONB storage
-                if (value instanceof Map || value instanceof List) {
-                    try {
-                        tools.jackson.databind.ObjectMapper mapper =
-                            new tools.jackson.databind.ObjectMapper();
-                        yield mapper.writeValueAsString(value);
-                    } catch (Exception e) {
-                        throw new StorageException("Failed to convert value to JSON", e);
-                    }
+                // Render the value as JSON text for the ?::jsonb bind. This must
+                // cover scalars too: a bare string like "en" is not valid JSONB
+                // input, but "\"en\"" is.
+                try {
+                    tools.jackson.databind.ObjectMapper mapper =
+                        new tools.jackson.databind.ObjectMapper();
+                    yield mapper.writeValueAsString(value);
+                } catch (Exception e) {
+                    throw new StorageException("Failed to convert value to JSON", e);
                 }
-                yield value;
             }
             case DATE, DATETIME -> {
                 // Handle Instant conversion

--- a/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/validation/DefaultValidationEngine.java
+++ b/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/validation/DefaultValidationEngine.java
@@ -165,7 +165,12 @@ public class DefaultValidationEngine implements ValidationEngine {
             case BOOLEAN -> value instanceof Boolean;
             case DATE -> isValidDate(value);
             case DATETIME -> isValidDateTime(value);
-            case JSON, GEOLOCATION -> value instanceof Map || value instanceof List;
+            // JSON accepts any JSON value — objects, arrays, and scalars. Scalars
+            // matter for fields.defaultValue, where a STRING field's default ("en")
+            // arrives as a bare JSON string.
+            case JSON -> value instanceof Map || value instanceof List
+                    || value instanceof String || value instanceof Number || value instanceof Boolean;
+            case GEOLOCATION -> value instanceof Map || value instanceof List;
             case REFERENCE, LOOKUP, MASTER_DETAIL -> value instanceof String;
             case ARRAY, MULTI_PICKLIST -> value instanceof List;
             case AUTO_NUMBER -> value instanceof String || value instanceof Number;

--- a/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/model/system/SystemCollectionJsonDefaultsTest.java
+++ b/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/model/system/SystemCollectionJsonDefaultsTest.java
@@ -11,13 +11,15 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Declared defaults on JSON-typed system fields must be JSON values (maps or
- * lists), never strings. {@code DefaultQueryEngine} injects the declared
- * default verbatim when the attribute is missing on create, and the field's
- * own type validation then runs on it — a String default like {@code "[]"}
- * makes every create that omits the field fail with
- * "Invalid type, expected JSON" (this is exactly what broke creating a
- * list view without explicit {@code filters}).
+ * Declared defaults on JSON-typed system fields must be JSON containers (maps
+ * or lists), never strings. {@code DefaultQueryEngine} injects the declared
+ * default verbatim when the attribute is missing on create. JSON-typed fields
+ * accept scalar values too (needed for {@code fields.defaultValue}), so a
+ * String default like {@code "[]"} would validate — but it would be stored as
+ * the JSON <em>string</em> {@code "[]"}, not an empty array, silently breaking
+ * every consumer that expects a container (this is exactly what broke creating
+ * a list view without explicit {@code filters}, back when it failed loudly
+ * with "Invalid type, expected JSON").
  */
 class SystemCollectionJsonDefaultsTest {
 

--- a/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/storage/PhysicalTableStorageAdapterTest.java
+++ b/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/storage/PhysicalTableStorageAdapterTest.java
@@ -102,6 +102,26 @@ class PhysicalTableStorageAdapterTest {
     }
     
     @Nested
+    @DisplayName("JSON Storage Conversion Tests")
+    class JsonStorageConversionTests {
+
+        @Test
+        @DisplayName("Should render JSON scalars as JSON text for the jsonb bind")
+        void rendersJsonScalarsAsJsonText() {
+            assertEquals("\"en\"", adapter.convertValueForStorage("en", FieldType.JSON));
+            assertEquals("true", adapter.convertValueForStorage(true, FieldType.JSON));
+            assertEquals("30", adapter.convertValueForStorage(30, FieldType.JSON));
+        }
+
+        @Test
+        @DisplayName("Should render JSON objects and arrays as JSON text")
+        void rendersJsonContainersAsJsonText() {
+            assertEquals("{\"a\":1}", adapter.convertValueForStorage(Map.of("a", 1), FieldType.JSON));
+            assertEquals("[1,2]", adapter.convertValueForStorage(List.of(1, 2), FieldType.JSON));
+        }
+    }
+
+    @Nested
     @DisplayName("Table Initialization Tests")
     class InitializationTests {
         

--- a/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/validation/DefaultValidationEngineTest.java
+++ b/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/validation/DefaultValidationEngineTest.java
@@ -304,11 +304,41 @@ class DefaultValidationEngineTest {
             CollectionDefinition definition = createTestCollection(
                 FieldDefinition.json("tags")
             );
-            
+
             ValidationResult result = validationEngine.validate(
                 definition, Map.of("tags", List.of("tag1", "tag2")), OperationType.CREATE);
-            
+
             assertTrue(result.valid());
+        }
+
+        @Test
+        @DisplayName("Should accept JSON scalar values (string, number, boolean)")
+        void shouldAcceptJsonScalarValues() {
+            CollectionDefinition definition = createTestCollection(
+                FieldDefinition.json("defaultValue")
+            );
+
+            assertTrue(validationEngine.validate(
+                definition, Map.of("defaultValue", "en"), OperationType.CREATE).valid());
+            assertTrue(validationEngine.validate(
+                definition, Map.of("defaultValue", 30), OperationType.CREATE).valid());
+            assertTrue(validationEngine.validate(
+                definition, Map.of("defaultValue", true), OperationType.CREATE).valid());
+        }
+
+        @Test
+        @DisplayName("Should still reject scalar values for GEOLOCATION")
+        void shouldRejectScalarForGeolocation() {
+            CollectionDefinition definition = createTestCollection(
+                new FieldDefinition("position", FieldType.GEOLOCATION, true, false, false,
+                    null, null, null, null, null)
+            );
+
+            ValidationResult result = validationEngine.validate(
+                definition, Map.of("position", "38.7,-9.1"), OperationType.CREATE);
+
+            assertFalse(result.valid());
+            assertEquals("type", result.errors().get(0).constraint());
         }
     }
 


### PR DESCRIPTION
## Summary
- `POST /api/fields` rejected any STRING-typed `defaultValue` with 400 "Invalid type, expected JSON", while boolean/integer defaults *appeared* to work but were silently dropped by the MCP tool — no scalar default ever reached the database. Found while building out the telehealth sample tenant (2026-07-11).
- Three-layer fix:
  - **DefaultValidationEngine**: JSON-typed fields now accept any JSON value — objects, arrays, and scalars (string/number/boolean). `fields.defaultValue` is JSON-typed and legitimately carries scalars (a STRING field's default `"en"` is a bare JSON string). GEOLOCATION keeps the container-only rule.
  - **PhysicalTableStorageAdapter**: all JSON values are rendered as JSON text for the `?::jsonb` bind — previously scalars passed through raw, and a bare string is not valid JSONB input.
  - **kelta-mcp `FieldBodyBuilder`** (add_field / create_collection inline fields): forwards Boolean/Number defaults instead of silently discarding them, matching UpdateFieldTool's existing behavior.
- Declared system-collection defaults must remain containers (a String default would now *validate* but store the wrong shape, silently breaking consumers) — `SystemCollectionJsonDefaultsTest` and the `SystemCollectionDefinitions` comment updated to document the new failure mode.

## Changes
- `kelta-platform/.../validation/DefaultValidationEngine.java` — split `JSON` from `GEOLOCATION`; JSON accepts scalars
- `kelta-platform/.../storage/PhysicalTableStorageAdapter.java` — JSON/ARRAY values always serialized to JSON text (`convertValueForStorage` package-private for tests)
- `kelta-mcp/.../admin/FieldBodyBuilder.java` — forward String/Boolean/Number `defaultValue`
- Tests: `DefaultValidationEngineTest` (JSON scalars accepted, GEOLOCATION still rejects), `PhysicalTableStorageAdapterTest` (scalar/container JSONB rendering), `AddFieldToolTest` (string + boolean + numeric defaults forwarded), `SystemCollectionJsonDefaultsTest` javadoc

## Testing
- Targeted: DefaultValidationEngineTest, PhysicalTableStorageAdapterTest, SystemCollectionJsonDefaultsTest, AddFieldToolTest — all green
- Full /verify: runtime modules build, gateway 488 tests, worker 2005 tests, kelta-mcp 218 tests, kelta-web lint/typecheck/format/coverage — all green; kelta-ui untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)