### PR TITLE
fix(worker): record-level Cerbos advice emptied portal telehealth lists

### DIFF
--- a/.claude/docs/architecture.md
+++ b/.claude/docs/architecture.md
@@ -90,7 +90,7 @@ Cerbos enforcement is **collection/record-scoped, not blanket**. Concretely:
     record to non-`VIEW_ALL_DATA` profiles (they'd see empty lists everywhere).
 - **Static routes** (`/api/admin/**`, `/api/me/**`, `/api/_search/**`, `/api/metrics/**`,
   `/api/operations`): `RouteAuthorizationFilter` **skips** ids starting `static-` — they get only
-  the blanket `API_ACCESS` system-permission check. The worker advices **exclude** `/api/admin/`.
+  the blanket `API_ACCESS` system-permission check. The worker advices **exclude** `/api/admin/` — and the record-level advice also excludes `/api/telehealth/` (those controllers scope access per participant themselves; the generic record check emptied portal users' appointment lists, fixed 2026-07-12).
   So a new `/api/admin/...` endpoint is, by default, reachable by **any** authenticated user with
   API access. To put a *specific* permission on it, **enforce it inside the controller/service**
   (see "Worker-side system-permission check" below — inject `CerbosPermissionResolver` and

--- a/kelta-worker/CLAUDE.md
+++ b/kelta-worker/CLAUDE.md
@@ -83,7 +83,7 @@ ls kelta-worker/src/main/resources/db/migration | sort -V | tail -3
 3. If it needs persistence, add methods to existing repository or create new `@Repository` with `JdbcTemplate`
 4. Add a test: `src/test/java/io/kelta/worker/controller/MyControllerTest.java`
 5. **Tenant context** is pre-bound per request by `filter/TenantContextFilter` from the gateway's `X-Tenant-ID` / `X-Tenant-Slug` headers — **read** `TenantContext` (or `@RequestHeader("X-Tenant-ID")`); do **not** call `runWithTenant` on a request path. RLS scopes queries automatically.
-6. **Authorization**: `/api/admin/**` (and other `static-*` routes) are **not** covered by per-resource Cerbos — they get only the blanket `API_ACCESS` check, and the worker advices exclude `/api/admin/`. Enforce a specific permission **in the controller/service**. A new top-level `/api/<x>/**` segment needs a gateway static route (`RouteConfigService.registerStaticRoutes()`) or it 404s. See `.claude/docs/architecture.md` → Authorizing a new endpoint.
+6. **Authorization**: `/api/admin/**` (and other `static-*` routes) are **not** covered by per-resource Cerbos — they get only the blanket `API_ACCESS` check, and the worker advices exclude `/api/admin/` (and the record advice excludes `/api/telehealth/` — participant scoping lives in those controllers). Enforce a specific permission **in the controller/service**. A new top-level `/api/<x>/**` segment needs a gateway static route (`RouteConfigService.registerStaticRoutes()`) or it 404s. See `.claude/docs/architecture.md` → Authorizing a new endpoint.
 
 **Reference**: `ModuleController.java` + `ScimUserControllerTest.java`. Full recipe: `.claude/docs/playbooks.md` → "Add a worker REST endpoint".
 

--- a/kelta-worker/src/main/java/io/kelta/worker/interceptor/CerbosRecordAuthorizationAdvice.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/interceptor/CerbosRecordAuthorizationAdvice.java
@@ -71,9 +71,16 @@ public class CerbosRecordAuthorizationAdvice implements ResponseBodyAdvice<Objec
         HttpServletRequest httpRequest = servletRequest.getServletRequest();
         String path = httpRequest.getRequestURI();
 
-        // Only apply to collection API paths (user record data, not metadata)
+        // Only apply to collection API paths (user record data, not metadata).
+        // /api/telehealth/** is excluded: those endpoints enforce access in the
+        // controller (portal users are scoped to their own appointments via
+        // view=mine / participant shares, staff via provider ownership), and
+        // their responses are plain maps — not generic record envelopes. Running
+        // the record-level Cerbos check here emptied every portal user's
+        // appointment list, because portal profiles have no record grants
+        // (found 2026-07-12 building the headless portal).
         if (!path.startsWith("/api/") || path.startsWith("/api/admin/") || path.startsWith("/api/me/")
-                || isMetadataPath(path)) {
+                || path.startsWith("/api/telehealth/") || isMetadataPath(path)) {
             return body;
         }
 

--- a/kelta-worker/src/test/java/io/kelta/worker/interceptor/CerbosRecordAuthorizationAdviceTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/interceptor/CerbosRecordAuthorizationAdviceTest.java
@@ -133,6 +133,20 @@ class CerbosRecordAuthorizationAdviceTest {
     }
 
     @Test
+    @DisplayName("Should skip /api/telehealth paths — access enforced in-controller (2026-07-12: record check emptied portal appointment lists)")
+    void shouldSkipTelehealthPaths() {
+        var request = createRequest("/api/telehealth/appointments");
+        Map<String, Object> body = Map.of("view", "mine", "data", List.of(
+                Map.of("id", "appt-1", "portalUserId", "portal-1", "status", "CONFIRMED")));
+
+        Object result = advice.beforeBodyWrite(body, null, MediaType.APPLICATION_JSON, null, request, null);
+
+        assertThat(result).isSameAs(body);
+        verify(authzService, never()).batchCheckRecordAccess(any(), any(), any(), any(), anyList(), any());
+        verify(authzService, never()).checkCollectionWideRecordAccess(any(), any(), any(), any(), any());
+    }
+
+    @Test
     @DisplayName("Should skip /api/api-specs paths")
     void shouldSkipApiSpecsPaths() {
         var request = createRequest("/api/api-specs/library");


### PR DESCRIPTION
## Problem

Every portal user's `GET /api/telehealth/appointments?view=mine` returns **`[]`** through the gateway — appointments exist, the controller returns them, and the same request without the gateway's Cerbos identity headers returns data. The platform portal UI is affected identically.

**Root cause:** `CerbosRecordAuthorizationAdvice` (generic record-level response filter) matches `/api/telehealth/**` responses. When the gateway's identity trio (`X-User-Email` + `X-User-Profile-Id` + `X-Cerbos-Scope`) is present it runs a record-level Cerbos check per row — but portal profiles have **no record-level grants** (their access model is participant shares, enforced in the telehealth controllers), so every row is stripped.

Isolated 2026-07-12 while wiring the headless portal (telehealth slice 8): packet capture on the worker + header bisection — `email+profileId+cerbosScope` deterministically flips the response from data to `[]`.

## Fix

Exclude `/api/telehealth/` from the record advice — same treatment as the existing `/api/admin/` exclusion for controller-authorized paths. The telehealth controllers already scope access per participant (`view=mine`, provider ownership, staff-only complete), and their responses are plain maps rather than record envelopes.

## Tests / docs

- New regression test: telehealth response passes through untouched, no Cerbos record calls.
- Full verify: worker 2015 · gateway 491 · kelta-web 983 — green.
- `architecture.md` + `kelta-worker/CLAUDE.md` updated to name the exclusion.

## Security note

This **loosens** a response filter on paths that carry their own in-controller authorization — review that the telehealth controllers' scoping is sufficient (portal: `view=mine` filter + platform ownership checks on cancel; staff: provider filter). Per SECURITY.md this PR is **not** auto-merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)