### PR TITLE
fix(worker): align telehealth availability time columns with STRING field defs

### DIFF
--- a/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/model/system/SystemCollectionDefinitions.java
+++ b/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/model/system/SystemCollectionDefinitions.java
@@ -334,8 +334,13 @@ public final class SystemCollectionDefinitions {
                 .withEnumValues(List.of("RULE", "EXCEPTION")))
             .addField(FieldDefinition.integer("weekday"))
             .addField(FieldDefinition.date("exceptionDate").withColumnName("exception_date"))
-            .addField(FieldDefinition.string("startTime", 8).withColumnName("start_time"))
-            .addField(FieldDefinition.string("endTime", 8).withColumnName("end_time"))
+            // Wall-clock "HH:mm" / "HH:mm:ss" strings (varchar(8) columns since
+            // V172); SlotService parses them with LocalTime.parse, so keep the
+            // pattern in lockstep with what java.time accepts.
+            .addField(FieldDefinition.string("startTime", 8).withColumnName("start_time")
+                .withValidation(ValidationRules.forString(null, 8, "^([01]\\d|2[0-3]):[0-5]\\d(:[0-5]\\d)?$")))
+            .addField(FieldDefinition.string("endTime", 8).withColumnName("end_time")
+                .withValidation(ValidationRules.forString(null, 8, "^([01]\\d|2[0-3]):[0-5]\\d(:[0-5]\\d)?$")))
             .addField(FieldDefinition.requiredString("timezone", 50).withDefault("UTC"))
             .addField(FieldDefinition.bool("closed").withDefault(false))
             .addField(FieldDefinition.bool("active").withDefault(true))

--- a/kelta-test-harness/src/test/java/io/kelta/testharness/scenarios/TelehealthSchedulingScenarioTest.java
+++ b/kelta-test-harness/src/test/java/io/kelta/testharness/scenarios/TelehealthSchedulingScenarioTest.java
@@ -17,7 +17,6 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -50,7 +49,7 @@ class TelehealthSchedulingScenarioTest extends ScenarioBase {
                 .retrieve().toEntity(Map.class);
         String portalUserId = (String) invited.getBody().get("userId");
 
-        // The admin user acts as the provider — find their id and seed a rule
+        // The admin user acts as the provider — find their id, then seed a rule
         // covering tomorrow's weekday, 09:00–17:00 UTC.
         LocalDate tomorrow = LocalDate.now(ZoneOffset.UTC).plusDays(1);
         int weekday = tomorrow.getDayOfWeek() == DayOfWeek.SUNDAY ? 0
@@ -66,17 +65,28 @@ class TelehealthSchedulingScenarioTest extends ScenarioBase {
                     providerId = rs.getString("id");
                 }
             }
-            try (PreparedStatement ps = conn.prepareStatement(
-                    "INSERT INTO telehealth_availability (id, tenant_id, provider_id, kind, weekday, "
-                            + "start_time, end_time, timezone, closed, active, created_at, updated_at) "
-                            + "VALUES (?, ?, ?, 'RULE', ?, '09:00', '17:00', 'UTC', false, true, NOW(), NOW())")) {
-                ps.setString(1, UUID.randomUUID().toString());
-                ps.setString(2, tenantId);
-                ps.setString(3, providerId);
-                ps.setInt(4, weekday);
-                ps.executeUpdate();
-            }
         }
+
+        // Seed the rule through the generic JSON:API route — the spec-designated
+        // management path for availability. Regression for the V169 TIME-column
+        // mismatch that failed every write here with a varchar/time bind error
+        // (fixed by V172 + the STRING(8) field defs).
+        Map<String, Object> ruleBody = Map.of("data", Map.of(
+                "type", "telehealth-availability",
+                "attributes", Map.of(
+                        "providerId", providerId,
+                        "kind", "RULE",
+                        "weekday", weekday,
+                        "startTime", "09:00",
+                        "endTime", "17:00",
+                        "timezone", "UTC",
+                        "active", true)));
+        ResponseEntity<Map> rule = gatewayClientWithToken(token)
+                .post().uri("/" + slug + "/api/telehealth-availability")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(ruleBody)
+                .retrieve().toEntity(Map.class);
+        assertThat(rule.getStatusCode()).isEqualTo(HttpStatus.CREATED);
 
         // Slots for tomorrow are offered.
         Instant from = tomorrow.atStartOfDay(ZoneOffset.UTC).toInstant();

--- a/kelta-worker/src/main/java/io/kelta/worker/service/telehealth/SlotService.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/service/telehealth/SlotService.java
@@ -144,11 +144,20 @@ public class SlotService {
                         rs.getString("kind"),
                         rs.getObject("weekday") == null ? null : rs.getInt("weekday"),
                         rs.getObject("exception_date", LocalDate.class),
-                        rs.getObject("start_time", LocalTime.class),
-                        rs.getObject("end_time", LocalTime.class),
+                        parseTime(rs.getString("start_time")),
+                        parseTime(rs.getString("end_time")),
                         ZoneId.of(rs.getString("timezone")),
                         rs.getBoolean("closed")),
                 tenantId, providerId);
+    }
+
+    /**
+     * start_time/end_time are varchar(8) (V172) holding "HH:mm" or "HH:mm:ss"
+     * wall-clock values — the columns match the STRING(8) field definitions so
+     * the generic JSON:API write path can bind them.
+     */
+    static LocalTime parseTime(String value) {
+        return value == null || value.isBlank() ? null : LocalTime.parse(value);
     }
 
     List<Busy> loadBusy(String tenantId, String providerId, Instant from, Instant to) {

--- a/kelta-worker/src/main/resources/db/migration/V172__availability_time_columns_to_varchar.sql
+++ b/kelta-worker/src/main/resources/db/migration/V172__availability_time_columns_to_varchar.sql
@@ -1,0 +1,11 @@
+-- V169 created start_time/end_time as TIME while their field definitions in
+-- SystemCollectionDefinitions are STRING(8). The generic JSON:API write path
+-- binds STRING fields as varchar, so every POST /api/telehealth-availability
+-- failed with "column is of type time without time zone but expression is of
+-- type character varying" — even though the slice-4 spec designates the
+-- generic admin JSON:API as the management path for availability rows.
+-- Align the physical columns with the declared field type; values keep the
+-- HH24:MI:SS shape, which SlotService parses and which orders identically.
+ALTER TABLE telehealth_availability
+    ALTER COLUMN start_time TYPE varchar(8) USING to_char(start_time, 'HH24:MI:SS'),
+    ALTER COLUMN end_time   TYPE varchar(8) USING to_char(end_time, 'HH24:MI:SS');

--- a/kelta-worker/src/test/java/io/kelta/worker/service/telehealth/SlotServiceTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/service/telehealth/SlotServiceTest.java
@@ -117,4 +117,13 @@ class SlotServiceTest {
         assertThat(SlotService.computeSlots(List.of(), List.of(), from, from.minusSeconds(1), 30, from))
                 .isEmpty();
     }
+
+    @Test
+    @DisplayName("parseTime: varchar(8) column values in both HH:mm and HH:mm:ss forms")
+    void parseTimeHandlesStoredForms() {
+        assertThat(SlotService.parseTime("09:00")).isEqualTo(LocalTime.of(9, 0));
+        assertThat(SlotService.parseTime("17:00:00")).isEqualTo(LocalTime.of(17, 0));
+        assertThat(SlotService.parseTime(null)).isNull();
+        assertThat(SlotService.parseTime("")).isNull();
+    }
 }


### PR DESCRIPTION
## Summary
- `POST /api/telehealth-availability` (the slice-4 spec's designated management path for availability rules) failed 500 on every write: V169 created `start_time`/`end_time` as `TIME` while `SystemCollectionDefinitions` declares them `STRING(8)`, so `PhysicalTableStorageAdapter` bound varchar into a time column. Found 2026-07-11 seeding provider availability on the telehealth tenant.
- Fix chosen: align the physical columns with the declared field type (option b) rather than teaching the adapter physical-column-type introspection — the platform convention is columns match FieldType mappings, and the string form (`HH:MM:SS`, fixed width) compares/orders identically.

## Changes
- `V172__availability_time_columns_to_varchar.sql` — `ALTER ... TYPE varchar(8) USING to_char(..., 'HH24:MI:SS')` for both columns (data + NULLs preserved)
- `SlotService` — row mapper parses stored strings via new `parseTime` (accepts `HH:mm` and `HH:mm:ss`, null-safe) instead of `rs.getObject(..., LocalTime.class)`
- `SystemCollectionDefinitions` — `startTime`/`endTime` gain a wall-clock regex (`^([01]\d|2[0-3]):[0-5]\d(:[0-5]\d)?$`) so the API can't store values `LocalTime.parse` would reject
- `TelehealthSchedulingScenarioTest` — availability rule now seeded through the **generic JSON:API route** instead of raw SQL: full-stack regression for exactly this write path (the SQL seed was masking the bug)

## Testing
- runtime-core 1432, worker 2006 (incl. new `SlotServiceTest.parseTimeHandlesStoredForms`), gateway 488, kelta-web lint/typecheck/format + 983 tests — all green
- Migration validated against a disposable `pgvector/pg15` container: TIME→varchar conversion, NULL rows, and post-migration inserts in both time forms
- Harness scenario runs on CI's integration runners — local Docker (7.6 GB) OOM-kills the full mini-stack, so it could not be executed locally; the test compiles and the seeding change is exercised there

🤖 Generated with [Claude Code](https://claude.com/claude-code)