### PR TITLE
fix(platform): gateway rate-limit window never reset — root cause of e2e storage-ready flake

### DIFF
--- a/.claude/docs/concerns.md
+++ b/.claude/docs/concerns.md
@@ -190,6 +190,30 @@ an audit feed.
 
 (No open bugs from the original audit. See Resolved → Bugs.)
 
+**FIXED (fix/gateway-rate-limiter-fixed-window) — gateway rate limiter never reset its
+window under continuous traffic → tenant-wide self-sustaining 429 lockout; root cause of
+the "storage-ready" e2e flake (found 2026-07-11 from PR #1240's failing run).**
+`RedisRateLimiter` refreshed the window key's TTL on EVERY request ("prevents keys from
+persisting forever"), which turned the 5-minute fixed window into an idle-expiry: the
+counter accumulated across the entire e2e run (~1700 requests ≈ the default 100k/day →
+1735-per-window limit), tripped mid-suite, and then every rejected poll re-incremented the
+counter and re-extended the TTL — permanent lockout until 5 full minutes of silence. In the
+e2e logs this looked like a "worker wedge" (worker+postgres go quiet, tenant-scoped requests
+vanish) but the worker was simply idle: the gateway was rejecting everything upstream, and
+Playwright's serially-run late-alphabet journeys (rollup-summary, validation-rules) inherited
+the exhausted window and burned their 30s readiness budgets on 429s. Same hazard existed in
+production for any steadily-active tenant. Fix: atomic Lua INCR that sets the TTL only when
+the window is new (or a prior EXPIRE was lost), plus Retry-After now reports the real
+remaining window TTL instead of the full window. E2E `data-factory` also fails fast and loud
+on 429 (no more silently sleeping through a multi-minute Retry-After inside a 30s budget).
+Same investigation fixed three latent bugs it surfaced: `DefaultQueryEngine` passed the
+literal `"default"` as tenantId to delete hooks (setup-audit rows for deletes always failed
+their tenant FK — never persisted for real tenants); `FieldQuotaEnforcementHook` counted
+`field WHERE tenant_id = ?` but `field` has no tenant_id column (query always threw, hook
+fail-open → per-collection field quota was never enforced; now JOINs through `collection`);
+and NATS consumers had no `maxDeliver`, so a poison message redelivered forever (now
+maxDeliver=5 with a 2s delayed NAK).
+
 **FIXED (fix/cerbos-record-check-shortcircuit) — per-record Cerbos batch checks ran (with
 full record payloads) even for collections with no record-level rules; a read burst could
 open the circuit breaker (found 2026-07-10, in production, after #1223).** The generated

--- a/.claude/docs/integrations.md
+++ b/.claude/docs/integrations.md
@@ -50,6 +50,7 @@ Files attach to any record via the `attachments` system collection (backed by `f
 Event envelope: `PlatformEvent<T>` with `eventId`, `eventType`, `tenantId`, `correlationId`, `timestamp`, `payload`
 Publishing: `PlatformEventPublisher` (transport-agnostic interface; the NATS impl is `NatsEventPublisher` in `runtime-messaging-nats`. The former Kafka publisher was removed in Phase 0 — do not reintroduce Kafka.)
 Subscriptions: `NatsSubscriptionConfig` registration. Delivery-mode rule: **broadcast** when the handler mutates per-pod state (caches, route registries, local WebSocket sessions — every gateway subscription qualifies, fixed 2026-07-08 after queue groups left other pods' realtime subscribers silent); **queue group** only for load-balanced work executed once per event (flows, search indexing)
+Redelivery: consumers are created with `maxDeliver=5`; a failing handler NAKs with a 2s delay (`NatsSubscriptionManager.nakBounded`), and after the fifth delivery JetStream stops redelivering (logged at ERROR as a dropped poison message). Handlers must stay idempotent across ≤5 deliveries; anything that must never be lost needs its own persistence, not infinite redelivery.
 Location: `kelta-platform/runtime/runtime-events/src/main/java/io/kelta/runtime/event/`
 
 ## Monitoring & Observability

--- a/e2e-tests/helpers/data-factory.ts
+++ b/e2e-tests/helpers/data-factory.ts
@@ -39,6 +39,29 @@ const STORAGE_READY_POLL_MS = 2_000;
  * transient spike instead of failing on the first stalled socket.
  */
 const READY_FETCH_TIMEOUT_MS = 5_000;
+/**
+ * Longest Retry-After we are willing to sleep through on a 429. A tenant-window
+ * rate-limit lockout (minutes) can never resolve within a test's budget —
+ * sleeping through it just converts a diagnosable failure into an opaque
+ * timeout. Beyond this cap we fail immediately with an explicit message.
+ */
+const MAX_RATE_LIMIT_WAIT_MS = 15_000;
+
+/** Builds the loud, self-explaining error for a gateway 429. */
+function rateLimitedError(context: string, retryAfterSeconds: number | null): Error {
+  return new Error(
+    `${context}: gateway returned 429 Too Many Requests — the tenant's API ` +
+      `rate-limit window is exhausted (Retry-After: ${retryAfterSeconds ?? "?"}s). ` +
+      `The e2e run is being throttled; this is NOT a storage/readiness problem.`,
+  );
+}
+
+function retryAfterSeconds(response: Response): number | null {
+  const header = response.headers.get("Retry-After");
+  if (!header) return null;
+  const parsed = parseInt(header, 10);
+  return Number.isFinite(parsed) ? parsed : null;
+}
 
 export class DataFactory {
   private createdEntities: Array<{ type: string; id: string }> = [];
@@ -73,6 +96,15 @@ export class DataFactory {
       ) {
         this.currentToken = await this.api.refreshToken();
         continue;
+      }
+
+      // Fail fast on a rate-limit lockout longer than any sane retry budget —
+      // sleeping through a multi-minute Retry-After only masks the real cause.
+      if (response.status === 429) {
+        const retryAfter = retryAfterSeconds(response);
+        if (retryAfter !== null && retryAfter * 1_000 > MAX_RATE_LIMIT_WAIT_MS) {
+          throw rateLimitedError(`API ${method} ${path}`, retryAfter);
+        }
       }
 
       // Retry on rate limiting (429) and transient server errors (500-503)
@@ -139,7 +171,18 @@ export class DataFactory {
         if (response.ok) {
           return;
         }
-      } catch {
+        // A rate-limit rejection will not clear within this poll's budget and
+        // every further poll only extends the lockout — surface it immediately.
+        if (response.status === 429) {
+          throw rateLimitedError(
+            `waitForStorageReady('${collectionName}')`,
+            retryAfterSeconds(response),
+          );
+        }
+      } catch (error) {
+        if (error instanceof Error && error.message.includes("429")) {
+          throw error;
+        }
         // Network error — keep retrying
       }
 
@@ -251,10 +294,18 @@ export class DataFactory {
           } else {
             consecutive = 0;
           }
+        } else if (response.status === 429) {
+          throw rateLimitedError(
+            `waitForFieldVisible('${fieldName}')`,
+            retryAfterSeconds(response),
+          );
         } else {
           consecutive = 0;
         }
-      } catch {
+      } catch (error) {
+        if (error instanceof Error && error.message.includes("429")) {
+          throw error;
+        }
         consecutive = 0;
       }
       await new Promise((resolve) =>

--- a/kelta-gateway/src/main/java/io/kelta/gateway/ratelimit/RedisRateLimiter.java
+++ b/kelta-gateway/src/main/java/io/kelta/gateway/ratelimit/RedisRateLimiter.java
@@ -4,42 +4,63 @@ import io.kelta.gateway.route.RateLimitConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.data.redis.core.ReactiveRedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
 
 import java.time.Duration;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
+import java.util.List;
 
 /**
  * Redis-based rate limiter implementation.
- * 
+ *
  * Uses Redis INCR command to track request counts per route and principal.
  * Implements a fixed window rate limiting algorithm with automatic TTL management.
  */
 @Service("keltaRedisRateLimiter")
 public class RedisRateLimiter {
-    
+
     private static final Logger log = LoggerFactory.getLogger(RedisRateLimiter.class);
     private static final String KEY_PREFIX = "ratelimit:";
     private static final String DAILY_KEY_PREFIX = "api-calls-daily:";
-    
+
+    /**
+     * Atomically increments the window counter and sets its TTL only when the
+     * window is new (count == 1) or a previous EXPIRE was lost (TTL < 0).
+     *
+     * <p>The TTL must NOT be refreshed on every request: doing so turns the
+     * fixed window into an idle-expiry, so under continuous traffic the counter
+     * never resets and the tenant ends up permanently locked out once the
+     * cumulative count crosses the limit (each rejected request re-extends the
+     * TTL, sustaining the lockout indefinitely).
+     */
+    private static final RedisScript<Long> INCREMENT_WINDOW_SCRIPT = RedisScript.of(
+            """
+            local count = redis.call('INCR', KEYS[1])
+            if count == 1 or redis.call('TTL', KEYS[1]) < 0 then
+              redis.call('EXPIRE', KEYS[1], ARGV[1])
+            end
+            return count
+            """,
+            Long.class);
+
     private final ReactiveRedisTemplate<String, String> redisTemplate;
-    
+
     public RedisRateLimiter(ReactiveRedisTemplate<String, String> redisTemplate) {
         this.redisTemplate = redisTemplate;
     }
-    
+
     /**
      * Checks if a request is allowed based on the rate limit configuration.
-     * 
+     *
      * Algorithm:
      * 1. Build Redis key: "ratelimit:{routeId}:{principal}"
-     * 2. Increment counter in Redis
-     * 3. If counter == 1, set TTL to window duration
-     * 4. If counter > limit, return not allowed with retry-after
-     * 5. If counter <= limit, return allowed with remaining count
-     * 
+     * 2. Atomically increment counter, setting TTL only for a new window
+     * 3. If counter > limit, return not allowed with retry-after = remaining window TTL
+     * 4. If counter <= limit, return allowed with remaining count
+     *
      * @param routeId The route identifier
      * @param principal The authenticated principal (username)
      * @param config The rate limit configuration
@@ -47,36 +68,33 @@ public class RedisRateLimiter {
      */
     public Mono<RateLimitResult> checkRateLimit(String routeId, String principal, RateLimitConfig config) {
         String key = buildKey(routeId, principal);
-        
-        return redisTemplate.opsForValue()
-            .increment(key)
+        String windowSeconds = String.valueOf(Math.max(1, config.getWindowDuration().toSeconds()));
+
+        return redisTemplate.execute(INCREMENT_WINDOW_SCRIPT, List.of(key), List.of(windowSeconds))
+            .next()
             .flatMap(count -> {
-                // Always set/refresh the TTL on every request. This is idempotent
-                // and prevents keys from persisting forever if a previous expire
-                // call was lost. The small overhead of re-setting TTL on each
-                // request is worth the guarantee that keys always expire.
-                return redisTemplate.expire(key, config.getWindowDuration())
-                    .thenReturn(count);
-            })
-            .map(count -> {
                 long limit = config.getRequestsPerWindow();
-                
+
                 if (count > limit) {
-                    // Rate limit exceeded
-                    log.debug("Rate limit exceeded for route={}, principal={}, count={}, limit={}", 
+                    // Rate limit exceeded — report the true time until the window
+                    // resets, not the full window duration.
+                    log.debug("Rate limit exceeded for route={}, principal={}, count={}, limit={}",
                         routeId, principal, count, limit);
-                    return RateLimitResult.notAllowed(config.getWindowDuration());
+                    return redisTemplate.getExpire(key)
+                        .map(ttl -> ttl.isPositive() ? ttl : config.getWindowDuration())
+                        .defaultIfEmpty(config.getWindowDuration())
+                        .map(RateLimitResult::notAllowed);
                 } else {
                     // Request allowed
                     long remaining = limit - count;
-                    log.debug("Rate limit check passed for route={}, principal={}, count={}, remaining={}", 
+                    log.debug("Rate limit check passed for route={}, principal={}, count={}, remaining={}",
                         routeId, principal, count, remaining);
-                    return RateLimitResult.allowed(remaining);
+                    return Mono.just(RateLimitResult.allowed(remaining));
                 }
             })
             .onErrorResume(error -> {
                 // Graceful degradation: if Redis is unavailable, allow the request
-                log.warn("Redis error during rate limit check for route={}, principal={}. Allowing request. Error: {}", 
+                log.warn("Redis error during rate limit check for route={}, principal={}. Allowing request. Error: {}",
                     routeId, principal, error.getMessage());
                 return Mono.just(RateLimitResult.allowed(config.getRequestsPerWindow()));
             });

--- a/kelta-gateway/src/test/java/io/kelta/gateway/ratelimit/RedisRateLimiterTest.java
+++ b/kelta-gateway/src/test/java/io/kelta/gateway/ratelimit/RedisRateLimiterTest.java
@@ -1,18 +1,21 @@
 package io.kelta.gateway.ratelimit;
 
 import io.kelta.gateway.route.RateLimitConfig;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.redis.core.ReactiveRedisTemplate;
-import org.springframework.data.redis.core.ReactiveValueOperations;
+import org.springframework.data.redis.core.script.RedisScript;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import java.time.Duration;
+import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
@@ -22,162 +25,175 @@ class RedisRateLimiterTest {
     @Mock
     private ReactiveRedisTemplate<String, String> redisTemplate;
 
-    @Mock
-    private ReactiveValueOperations<String, String> valueOps;
+    private RedisRateLimiter newLimiter() {
+        return new RedisRateLimiter(redisTemplate);
+    }
 
-    private RedisRateLimiter rateLimiter;
-
-    @BeforeEach
-    void setUp() {
-        when(redisTemplate.opsForValue()).thenReturn(valueOps);
-        // Every request calls expire to ensure TTL is always set
-        lenient().when(redisTemplate.expire(anyString(), any(Duration.class))).thenReturn(Mono.just(true));
-        rateLimiter = new RedisRateLimiter(redisTemplate);
+    @SuppressWarnings("unchecked")
+    private void givenWindowCount(long count) {
+        when(redisTemplate.execute(any(RedisScript.class), anyList(), anyList()))
+            .thenReturn(Flux.just(count));
     }
 
     @Test
     void testFirstRequestInWindow() {
-        // Given
         RateLimitConfig config = new RateLimitConfig(10, Duration.ofMinutes(1));
-        String expectedKey = "ratelimit:users-collection:user@example.com";
+        givenWindowCount(1L);
 
-        when(valueOps.increment(expectedKey)).thenReturn(Mono.just(1L));
-
-        // When & Then
-        StepVerifier.create(rateLimiter.checkRateLimit("users-collection", "user@example.com", config))
+        StepVerifier.create(newLimiter().checkRateLimit("users-collection", "user@example.com", config))
             .expectNextMatches(result -> result.isAllowed() && result.getRemainingRequests() == 9)
             .verifyComplete();
-
-        verify(valueOps).increment(expectedKey);
-        verify(redisTemplate).expire(expectedKey, Duration.ofMinutes(1));
     }
 
     @Test
-    void testSubsequentRequestInWindow() {
-        // Given
+    @SuppressWarnings("unchecked")
+    void testWindowKeyAndTtlPassedToScript() {
+        RateLimitConfig config = new RateLimitConfig(10, Duration.ofMinutes(5));
+        givenWindowCount(1L);
+
+        StepVerifier.create(newLimiter().checkRateLimit("users-collection", "user@example.com", config))
+            .expectNextMatches(RateLimitResult::isAllowed)
+            .verifyComplete();
+
+        ArgumentCaptor<List<String>> keysCaptor = ArgumentCaptor.forClass(List.class);
+        ArgumentCaptor<List<String>> argsCaptor = ArgumentCaptor.forClass(List.class);
+        verify(redisTemplate).execute(any(RedisScript.class), keysCaptor.capture(), argsCaptor.capture());
+        assertThat(keysCaptor.getValue()).containsExactly("ratelimit:users-collection:user@example.com");
+        assertThat(argsCaptor.getValue()).containsExactly("300");
+    }
+
+    @Test
+    void testSubsequentRequestDoesNotRefreshTtl() {
+        // The window TTL is managed inside the atomic script (set only when the
+        // window is new or its TTL was lost). Refreshing it per request would
+        // turn the fixed window into an idle-expiry that never resets under
+        // continuous traffic — the root cause of a tenant-wide 429 lockout.
         RateLimitConfig config = new RateLimitConfig(10, Duration.ofMinutes(1));
-        String expectedKey = "ratelimit:users-collection:user@example.com";
+        givenWindowCount(5L);
 
-        when(valueOps.increment(expectedKey)).thenReturn(Mono.just(5L));
-
-        // When & Then
-        StepVerifier.create(rateLimiter.checkRateLimit("users-collection", "user@example.com", config))
+        StepVerifier.create(newLimiter().checkRateLimit("users-collection", "user@example.com", config))
             .expectNextMatches(result -> result.isAllowed() && result.getRemainingRequests() == 5)
             .verifyComplete();
 
-        verify(valueOps).increment(expectedKey);
-        // TTL is always refreshed
-        verify(redisTemplate).expire(expectedKey, Duration.ofMinutes(1));
+        verify(redisTemplate, never()).expire(anyString(), any(Duration.class));
     }
 
     @Test
-    void testRateLimitExceeded() {
-        // Given
-        RateLimitConfig config = new RateLimitConfig(10, Duration.ofMinutes(1));
-        String expectedKey = "ratelimit:users-collection:user@example.com";
+    void testRateLimitExceededUsesRemainingWindowTtlAsRetryAfter() {
+        RateLimitConfig config = new RateLimitConfig(10, Duration.ofMinutes(5));
+        givenWindowCount(11L);
+        when(redisTemplate.getExpire("ratelimit:users-collection:user@example.com"))
+            .thenReturn(Mono.just(Duration.ofSeconds(37)));
 
-        when(valueOps.increment(expectedKey)).thenReturn(Mono.just(11L));
-
-        // When & Then
-        StepVerifier.create(rateLimiter.checkRateLimit("users-collection", "user@example.com", config))
+        StepVerifier.create(newLimiter().checkRateLimit("users-collection", "user@example.com", config))
             .expectNextMatches(result ->
                 !result.isAllowed() &&
                 result.getRemainingRequests() == 0 &&
-                result.getRetryAfter().equals(Duration.ofMinutes(1)))
+                result.getRetryAfter().equals(Duration.ofSeconds(37)))
             .verifyComplete();
+    }
 
-        verify(valueOps).increment(expectedKey);
+    @Test
+    void testRateLimitExceededFallsBackToWindowDurationWhenTtlMissing() {
+        RateLimitConfig config = new RateLimitConfig(10, Duration.ofMinutes(1));
+        givenWindowCount(11L);
+        when(redisTemplate.getExpire("ratelimit:users-collection:user@example.com"))
+            .thenReturn(Mono.empty());
+
+        StepVerifier.create(newLimiter().checkRateLimit("users-collection", "user@example.com", config))
+            .expectNextMatches(result ->
+                !result.isAllowed() && result.getRetryAfter().equals(Duration.ofMinutes(1)))
+            .verifyComplete();
+    }
+
+    @Test
+    void testRateLimitExceededFallsBackToWindowDurationWhenTtlNonPositive() {
+        RateLimitConfig config = new RateLimitConfig(10, Duration.ofMinutes(1));
+        givenWindowCount(11L);
+        when(redisTemplate.getExpire("ratelimit:users-collection:user@example.com"))
+            .thenReturn(Mono.just(Duration.ofSeconds(-1)));
+
+        StepVerifier.create(newLimiter().checkRateLimit("users-collection", "user@example.com", config))
+            .expectNextMatches(result ->
+                !result.isAllowed() && result.getRetryAfter().equals(Duration.ofMinutes(1)))
+            .verifyComplete();
     }
 
     @Test
     void testExactlyAtLimit() {
-        // Given
         RateLimitConfig config = new RateLimitConfig(10, Duration.ofMinutes(1));
-        String expectedKey = "ratelimit:users-collection:user@example.com";
+        givenWindowCount(10L);
 
-        when(valueOps.increment(expectedKey)).thenReturn(Mono.just(10L));
-
-        // When & Then
-        StepVerifier.create(rateLimiter.checkRateLimit("users-collection", "user@example.com", config))
+        StepVerifier.create(newLimiter().checkRateLimit("users-collection", "user@example.com", config))
             .expectNextMatches(result -> result.isAllowed() && result.getRemainingRequests() == 0)
             .verifyComplete();
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     void testRedisUnavailable() {
-        // Given
         RateLimitConfig config = new RateLimitConfig(10, Duration.ofMinutes(1));
-        String expectedKey = "ratelimit:users-collection:user@example.com";
+        when(redisTemplate.execute(any(RedisScript.class), anyList(), anyList()))
+            .thenReturn(Flux.error(new RuntimeException("Redis connection failed")));
 
-        when(valueOps.increment(expectedKey))
-            .thenReturn(Mono.error(new RuntimeException("Redis connection failed")));
-
-        // When & Then - should allow request and not throw exception
-        StepVerifier.create(rateLimiter.checkRateLimit("users-collection", "user@example.com", config))
+        // Should allow request and not throw exception
+        StepVerifier.create(newLimiter().checkRateLimit("users-collection", "user@example.com", config))
             .expectNextMatches(result -> result.isAllowed() && result.getRemainingRequests() == 10)
             .verifyComplete();
     }
 
     @Test
-    void testDifferentPrincipalsHaveSeparateLimits() {
-        // Given
+    @SuppressWarnings("unchecked")
+    void testDifferentPrincipalsHaveSeparateKeys() {
         RateLimitConfig config = new RateLimitConfig(10, Duration.ofMinutes(1));
-        String key1 = "ratelimit:users-collection:user1@example.com";
-        String key2 = "ratelimit:users-collection:user2@example.com";
+        givenWindowCount(1L);
 
-        when(valueOps.increment(key1)).thenReturn(Mono.just(1L));
-        when(valueOps.increment(key2)).thenReturn(Mono.just(1L));
-
-        // When & Then
-        StepVerifier.create(rateLimiter.checkRateLimit("users-collection", "user1@example.com", config))
+        StepVerifier.create(newLimiter().checkRateLimit("users-collection", "user1@example.com", config))
+            .expectNextMatches(RateLimitResult::isAllowed)
+            .verifyComplete();
+        StepVerifier.create(newLimiter().checkRateLimit("users-collection", "user2@example.com", config))
             .expectNextMatches(RateLimitResult::isAllowed)
             .verifyComplete();
 
-        StepVerifier.create(rateLimiter.checkRateLimit("users-collection", "user2@example.com", config))
-            .expectNextMatches(RateLimitResult::isAllowed)
-            .verifyComplete();
-
-        verify(valueOps).increment(key1);
-        verify(valueOps).increment(key2);
+        ArgumentCaptor<List<String>> keysCaptor = ArgumentCaptor.forClass(List.class);
+        verify(redisTemplate, times(2)).execute(any(RedisScript.class), keysCaptor.capture(), anyList());
+        assertThat(keysCaptor.getAllValues()).containsExactly(
+            List.of("ratelimit:users-collection:user1@example.com"),
+            List.of("ratelimit:users-collection:user2@example.com"));
     }
 
     @Test
-    void testDifferentRoutesHaveSeparateLimits() {
-        // Given
+    @SuppressWarnings("unchecked")
+    void testDifferentRoutesHaveSeparateKeys() {
         RateLimitConfig config = new RateLimitConfig(10, Duration.ofMinutes(1));
-        String key1 = "ratelimit:users-collection:user@example.com";
-        String key2 = "ratelimit:posts-collection:user@example.com";
+        givenWindowCount(1L);
 
-        when(valueOps.increment(key1)).thenReturn(Mono.just(1L));
-        when(valueOps.increment(key2)).thenReturn(Mono.just(1L));
-
-        // When & Then
-        StepVerifier.create(rateLimiter.checkRateLimit("users-collection", "user@example.com", config))
+        StepVerifier.create(newLimiter().checkRateLimit("users-collection", "user@example.com", config))
+            .expectNextMatches(RateLimitResult::isAllowed)
+            .verifyComplete();
+        StepVerifier.create(newLimiter().checkRateLimit("posts-collection", "user@example.com", config))
             .expectNextMatches(RateLimitResult::isAllowed)
             .verifyComplete();
 
-        StepVerifier.create(rateLimiter.checkRateLimit("posts-collection", "user@example.com", config))
-            .expectNextMatches(RateLimitResult::isAllowed)
-            .verifyComplete();
-
-        verify(valueOps).increment(key1);
-        verify(valueOps).increment(key2);
+        ArgumentCaptor<List<String>> keysCaptor = ArgumentCaptor.forClass(List.class);
+        verify(redisTemplate, times(2)).execute(any(RedisScript.class), keysCaptor.capture(), anyList());
+        assertThat(keysCaptor.getAllValues()).containsExactly(
+            List.of("ratelimit:users-collection:user@example.com"),
+            List.of("ratelimit:posts-collection:user@example.com"));
     }
 
     @Test
-    void testCustomWindowDuration() {
-        // Given
+    @SuppressWarnings("unchecked")
+    void testCustomWindowDurationPassedAsSeconds() {
         RateLimitConfig config = new RateLimitConfig(100, Duration.ofSeconds(30));
-        String expectedKey = "ratelimit:users-collection:user@example.com";
+        givenWindowCount(1L);
 
-        when(valueOps.increment(expectedKey)).thenReturn(Mono.just(1L));
-        when(redisTemplate.expire(expectedKey, Duration.ofSeconds(30))).thenReturn(Mono.just(true));
-
-        // When & Then
-        StepVerifier.create(rateLimiter.checkRateLimit("users-collection", "user@example.com", config))
+        StepVerifier.create(newLimiter().checkRateLimit("users-collection", "user@example.com", config))
             .expectNextMatches(RateLimitResult::isAllowed)
             .verifyComplete();
 
-        verify(redisTemplate).expire(expectedKey, Duration.ofSeconds(30));
+        ArgumentCaptor<List<String>> argsCaptor = ArgumentCaptor.forClass(List.class);
+        verify(redisTemplate).execute(any(RedisScript.class), anyList(), argsCaptor.capture());
+        assertThat(argsCaptor.getValue()).containsExactly("30");
     }
 }

--- a/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/query/DefaultQueryEngine.java
+++ b/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/query/DefaultQueryEngine.java
@@ -438,7 +438,7 @@ public class DefaultQueryEngine implements QueryEngine {
         // Evaluate before-delete hooks — any error vetoes the delete
         if (hasHooks) {
             BeforeSaveResult hookResult = beforeSaveHookRegistry.evaluateBeforeDelete(
-                    definition.name(), id, recordData != null ? extractTenantId(recordData) : "default");
+                    definition.name(), id, extractTenantId(recordData != null ? recordData : Map.of()));
             if (!hookResult.isSuccess()) {
                 throw new ValidationException(ValidationResult.failure(hookResult.getErrors().stream()
                         .map(e -> new FieldError(
@@ -454,7 +454,7 @@ public class DefaultQueryEngine implements QueryEngine {
             logger.debug("Deleted record '{}' from collection '{}'", id, definition.name());
 
             // Invoke after-delete hooks
-            invokeAfterDeleteHooks(definition, id);
+            invokeAfterDeleteHooks(definition, id, recordData);
 
             // Publish record change event with the pre-fetched data
             if (recordData != null) {
@@ -771,11 +771,13 @@ public class DefaultQueryEngine implements QueryEngine {
     /**
      * Invokes after-delete hooks. Failures are logged but do not block the operation.
      */
-    private void invokeAfterDeleteHooks(CollectionDefinition definition, String id) {
+    private void invokeAfterDeleteHooks(CollectionDefinition definition, String id,
+                                         Map<String, Object> recordData) {
         if (beforeSaveHookRegistry == null) {
             return;
         }
-        beforeSaveHookRegistry.invokeAfterDelete(definition.name(), id, "default");
+        beforeSaveHookRegistry.invokeAfterDelete(definition.name(), id,
+                extractTenantId(recordData != null ? recordData : Map.of()));
     }
 
     /**

--- a/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/query/DefaultQueryEngineTest.java
+++ b/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/query/DefaultQueryEngineTest.java
@@ -1,5 +1,6 @@
 package io.kelta.runtime.query;
 
+import io.kelta.runtime.context.TenantContext;
 import io.kelta.runtime.event.ChangeType;
 import io.kelta.runtime.event.PlatformEvent;
 import io.kelta.runtime.event.RecordChangedPayload;
@@ -30,6 +31,7 @@ import org.mockito.ArgumentCaptor;
 import java.time.Instant;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -1242,6 +1244,45 @@ class DefaultQueryEngineTest {
 
             engineWithHooks.delete(testCollection, id);
             assertTrue(afterHookCalled.get(), "After-delete hook should have been called");
+        }
+
+        @Test
+        @DisplayName("Should pass tenant from TenantContext to delete hooks, not the literal 'default'")
+        void shouldPassContextTenantToDeleteHooks() {
+            String contextTenant = UUID.randomUUID().toString();
+            AtomicReference<String> beforeHookTenant = new AtomicReference<>();
+            AtomicReference<String> afterHookTenant = new AtomicReference<>();
+            hookRegistry.register(new BeforeSaveHook() {
+                @Override
+                public String getCollectionName() { return "products"; }
+                @Override
+                public BeforeSaveResult beforeDelete(String id, String tenantId) {
+                    beforeHookTenant.set(tenantId);
+                    return BeforeSaveResult.ok();
+                }
+                @Override
+                public void afterDelete(String id, String tenantId) {
+                    afterHookTenant.set(tenantId);
+                }
+            });
+
+            String id = UUID.randomUUID().toString();
+            // User-collection records carry no tenantId attribute — the engine
+            // must fall back to TenantContext, never the literal "default".
+            Map<String, Object> existingRecord = new HashMap<>(Map.of(
+                "id", id, "name", "Widget", "price", 9.99));
+            when(storageAdapter.getById(any(CollectionDefinition.class), eq(id)))
+                .thenReturn(Optional.of(existingRecord));
+            when(storageAdapter.delete(any(CollectionDefinition.class), eq(id)))
+                .thenReturn(true);
+
+            TenantContext.runWithTenant(contextTenant, () ->
+                engineWithHooks.delete(testCollection, id));
+
+            assertEquals(contextTenant, beforeHookTenant.get(),
+                "Before-delete hook should receive the context tenant");
+            assertEquals(contextTenant, afterHookTenant.get(),
+                "After-delete hook should receive the context tenant");
         }
     }
 

--- a/kelta-platform/runtime/runtime-messaging-nats/src/main/java/io/kelta/runtime/messaging/nats/NatsSubscriptionManager.java
+++ b/kelta-platform/runtime/runtime-messaging-nats/src/main/java/io/kelta/runtime/messaging/nats/NatsSubscriptionManager.java
@@ -55,6 +55,16 @@ public class NatsSubscriptionManager implements DisposableBean {
 
     static final long RETRY_SECONDS = 5;
 
+    /**
+     * Bound redelivery of failing messages. Without a max-deliver cap a message
+     * whose handler always throws is redelivered forever (a poison-message loop
+     * that grinds one consumer and floods logs/DB with the same failure). After
+     * {@code MAX_DELIVER} attempts JetStream stops redelivering the message.
+     * The delayed NAK spaces attempts out instead of hot-looping.
+     */
+    static final long MAX_DELIVER = 5;
+    static final Duration NAK_DELAY = Duration.ofSeconds(2);
+
     private final NatsConnectionManager connectionManager;
     private final ObjectMapper objectMapper;
     private final NatsTracing tracing;
@@ -170,6 +180,7 @@ public class NatsSubscriptionManager implements DisposableBean {
                 .filterSubject(sub.subject())
                 .deliverPolicy(DeliverPolicy.Last)
                 .ackWait(Duration.ofSeconds(30))
+                .maxDeliver(MAX_DELIVER)
                 .build();
 
         PullSubscribeOptions options = PullSubscribeOptions.builder()
@@ -198,9 +209,7 @@ public class NatsSubscriptionManager implements DisposableBean {
                             msg.ack();
                             recordProcessed(sub.name(), start);
                         } catch (Exception e) {
-                            log.error("Error processing message in '{}': {}",
-                                    sub.name(), e.getMessage(), e);
-                            msg.nak();
+                            nakBounded(sub.name(), msg, e);
                             recordFailed(sub.name(), start);
                         }
                     }
@@ -217,6 +226,31 @@ public class NatsSubscriptionManager implements DisposableBean {
                 }
             }
         });
+    }
+
+    /**
+     * NAKs a failed message with a redelivery delay, logging loudly on the final
+     * attempt (after which JetStream stops redelivering it — see {@link #MAX_DELIVER}).
+     */
+    private static void nakBounded(String subName, Message msg, Exception e) {
+        long delivered = deliveredCount(msg);
+        if (delivered >= MAX_DELIVER) {
+            log.error("Error processing message in '{}' on final delivery attempt {}/{} — "
+                            + "message will NOT be redelivered: {}",
+                    subName, delivered, MAX_DELIVER, e.getMessage(), e);
+        } else {
+            log.error("Error processing message in '{}' (attempt {}/{}): {}",
+                    subName, delivered, MAX_DELIVER, e.getMessage(), e);
+        }
+        msg.nakWithDelay(NAK_DELAY);
+    }
+
+    private static long deliveredCount(Message msg) {
+        try {
+            return msg.metaData() != null ? msg.metaData().deliveredCount() : -1;
+        } catch (Exception ignored) {
+            return -1;
+        }
     }
 
     /**
@@ -240,6 +274,7 @@ public class NatsSubscriptionManager implements DisposableBean {
         ConsumerConfiguration cc = ConsumerConfiguration.builder()
                 .deliverPolicy(DeliverPolicy.New)
                 .ackWait(Duration.ofSeconds(30))
+                .maxDeliver(MAX_DELIVER)
                 .build();
 
         PushSubscribeOptions options = PushSubscribeOptions.builder()
@@ -259,9 +294,7 @@ public class NatsSubscriptionManager implements DisposableBean {
                 msg.ack();
                 recordProcessed(sub.name(), start);
             } catch (Exception e) {
-                log.error("Error processing broadcast message in '{}': {}",
-                        sub.name(), e.getMessage(), e);
-                msg.nak();
+                nakBounded(sub.name(), msg, e);
                 recordFailed(sub.name(), start);
             }
         }, false, options);

--- a/kelta-worker/src/main/java/io/kelta/worker/listener/FieldQuotaEnforcementHook.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/listener/FieldQuotaEnforcementHook.java
@@ -21,8 +21,10 @@ public class FieldQuotaEnforcementHook implements BeforeSaveHook {
 
     private static final Logger log = LoggerFactory.getLogger(FieldQuotaEnforcementHook.class);
 
+    // field has no tenant_id column — tenant scope comes from the parent collection
     private static final String COUNT_FIELDS =
-            "SELECT COUNT(*) FROM field WHERE tenant_id = ? AND collection_id = ?";
+            "SELECT COUNT(*) FROM field f JOIN collection c ON c.id = f.collection_id "
+                    + "WHERE c.tenant_id = ? AND f.collection_id = ?";
 
     private final TenantQuotaResolver quotaResolver;
     private final JdbcTemplate jdbcTemplate;


### PR DESCRIPTION
## Summary
- **Root-causes and fixes the long-standing `storage-ready` e2e flake** (validation-rules-journey + rollup-summary-journey) that has been failing PRs including #1240. It was never a worker wedge: the gateway `RedisRateLimiter` refreshed the 5-minute window key's TTL on **every** request, so under continuous traffic the window never reset. The counter accumulated across the whole e2e run, tripped the per-tenant limit mid-suite (~1700 cumulative requests vs the 1735 default window limit), and every rejected poll re-incremented + re-extended the TTL — a **self-sustaining tenant-wide 429 lockout** with `Retry-After: 300`. Playwright runs serially, so the late-alphabet journeys always inherited the exhausted window and burned their 30s readiness budgets on 429s. Loaded runners = slower ops = more retries = earlier trip, which was the "runner load" correlation.
- Same defect was a **production hazard**: any steadily-active tenant could be permanently locked out.
- Fixes three latent bugs the investigation surfaced from the same CI logs (delete-hook tenant, field-quota SQL, unbounded NATS redelivery).

## Changes
- `kelta-gateway/.../ratelimit/RedisRateLimiter.java` — atomic Lua `INCR` that sets the TTL only when the window is new (or a prior `EXPIRE` was lost, preserving the no-orphan-keys guarantee). Rejections now report the **real remaining window TTL** as Retry-After instead of the full window. Reviewer note: this changes limiter semantics from "resets after 5 idle minutes" (accidental) to a true fixed window (intended design per its own Javadoc).
- `e2e-tests/helpers/data-factory.ts` — 429s now fail fast and loud: readiness polls throw immediately with an explicit rate-limit message; `request()` refuses to silently sleep through a Retry-After above 15s.
- `runtime-core/.../DefaultQueryEngine.java` — delete hooks received the literal `"default"` as tenantId; setup-audit rows for deletes always violated the tenant FK and **never persisted** (plus a per-delete error storm in logs). Delete hooks now resolve the tenant like create/update hooks.
- `kelta-worker/.../FieldQuotaEnforcementHook.java` — counted `field WHERE tenant_id = ?` but `field` has no `tenant_id` column; the query always threw and the fail-open hook **never enforced** the per-collection field quota. Now joins through `collection`.
- `runtime-messaging-nats/.../NatsSubscriptionManager.java` — consumers now use `maxDeliver=5` + 2s delayed NAK (was: infinite hot redelivery of poison messages); final attempt logged at ERROR.
- Docs: `concerns.md` (full post-mortem entry), `integrations.md` (redelivery contract: handlers idempotent across ≤5 deliveries).

## Testing
- Unit: gateway 491/491, worker 2005/2005, runtime-core 1433/1433, messaging-nats 18/18; new regression tests for TTL-not-refreshed, Retry-After-from-TTL, and delete-hook tenant propagation.
- Live JVM stack (docker compose, CI images): **7 consecutive runs of both journey specs green (~11s each — previously 1.5m timeouts)**; Redis window key TTL observed decaying (195s and falling) instead of pinned at 300; zero `Rate limit exceeded`, zero `column "tenant_id" does not exist`, zero `setup_audit_trail` FK errors across all runs; `DELETED` setup-audit rows persisted (42) for the first time.
- `/verify` fully green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)