### PR TITLE
fix(mcp): bulk_apply targeted a nonexistent path with the wrong body shape

### DIFF
--- a/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/BulkApplyTool.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/tool/user/BulkApplyTool.java
@@ -32,7 +32,9 @@ public class BulkApplyTool implements UserTool {
         opSchema.put("type", "object");
         opSchema.put("description",
                 "One operation. {\"op\":\"add\"|\"update\"|\"remove\", \"type\":\"<collection>\", "
-                + "\"id\":\"<id>\" (required for update/remove), \"attributes\":{...} (for add/update), "
+                + "\"id\":\"<id>\" (required for update/remove; a \"lid\" from an earlier add works too), "
+                + "\"lid\":\"<local-id>\" (optional on add — lets later operations reference the new record), "
+                + "\"attributes\":{...} (for add/update), "
                 + "\"relationships\":{...} (optional for add/update)}");
         opSchema.put("additionalProperties", true);
 
@@ -48,7 +50,7 @@ public class BulkApplyTool implements UserTool {
         Tool tool = Tool.builder()
                 .name("bulk_apply")
                 .title("Bulk Apply")
-                .description("Apply multiple record changes atomically via /api/_atomic. All operations succeed together or none do. Use this for multi-record changes that must roll back as a unit (e.g. moving line items between orders, rewiring relationships).")
+                .description("Apply multiple record changes atomically via POST /api/operations (JSON:API Atomic Operations). All operations succeed together or none do. Use this for multi-record changes that must roll back as a unit (e.g. moving line items between orders, rewiring relationships).")
                 .inputSchema(Schemas.object(properties, List.of("operations")))
                 .annotations(ToolHints.write(true, false))
                 .build();
@@ -62,6 +64,7 @@ public class BulkApplyTool implements UserTool {
                     if (!(opsObj instanceof List<?> ops) || ops.isEmpty()) {
                         return error("Argument \"operations\" must be a non-empty array.");
                     }
+                    List<Map<String, Object>> jsonApiOps = new java.util.ArrayList<>(ops.size());
                     for (int i = 0; i < ops.size(); i++) {
                         Object o = ops.get(i);
                         if (!(o instanceof Map<?, ?> op)) {
@@ -75,19 +78,57 @@ public class BulkApplyTool implements UserTool {
                             return error("operations[" + i + "].type (collection name) is required.");
                         }
                         if (("update".equals(opName.toString()) || "remove".equals(opName.toString()))
-                                && op.get("id") == null) {
-                            return error("operations[" + i + "].id is required for update/remove.");
+                                && op.get("id") == null && op.get("lid") == null) {
+                            return error("operations[" + i + "].id (or lid) is required for update/remove.");
                         }
+                        jsonApiOps.add(toJsonApiOperation(opName.toString(), op));
                     }
 
-                    Map<String, Object> body = Map.of("atomic:operations", ops);
+                    Map<String, Object> body = Map.of("atomic:operations", jsonApiOps);
                     try {
-                        return McpErrorMapper.toResult(gateway.post("/api/_atomic", body));
+                        return McpErrorMapper.toResult(gateway.post("/api/operations", body));
                     } catch (RuntimeException e) {
                         return McpErrorMapper.fromException(e);
                     }
                 })
                 .build();
+    }
+
+    /**
+     * Translates the tool's flat operation shape ({@code op/type/id/lid/attributes/
+     * relationships}) into a JSON:API Atomic Operations entry — {@code add} carries a
+     * {@code data} resource; {@code update}/{@code remove} address the target via
+     * {@code ref} (id or a lid minted by an earlier add in the same batch).
+     */
+    private static Map<String, Object> toJsonApiOperation(String opName, Map<?, ?> op) {
+        Map<String, Object> out = new LinkedHashMap<>();
+        out.put("op", opName);
+
+        if ("remove".equals(opName)) {
+            out.put("ref", ref(op));
+            return out;
+        }
+
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("type", op.get("type"));
+        if (op.get("id") != null) data.put("id", op.get("id"));
+        if (op.get("lid") != null) data.put("lid", op.get("lid"));
+        if (op.get("attributes") != null) data.put("attributes", op.get("attributes"));
+        if (op.get("relationships") != null) data.put("relationships", op.get("relationships"));
+
+        if ("update".equals(opName)) {
+            out.put("ref", ref(op));
+        }
+        out.put("data", data);
+        return out;
+    }
+
+    private static Map<String, Object> ref(Map<?, ?> op) {
+        Map<String, Object> ref = new LinkedHashMap<>();
+        ref.put("type", op.get("type"));
+        if (op.get("id") != null) ref.put("id", op.get("id"));
+        else ref.put("lid", op.get("lid"));
+        return ref;
     }
 
     private static CallToolResult error(String message) {

--- a/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/BulkApplyToolTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/tool/user/BulkApplyToolTest.java
@@ -74,13 +74,16 @@ class BulkApplyToolTest {
     }
 
     @Test
-    void postsAtomicOperationsBundle() {
-        wm.stubFor(post(urlEqualTo("/api/_atomic"))
+    void postsJsonApiAtomicOperationsToOperationsEndpoint() {
+        // Regression: the tool used to POST /api/_atomic (a path nothing serves — 404
+        // at the gateway) with flat operation objects the worker would reject. It must
+        // target /api/operations with JSON:API Atomic Operations envelopes (data/ref).
+        wm.stubFor(post(urlEqualTo("/api/operations"))
                 .willReturn(aResponse().withStatus(200).withBody("{\"atomic:results\":[]}")));
 
         CallToolResult result = tool.toSpecification().callHandler().apply(
                 null, new CallToolRequest("bulk_apply", Map.of("operations", List.of(
-                        Map.of("op", "add", "type", "accounts",
+                        Map.of("op", "add", "type", "accounts", "lid", "new-1",
                                 "attributes", Map.of("name", "Acme")),
                         Map.of("op", "update", "type", "accounts", "id", "a2",
                                 "attributes", Map.of("name", "Updated")),
@@ -88,10 +91,37 @@ class BulkApplyToolTest {
                 )), null));
 
         assertThat(result.isError()).isNotEqualTo(Boolean.TRUE);
-        wm.verify(WireMock.postRequestedFor(urlEqualTo("/api/_atomic"))
+        wm.verify(WireMock.postRequestedFor(urlEqualTo("/api/operations"))
                 .withHeader("Authorization", equalTo("Bearer klt_bulk_test"))
+                // add: data resource with type/lid/attributes
                 .withRequestBody(matchingJsonPath("$.['atomic:operations'][0].op", equalTo("add")))
-                .withRequestBody(matchingJsonPath("$.['atomic:operations'][1].op", equalTo("update")))
-                .withRequestBody(matchingJsonPath("$.['atomic:operations'][2].op", equalTo("remove"))));
+                .withRequestBody(matchingJsonPath("$.['atomic:operations'][0].data.type", equalTo("accounts")))
+                .withRequestBody(matchingJsonPath("$.['atomic:operations'][0].data.lid", equalTo("new-1")))
+                .withRequestBody(matchingJsonPath("$.['atomic:operations'][0].data.attributes.name", equalTo("Acme")))
+                // update: ref addresses the target, data carries the changes
+                .withRequestBody(matchingJsonPath("$.['atomic:operations'][1].ref.type", equalTo("accounts")))
+                .withRequestBody(matchingJsonPath("$.['atomic:operations'][1].ref.id", equalTo("a2")))
+                .withRequestBody(matchingJsonPath("$.['atomic:operations'][1].data.attributes.name", equalTo("Updated")))
+                // remove: ref only
+                .withRequestBody(matchingJsonPath("$.['atomic:operations'][2].op", equalTo("remove")))
+                .withRequestBody(matchingJsonPath("$.['atomic:operations'][2].ref.id", equalTo("a3"))));
+    }
+
+    @Test
+    void updateByLidFromEarlierAddIsAccepted() {
+        wm.stubFor(post(urlEqualTo("/api/operations"))
+                .willReturn(aResponse().withStatus(200).withBody("{\"atomic:results\":[]}")));
+
+        CallToolResult result = tool.toSpecification().callHandler().apply(
+                null, new CallToolRequest("bulk_apply", Map.of("operations", List.of(
+                        Map.of("op", "add", "type", "accounts", "lid", "new-1",
+                                "attributes", Map.of("name", "Acme")),
+                        Map.of("op", "update", "type", "accounts", "lid", "new-1",
+                                "attributes", Map.of("name", "Renamed"))
+                )), null));
+
+        assertThat(result.isError()).isNotEqualTo(Boolean.TRUE);
+        wm.verify(WireMock.postRequestedFor(urlEqualTo("/api/operations"))
+                .withRequestBody(matchingJsonPath("$.['atomic:operations'][1].ref.lid", equalTo("new-1"))));
     }
 }


### PR DESCRIPTION
## Problem

MCP `bulk_apply` 404'd on every call (reproduced 2026-07-12, telehealth tenant). The chip hypothesis was a missing gateway static route for `/api/_atomic` — recon shows the platform side is fine and the bug is entirely in the tool:

- The real endpoint is **`POST /api/operations`** (`AtomicOperationsController`, JSON:API Atomic Operations). The gateway already registers the `operations` static route, and the controller already mirrors per-collection Cerbos verb checks (deduplicated per collection+action, fail-closed, whole-batch denial) — exactly the authorization treatment the chip asked to verify.
- `BulkApplyTool` POSTed **`/api/_atomic`** — a path nothing serves anywhere.
- Its body was wrong as well: flat `{op,type,id,attributes}` objects forwarded verbatim, where the endpoint requires JSON:API envelopes (`add` → `data`; `update`/`remove` → `ref` + optional `data`). Even with the right URL every op would have failed validation.

## Fix

Tool-side only:
- URL → `/api/operations`.
- Handler translates the flat public schema into JSON:API Atomic Operations (`data`/`ref` envelopes) — callers keep the simple flat shape.
- `lid` support: an `add` can mint a local id and a later `update`/`remove` in the same batch can reference it (`ref.lid`), matching the executor's lid resolution.

No gateway change: the static route exists, and `DelegatedAdminScenarioTest.genericWriteRoutesStayClosedToDelegatedUsers` already round-trips `/api/operations` through the gateway incl. the 4xx + rollback path.

## Tests

`BulkApplyToolTest` — regression pins the URL and the exact envelope per op kind (data.type/lid/attributes for add, ref.id + data for update, ref-only for remove), plus the update-by-lid path. Full verify: kelta-mcp 219 · gateway 491 · worker 2014 · kelta-web 983 — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)