### PR TITLE
fix(messaging): self-heal JetStream durable-consumer config drift on bind

### DIFF
--- a/.claude/docs/concerns.md
+++ b/.claude/docs/concerns.md
@@ -438,6 +438,15 @@ for removal ("inline the current value"). Findings:
   call. Telehealth slices 2 (chat) + 5 (video) added subjects without streams → chat realtime was fully
   broken on prod (gateway push consumer looped `[SUB-90007] No matching streams`) and video lifecycle
   events failed to publish, until `KELTA_CHAT` + `KELTA_VIDEO_SESSION` were added (2026-07-11).
+- **Changing any durable-consumer setting (maxDeliver, ackWait, deliverPolicy, …) is a rolling-upgrade
+  hazard.** The durable consumers on the NATS server keep the old config; jnats then rejects every bind
+  with `[SUB-90016] Existing consumer cannot be modified`, and the subscribe retry loop can never succeed.
+  The 2026-07-12 worker rollout (maxDeliver=5 introduced by #1215-era code) took ALL six worker
+  subscriptions — flows, NATS triggers, search index, Svix, Superset — down for ~30 min until the
+  consumers were hand-edited. `NatsSubscriptionManager` now self-heals: on a drift rejection it
+  `addOrUpdateConsumer`s the durable in place (delivery cursor preserved — never delete/recreate, that
+  drops the backlog) and re-subscribes. If flows stop after a deploy anyway, grep worker logs for
+  `SUB-90016` first.
 - Multiple BOM version overrides in worker POM increase transitive conflict risk (`kelta-worker/pom.xml`). Audit on every Spring Boot bump.
 - **pgvector required for VECTOR fields / semantic search.** `PhysicalTableStorageAdapter.initializeCollection` runs `CREATE EXTENSION IF NOT EXISTS vector` lazily — only when a collection actually has a VECTOR field — and throws an actionable `StorageException` if it can't. Local dev + CI use the `pgvector/pgvector:pg15` image (docker-compose + `KeltaStack` Testcontainers). **The standalone prod Postgres at `192.168.0.5` is plain `postgres:15` and must have the pgvector extension installed** (the `.so` available + the worker's DB role allowed to `CREATE EXTENSION`, or an admin pre-creates it) before any tenant defines a VECTOR field; otherwise that collection's table creation fails with the guidance above. Collections without VECTOR fields are unaffected.
 - **Stale `spring-kafka` dependency retired** (Phase 0): `runtime-core/pom.xml` previously declared `spring-kafka`, `spring-kafka-test`, and `testcontainers-kafka` despite the platform using NATS JetStream exclusively. Removed; the misnamed `KafkaRecordEventPublisher` was renamed to `NatsRecordEventPublisher`. The stale event-bus comments and docs that mislabeled NATS as the previous broker have since been corrected to NATS across the codebase.

--- a/kelta-platform/runtime/runtime-messaging-nats/src/main/java/io/kelta/runtime/messaging/nats/NatsSubscriptionManager.java
+++ b/kelta-platform/runtime/runtime-messaging-nats/src/main/java/io/kelta/runtime/messaging/nats/NatsSubscriptionManager.java
@@ -9,6 +9,7 @@ import io.micrometer.core.instrument.Timer;
 import io.nats.client.Connection;
 import io.nats.client.Dispatcher;
 import io.nats.client.JetStream;
+import io.nats.client.JetStreamManagement;
 import io.nats.client.JetStreamSubscription;
 import io.nats.client.Message;
 import io.nats.client.PullSubscribeOptions;
@@ -187,15 +188,25 @@ public class NatsSubscriptionManager implements DisposableBean {
                 .configuration(cc)
                 .build();
 
-        JetStreamSubscription jsSub = js.subscribe(sub.subject(), options);
-        activeSubscriptions.add(jsSub);
-        registerForLagPolling(sub.name(), jsSub);
+        JetStreamSubscription jsSub;
+        try {
+            jsSub = js.subscribe(sub.subject(), options);
+        } catch (Exception e) {
+            if (!isConsumerConfigDrift(e)) {
+                throw e;
+            }
+            healConsumerConfigDrift(sub, cc, e);
+            jsSub = js.subscribe(sub.subject(), options);
+        }
+        final JetStreamSubscription attached = jsSub;
+        activeSubscriptions.add(attached);
+        registerForLagPolling(sub.name(), attached);
 
         pullExecutor.submit(() -> {
             log.info("Pull consumer '{}' started on subject '{}'", sub.name(), sub.subject());
             while (running) {
                 try {
-                    List<Message> messages = jsSub.fetch(10, Duration.ofSeconds(1));
+                    List<Message> messages = attached.fetch(10, Duration.ofSeconds(1));
                     for (Message msg : messages) {
                         long start = System.nanoTime();
                         try (NatsTracing.Scope ignored = tracing.extractAndOpen(msg.getHeaders())) {
@@ -226,6 +237,46 @@ public class NatsSubscriptionManager implements DisposableBean {
                 }
             }
         });
+    }
+
+    /**
+     * True when a subscribe failed because the durable consumer already exists
+     * on the server with a different configuration. jnats pre-checks the
+     * requested config against the existing durable and rejects the bind with
+     * {@code [SUB-90016] Existing consumer cannot be modified} — a state a
+     * rolling upgrade reaches whenever a release changes any consumer setting
+     * (maxDeliver, ackWait, …), because the durable on the server keeps the
+     * old config. Retrying the same subscribe can never succeed.
+     */
+    static boolean isConsumerConfigDrift(Exception e) {
+        String msg = e.getMessage();
+        if (msg == null) {
+            return false;
+        }
+        return msg.contains("SUB-90016")
+                || msg.toLowerCase(java.util.Locale.ROOT).contains("consumer cannot be modified");
+    }
+
+    /**
+     * Self-heals consumer-config drift: updates the existing durable's config
+     * in place via {@code addOrUpdateConsumer} — which preserves the delivery
+     * cursor, so the pending backlog is delivered instead of dropped (delete +
+     * recreate would lose the cursor) — then the caller re-subscribes.
+     * The 2026-07-12 rollout outage (all six worker subscriptions down ~30 min
+     * after MAX_DELIVER was introduced) is the incident this guards against.
+     */
+    private void healConsumerConfigDrift(EventSubscription sub, ConsumerConfiguration cc,
+                                         Exception cause) throws Exception {
+        JetStreamManagement jsm = connectionManager.jetStreamManagement();
+        List<String> streams = jsm.getStreamNames(sub.subject());
+        if (streams == null || streams.isEmpty()) {
+            throw cause;
+        }
+        String stream = streams.get(0);
+        log.warn("Durable consumer '{}' on '{}' has drifted server-side config ({}) — "
+                        + "updating it in place on stream '{}' (delivery cursor preserved) and re-attaching",
+                sub.name(), sub.subject(), cause.getMessage(), stream);
+        jsm.addOrUpdateConsumer(stream, cc);
     }
 
     /**

--- a/kelta-platform/runtime/runtime-messaging-nats/src/test/java/io/kelta/runtime/messaging/nats/NatsSubscriptionManagerTest.java
+++ b/kelta-platform/runtime/runtime-messaging-nats/src/test/java/io/kelta/runtime/messaging/nats/NatsSubscriptionManagerTest.java
@@ -118,6 +118,68 @@ class NatsSubscriptionManagerTest {
     }
 
     @Test
+    @DisplayName("consumer-config drift is healed in place and the subscribe retried (2026-07-12 outage)")
+    void healsConsumerConfigDrift() throws Exception {
+        JetStream jetStream = mock(JetStream.class);
+        io.nats.client.JetStreamManagement jsm = mock(io.nats.client.JetStreamManagement.class);
+        JetStreamSubscription jsSub = mock(JetStreamSubscription.class);
+        when(connectionManager.jetStream()).thenReturn(jetStream);
+        when(connectionManager.jetStreamManagement()).thenReturn(jsm);
+        when(jetStream.subscribe(anyString(), any(io.nats.client.PullSubscribeOptions.class)))
+                .thenThrow(new IllegalArgumentException(
+                        "[SUB-90016] Existing consumer cannot be modified. Changed fields: [maxDeliver]"))
+                .thenReturn(jsSub);
+        when(jsm.getStreamNames("kelta.record.changed.>")).thenReturn(List.of("KELTA_RECORDS"));
+        // The pull loop races the assertion on a virtual thread — lenient, it
+        // may or may not fetch before destroy().
+        org.mockito.Mockito.lenient()
+                .when(jsSub.fetch(org.mockito.ArgumentMatchers.anyInt(), any()))
+                .thenReturn(List.of());
+
+        EventSubscription sub = EventSubscription.queueGroup(
+                "worker-flows", "kelta.record.changed.>", "worker-flows", msg -> { });
+
+        assertThat(subscriptionManager.tryStartSubscription(sub, true)).isTrue();
+
+        var ccCaptor = org.mockito.ArgumentCaptor.forClass(io.nats.client.api.ConsumerConfiguration.class);
+        verify(jsm).addOrUpdateConsumer(org.mockito.ArgumentMatchers.eq("KELTA_RECORDS"), ccCaptor.capture());
+        assertThat(ccCaptor.getValue().getDurable()).isEqualTo("worker-flows");
+        assertThat(ccCaptor.getValue().getMaxDeliver()).isEqualTo(NatsSubscriptionManager.MAX_DELIVER);
+        verify(jetStream, org.mockito.Mockito.times(2))
+                .subscribe(anyString(), any(io.nats.client.PullSubscribeOptions.class));
+
+        subscriptionManager.destroy();
+    }
+
+    @Test
+    @DisplayName("non-drift subscribe failures are not healed — normal retry handles them")
+    void nonDriftFailuresAreNotHealed() throws Exception {
+        JetStream jetStream = mock(JetStream.class);
+        when(connectionManager.jetStream()).thenReturn(jetStream);
+        when(jetStream.subscribe(anyString(), any(io.nats.client.PullSubscribeOptions.class)))
+                .thenThrow(new IllegalStateException("NATS not reachable"));
+
+        EventSubscription sub = EventSubscription.queueGroup(
+                "worker-flows", "kelta.record.changed.>", "worker-flows", msg -> { });
+
+        assertThat(subscriptionManager.tryStartSubscription(sub, true)).isFalse();
+        verify(connectionManager, org.mockito.Mockito.never()).jetStreamManagement();
+    }
+
+    @Test
+    @DisplayName("drift detection matches the jnats SUB-90016 message shape only")
+    void driftDetection() {
+        assertThat(NatsSubscriptionManager.isConsumerConfigDrift(new IllegalArgumentException(
+                "[SUB-90016] Existing consumer cannot be modified. Changed fields: [maxDeliver]"))).isTrue();
+        assertThat(NatsSubscriptionManager.isConsumerConfigDrift(new IllegalArgumentException(
+                "existing Consumer Cannot Be Modified"))).isTrue();
+        assertThat(NatsSubscriptionManager.isConsumerConfigDrift(
+                new IllegalStateException("NATS not connected"))).isFalse();
+        assertThat(NatsSubscriptionManager.isConsumerConfigDrift(
+                new RuntimeException((String) null))).isFalse();
+    }
+
+    @Test
     @DisplayName("counters segregate by subscription tag")
     void countersSegregateBySubscription() {
         long start = System.nanoTime();


### PR DESCRIPTION
## Summary
- **Incident (2026-07-12):** the worker rollout carrying `maxDeliver=5` couldn't bind ANY of its six durable consumers — the durables on the NATS server kept the old unlimited config, jnats rejected every bind with `[SUB-90016] Existing consumer cannot be modified. Changed fields: [maxDeliver]`, and the 5-second subscribe-retry loop can never resolve a config mismatch. Record-triggered flows, NATS-triggered flows, search indexing, Svix webhooks, and Superset sync were all down ~30 minutes until the consumers were hand-edited (`nats consumer edit … --max-deliver 5 -f`).
- **Fix:** `NatsSubscriptionManager` detects the drift rejection on pull-consumer subscribe, updates the existing durable in place via `JetStreamManagement.addOrUpdateConsumer` — **cursor preserved**, so the pending backlog delivers instead of being dropped (delete/recreate would lose it) — logs a WARN naming the drift, and re-subscribes. Non-drift failures still flow to the existing retry loop; push consumers are ephemeral and unaffected.

## Changes
- `NatsSubscriptionManager` — drift detection (`isConsumerConfigDrift`, matches the jnats SUB-90016 client precheck) + in-place heal (`healConsumerConfigDrift`: stream lookup by subject → `addOrUpdateConsumer` → resubscribe)
- `NatsSubscriptionManagerTest` — 3 new tests: drift → heal (verifies `addOrUpdateConsumer` on the right stream with durable name + `MAX_DELIVER`, subscribe retried) → attached; non-drift failures never touch `jetStreamManagement`; detection message-shape matrix
- `concerns.md` — consumer-config changes documented as a rolling-upgrade hazard handled by this path (`SUB-90016` = triage grep)

## Testing
- runtime-messaging-nats 22 tests, gateway 491, worker 2014, kelta-web lint/typecheck/format + 983 — all green

Related: #1214–#1216 (NATS reliability sweep), #1215 (maxDeliver introduction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)