### PR TITLE
fix(worker): field delete no longer 500s when layouts still reference it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,7 +142,7 @@ visual system.
 | Frontend | React | 19.2 | `kelta-ui/app/package.json` |
 | Frontend build | Vite / Vitest | web 5.1/1.3, ui 7.2/4.0 | package.json (npm, Node 18 in CI) |
 | E2E | Playwright | 1.50 | `e2e-tests/package.json` |
-| Migrations | Flyway | baseline **V1__baseline** (#1189 flatten), next new migration **V167** (deployed history keeps pre-flatten numbering) | `kelta-worker/.../db/migration/` |
+| Migrations | Flyway | baseline **V1__baseline** (#1189 flatten); check the migration directory for the current head before adding one (deployed history keeps pre-flatten numbering) | `kelta-worker/.../db/migration/` |
 
 Check the relevant `pom.xml` / `package.json` for exact current versions before pinning.
 
@@ -264,7 +264,7 @@ Java tests: surefire runs `*Test`/`*Tests`/`*Properties` in parallel; failsafe r
 ## Database Migrations
 
 - Location: `kelta-worker/src/main/resources/db/migration/`
-- Naming: `V<n>__<snake_description>.sql`. **Baseline file is V1__baseline (#1189 flatten); next new migration is V167 (directory head V166) — deployed flyway_schema_history retains pre-flatten numbering, so a lower-numbered migration is silently skipped on existing databases.**
+- Naming: `V<n>__<snake_description>.sql`. **Baseline file is V1__baseline (#1189 flatten) — deployed flyway_schema_history retains pre-flatten numbering, so a lower-numbered migration is silently skipped on existing databases.** The directory head moves often; always take head+1.
   Check the directory for the true highest number before creating one — never reuse/skip.
 - Flyway runs at worker startup. Migrations execute under the platform sentinel tenant.
 

--- a/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/router/GlobalExceptionHandler.java
+++ b/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/router/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package io.kelta.runtime.router;
 
 import io.kelta.jsonapi.JsonApiError;
 import io.kelta.runtime.query.InvalidQueryException;
+import io.kelta.runtime.storage.ReferencedRecordConflictException;
 import io.kelta.runtime.storage.StaleWriteException;
 import io.kelta.runtime.storage.StorageException;
 import io.kelta.runtime.storage.UniqueConstraintViolationException;
@@ -179,6 +180,26 @@ public class GlobalExceptionHandler {
         JsonApiError error = new JsonApiError(
             "409", "STALE_WRITE", "Conflict",
             "This record was modified since you opened it. Reload the latest version and try again.");
+        error.setMeta(Map.of("requestId", requestId, "path", request.getRequestURI()));
+
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(errorBody(error));
+    }
+
+    /**
+     * Handles deletes rejected by a restricting foreign key (SQL state 23503).
+     * Returns 409 Conflict — the record is still referenced, which is a client
+     * situation to resolve, not a server fault.
+     */
+    @ExceptionHandler(ReferencedRecordConflictException.class)
+    public ResponseEntity<Map<String, Object>> handleReferencedRecordConflict(
+            ReferencedRecordConflictException ex, HttpServletRequest request) {
+
+        String requestId = generateRequestId();
+        logger.warn("Referenced-record delete conflict [requestId={}]: {}", requestId, ex.getMessage());
+
+        JsonApiError error = new JsonApiError(
+            "409", "REFERENCED_RECORD", "Conflict",
+            ex.getMessage());
         error.setMeta(Map.of("requestId", requestId, "path", request.getRequestURI()));
 
         return ResponseEntity.status(HttpStatus.CONFLICT).body(errorBody(error));

--- a/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/storage/PhysicalTableStorageAdapter.java
+++ b/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/storage/PhysicalTableStorageAdapter.java
@@ -691,8 +691,25 @@ public class PhysicalTableStorageAdapter implements StorageAdapter {
             }
             return rowsAffected > 0;
         } catch (DataAccessException e) {
+            if (isForeignKeyViolation(e)) {
+                throw new ReferencedRecordConflictException(definition.name(), id, e);
+            }
             throw new StorageException("Failed to delete record from collection: " + definition.name(), e);
         }
+    }
+
+    /**
+     * True when the failure is a Postgres foreign-key violation (SQL state
+     * 23503) — a restricting reference, not a storage fault. Callers translate
+     * it to 409 instead of 500.
+     */
+    static boolean isForeignKeyViolation(Throwable e) {
+        for (Throwable t = e; t != null; t = t.getCause()) {
+            if (t instanceof java.sql.SQLException sql && "23503".equals(sql.getSQLState())) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override

--- a/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/storage/ReferencedRecordConflictException.java
+++ b/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/storage/ReferencedRecordConflictException.java
@@ -1,0 +1,31 @@
+package io.kelta.runtime.storage;
+
+/**
+ * Thrown when a delete is rejected by a Postgres foreign-key constraint
+ * (SQL state 23503): other records still reference the target row.
+ *
+ * <p>Maps to HTTP 409 Conflict in {@code GlobalExceptionHandler} — before this
+ * existed, every restricting FK surfaced as an opaque 500 {@link StorageException}.
+ *
+ * @since 1.0.0
+ */
+public class ReferencedRecordConflictException extends StorageException {
+
+    private final String collectionName;
+    private final String recordId;
+
+    public ReferencedRecordConflictException(String collectionName, String recordId, Throwable cause) {
+        super("Record '" + recordId + "' in collection '" + collectionName
+                + "' is still referenced by other records and cannot be deleted", cause);
+        this.collectionName = collectionName;
+        this.recordId = recordId;
+    }
+
+    public String getCollectionName() {
+        return collectionName;
+    }
+
+    public String getRecordId() {
+        return recordId;
+    }
+}

--- a/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/storage/PhysicalTableStorageAdapterTest.java
+++ b/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/storage/PhysicalTableStorageAdapterTest.java
@@ -1080,4 +1080,57 @@ class PhysicalTableStorageAdapterTest {
             assertTrue(PhysicalTableStorageAdapter.extractViolatedColumns(h2Style).isEmpty());
         }
     }
+
+    @Nested
+    @DisplayName("Delete blocked by a restricting foreign key (SQL state 23503)")
+    class DeleteForeignKeyConflict {
+
+        private PhysicalTableStorageAdapter adapterWithFailingJdbc(RuntimeException toThrow) {
+            JdbcTemplate failing = org.mockito.Mockito.mock(JdbcTemplate.class);
+            org.mockito.Mockito.when(failing.update(org.mockito.ArgumentMatchers.anyString(),
+                    org.mockito.ArgumentMatchers.<Object>any())).thenThrow(toThrow);
+            return new PhysicalTableStorageAdapter(failing, migrationEngine,
+                    new tools.jackson.databind.ObjectMapper());
+        }
+
+        @Test
+        @DisplayName("maps a Postgres 23503 to ReferencedRecordConflictException (409), not a 500 StorageException")
+        void fkViolationBecomesConflict() {
+            // Regression: DELETE /api/fields/{id} 500'd when layout_field rows still
+            // referenced the field — the 23503 was swallowed into StorageException.
+            RuntimeException fk = new org.springframework.dao.DataIntegrityViolationException(
+                    "delete violates foreign key",
+                    new java.sql.SQLException(
+                            "update or delete on table \"field\" violates foreign key constraint "
+                            + "\"layout_field_field_id_fkey\" on table \"layout_field\"", "23503"));
+
+            ReferencedRecordConflictException ex = assertThrows(
+                    ReferencedRecordConflictException.class,
+                    () -> adapterWithFailingJdbc(fk).delete(testCollection, "rec-1"));
+            assertEquals("test_products", ex.getCollectionName());
+            assertEquals("rec-1", ex.getRecordId());
+        }
+
+        @Test
+        @DisplayName("other data-access failures still surface as StorageException")
+        void nonFkFailuresStayStorageException() {
+            RuntimeException down = new org.springframework.dao.DataAccessResourceFailureException(
+                    "connection refused");
+            StorageException ex = assertThrows(StorageException.class,
+                    () -> adapterWithFailingJdbc(down).delete(testCollection, "rec-1"));
+            assertFalse(ex instanceof ReferencedRecordConflictException);
+        }
+
+        @Test
+        @DisplayName("detection walks the cause chain and matches only SQL state 23503")
+        void detectionMatrix() {
+            assertTrue(PhysicalTableStorageAdapter.isForeignKeyViolation(
+                    new RuntimeException(new RuntimeException(
+                            new java.sql.SQLException("fk", "23503")))));
+            assertFalse(PhysicalTableStorageAdapter.isForeignKeyViolation(
+                    new java.sql.SQLException("unique", "23505")));
+            assertFalse(PhysicalTableStorageAdapter.isForeignKeyViolation(
+                    new RuntimeException("no sql cause")));
+        }
+    }
 }

--- a/kelta-worker/src/main/resources/db/migration/V173__field_fk_cascade.sql
+++ b/kelta-worker/src/main/resources/db/migration/V173__field_fk_cascade.sql
@@ -1,0 +1,29 @@
+-- Deleting a field 500'd (SQL state 23503) whenever layout or picklist metadata
+-- still referenced it: five FKs to field(id) had no ON DELETE action, so Postgres
+-- rejected the delete. Field deletion is documented as destructive (the column and
+-- its data are dropped), so dependent UI/metadata rows must go with the field —
+-- the same semantics profile_field_permission (ON DELETE CASCADE) and
+-- collection.display_field_id (ON DELETE SET NULL) already have.
+
+ALTER TABLE layout_field
+    DROP CONSTRAINT layout_field_field_id_fkey,
+    ADD CONSTRAINT layout_field_field_id_fkey
+        FOREIGN KEY (field_id) REFERENCES field(id) ON DELETE CASCADE;
+
+ALTER TABLE layout_related_list
+    DROP CONSTRAINT layout_related_list_relationship_field_id_fkey,
+    ADD CONSTRAINT layout_related_list_relationship_field_id_fkey
+        FOREIGN KEY (relationship_field_id) REFERENCES field(id) ON DELETE CASCADE;
+
+ALTER TABLE picklist_dependency
+    DROP CONSTRAINT picklist_dependency_controlling_field_id_fkey,
+    ADD CONSTRAINT picklist_dependency_controlling_field_id_fkey
+        FOREIGN KEY (controlling_field_id) REFERENCES field(id) ON DELETE CASCADE,
+    DROP CONSTRAINT picklist_dependency_dependent_field_id_fkey,
+    ADD CONSTRAINT picklist_dependency_dependent_field_id_fkey
+        FOREIGN KEY (dependent_field_id) REFERENCES field(id) ON DELETE CASCADE;
+
+ALTER TABLE record_type_picklist
+    DROP CONSTRAINT record_type_picklist_field_id_fkey,
+    ADD CONSTRAINT record_type_picklist_field_id_fkey
+        FOREIGN KEY (field_id) REFERENCES field(id) ON DELETE CASCADE;


### PR DESCRIPTION
## Problem

`DELETE /api/fields/{id}` returns **500 STORAGE_ERROR** whenever the field still sits on a page layout — i.e. for practically every field that was ever placed on a UI. Root cause: `layout_field.field_id` (and four sibling FKs) reference `field(id)` with no `ON DELETE` action, so Postgres rejects the delete with SQL state **23503**, and `PhysicalTableStorageAdapter.delete` wraps every `DataAccessException` into a generic 500 `StorageException`.

Hit live 2026-07-12 on the telehealth tenant (upgrading `appointment-details.orderId/invoiceId` from STRING to LOOKUP required hand-deleting `layout-fields` rows first).

## Fix

**V173 migration** — brings the five non-cascading field FKs in line with the existing precedent (`profile_field_permission` is already `ON DELETE CASCADE`, `collection.display_field_id` is `SET NULL`):

| Table | FK | Now |
|---|---|---|
| layout_field | field_id | CASCADE |
| layout_related_list | relationship_field_id | CASCADE |
| picklist_dependency | controlling_field_id / dependent_field_id | CASCADE |
| record_type_picklist | field_id | CASCADE |

Field deletion is documented as destructive (column + data dropped), so dependent UI/metadata rows go with it — Salesforce semantics. `list_view.columns` is JSONB (no FK); a stale name there is ignored by the UI.

**23503 → 409 translation (defense in depth)** — `PhysicalTableStorageAdapter.delete` now detects SQL state 23503 anywhere in the cause chain and throws `ReferencedRecordConflictException`; `GlobalExceptionHandler` maps it to **409 `REFERENCED_RECORD`** with a message naming the record. Any remaining restricting FK (user-collection LOOKUPs, future system tables) now surfaces as the client conflict it is instead of an opaque 500.

**Docs** — CLAUDE.md's hardcoded "next migration is V167" had drifted (head was V172); now says take head+1.

## Tests

- New `PhysicalTableStorageAdapterTest$DeleteForeignKeyConflict`: 23503 → `ReferencedRecordConflictException` (collection/record captured), non-FK failures stay `StorageException`, cause-chain detection matrix (23505 ≠ match).
- Full verify: runtime-core 1443 · gateway 491 · worker 2014 · kelta-web 983 — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)