### PR TITLE
fix(telehealth): land visit links on the headless portal callback

### DIFF
--- a/.claude/docs/specs/telehealth/4-scheduling.md
+++ b/.claude/docs/specs/telehealth/4-scheduling.md
@@ -21,9 +21,11 @@
 >   `KELTA_TELEHEALTH_VISIT_SECRET` in prod) bound to (tenant, appointment, portalUser, exp
 >   = scheduledEnd+1h), multi-use until exp; `GET /api/telehealth/visits/{token}` (gateway
 >   unauthenticated path) re-checks the LIVE appointment row (cancelled kills the link),
->   mints a fresh single-use 15-min portal login token, and 302s into the kelta-auth
->   verify — one click from email to an authenticated `/app` session. Slice 6 adds the
->   `next`-page landing.
+>   mints a fresh single-use 15-min portal login token, and 302s — to the tenant's
+>   headless `portalAuth.inviteRedirectUri` callback (slice 8) as
+>   `?token=<raw>&appointmentId=<id>` when configured, so the portal exchanges the
+>   token via `POST /portal/api/login/verify` and deep-links its visit page; else
+>   into the kelta-auth verify — one click from email to an authenticated session.
 > - **Availability model**: RULE rows (weekday 0=Sun..6=Sat, start/end LOCAL time, per-row
 >   timezone — wall-clock stable across DST) + EXCEPTION rows (closed date, or an additive
 >   window for a date). Managed via the admin-only generic JSON:API for now (no authoring
@@ -75,7 +77,7 @@ detail shows status timeline, linked conversation, reschedule/cancel actions.
 GET  /api/telehealth/slots?providerId&from&to&duration=30 → {slots:[{start,end}]}   (tenant TZ math server-side)
 POST /api/telehealth/appointments {providerId, start, visitType, reason?}           → 201 (portal: self; staff: any portalUserId)
 POST /api/telehealth/appointments/{id}/cancel|reschedule|complete
-GET  /api/telehealth/visits/{token}                                                 → 302 into portal appointment page
+GET  /api/telehealth/visits/{token}    → 302: headless portal callback (?token&appointmentId) when configured, else kelta-auth verify
 ```
 
 Availability shape: weekday, startTime, endTime, timezone, effectiveFrom/To, plus exception

--- a/.claude/docs/specs/telehealth/8-portal-auth-headless.md
+++ b/.claude/docs/specs/telehealth/8-portal-auth-headless.md
@@ -63,6 +63,9 @@ Stored under `tenant.settings.portalAuth`:
 - `inviteRedirectUri`: when set, `portal.invite` emails (worker
   `PortalUserService`) link there instead of the kelta-auth verify page — the
   external site completes the invite via the same `/portal/api/login/verify`.
+  Visit links (`GET /api/telehealth/visits/{token}`, slice 4) 302 to the same
+  callback with `?token=<raw>&appointmentId=<id>` so headless portals land
+  authenticated on their own visit page instead of the built-in `/app`.
 - Managed via worker **`GET|PUT /api/admin/tenant/portal-auth-settings`**
   (MANAGE_USERS, in-controller gate like the other `/api/admin` endpoints).
   PUT validates: ≤ 10 entries, absolute `https://` URLs (`http://localhost…`

--- a/kelta-worker/src/main/java/io/kelta/worker/controller/TelehealthController.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/controller/TelehealthController.java
@@ -40,9 +40,11 @@ import java.util.UUID;
  *
  * <p>{@code GET /visits/{token}} is a PUBLIC (unauthenticated) path: it
  * validates the signed visit token against the live appointment, mints a
- * single-use 15-minute portal login token, and redirects into the kelta-auth
- * magic-link verify — one click from the email into an authenticated portal
- * session.
+ * single-use 15-minute portal login token, and redirects — one click from the
+ * email into an authenticated portal session. Headless portals (slice 8) land
+ * on their allowlisted {@code portalAuth.inviteRedirectUri} with the
+ * appointment id for deep-linking; otherwise the kelta-auth magic-link verify
+ * page signs the user into the built-in end-user app.
  */
 @RestController
 @RequestMapping("/api/telehealth")
@@ -167,7 +169,9 @@ public class TelehealthController {
     /**
      * PUBLIC visit-link landing (gateway unauthenticated path). Stateless HMAC
      * validation + live-appointment re-check, then a fresh single-use portal
-     * login token and a redirect into the auth verify endpoint.
+     * login token and a redirect: a headless portal's allowlisted callback
+     * (with the appointment id, so the portal can deep-link the visit page)
+     * when the tenant configured one, else the auth verify endpoint.
      */
     @GetMapping("/visits/{token}")
     public ResponseEntity<Void> visit(@PathVariable String token) {
@@ -192,10 +196,27 @@ public class TelehealthController {
                 PortalTokens.sha256(rawLogin),
                 Timestamp.from(Instant.now().plus(java.time.Duration.ofMinutes(15))));
 
-        String base = authBaseUrl.endsWith("/") ? authBaseUrl.substring(0, authBaseUrl.length() - 1) : authBaseUrl;
+        // Same headless-portal landing the portal.invite email uses (slice 8):
+        // exchange happens on the portal via POST /portal/api/login/verify. The
+        // built-in verify page would strand these tenants' users on the
+        // platform app, where their portal has no session.
+        String portalRedirect = jdbcTemplate.queryForList(
+                        "SELECT settings#>>'{portalAuth,inviteRedirectUri}' FROM tenant WHERE id = ?",
+                        String.class, claim.tenantId()).stream()
+                .filter(v -> v != null && !v.isBlank())
+                .findFirst().orElse(null);
+        String location;
+        if (portalRedirect != null) {
+            location = portalRedirect + (portalRedirect.contains("?") ? "&" : "?")
+                    + "token=" + rawLogin + "&appointmentId=" + claim.appointmentId();
+        } else {
+            String base = authBaseUrl.endsWith("/")
+                    ? authBaseUrl.substring(0, authBaseUrl.length() - 1) : authBaseUrl;
+            location = base + "/portal/login/verify?token=" + rawLogin;
+        }
         log.debug("Visit link accepted for appointment {}", claim.appointmentId());
         return ResponseEntity.status(HttpStatus.FOUND)
-                .header(HttpHeaders.LOCATION, base + "/portal/login/verify?token=" + rawLogin)
+                .header(HttpHeaders.LOCATION, location)
                 .build();
     }
 

--- a/kelta-worker/src/test/java/io/kelta/worker/controller/TelehealthControllerTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/controller/TelehealthControllerTest.java
@@ -1,0 +1,133 @@
+package io.kelta.worker.controller;
+
+import io.kelta.runtime.router.UserIdResolver;
+import io.kelta.worker.service.telehealth.AppointmentService;
+import io.kelta.worker.service.telehealth.AvailabilityService;
+import io.kelta.worker.service.telehealth.SlotService;
+import io.kelta.worker.service.telehealth.VisitTokenService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@DisplayName("TelehealthController — public visit links")
+class TelehealthControllerTest {
+
+    private static final String TENANT = "t1";
+    private static final String APPOINTMENT = "a0b1c2d3-0000-0000-0000-000000000001";
+    private static final String PORTAL_USER = "pu-1";
+
+    private VisitTokenService visitTokenService;
+    private JdbcTemplate jdbcTemplate;
+    private TelehealthController controller;
+
+    @BeforeEach
+    void setUp() {
+        visitTokenService = mock(VisitTokenService.class);
+        jdbcTemplate = mock(JdbcTemplate.class);
+        controller = new TelehealthController(mock(AppointmentService.class), mock(SlotService.class),
+                mock(AvailabilityService.class), visitTokenService, mock(UserIdResolver.class),
+                jdbcTemplate, "https://auth.example.com/");
+    }
+
+    private void givenLiveAppointment() {
+        when(visitTokenService.verify(eq("signed"), any(Instant.class))).thenReturn(
+                Optional.of(new VisitTokenService.VisitClaim(TENANT, APPOINTMENT, PORTAL_USER,
+                        Instant.now().plusSeconds(600))));
+        when(jdbcTemplate.queryForObject(contains("FROM telehealth_appointment"), eq(Integer.class),
+                eq(APPOINTMENT), eq(TENANT), eq(PORTAL_USER))).thenReturn(1);
+    }
+
+    private void givenPortalCallback(List<String> values) {
+        when(jdbcTemplate.queryForList(contains("inviteRedirectUri"), eq(String.class), eq(TENANT)))
+                .thenReturn(values);
+    }
+
+    @Test
+    @DisplayName("redirects to the tenant's headless portal callback with the appointment id")
+    void redirectsToHeadlessPortalCallback() {
+        givenLiveAppointment();
+        givenPortalCallback(List.of("https://portal.example.com/auth/callback"));
+
+        ResponseEntity<Void> response = controller.visit("signed");
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FOUND);
+        String location = response.getHeaders().getFirst(HttpHeaders.LOCATION);
+        assertThat(location).startsWith("https://portal.example.com/auth/callback?token=");
+        assertThat(location).endsWith("&appointmentId=" + APPOINTMENT);
+    }
+
+    @Test
+    @DisplayName("appends with & when the callback already carries a query string")
+    void appendsToExistingQueryString() {
+        givenLiveAppointment();
+        givenPortalCallback(List.of("https://portal.example.com/auth/callback?src=email"));
+
+        String location = controller.visit("signed").getHeaders().getFirst(HttpHeaders.LOCATION);
+
+        assertThat(location).startsWith("https://portal.example.com/auth/callback?src=email&token=");
+    }
+
+    @Test
+    @DisplayName("falls back to the auth verify page when no headless callback is configured")
+    void fallsBackToAuthVerifyWhenUnset() {
+        givenLiveAppointment();
+        givenPortalCallback(List.of());
+
+        String location = controller.visit("signed").getHeaders().getFirst(HttpHeaders.LOCATION);
+
+        assertThat(location).startsWith("https://auth.example.com/portal/login/verify?token=");
+        assertThat(location).doesNotContain("appointmentId");
+    }
+
+    @Test
+    @DisplayName("treats a blank configured callback as unset")
+    void fallsBackToAuthVerifyWhenBlank() {
+        givenLiveAppointment();
+        givenPortalCallback(List.of(" "));
+
+        String location = controller.visit("signed").getHeaders().getFirst(HttpHeaders.LOCATION);
+
+        assertThat(location).startsWith("https://auth.example.com/portal/login/verify?token=");
+    }
+
+    @Test
+    @DisplayName("404s when the appointment row is no longer live")
+    void rejectsWhenAppointmentNotLive() {
+        when(visitTokenService.verify(eq("signed"), any(Instant.class))).thenReturn(
+                Optional.of(new VisitTokenService.VisitClaim(TENANT, APPOINTMENT, PORTAL_USER,
+                        Instant.now().plusSeconds(600))));
+        when(jdbcTemplate.queryForObject(contains("FROM telehealth_appointment"), eq(Integer.class),
+                eq(APPOINTMENT), eq(TENANT), eq(PORTAL_USER))).thenReturn(0);
+
+        assertThatThrownBy(() -> controller.visit("signed"))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("Invalid or expired visit link");
+    }
+
+    @Test
+    @DisplayName("404s on an invalid or expired signed token")
+    void rejectsInvalidToken() {
+        when(visitTokenService.verify(eq("bad"), any(Instant.class))).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> controller.visit("bad"))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("Invalid or expired visit link");
+    }
+}


### PR DESCRIPTION
## Problem

"Open your visit" links in appointment emails were broken for headless-portal tenants. The chain:

1. `GET /api/telehealth/visits/{token}` validated the HMAC token, minted a login token, and always 302'd to the kelta-auth verify page.
2. `PortalLoginController.verify` redirects to `{uiBaseUrl}/{slug}/app` — the built-in end-user app.

Tenants running their own portal (slice 8 headless auth, e.g. the Atlântico sample tenant at atlantico.rzware.com) stranded patients on app.kelta.io with no portal session.

## Fix

`TelehealthController.visit` reuses the `portal.invite` precedent (`PortalUserService.issueInviteLink`): when `tenant.settings.portalAuth.inviteRedirectUri` is set, 302 to that allowlisted callback as `?token=<raw>&appointmentId=<id>`. The portal exchanges the single-use token via `POST /portal/api/login/verify` and deep-links its visit page. No setting → current auth-verify fallback, behavior unchanged.

No new config: the redirect target is the existing exact-match allowlisted URI; the appointment id is from the verified HMAC claim.

## Tests

- New `TelehealthControllerTest` (6 cases): headless redirect + appointmentId, query-string append, unset/blank fallback, dead-appointment 404, invalid-token 404.
- Telehealth package suite: 26/26 green.
- Companion portal PR (atlantico-web) verified end-to-end against this redirect shape with a real login token.

Specs updated: `4-scheduling.md`, `8-portal-auth-headless.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)