### PR TITLE
fix(worker): register Locale reflection so flow scripts can use JS Date on the native image

### DIFF
--- a/.claude/docs/concerns.md
+++ b/.claude/docs/concerns.md
@@ -430,6 +430,17 @@ for removal ("inline the current value"). Findings:
   an empty bean, so consumers (e.g. NATS_TRIGGERED post-visit flows) get no data. `EventPayloadReflectConfigTest`
   now fails CI if any `io.kelta.runtime.event.*Payload` is unregistered. **Rule: a new event payload
   gets a reflect-config entry in BOTH `kelta-worker` and `kelta-gateway` in the same PR.**
+- **Script-engine JS builtins can require host reflection on the native worker.** Found 2026-07-12:
+  any flow `INVOKE_SCRIPT` whose script called `new Date()` died on the native image with
+  `MissingReflectionRegistrationError: java.util.Locale.getDefault(Locale$Category)` — GraalJS
+  resolves the default locale reflectively. Works on the JVM and in every CI test; only the
+  deployed native worker fails, and the flow execution just shows FAILED with the error in
+  `flow_executions.error_message`. `java.util.Locale`/`Locale$Category`/`TimeZone.getDefault`
+  are now registered in `kelta-worker/.../reflect-config.json`. If another JS builtin trips this
+  (e.g. `Intl.*`, `toLocaleString` variants), the `MissingReflectionRegistrationError` message
+  prints the exact JSON entry to add — copy it into the worker reflect-config in the fix PR.
+  Until deployed, scripts can avoid `Date` entirely: pass `${$.record.data.updatedAt}` in
+  `inputPayload` and do string/int calendar math (the F3/F6 billing flows show the pattern).
 - **Every new `kelta.*` NATS subject namespace needs its own JetStream stream in `JetStreamInitializer`.**
   `NatsEventPublisher` always JetStream-publishes and awaits an ack; a subject matched by no stream never
   acks → `CancellationException: response not registered in time` and the event is dropped (publish is

--- a/kelta-platform/runtime/runtime-module-integration/src/test/java/io/kelta/runtime/module/integration/spi/graalvm/GraalVmScriptExecutorTest.java
+++ b/kelta-platform/runtime/runtime-module-integration/src/test/java/io/kelta/runtime/module/integration/spi/graalvm/GraalVmScriptExecutorTest.java
@@ -75,6 +75,22 @@ class GraalVmScriptExecutorTest {
     }
 
     @Test
+    @DisplayName("JS Date works — its Locale lookup needs native reflection metadata (2026-07-12 outage)")
+    void jsDateBuiltinWorks() {
+        // On the GraalVM native image, `new Date()` reflectively calls
+        // java.util.Locale.getDefault(Locale$Category); without the entries in
+        // kelta-worker's reflect-config.json the script dies with
+        // MissingReflectionRegistrationError — invisible here on the JVM.
+        // This test pins the JVM behavior; the native half is the metadata.
+        ScriptExecutionResult result = executor.execute(
+            new ScriptExecutionRequest(
+                "var d = new Date(1752285000000); d.toISOString().slice(0, 10)", Map.of()));
+
+        assertTrue(result.success(), () -> "script failed: " + result.errorMessage());
+        assertEquals("2025-07-12", result.output().get("result"));
+    }
+
+    @Test
     @DisplayName("Should execute script with object result")
     void shouldExecuteObjectResult() {
         String script = "({ name: 'test', value: 42 })";

--- a/kelta-worker/src/main/resources/META-INF/native-image/io.kelta/kelta-worker/reflect-config.json
+++ b/kelta-worker/src/main/resources/META-INF/native-image/io.kelta/kelta-worker/reflect-config.json
@@ -88,5 +88,26 @@
     "allDeclaredConstructors": true,
     "allDeclaredMethods": true,
     "allDeclaredFields": true
+  },
+  {
+    "name": "java.util.Locale",
+    "methods": [
+      { "name": "getDefault", "parameterTypes": [] },
+      { "name": "getDefault", "parameterTypes": ["java.util.Locale$Category"] }
+    ]
+  },
+  {
+    "name": "java.util.Locale$Category",
+    "allDeclaredFields": true,
+    "methods": [
+      { "name": "values", "parameterTypes": [] },
+      { "name": "valueOf", "parameterTypes": ["java.lang.String"] }
+    ]
+  },
+  {
+    "name": "java.util.TimeZone",
+    "methods": [
+      { "name": "getDefault", "parameterTypes": [] }
+    ]
   }
 ]


### PR DESCRIPTION
## Problem

Flow `INVOKE_SCRIPT` scripts that call `new Date()` / `Date.now()` crash **only on the deployed native worker**:

```
MissingReflectionRegistrationError: Cannot reflectively invoke method
'public static java.util.Locale java.util.Locale.getDefault(java.util.Locale$Category)'
```

GraalJS resolves the default locale reflectively when materializing the `Date` builtin. On the JVM (all of CI, `/verify`) reflection is free, so this is invisible — same failure class as the gateway-bootstrap and NATS-payload reflection outages already documented in concerns.md. Hit live 2026-07-12: the telehealth tenant's postpaid-invoice flow computed due dates with `new Date()` and every execution landed FAILED.

## Fix

- `kelta-worker/.../reflect-config.json`: register `java.util.Locale` (both `getDefault` overloads), `java.util.Locale$Category` (enum fields + values/valueOf), and `java.util.TimeZone.getDefault` (the obvious next hop for `Date` timezone resolution).
- `GraalVmScriptExecutorTest`: new test pinning the `Date` builtin on the JVM side, with a comment tying it to the native metadata half.
- `concerns.md`: new Dependency-Risks bullet — script-engine JS builtins can require host reflection on native; the `MissingReflectionRegistrationError` message prints the exact JSON entry to add, and the F3/F6 string-math pattern is the interim workaround for date math.

## Verification

No native build runs in CI or locally — the native half verifies at the next worker deploy (run a flow with `new Date()`; the tenant's F3/F6 currently avoid Date and can be switched back after). JVM side: module-integration 115 · gateway 491 · worker 2014 · kelta-web 983 — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)