### PR TITLE
fix(worker): bridge video-session lifecycle events onto the flow-trigger namespace

### DIFF
--- a/.claude/docs/integrations.md
+++ b/.claude/docs/integrations.md
@@ -142,6 +142,12 @@ the tenant token). `NatsTriggerFlowListener` consumes the namespace as a queue g
 (`trigger.type = "NATS_MESSAGE"`, with `subject` + `topic`; a non-JSON body arrives as
 `{ "raw": "<text>" }`). The body is arbitrary publisher JSON — not a `PlatformEvent`.
 
+One platform publisher does use the namespace: the LiveKit webhook bridges every
+video-session lifecycle event onto `kelta.trigger.<tenantId>.video.session` (same
+`PlatformEvent<VideoSessionPayload>` envelope as `kelta.video.session.*`), so a
+NATS_TRIGGERED flow with trigger topic `video.session` reads
+`$.input.payload.{sessionId,appointmentId,conversationId,status,durationSeconds}`.
+
 ### Wait states — persistence and resume
 
 A Wait with `Seconds` ≤ 10 sleeps in-process. Longer, timestamp-based

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,7 +216,7 @@ Each maps to a real mistake an agent has made here. Violating one usually compil
 | `kelta.config.promotion.executed.<tenantId>.<promotionId>` | Metadata promotion executed/failed/rolled back |
 | `kelta.chat.message.<tenantId>.<conversationId>` | Chat message created (telehealth slice 2) — ids/sender/kind ONLY, never the body; gateway `ChatMessageBridge` fans to conversation-joined sockets (membership-checked `chat.join`) as an invalidation signal |
 | `kelta.chat.conversation.<tenantId>.<conversationId>` | Chat conversation lifecycle (OPEN\|ASSIGNED\|CLOSED\|ARCHIVED) — ids/state only; same conversation-scoped fanout |
-| `kelta.video.session.<tenantId>.<sessionId>` | Video session lifecycle (ACTIVE\|ENDED + durationSeconds, telehealth slice 5) — published by the verified LiveKit webhook; ids/state only. Feeds NATS_TRIGGERED flows (post-visit follow-up) |
+| `kelta.video.session.<tenantId>.<sessionId>` | Video session lifecycle (ACTIVE\|ENDED + durationSeconds, telehealth slice 5) — published by the verified LiveKit webhook; ids/state only. The same envelope is bridged onto `kelta.trigger.<tenantId>.video.session`, so NATS_TRIGGERED flows with topic `video.session` fire (post-visit follow-up; flows read `$.input.payload.*`) |
 | `kelta.record.changed.<tenantId>.<collection>` | Record CRUD (flows, search index, webhooks, realtime, cross-pod system-collection cache eviction). Payload `containsMaskedFields=true` ⇒ realtime bridge omits record data |
 | `kelta.trigger.<tenantId>.<topic>` | External flow trigger — starts active `NATS_TRIGGERED` flows whose trigger-config `topic` matches (KELTA_TRIGGERS stream, queue-group consumed; body = arbitrary JSON, not a `PlatformEvent`) |
 

--- a/kelta-worker/src/main/java/io/kelta/worker/service/telehealth/LiveKitWebhookService.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/service/telehealth/LiveKitWebhookService.java
@@ -29,6 +29,8 @@ import java.util.Map;
 public class LiveKitWebhookService {
 
     static final String SUBJECT_PREFIX = "kelta.video.session.";
+    static final String TRIGGER_SUBJECT_PREFIX = "kelta.trigger.";
+    static final String TRIGGER_TOPIC = "video.session";
 
     private static final Logger log = LoggerFactory.getLogger(LiveKitWebhookService.class);
     private static final ObjectMapper MAPPER = new ObjectMapper();
@@ -150,6 +152,12 @@ public class LiveKitWebhookService {
         PlatformEvent<VideoSessionPayload> event =
                 EventFactory.createEvent("kelta.video.session", payload);
         eventPublisher.publish(SUBJECT_PREFIX + tenantId + "." + sessionId, event);
+
+        // Bridge onto the flow-trigger namespace so NATS_TRIGGERED flows with
+        // trigger topic "video.session" fire (the documented post-visit
+        // follow-up contract). The trigger listener hands the message body to
+        // the flow as $.input, so flows read $.input.payload.status etc.
+        eventPublisher.publish(TRIGGER_SUBJECT_PREFIX + tenantId + "." + TRIGGER_TOPIC, event);
     }
 
     private static String firstFileResult(JsonNode event) {

--- a/kelta-worker/src/test/java/io/kelta/worker/service/telehealth/LiveKitWebhookServiceTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/service/telehealth/LiveKitWebhookServiceTest.java
@@ -46,7 +46,7 @@ class LiveKitWebhookServiceTest {
     }
 
     @Test
-    @DisplayName("room_started marks the session ACTIVE and publishes on the tenant/session subject")
+    @DisplayName("room_started marks the session ACTIVE and publishes lifecycle + trigger subjects")
     void roomStarted() {
         stubSession();
         service.process("{\"event\":\"room_started\",\"id\":\"EV_1\",\"room\":{\"name\":\"t_t1_room\"}}");
@@ -54,9 +54,11 @@ class LiveKitWebhookServiceTest {
         verify(jdbcTemplate).update(contains("SET status = 'ACTIVE'"), eq("vs-1"));
         ArgumentCaptor<String> subject = ArgumentCaptor.forClass(String.class);
         ArgumentCaptor<PlatformEvent> event = ArgumentCaptor.forClass(PlatformEvent.class);
-        verify(eventPublisher).publish(subject.capture(), event.capture());
-        assertThat(subject.getValue()).isEqualTo("kelta.video.session.t1.vs-1");
-        assertThat(((VideoSessionPayload) event.getValue().getPayload()).getStatus())
+        verify(eventPublisher, times(2)).publish(subject.capture(), event.capture());
+        assertThat(subject.getAllValues()).containsExactly(
+                "kelta.video.session.t1.vs-1",
+                "kelta.trigger.t1.video.session");
+        assertThat(((VideoSessionPayload) event.getAllValues().get(0).getPayload()).getStatus())
                 .isEqualTo("ACTIVE");
     }
 
@@ -70,12 +72,31 @@ class LiveKitWebhookServiceTest {
         service.process("{\"event\":\"room_finished\",\"id\":\"EV_2\",\"room\":{\"name\":\"t_t1_room\"}}");
 
         ArgumentCaptor<PlatformEvent> event = ArgumentCaptor.forClass(PlatformEvent.class);
-        verify(eventPublisher).publish(anyString(), event.capture());
-        VideoSessionPayload payload = (VideoSessionPayload) event.getValue().getPayload();
+        verify(eventPublisher, times(2)).publish(anyString(), event.capture());
+        VideoSessionPayload payload = (VideoSessionPayload) event.getAllValues().get(0).getPayload();
         assertThat(payload.getStatus()).isEqualTo("ENDED");
         assertThat(payload.getDurationSeconds()).isEqualTo(1234);
         // The ended session is auto-archived (telehealth slice 7).
         verify(archiveService).archiveVideoSession("t1", "vs-1");
+    }
+
+    @Test
+    @DisplayName("lifecycle events bridge onto kelta.trigger.<tenant>.video.session for NATS_TRIGGERED flows")
+    void bridgesToFlowTriggerNamespace() {
+        stubSession();
+        when(jdbcTemplate.queryForObject(contains("SET status = 'ENDED'"), eq(Integer.class),
+                eq("vs-1"))).thenReturn(60);
+
+        service.process("{\"event\":\"room_finished\",\"id\":\"EV_6\",\"room\":{\"name\":\"t_t1_room\"}}");
+
+        ArgumentCaptor<String> subject = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<PlatformEvent> event = ArgumentCaptor.forClass(PlatformEvent.class);
+        verify(eventPublisher, times(2)).publish(subject.capture(), event.capture());
+        assertThat(subject.getAllValues().get(1)).isEqualTo("kelta.trigger.t1.video.session");
+        // Same envelope on both subjects — flows read $.input.payload.*.
+        VideoSessionPayload bridged = (VideoSessionPayload) event.getAllValues().get(1).getPayload();
+        assertThat(bridged.getStatus()).isEqualTo("ENDED");
+        assertThat(bridged.getAppointmentId()).isEqualTo("appt-1");
     }
 
     @Test


### PR DESCRIPTION
## Summary
- CLAUDE.md's messaging table says `kelta.video.session.<tenantId>.<sessionId>` "feeds NATS_TRIGGERED flows (post-visit follow-up)" — but nothing consumes that namespace: `NatsTriggerFlowListener` subscribes only to `kelta.trigger.>`. Post-visit flows could never fire. Found wiring the telehealth sample tenant's completion flow (2026-07-11).
- The LiveKit webhook now publishes the **same** `PlatformEvent<VideoSessionPayload>` envelope to `kelta.trigger.<tenantId>.video.session` alongside the lifecycle subject. The `KELTA_TRIGGERS` stream already covers the subject and the payload is already in the native reflect-config (#1240) — no stream or reflection changes.
- A `NATS_TRIGGERED` flow with trigger topic `video.session` reads `$.input.payload.{sessionId,appointmentId,conversationId,status,durationSeconds}`.

## Changes
- `LiveKitWebhookService` — second publish in `publish(...)`; `TRIGGER_SUBJECT_PREFIX`/`TRIGGER_TOPIC` constants
- `LiveKitWebhookServiceTest` — dual-publish assertions on room_started/room_finished + new bridge test (subject + payload)
- `CLAUDE.md` messaging table + `integrations.md` NATS-triggered section now describe the bridge instead of implying it

## Testing
- `LiveKitWebhookServiceTest` 7/7; full kelta-worker suite 2014 green. No gateway/runtime/frontend changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)