### PR TITLE
fix(ui): require a profile in the admin Create User dialog

### DIFF
--- a/e2e-tests/tests/admin/security/users.spec.ts
+++ b/e2e-tests/tests/admin/security/users.spec.ts
@@ -66,4 +66,32 @@ test.describe("Users", () => {
     ]);
     expect(found).toBe(true);
   });
+
+  test("create dialog requires a profile choice", async ({ page }) => {
+    const hasCreate = await usersPage.createButton
+      .isVisible({ timeout: 5_000 })
+      .catch(() => false);
+    if (!hasCreate) return;
+
+    await usersPage.createButton.click();
+
+    // The profile selector must be present and populated with the tenant's
+    // profiles (creating a user without a profileId is a worker-side 400).
+    const profileSelect = page.getByTestId("create-profile-select");
+    await expect(profileSelect).toBeVisible({ timeout: 10_000 });
+    await expect
+      .poll(async () => profileSelect.locator("option").count(), {
+        timeout: 10_000,
+      })
+      .toBeGreaterThan(1);
+
+    // Submitting without a profile is blocked client-side.
+    await page.getByLabel(/Email/).fill("e2e-profile-check@example.com");
+    await page.getByLabel(/First Name/).fill("E2e");
+    await page.getByLabel(/Last Name/).fill("Check");
+    await page.getByRole("button", { name: "Create", exact: true }).click();
+    await expect(page.getByText("Profile is required")).toBeVisible();
+
+    await page.getByRole("button", { name: "Cancel", exact: true }).click();
+  });
 });

--- a/kelta-ui/app/src/pages/UsersPage/UsersPage.test.tsx
+++ b/kelta-ui/app/src/pages/UsersPage/UsersPage.test.tsx
@@ -32,6 +32,8 @@ vi.mock('../../hooks/useDelegatedAdmin', () => ({
 vi.mock('../../components/Toast', () => ({ useToast: () => ({ showToast: vi.fn() }) }))
 
 const adminUsersList = vi.fn()
+const adminUsersCreate = vi.fn()
+const profilesList = vi.fn()
 const delegatedUsersList = vi.fn()
 const delegatedUsersCreate = vi.fn()
 const delegatedUsersUpdate = vi.fn()
@@ -40,7 +42,13 @@ vi.mock('../../context/ApiContext', () => ({
   useApi: () => ({
     keltaClient: {
       admin: {
-        users: { list: adminUsersList, create: vi.fn(), activate: vi.fn(), deactivate: vi.fn() },
+        users: {
+          list: adminUsersList,
+          create: adminUsersCreate,
+          activate: vi.fn(),
+          deactivate: vi.fn(),
+        },
+        profiles: { list: profilesList },
         delegated: {
           users: {
             list: delegatedUsersList,
@@ -117,6 +125,11 @@ describe('UsersPage', () => {
     mockNavigate.mockClear()
     hasPermission.mockReset()
     adminUsersList.mockReset().mockResolvedValue({ content: [], totalPages: 0 })
+    adminUsersCreate.mockReset().mockResolvedValue(ADMIN_USER)
+    profilesList.mockReset().mockResolvedValue([
+      { id: 'p1', name: 'Standard User' },
+      { id: 'p2', name: 'System Administrator' },
+    ])
     delegatedUsersList.mockReset().mockResolvedValue([])
     delegatedUsersCreate.mockReset().mockResolvedValue(DELEGATED_USER)
   })
@@ -178,6 +191,45 @@ describe('UsersPage', () => {
       expect(await screen.findByText('Full Listed')).toBeInTheDocument()
       // No delegated badge in full-admin mode.
       expect(screen.queryByTestId('delegated-scope-badge')).not.toBeInTheDocument()
+    })
+
+    it("offers the tenant's profiles in the create form", async () => {
+      renderPage()
+      await waitFor(() => expect(profilesList).toHaveBeenCalled())
+
+      fireEvent.click(screen.getByText('Create User'))
+
+      const select = (await screen.findByTestId('create-profile-select')) as HTMLSelectElement
+      await waitFor(() =>
+        expect(Array.from(select.options).map((o) => o.textContent)).toEqual(
+          expect.arrayContaining(['Standard User', 'System Administrator'])
+        )
+      )
+    })
+
+    it('blocks submit until a profile is chosen, then creates with the profileId', async () => {
+      renderPage()
+      await waitFor(() => expect(adminUsersList).toHaveBeenCalled())
+
+      fireEvent.click(screen.getByText('Create User'))
+      fireEvent.change(await screen.findByLabelText(/Email/), {
+        target: { value: 'new@example.com' },
+      })
+      fireEvent.change(screen.getByLabelText(/First Name/), { target: { value: 'New' } })
+      fireEvent.change(screen.getByLabelText(/Last Name/), { target: { value: 'User' } })
+
+      // No profile chosen — the submit is rejected client-side, never hitting the API.
+      fireEvent.click(screen.getByText('Create'))
+      expect(await screen.findByText('Profile is required')).toBeInTheDocument()
+      expect(adminUsersCreate).not.toHaveBeenCalled()
+
+      fireEvent.change(screen.getByTestId('create-profile-select'), { target: { value: 'p2' } })
+      fireEvent.click(screen.getByText('Create'))
+      await waitFor(() =>
+        expect(adminUsersCreate).toHaveBeenCalledWith(
+          expect.objectContaining({ email: 'new@example.com', profileId: 'p2' })
+        )
+      )
     })
   })
 })

--- a/kelta-ui/app/src/pages/UsersPage/UsersPage.tsx
+++ b/kelta-ui/app/src/pages/UsersPage/UsersPage.tsx
@@ -79,8 +79,12 @@ function UserForm({
   onSubmit: (data: CreateUserFormData) => void
   onCancel: () => void
   isSubmitting: boolean
-  /** When set (delegated scoped mode), a profile choice is required and limited to these. */
-  profileOptions?: DelegatedNamedRef[]
+  /**
+   * Profile choices — always required (the worker rejects a create without a
+   * profileId). Delegated scoped mode passes the caller's manageable subset;
+   * full-admin mode passes the tenant's profiles.
+   */
+  profileOptions: DelegatedNamedRef[]
 }) {
   const { t } = useI18n()
   const [formData, setFormData] = useState<CreateUserFormData>({
@@ -98,9 +102,9 @@ function UserForm({
     else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(formData.email)) errs.email = 'Invalid email'
     if (!formData.firstName.trim()) errs.firstName = 'First name is required'
     if (!formData.lastName.trim()) errs.lastName = 'Last name is required'
-    if (profileOptions && !formData.profileId) errs.profileId = 'Profile is required'
+    if (!formData.profileId) errs.profileId = 'Profile is required'
     return errs
-  }, [formData, profileOptions])
+  }, [formData])
 
   const handleSubmit = useCallback(
     (e: React.FormEvent) => {
@@ -196,33 +200,31 @@ function UserForm({
               className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm"
             />
           </div>
-          {profileOptions && (
-            <div className="mb-4">
-              <label htmlFor="profileId" className="mb-1 block text-sm font-medium text-foreground">
-                {t('users.profile')} *
-              </label>
-              <select
-                id="profileId"
-                data-testid="create-profile-select"
-                value={formData.profileId}
-                onChange={(e) => setFormData({ ...formData, profileId: e.target.value })}
-                className={cn(
-                  'w-full rounded-md border border-border bg-background px-3 py-2 text-sm',
-                  errors.profileId && 'border-destructive'
-                )}
-              >
-                <option value="">{t('common.select')}</option>
-                {profileOptions.map((p) => (
-                  <option key={p.id} value={p.id}>
-                    {p.name}
-                  </option>
-                ))}
-              </select>
-              {errors.profileId && (
-                <span className="mt-1 block text-xs text-destructive">{errors.profileId}</span>
+          <div className="mb-4">
+            <label htmlFor="profileId" className="mb-1 block text-sm font-medium text-foreground">
+              {t('users.profile')} *
+            </label>
+            <select
+              id="profileId"
+              data-testid="create-profile-select"
+              value={formData.profileId}
+              onChange={(e) => setFormData({ ...formData, profileId: e.target.value })}
+              className={cn(
+                'w-full rounded-md border border-border bg-background px-3 py-2 text-sm',
+                errors.profileId && 'border-destructive'
               )}
-            </div>
-          )}
+            >
+              <option value="">{t('common.select')}</option>
+              {profileOptions.map((p) => (
+                <option key={p.id} value={p.id}>
+                  {p.name}
+                </option>
+              ))}
+            </select>
+            {errors.profileId && (
+              <span className="mt-1 block text-xs text-destructive">{errors.profileId}</span>
+            )}
+          </div>
           <div className="mt-6 flex justify-end gap-2">
             <button
               type="button"
@@ -401,6 +403,19 @@ export function UsersPage({ testId = 'users-page' }: UsersPageProps) {
   // Delegated scoped mode: caller lacks MANAGE_USERS but is listed in an active
   // delegated-admin scope. All data flows through /api/admin/delegated/* then.
   const scoped = !hasPermission('MANAGE_USERS') && isDelegated
+
+  // The create form always requires a profile (the worker rejects a create
+  // without a profileId): scoped mode offers the caller's manageable subset,
+  // full-admin mode offers the tenant's profiles.
+  const { data: allProfiles } = useQuery({
+    queryKey: ['profiles'],
+    queryFn: () =>
+      keltaClient.admin.profiles.list() as unknown as Promise<{ id: string; name: string }[]>,
+    enabled: !scoped,
+  })
+  const createProfileOptions: DelegatedNamedRef[] = scoped
+    ? (summary?.manageableProfiles ?? [])
+    : (allProfiles ?? []).map((p) => ({ id: p.id, name: p.name }))
 
   const [isFormOpen, setIsFormOpen] = useState(false)
   const [editUser, setEditUser] = useState<PlatformUser | null>(null)
@@ -756,7 +771,7 @@ export function UsersPage({ testId = 'users-page' }: UsersPageProps) {
           onSubmit={(formData) => createMutation.mutate(formData)}
           onCancel={() => setIsFormOpen(false)}
           isSubmitting={createMutation.isPending}
-          profileOptions={scoped ? (summary?.manageableProfiles ?? []) : undefined}
+          profileOptions={createProfileOptions}
         />
       )}
 


### PR DESCRIPTION
## Summary
- Full-admin (non-delegated) Create User dialog never rendered the profile selector: `UserForm` only showed it when the delegated-scope `profileOptions` prop was passed, and skipped the required-profile validation the same way. Every non-delegated create posted `profileId: ""` → worker 400 — admins could not create internal users from the UI at all. (Found 2026-07-11 creating providers on the telehealth tenant; the same payload with a real profileId succeeds via the API, confirming UI-only.)
- The dialog now always requires a profile: delegated mode keeps the caller's manageable subset; full-admin mode fetches the tenant's profiles (shared `['profiles']` query key with ProfilesPage). Selector renders and validates unconditionally.

## Changes
- `kelta-ui/app/src/pages/UsersPage/UsersPage.tsx` — `profileOptions` prop now required; unconditional selector + validation; `useQuery(['profiles'])` (enabled only in non-scoped mode) feeding `createProfileOptions`
- `kelta-ui/app/src/pages/UsersPage/UsersPage.test.tsx` — mocks `admin.profiles.list`; new full-admin tests: options populated, submit blocked without a choice, `admin.users.create` called with the chosen `profileId`
- `e2e-tests/tests/admin/security/users.spec.ts` — dialog exposes a populated profile selector and blocks an empty submit

## Testing
- UsersPage unit tests 7/7; full kelta-ui suite 2585 passed; lint + format:check green
- `npx vite build` clean (kelta-ui has no typecheck step in /verify — build is where type/import bugs surface)
- No backend changes; kelta-web untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)