### PR TITLE
fix(worker): sync Cerbos when object/system permission rows change

### DIFF
--- a/kelta-worker/src/main/java/io/kelta/worker/config/FlowConfig.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/config/FlowConfig.java
@@ -26,6 +26,7 @@ import io.kelta.worker.listener.ApprovalProcessConfigHook;
 import io.kelta.worker.listener.ApprovalRecordLockHook;
 import io.kelta.worker.listener.CerbosPolicySyncHook;
 import io.kelta.worker.listener.FieldPermissionSyncHook;
+import io.kelta.worker.listener.ProfilePermissionSyncHook;
 import io.kelta.worker.listener.ApiSpecConfigHook;
 import io.kelta.worker.listener.CredentialEncryptionHook;
 import io.kelta.worker.listener.CredentialEventPublisher;
@@ -415,6 +416,26 @@ public class FlowConfig {
             BeforeSaveHookRegistry hookRegistry,
             CerbosPolicySyncCoalescer syncCoalescer) {
         FieldPermissionSyncHook hook = new FieldPermissionSyncHook(syncCoalescer);
+        hookRegistry.register(hook);
+        return hook;
+    }
+
+    @Bean
+    public ProfilePermissionSyncHook objectPermissionSyncHook(
+            BeforeSaveHookRegistry hookRegistry,
+            CerbosPolicySyncCoalescer syncCoalescer) {
+        ProfilePermissionSyncHook hook =
+                new ProfilePermissionSyncHook("profile-object-permissions", syncCoalescer);
+        hookRegistry.register(hook);
+        return hook;
+    }
+
+    @Bean
+    public ProfilePermissionSyncHook systemPermissionSyncHook(
+            BeforeSaveHookRegistry hookRegistry,
+            CerbosPolicySyncCoalescer syncCoalescer) {
+        ProfilePermissionSyncHook hook =
+                new ProfilePermissionSyncHook("profile-system-permissions", syncCoalescer);
         hookRegistry.register(hook);
         return hook;
     }

--- a/kelta-worker/src/main/java/io/kelta/worker/listener/ProfilePermissionSyncHook.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/listener/ProfilePermissionSyncHook.java
@@ -1,0 +1,84 @@
+package io.kelta.worker.listener;
+
+import io.kelta.runtime.workflow.BeforeSaveHook;
+import io.kelta.worker.service.CerbosPolicySyncCoalescer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Before-save hook that triggers Cerbos policy sync when a profile's
+ * object-level or system-level permissions change.
+ *
+ * <p>Grants are edited via the {@code profile-object-permissions} and
+ * {@code profile-system-permissions} system collections, not the
+ * {@code profiles} collection — so {@link CerbosPolicySyncHook} never fired
+ * for them and, before this hook existed, a permission change did not reach
+ * Cerbos until some unrelated profile save. That cut both ways and the
+ * revocation direction is the dangerous one: deleting a permission row left
+ * the old grant live in the PDP indefinitely.
+ *
+ * <p>Registered once per collection (a {@link BeforeSaveHook} targets a single
+ * collection name). Syncs go through {@link CerbosPolicySyncCoalescer} — a
+ * permission matrix is saved one row at a time, and the coalescer debounces
+ * the burst into a single serialized sync per tenant. The sync publishes the
+ * existing {@code kelta.cerbos.policies.changed.<tenantId>} subject, which
+ * every pod consumes to evict its permission caches — the multi-pod broadcast
+ * rule is satisfied with no new subject.
+ */
+public class ProfilePermissionSyncHook implements BeforeSaveHook {
+
+    /** The permission collections this hook is registered for (one instance each). */
+    public static final Set<String> PERMISSION_COLLECTIONS = Set.of(
+            "profile-object-permissions", "profile-system-permissions");
+
+    private static final Logger log = LoggerFactory.getLogger(ProfilePermissionSyncHook.class);
+
+    private final String collectionName;
+    private final CerbosPolicySyncCoalescer syncCoalescer;
+
+    public ProfilePermissionSyncHook(String collectionName,
+                                     CerbosPolicySyncCoalescer syncCoalescer) {
+        if (!PERMISSION_COLLECTIONS.contains(collectionName)) {
+            throw new IllegalArgumentException(
+                    "Unsupported permission collection: " + collectionName);
+        }
+        this.collectionName = collectionName;
+        this.syncCoalescer = syncCoalescer;
+    }
+
+    @Override
+    public String getCollectionName() {
+        return collectionName;
+    }
+
+    @Override
+    public int getOrder() {
+        return 100; // Run after validation and audit hooks, like CerbosPolicySyncHook
+    }
+
+    @Override
+    public void afterCreate(Map<String, Object> record, String tenantId) {
+        log.debug("{} row created — scheduling Cerbos policy sync for tenant {}",
+                collectionName, tenantId);
+        syncCoalescer.requestSync(tenantId);
+    }
+
+    @Override
+    public void afterUpdate(String id, Map<String, Object> record,
+                             Map<String, Object> previous, String tenantId) {
+        log.debug("{} row {} updated — scheduling Cerbos policy sync for tenant {}",
+                collectionName, id, tenantId);
+        syncCoalescer.requestSync(tenantId);
+    }
+
+    @Override
+    public void afterDelete(String id, String tenantId) {
+        // Revocation path — before this hook, a deleted grant stayed live in Cerbos.
+        log.debug("{} row {} deleted — scheduling Cerbos policy sync for tenant {}",
+                collectionName, id, tenantId);
+        syncCoalescer.requestSync(tenantId);
+    }
+}

--- a/kelta-worker/src/test/java/io/kelta/worker/listener/ProfilePermissionSyncHookTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/listener/ProfilePermissionSyncHookTest.java
@@ -1,0 +1,84 @@
+package io.kelta.worker.listener;
+
+import io.kelta.worker.service.CerbosPolicySyncCoalescer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@DisplayName("ProfilePermissionSyncHook")
+class ProfilePermissionSyncHookTest {
+
+    private CerbosPolicySyncCoalescer syncCoalescer;
+
+    @BeforeEach
+    void setUp() {
+        syncCoalescer = mock(CerbosPolicySyncCoalescer.class);
+    }
+
+    @Test
+    @DisplayName("Targets exactly the collection it was registered for")
+    void targetsRegisteredCollection() {
+        assertEquals("profile-object-permissions",
+                new ProfilePermissionSyncHook("profile-object-permissions", syncCoalescer)
+                        .getCollectionName());
+        assertEquals("profile-system-permissions",
+                new ProfilePermissionSyncHook("profile-system-permissions", syncCoalescer)
+                        .getCollectionName());
+    }
+
+    @Test
+    @DisplayName("Rejects collections it does not own")
+    void rejectsUnknownCollection() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new ProfilePermissionSyncHook("profiles", syncCoalescer));
+    }
+
+    @Test
+    @DisplayName("Runs after validation and audit hooks, like CerbosPolicySyncHook")
+    void runsAtOrder100() {
+        assertEquals(100,
+                new ProfilePermissionSyncHook("profile-object-permissions", syncCoalescer)
+                        .getOrder());
+    }
+
+    @Test
+    @DisplayName("afterCreate requests a coalesced tenant sync (grant path)")
+    void afterCreateRequestsSync() {
+        var hook = new ProfilePermissionSyncHook("profile-object-permissions", syncCoalescer);
+
+        hook.afterCreate(Map.of(
+                "profileId", "profile-1", "collectionId", "col-1",
+                "canRead", true, "canViewAll", true), "tenant-1");
+
+        verify(syncCoalescer).requestSync("tenant-1");
+    }
+
+    @Test
+    @DisplayName("afterUpdate requests a coalesced tenant sync")
+    void afterUpdateRequestsSync() {
+        var hook = new ProfilePermissionSyncHook("profile-system-permissions", syncCoalescer);
+
+        hook.afterUpdate("perm-1",
+                Map.of("permissionName", "API_ACCESS", "granted", true),
+                Map.of("permissionName", "API_ACCESS", "granted", false), "tenant-2");
+
+        verify(syncCoalescer).requestSync("tenant-2");
+    }
+
+    @Test
+    @DisplayName("afterDelete requests a coalesced tenant sync (revocation path — 2026-07-12: deletes left grants live in Cerbos)")
+    void afterDeleteRequestsSync() {
+        var hook = new ProfilePermissionSyncHook("profile-object-permissions", syncCoalescer);
+
+        hook.afterDelete("perm-1", "tenant-3");
+
+        verify(syncCoalescer).requestSync("tenant-3");
+    }
+}


### PR DESCRIPTION
## Problem

Editing `profile-object-permissions` or `profile-system-permissions` rows never schedules a Cerbos policy sync. `CerbosPolicySyncHook` registers only for `profiles`; `FieldPermissionSyncHook` covers `profile-field-permissions`; nothing covered the object/system permission collections. Grants — and, worse, **revocations** — don't take effect until something unrelated touches the profiles collection.

Repro (telehealth tenant, 2026-07-12): new "Portal Read Service" profile + 9 object-permission rows (canRead/canViewAll) → PAT on that profile kept getting 403 "Insufficient permissions for read on <collection>" from the gateway until the profile record was PATCHed (which fires the sync). The revocation direction means a **deleted permission row leaves the old grant live in the PDP indefinitely** — security-relevant.

## Fix

New `ProfilePermissionSyncHook` (one class, registered once per collection since a `BeforeSaveHook` targets a single collection name) for `profile-object-permissions` + `profile-system-permissions`. Create/update/delete all funnel into the existing `CerbosPolicySyncCoalescer` — row-at-a-time matrix saves debounce into a single serialized sync per tenant, and the existing `kelta.cerbos.policies.changed.<tenantId>` broadcast keeps every pod's permission caches consistent (no new NATS subject).

## Tests

`ProfilePermissionSyncHookTest` mirrors `FieldPermissionSyncHookTest`: collection targeting (both), unknown-collection rejection, order 100, create/update/delete → `requestSync`, with the delete case named as the revocation regression. Full verify: worker 2020 · gateway 491 · kelta-web 983 — green.

## Security

Per SECURITY.md this is security-typed: **no auto-merge** — please review and merge manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)