### PR TITLE
fix(runtime): PATCH no longer re-validates untouched DATE fields

### DIFF
--- a/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/query/DefaultQueryEngine.java
+++ b/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/query/DefaultQueryEngine.java
@@ -365,19 +365,27 @@ public class DefaultQueryEngine implements QueryEngine {
         // Coerce string values to expected types (e.g., "10" → 10.0 for DOUBLE fields)
         TypeCoercionService.coerce(definition, recordData);
 
-        // Merge with existing data for validation
+        // Merged view of the record (existing + patch) for cross-field custom rules.
         Map<String, Object> mergedData = new HashMap<>(existing.get());
         mergedData.putAll(recordData);
 
-        // Validate data (field-level constraints)
+        // Field-level validation runs against the PATCH, not the merged record.
+        // The engine already skips fields absent from an UPDATE payload; feeding
+        // it the merged record instead makes every field "present" and
+        // re-validates untouched columns against their stored read-back form,
+        // which differs from the accepted input form (a DATE column reads back
+        // as an ISO datetime at midnight and fails the DATE type check). That
+        // rejected any PATCH on a record with a populated DATE field. Validating
+        // only the patch is both correct and matches the partial-update intent.
         if (validationEngine != null) {
-            ValidationResult validation = validationEngine.validate(definition, mergedData, OperationType.UPDATE, id);
+            ValidationResult validation = validationEngine.validate(definition, recordData, OperationType.UPDATE, id);
             if (!validation.valid()) {
                 throw new ValidationException(validation);
             }
         }
 
-        // Evaluate custom validation rules (formula-based) against the merged record
+        // Custom (formula) rules may reference sibling fields, so they still see
+        // the merged record.
         if (customValidationRuleEngine != null) {
             customValidationRuleEngine.evaluate(definition.name(), mergedData, OperationType.UPDATE);
         }

--- a/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/validation/DefaultValidationEngine.java
+++ b/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/validation/DefaultValidationEngine.java
@@ -208,10 +208,18 @@ public class DefaultValidationEngine implements ValidationEngine {
     }
     
     /**
-     * Validates a date value (ISO-8601 format string or LocalDate).
+     * Validates a date value.
+     *
+     * <p>Accepts {@code LocalDate}, an ISO date string ({@code 2026-07-12}),
+     * {@code java.util.Date}/{@code java.sql.Date} (JDBC read-back), and an ISO
+     * datetime string at midnight ({@code 2026-07-12T00:00:00.000Z}) — a DATE
+     * column reads back as a midnight datetime through the JSON layer, so this
+     * canonical stored form must validate as a DATE. (The primary fix validates
+     * only the patch on update; this keeps any other merged-validation path from
+     * regressing.)
      */
     private boolean isValidDate(Object value) {
-        if (value instanceof LocalDate) {
+        if (value instanceof LocalDate || value instanceof java.util.Date) {
             return true;
         }
         if (value instanceof String str) {
@@ -219,7 +227,18 @@ public class DefaultValidationEngine implements ValidationEngine {
                 LocalDate.parse(str);
                 return true;
             } catch (DateTimeParseException e) {
-                return false;
+                // Fall through to the datetime-at-midnight form below.
+            }
+            try {
+                java.time.Instant.parse(str); // e.g. 2026-07-12T00:00:00.000Z
+                return true;
+            } catch (DateTimeParseException e) {
+                try {
+                    LocalDateTime.parse(str); // e.g. 2026-07-12T00:00:00
+                    return true;
+                } catch (DateTimeParseException e2) {
+                    return false;
+                }
             }
         }
         return false;

--- a/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/validation/DefaultValidationEngine.java
+++ b/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/validation/DefaultValidationEngine.java
@@ -67,19 +67,34 @@ public class DefaultValidationEngine implements ValidationEngine {
     
     @Override
     public ValidationResult validate(CollectionDefinition definition, Map<String, Object> data, OperationType operationType) {
+        return validate(definition, data, operationType, null);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Overridden so {@code excludeId} actually reaches the uniqueness check.
+     * The interface default silently ignores it — self-exclusion on update only
+     * ever worked because callers validated a merged record whose map happened
+     * to carry {@code id}. Update validation now runs against the bare patch
+     * (which has no {@code id} key), so the explicit parameter is load-bearing.
+     */
+    @Override
+    public ValidationResult validate(CollectionDefinition definition, Map<String, Object> data,
+                                     OperationType operationType, String excludeId) {
         Objects.requireNonNull(definition, "definition cannot be null");
         Objects.requireNonNull(data, "data cannot be null");
         Objects.requireNonNull(operationType, "operationType cannot be null");
-        
+
         List<FieldError> errors = new ArrayList<>();
-        
+
         for (FieldDefinition field : definition.fields()) {
-            validateField(definition, field, data, operationType, errors);
+            validateField(definition, field, data, operationType, excludeId, errors);
         }
-        
+
         return errors.isEmpty() ? ValidationResult.success() : ValidationResult.failure(errors);
     }
-    
+
     /**
      * Validates a single field against its definition.
      */
@@ -88,6 +103,7 @@ public class DefaultValidationEngine implements ValidationEngine {
             FieldDefinition field,
             Map<String, Object> data,
             OperationType operationType,
+            String excludeId,
             List<FieldError> errors) {
         
         String fieldName = field.name();
@@ -139,7 +155,7 @@ public class DefaultValidationEngine implements ValidationEngine {
         
         // 6. Unique constraint validation
         if (field.unique()) {
-            validateUnique(definition, field, value, data, errors);
+            validateUnique(definition, field, value, data, excludeId, errors);
         }
         
         // 7. Reference validation
@@ -350,12 +366,17 @@ public class DefaultValidationEngine implements ValidationEngine {
             FieldDefinition field,
             Object value,
             Map<String, Object> data,
+            String excludeId,
             List<FieldError> errors) {
-        
-        // Get the record ID to exclude from uniqueness check (for updates)
-        String excludeId = data.get("id") != null ? data.get("id").toString() : null;
-        
-        boolean isUnique = storageAdapter.isUnique(definition, field.name(), value, excludeId);
+
+        // Record ID to exclude from the uniqueness check (for updates): the
+        // explicit parameter wins; fall back to an id carried in the data map
+        // (create-with-client-supplied-id, legacy 3-arg callers).
+        String effectiveExcludeId = excludeId != null
+                ? excludeId
+                : (data.get("id") != null ? data.get("id").toString() : null);
+
+        boolean isUnique = storageAdapter.isUnique(definition, field.name(), value, effectiveExcludeId);
         if (!isUnique) {
             errors.add(FieldError.unique(field.name()));
         }

--- a/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/query/DefaultQueryEngineTest.java
+++ b/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/query/DefaultQueryEngineTest.java
@@ -388,12 +388,79 @@ class DefaultQueryEngineTest {
                 });
             
             Optional<Map<String, Object>> result = queryEngine.update(testCollection, id, updateData);
-            
+
             assertTrue(result.isPresent());
             assertEquals("New Name", result.get().get("name"));
             assertNotNull(result.get().get("updatedAt"));
         }
-        
+
+        @Test
+        @DisplayName("Field validation sees only the patch, not the merged record (2026-07-12: merged DATE re-validation)")
+        void validatesOnlyThePatchNotMergedRecord() {
+            String id = "test-id";
+            Map<String, Object> existingRecord = new HashMap<>();
+            existingRecord.put("id", id);
+            existingRecord.put("name", "Old Name");
+            existingRecord.put("price", 50.0);
+
+            Map<String, Object> updateData = new HashMap<>();
+            updateData.put("name", "New Name");
+
+            when(storageAdapter.getById(testCollection, id)).thenReturn(Optional.of(existingRecord));
+            when(validationEngine.validate(eq(testCollection), any(), any(), eq(id)))
+                .thenReturn(io.kelta.runtime.validation.ValidationResult.success());
+            when(storageAdapter.update(eq(testCollection), eq(id), any()))
+                .thenReturn(Optional.of(existingRecord));
+
+            queryEngine.update(testCollection, id, updateData);
+
+            ArgumentCaptor<Map<String, Object>> validated = ArgumentCaptor.forClass(Map.class);
+            verify(validationEngine).validate(eq(testCollection), validated.capture(), any(), eq(id));
+            // Only the patched field reaches validation — untouched stored columns
+            // (whose read-back form may not match their input form) are not re-checked.
+            assertTrue(validated.getValue().containsKey("name"));
+            assertFalse(validated.getValue().containsKey("price"),
+                "merged stored fields must not leak into UPDATE field-validation");
+        }
+
+        @Test
+        @DisplayName("End-to-end: PATCH an unrelated field on a record with a populated DATE succeeds (real validator)")
+        void patchUnrelatedFieldWithStoredDateSucceeds() {
+            CollectionDefinition invoices = new CollectionDefinitionBuilder()
+                .name("invoices")
+                .displayName("Invoices")
+                .addField(new FieldDefinitionBuilder()
+                    .name("status").type(FieldType.STRING).nullable(false).build())
+                .addField(new FieldDefinitionBuilder()
+                    .name("issueDate").type(FieldType.DATE).nullable(true).build())
+                .build();
+
+            DefaultQueryEngine engineRealValidation = new DefaultQueryEngine(
+                storageAdapter, new io.kelta.runtime.validation.DefaultValidationEngine(storageAdapter));
+
+            String id = "inv-1";
+            Map<String, Object> stored = new HashMap<>();
+            stored.put("id", id);
+            stored.put("status", "ISSUED");
+            // DATE column reads back as a midnight datetime through the JSON layer.
+            stored.put("issueDate", "2026-07-12T00:00:00.000Z");
+
+            when(storageAdapter.getById(invoices, id)).thenReturn(Optional.of(stored));
+            when(storageAdapter.update(eq(invoices), eq(id), any()))
+                .thenAnswer(inv -> {
+                    Map<String, Object> merged = new HashMap<>(stored);
+                    merged.putAll(inv.getArgument(2));
+                    return Optional.of(merged);
+                });
+
+            // Before the fix this threw ValidationException (issueDate "expected DATE").
+            Optional<Map<String, Object>> result =
+                engineRealValidation.update(invoices, id, Map.of("status", "PAID"));
+
+            assertTrue(result.isPresent());
+            assertEquals("PAID", result.get().get("status"));
+        }
+
         @Test
         @DisplayName("Should return empty when record not found")
         void shouldReturnEmptyWhenRecordNotFound() {

--- a/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/validation/DefaultValidationEngineTest.java
+++ b/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/validation/DefaultValidationEngineTest.java
@@ -238,11 +238,26 @@ class DefaultValidationEngineTest {
             CollectionDefinition definition = createTestCollection(
                 FieldDefinition.date("birthDate")
             );
-            
+
             ValidationResult result = validationEngine.validate(
                 definition, Map.of("birthDate", "2024-01-15"), OperationType.CREATE);
-            
+
             assertTrue(result.valid());
+        }
+
+        @Test
+        @DisplayName("Should accept a DATE column's stored read-back form (midnight datetime + java.util.Date)")
+        void shouldAcceptStoredDateReadBackForms() {
+            CollectionDefinition definition = createTestCollection(FieldDefinition.date("issueDate"));
+
+            // ISO datetime at midnight — how a DATE column reads back through the JSON layer.
+            assertTrue(validationEngine.validate(
+                definition, Map.of("issueDate", "2026-07-12T00:00:00.000Z"), OperationType.UPDATE).valid());
+            assertTrue(validationEngine.validate(
+                definition, Map.of("issueDate", "2026-07-12T00:00:00"), OperationType.UPDATE).valid());
+            // JDBC read-back type.
+            assertTrue(validationEngine.validate(
+                definition, Map.of("issueDate", java.sql.Date.valueOf("2026-07-12")), OperationType.UPDATE).valid());
         }
 
         @Test

--- a/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/validation/DefaultValidationEngineTest.java
+++ b/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/validation/DefaultValidationEngineTest.java
@@ -658,6 +658,28 @@ class DefaultValidationEngineTest {
         }
 
         @Test
+        @DisplayName("excludeId parameter reaches the uniqueness check when the data map has no id (patch-only update)")
+        void excludeIdParameterReachesUniquenessCheck() {
+            FieldDefinition field = new FieldDefinition(
+                "name", FieldType.STRING, false, false, true, null, null, null, null, null
+            );
+            CollectionDefinition definition = createTestCollection(field);
+
+            // Re-sending the record's own unique value in a patch (no "id" key,
+            // like a metadata-promotion upsert) must exclude the record itself
+            // via the explicit excludeId parameter — the interface default used
+            // to drop it, and self-exclusion silently relied on a merged map.
+            when(storageAdapter.isUnique(eq(definition), eq("name"), eq("sbxcustomers"), eq("rec-1")))
+                .thenReturn(true);
+
+            ValidationResult result = validationEngine.validate(
+                definition, Map.of("name", "sbxcustomers"), OperationType.UPDATE, "rec-1");
+
+            assertTrue(result.valid());
+            verify(storageAdapter).isUnique(eq(definition), eq("name"), eq("sbxcustomers"), eq("rec-1"));
+        }
+
+        @Test
         @DisplayName("Should exclude current record ID when checking uniqueness on UPDATE")
         void shouldExcludeCurrentRecordIdOnUpdate() {
             FieldDefinition field = new FieldDefinition(


### PR DESCRIPTION
## Problem

PATCHing a record that has a populated DATE field fails validation even when the patch doesn't touch it.

Repro (telehealth tenant, 2026-07-12): an `invoices` row created by a flow with `issueDate`/`dueDate` = `2026-07-12`; GET echoes them as `2026-07-12T00:00:00.000Z`; `PATCH /api/invoices/{id}` with `{"status":"PAID"}` → **400** `[{"code":"type","detail":"Invalid type, expected DATE","source":{"pointer":"/data/attributes/issueDate"}}, …dueDate]`.

**Root cause:** `DefaultQueryEngine.update` merges the full stored record into the patch and validates the merged map. `DefaultValidationEngine` skips fields absent from an UPDATE payload — but after the merge *every* field is present, so it re-validates untouched columns against their **stored read-back form**. A DATE column reads back through the JSON layer as a midnight datetime, which fails `isValidDate`. Any PATCH on any record with a populated DATE is rejected.

## Fix

**Primary:** field-level validation runs against the incoming patch, not the merged record. The engine already has partial-update semantics (skip absent fields on UPDATE); feeding it the merge defeated them. Validating the patch is both correct and fixes the whole class — any field type whose stored form differs from its accepted input form, not just DATE. Custom formula rules still see the merged record (they may reference sibling fields).

**Defense in depth:** `isValidDate` also accepts a DATE's canonical stored forms — ISO datetime at midnight, `java.util.Date`/`java.sql.Date` — so no other merged-validation path can regress.

## Tests

- `DefaultQueryEngineTest`: field validation sees only the patch (ArgumentCaptor asserts untouched `price` never reaches the validator); end-to-end PATCH of an unrelated field on a record with a stored midnight-datetime DATE succeeds via the **real** validator.
- `DefaultValidationEngineTest`: the validator accepts the stored DATE read-back forms.
- Full verify: runtime-core 1446 · worker 2014 · gateway 491 · kelta-web 983 — green.

Removes the need for the atlantico-web BFF workaround (yyyy-MM-dd normalization on invoice status patches) once deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)