### PR TITLE
fix(worker): register jsonapi atomic-operation records for native reflection

### DIFF
--- a/.claude/docs/concerns.md
+++ b/.claude/docs/concerns.md
@@ -524,6 +524,7 @@ Regression guard: `TenantAwareDataSourceTest` asserts tenant connections use tra
 
 ### Bugs (all addressed)
 
+- **`/api/operations` 500 on the native worker (2026-07-12)** — `AtomicOperationExecutor` maps request maps into the `io.kelta.jsonapi.AtomicOperation`/`AtomicResult` records reflectively, but none of the jsonapi records were in the worker `reflect-config.json`, so every atomic-operations call failed with `MissingReflectionRegistrationError` on the native image only (JVM/CI green — same invisible-on-CI class as the NATS payload gaps). All five records (`AtomicOperation` + `ResourceRef`/`ResourceData`, `AtomicResult` + `ResourceObject`) are now registered.
 - **Federated users stuck PENDING_ACTIVATION** — `FederatedUserMapper.lookupProfileId` (line 199) calls `WorkerClient.findProfileByName` against `/internal/profile/by-name`.
 - **Password reset sends no email** — `PasswordController.sendPasswordResetEmail` (line 212) calls `WorkerClient.sendTemplateEmail` with the `user.password_reset` template.
 - **Unhandled EmptyResultDataAccessException** — `PasswordController.changePassword` (line 82) catches `EmptyResultDataAccessException` and returns the generic 400 to prevent username enumeration.

--- a/kelta-worker/src/main/resources/META-INF/native-image/io.kelta/kelta-worker/reflect-config.json
+++ b/kelta-worker/src/main/resources/META-INF/native-image/io.kelta/kelta-worker/reflect-config.json
@@ -6,6 +6,36 @@
     ]
   },
   {
+    "name": "io.kelta.jsonapi.AtomicOperation",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "io.kelta.jsonapi.AtomicOperation$ResourceRef",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "io.kelta.jsonapi.AtomicOperation$ResourceData",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "io.kelta.jsonapi.AtomicResult",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "io.kelta.jsonapi.AtomicResult$ResourceObject",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
     "name": "io.kelta.runtime.event.PlatformEvent",
     "allDeclaredConstructors": true,
     "allDeclaredMethods": true,


### PR DESCRIPTION
/api/operations failed with MissingReflectionRegistrationError on the native
worker image — AtomicOperationExecutor materializes the AtomicOperation and
AtomicResult records reflectively and none of the io.kelta.jsonapi records
were in reflect-config.json. JVM and CI never see this (same class of gap as
the NATS payload entries). Registers AtomicOperation (+ResourceRef,
+ResourceData) and AtomicResult (+ResourceObject).

Found live: MCP bulk_apply → POST /api/operations 500 while filling catalog
translations for the telehealth sample tenant.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
