### PR TITLE
fix(worker): stop caching failed user-id resolutions forever

### DIFF
--- a/kelta-worker/src/main/java/io/kelta/worker/service/JdbcUserIdResolver.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/service/JdbcUserIdResolver.java
@@ -8,23 +8,33 @@ import org.springframework.stereotype.Component;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Pattern;
 
 /**
  * Resolves user identifiers (email addresses) to platform_user UUIDs using JDBC.
  *
  * <p>System collections (flow, dashboard, report, etc.) have foreign key constraints
  * from {@code created_by}/{@code updated_by} to {@code platform_user(id)}.
- * The gateway forwards the JWT subject (typically an email address) in the
- * {@code X-User-Id} header, so this resolver translates that email to the
- * corresponding {@code platform_user.id} UUID.
+ * The gateway forwards the authenticated user's email in the {@code X-User-Id}
+ * header for JWT logins (and the UUID itself for PAT requests), so this
+ * resolver translates emails to the corresponding {@code platform_user.id}
+ * UUID and passes UUIDs through without a lookup.
  *
- * <p>Results are cached per (tenantId, email) pair for the lifetime of the
- * application to avoid repeated lookups.
+ * <p><strong>Only successful resolutions are cached.</strong> A failed lookup
+ * (row not visible yet, transient DB error) returns the raw identifier as a
+ * best-effort fallback but is never remembered. The previous version cached
+ * that fallback for the process lifetime: one lookup racing a portal-user
+ * insert permanently poisoned the pod, telehealth endpoints then filtered on
+ * {@code portal_user_id = <email>}, and the user's own appointments read as
+ * empty on that pod until the next deploy (2026-07-12).
  */
 @Component
 public class JdbcUserIdResolver implements UserIdResolver {
 
     private static final Logger log = LoggerFactory.getLogger(JdbcUserIdResolver.class);
+
+    private static final Pattern UUID_PATTERN = Pattern.compile(
+            "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$");
 
     private final JdbcTemplate jdbcTemplate;
     private final Map<String, String> cache = new ConcurrentHashMap<>();
@@ -41,26 +51,36 @@ public class JdbcUserIdResolver implements UserIdResolver {
         if (tenantId == null || tenantId.isBlank()) {
             return userIdentifier;
         }
+        // PAT paths already carry the platform_user UUID — nothing to resolve.
+        if (UUID_PATTERN.matcher(userIdentifier).matches()) {
+            return userIdentifier;
+        }
 
         String cacheKey = tenantId + ":" + userIdentifier;
-        return cache.computeIfAbsent(cacheKey, k -> lookupUserId(userIdentifier, tenantId));
+        String cached = cache.get(cacheKey);
+        if (cached != null) {
+            return cached;
+        }
+
+        String userId = lookupUserId(userIdentifier, tenantId);
+        if (userId != null) {
+            // Successes only — a miss must stay retryable (see class doc).
+            cache.put(cacheKey, userId);
+            return userId;
+        }
+        // Best-effort fallback, deliberately uncached.
+        return userIdentifier;
     }
 
     private String lookupUserId(String email, String tenantId) {
         try {
-            String userId = jdbcTemplate.queryForObject(
+            return jdbcTemplate.queryForObject(
                     "SELECT id FROM platform_user WHERE tenant_id = ? AND email = ? LIMIT 1",
                     String.class, tenantId, email);
-            if (userId != null) {
-                log.debug("Resolved user '{}' to platform_user UUID '{}' for tenant '{}'",
-                        email, userId, tenantId);
-                return userId;
-            }
         } catch (Exception e) {
             log.warn("Failed to resolve user '{}' for tenant '{}': {}",
                     email, tenantId, e.getMessage());
+            return null;
         }
-        // Return original identifier as fallback
-        return email;
     }
 }

--- a/kelta-worker/src/test/java/io/kelta/worker/service/JdbcUserIdResolverTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/service/JdbcUserIdResolverTest.java
@@ -76,6 +76,64 @@ class JdbcUserIdResolverTest {
     }
 
     @Nested
+    @DisplayName("UUID passthrough")
+    class UuidPassthrough {
+
+        @Test
+        @DisplayName("identifiers that are already UUIDs skip the lookup (PAT paths)")
+        void uuidSkipsLookup() {
+            String uuid = "587d2c38-0b72-4cd1-a587-42a85596e0c7";
+            assertEquals(uuid, resolver.resolve(uuid, "tenant-1"));
+            verifyNoInteractions(jdbcTemplate);
+        }
+    }
+
+    @Nested
+    @DisplayName("Failure handling — never cache the fallback (2026-07-12 pod poisoning)")
+    class FailureNotCached {
+
+        @Test
+        @DisplayName("empty result is not cached: the next call re-queries and can succeed")
+        void emptyResultRetries() {
+            when(jdbcTemplate.queryForObject(anyString(), eq(String.class), eq("tenant-1"), eq("user@example.com")))
+                    .thenThrow(new EmptyResultDataAccessException(1))
+                    .thenReturn("uuid-123");
+
+            assertEquals("user@example.com", resolver.resolve("user@example.com", "tenant-1"));
+            assertEquals("uuid-123", resolver.resolve("user@example.com", "tenant-1"));
+
+            verify(jdbcTemplate, times(2)).queryForObject(anyString(), eq(String.class), any(), any());
+        }
+
+        @Test
+        @DisplayName("exceptions are not cached: the next call re-queries and can succeed")
+        void exceptionRetries() {
+            when(jdbcTemplate.queryForObject(anyString(), eq(String.class), eq("tenant-1"), eq("user@example.com")))
+                    .thenThrow(new RuntimeException("connection reset"))
+                    .thenReturn("uuid-123");
+
+            assertEquals("user@example.com", resolver.resolve("user@example.com", "tenant-1"));
+            assertEquals("uuid-123", resolver.resolve("user@example.com", "tenant-1"));
+
+            verify(jdbcTemplate, times(2)).queryForObject(anyString(), eq(String.class), any(), any());
+        }
+
+        @Test
+        @DisplayName("a success after a failure is cached like any other success")
+        void successAfterFailureIsCached() {
+            when(jdbcTemplate.queryForObject(anyString(), eq(String.class), eq("tenant-1"), eq("user@example.com")))
+                    .thenThrow(new EmptyResultDataAccessException(1))
+                    .thenReturn("uuid-123");
+
+            resolver.resolve("user@example.com", "tenant-1"); // miss, uncached
+            resolver.resolve("user@example.com", "tenant-1"); // success, cached
+            assertEquals("uuid-123", resolver.resolve("user@example.com", "tenant-1"));
+
+            verify(jdbcTemplate, times(2)).queryForObject(anyString(), eq(String.class), any(), any());
+        }
+    }
+
+    @Nested
     @DisplayName("Caching")
     class Caching {
 


### PR DESCRIPTION
## Problem

`JdbcUserIdResolver` caches `(tenantId:email → result)` in an unbounded `ConcurrentHashMap` via `computeIfAbsent`, and `lookupUserId()` returns the **raw identifier** as a fallback on an empty result or any exception. `computeIfAbsent` then caches that fallback **for the process lifetime** — one failed lookup poisons the pod permanently.

Observed live 2026-07-12 (telehealth tenant): a portal user's email→UUID resolution failed once on two worker pods (the lookup raced the `platform_user` insert), the email was cached as the "user id", and every telehealth endpoint on those pods then filtered `portal_user_id = <email>` — matching nothing. `GET /api/telehealth/appointments?view=mine` returned `[]` forever for that user while a freshly rolled pod resolved the same header correctly. The booking succeeded (confirmation email arrived) but the account page read empty — **pod-dependent data loss from the user's perspective, curable only by a deploy.**

## Fix

- **Cache successes only.** A miss returns the best-effort fallback but is never remembered, so the next request re-queries and resolves once the row is visible.
- **UUID passthrough.** Identifiers that already match the UUID shape (PAT requests send the `platform_user` UUID) skip the DB lookup entirely — no query, no cache entry.

## Tests

New cases in `JdbcUserIdResolverTest`: empty-result not cached (second call re-queries → succeeds), exception not cached (same), success-after-failure cached, UUID passthrough skips the lookup. Full verify: worker 2018 · gateway 491 · kelta-web 983 — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)