### PR TITLE
fix(runtime): AUTO_NUMBER silently null on kebab-case collections

### DIFF
--- a/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/query/DefaultQueryEngine.java
+++ b/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/query/DefaultQueryEngine.java
@@ -543,7 +543,7 @@ public class DefaultQueryEngine implements QueryEngine {
         }
         for (FieldDefinition field : definition.fields()) {
             if (field.type() == FieldType.AUTO_NUMBER && !data.containsKey(field.name())) {
-                String seqName = "seq_" + definition.name() + "_" + field.name();
+                String seqName = autoNumberSequenceName(definition.name(), field.name());
                 Map<String, Object> config = field.fieldTypeConfig();
                 String prefix = "";
                 int padding = 6;
@@ -568,6 +568,17 @@ public class DefaultQueryEngine implements QueryEngine {
                 }
             }
         }
+    }
+
+    /**
+     * Builds the Postgres sequence name for an AUTO_NUMBER field. Collection
+     * names are kebab-case ({@code credit-notes}), which is not a valid
+     * Postgres identifier — {@link AutoNumberService} rejects it and the
+     * record would silently save with a null number. Map every non-identifier
+     * character to underscore so the derived name is always valid.
+     */
+    static String autoNumberSequenceName(String collectionName, String fieldName) {
+        return ("seq_" + collectionName + "_" + fieldName).replaceAll("[^a-zA-Z0-9_]", "_");
     }
 
     /**

--- a/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/query/DefaultQueryEngineTest.java
+++ b/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/query/DefaultQueryEngineTest.java
@@ -1399,4 +1399,32 @@ class DefaultQueryEngineTest {
         }
     }
 
+    @Nested
+    @DisplayName("Auto-number sequence naming")
+    class AutoNumberSequenceNaming {
+
+        @Test
+        @DisplayName("kebab-case collection names map to valid Postgres identifiers")
+        void kebabCaseCollectionName() {
+            // Regression: seq_credit-notes_creditNoteNumber failed AutoNumberService's
+            // identifier check and the record silently saved with a null number.
+            assertEquals("seq_credit_notes_creditNoteNumber",
+                    DefaultQueryEngine.autoNumberSequenceName("credit-notes", "creditNoteNumber"));
+        }
+
+        @Test
+        @DisplayName("plain names are unchanged")
+        void plainName() {
+            assertEquals("seq_orders_orderNumber",
+                    DefaultQueryEngine.autoNumberSequenceName("orders", "orderNumber"));
+        }
+
+        @Test
+        @DisplayName("any non-identifier character is mapped to underscore")
+        void otherSpecialCharacters() {
+            assertEquals("seq_a_b_c_n_1",
+                    DefaultQueryEngine.autoNumberSequenceName("a-b.c", "n 1"));
+        }
+    }
+
 }


### PR DESCRIPTION
## Problem

`AUTO_NUMBER` fields on kebab-case collections never generate a value — the record saves with a **null number** and only a WARN log hints why.

`DefaultQueryEngine.generateAutoNumbers()` derives the sequence name as `seq_<collection>_<field>` verbatim. For `credit-notes.creditNoteNumber` that is `seq_credit-notes_creditNoteNumber`, which fails `AutoNumberService.sanitize()` (`^[a-zA-Z_][a-zA-Z0-9_]*$`). The catch block swallows the `IllegalArgumentException`, so creation succeeds with a null number.

Kebab-case is the platform's own collection naming convention — every multi-word collection is affected. Single-word ones (`orders`, `invoices`) work, which is how this survived until the first real kebab-case series (`credit-notes` in the telehealth sample tenant, 2026-07-12) came back `creditNoteNumber: null`.

## Fix

Derive the sequence name with every non-identifier character mapped to `_`:
`seq_credit_notes_creditNoteNumber`. One-line change + a static helper so it's testable. No migration concerns — hyphenated sequences could never have been created, and single-word names are byte-identical.

## Tests

- `DefaultQueryEngineTest` → new "Auto-number sequence naming" group: kebab-case regression, plain-name unchanged, special-char matrix.
- Full `/verify`: runtime-core 1440 · gateway 491 · worker 2014 · kelta-web 983 — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)