### PR TITLE
fix(ui): always show Created by / Updated by rows in System information

### DIFF
--- a/kelta-ui/app/src/pages/ResourceDetailPage/DetailTabBar.tsx
+++ b/kelta-ui/app/src/pages/ResourceDetailPage/DetailTabBar.tsx
@@ -399,46 +399,46 @@ export function DetailTabBar({
                 </span>
               </div>
             )}
-            {createdBy != null && (
-              <div className="flex flex-col gap-1">
-                <span className="text-sm font-medium text-muted-foreground">Created by</span>
-                <span className="text-base text-foreground" data-testid="system-created-by">
-                  {(() => {
-                    const display = getUserDisplay(String(createdBy))
-                    return display ? (
-                      <Link
-                        to={display.linkTo}
-                        className="text-primary no-underline hover:text-primary/80 hover:underline"
-                      >
-                        {display.name}
-                      </Link>
-                    ) : (
-                      String(createdBy)
-                    )
-                  })()}
-                </span>
-              </div>
-            )}
-            {updatedBy != null && (
-              <div className="flex flex-col gap-1">
-                <span className="text-sm font-medium text-muted-foreground">Last modified by</span>
-                <span className="text-base text-foreground" data-testid="system-updated-by">
-                  {(() => {
-                    const display = getUserDisplay(String(updatedBy))
-                    return display ? (
-                      <Link
-                        to={display.linkTo}
-                        className="text-primary no-underline hover:text-primary/80 hover:underline"
-                      >
-                        {display.name}
-                      </Link>
-                    ) : (
-                      String(updatedBy)
-                    )
-                  })()}
-                </span>
-              </div>
-            )}
+            {/* Audit users render even when absent (system/legacy writes) so
+                the empty value is visible rather than the row vanishing. */}
+            <div className="flex flex-col gap-1">
+              <span className="text-sm font-medium text-muted-foreground">Created by</span>
+              <span className="text-base text-foreground" data-testid="system-created-by">
+                {(() => {
+                  if (createdBy == null) return '—'
+                  const display = getUserDisplay(String(createdBy))
+                  return display ? (
+                    <Link
+                      to={display.linkTo}
+                      className="text-primary no-underline hover:text-primary/80 hover:underline"
+                    >
+                      {display.name}
+                    </Link>
+                  ) : (
+                    String(createdBy)
+                  )
+                })()}
+              </span>
+            </div>
+            <div className="flex flex-col gap-1">
+              <span className="text-sm font-medium text-muted-foreground">Last modified by</span>
+              <span className="text-base text-foreground" data-testid="system-updated-by">
+                {(() => {
+                  if (updatedBy == null) return '—'
+                  const display = getUserDisplay(String(updatedBy))
+                  return display ? (
+                    <Link
+                      to={display.linkTo}
+                      className="text-primary no-underline hover:text-primary/80 hover:underline"
+                    >
+                      {display.name}
+                    </Link>
+                  ) : (
+                    String(updatedBy)
+                  )
+                })()}
+              </span>
+            </div>
           </div>
         </TabsContent>
       </Tabs>

--- a/kelta-ui/app/src/pages/app/ObjectDetailPage/ObjectDetailPage.tsx
+++ b/kelta-ui/app/src/pages/app/ObjectDetailPage/ObjectDetailPage.tsx
@@ -235,16 +235,18 @@ function deriveSystemRows(
   const createdBy = record.createdBy ?? record.created_by
   const updatedBy = record.updatedBy ?? record.updated_by
 
+  // Audit-user rows render even when absent (system/legacy writes) so the
+  // empty value is visible rather than the row vanishing.
+  const userRowValue = (userId: unknown): string => {
+    if (userId == null) return '—'
+    const display = getUserDisplay(String(userId))
+    return display?.name ?? String(userId)
+  }
+
   if (createdAt) rows.push({ label: 'Created', value: formatStamp(createdAt) })
-  if (createdBy != null) {
-    const display = getUserDisplay(String(createdBy))
-    rows.push({ label: 'Created by', value: display?.name ?? String(createdBy) })
-  }
+  rows.push({ label: 'Created by', value: userRowValue(createdBy) })
   if (updatedAt) rows.push({ label: 'Updated', value: formatStamp(updatedAt) })
-  if (updatedBy != null) {
-    const display = getUserDisplay(String(updatedBy))
-    rows.push({ label: 'Updated by', value: display?.name ?? String(updatedBy) })
-  }
+  rows.push({ label: 'Updated by', value: userRowValue(updatedBy) })
   return rows
 }
 


### PR DESCRIPTION
## Summary
- The right-rail "System information" card and the System Information tab hid the **Created by** / **Updated by** rows entirely when the value was null (records written by flows/system paths before #1270, e.g. all couchpicks titles)
- Rows now always render, with an em-dash (—) when no user is recorded — an unstamped record reads as visibly unattributed instead of the fields silently missing

## Changes
- `ObjectDetailPage.deriveSystemRows` (rail card, end-user)
- `DetailTabBar` System Information tab (shared by both stacks)

## Testing
- 2639 kelta-ui unit tests, lint, format, `vite build` all green
- Visual baselines unaffected — the e2e-seeded records carry audit users so those rows were already present

🤖 Generated with [Claude Code](https://claude.com/claude-code)