### PR TITLE
fix(runtime,ui): stop caching read-only system collections; simplify activity version entries

### DIFF
--- a/.claude/docs/architecture.md
+++ b/.claude/docs/architecture.md
@@ -260,7 +260,14 @@ jobs. RLS then scopes every query automatically.
 ## Worker Layers
 
 - **Controllers**: `kelta-worker/src/main/java/io/kelta/controller/` — Admin REST endpoints
-- **Dynamic Router**: `runtime-core/.../router/DynamicCollectionRouter.java` — Routes `/api/{collectionName}`
+- **Dynamic Router**: `runtime-core/.../router/DynamicCollectionRouter.java` — Routes `/api/{collectionName}`.
+  System-collection GET responses are cached (`SystemCollectionCache` → worker Caffeine;
+  evicted same-pod on router writes and fleet-wide via `SystemCollectionCacheInvalidationListener` on
+  `kelta.record.changed.>`) — **except read-only system collections** (`record-versions`,
+  `field-history`, `email-logs`, `login-history`, audit logs, …): those are written by backend
+  services via direct JDBC, so no write path ever evicts their entries; the router serves them
+  uncached (previously each pod served stale per-pod version/history lists until the TTL —
+  Activity vs History tab count mismatch, flapping across refreshes).
 - **Services**: `kelta-worker/src/main/java/io/kelta/service/` — Business logic (CollectionLifecycleManager, CerbosAuthorizationService, SearchIndexService, S3StorageService)
 - **Listeners**: `kelta-worker/src/main/java/io/kelta/listener/` — NATS subscribers (CollectionSchemaListener, SearchIndexListener, CerbosCacheInvalidationListener, SvixWebhookPublisher)
 - **Data**: `kelta-worker/src/main/java/io/kelta/repository/` — JdbcTemplate + JPA repositories

--- a/e2e-tests/tests/end-user/record-history.spec.ts
+++ b/e2e-tests/tests/end-user/record-history.spec.ts
@@ -99,7 +99,7 @@ test.describe("Record History", () => {
     // The activity timeline shows a click-through entry for the update
     await expect(
       detailPage.activityVersionLinks.filter({
-        hasText: "Record updated to v2",
+        hasText: "Updated 1 field:",
       }),
     ).toBeVisible();
   });

--- a/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/router/DynamicCollectionRouter.java
+++ b/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/router/DynamicCollectionRouter.java
@@ -181,7 +181,7 @@ public class DynamicCollectionRouter {
             // Check system collection cache before querying
             String tenantId = request.getHeader("X-Tenant-ID");
             List<String> includeNames = parseIncludeParam(params);
-            if (definition.systemCollection() && systemCollectionCache != null && includeNames.isEmpty()) {
+            if (cacheable(definition) && includeNames.isEmpty()) {
                 String queryHash = buildQueryHash(queryRequest);
                 Optional<Map<String, Object>> cached = systemCollectionCache.getListResponse(
                         tenantId, collectionName, queryHash);
@@ -210,7 +210,7 @@ public class DynamicCollectionRouter {
             }
 
             // Cache the response for system collections (only when no includes, to keep cache simple)
-            if (definition.systemCollection() && systemCollectionCache != null && includeNames.isEmpty()) {
+            if (cacheable(definition) && includeNames.isEmpty()) {
                 String queryHash = buildQueryHash(queryRequest);
                 systemCollectionCache.putListResponse(tenantId, collectionName, queryHash, response);
             }
@@ -252,8 +252,7 @@ public class DynamicCollectionRouter {
 
             // Check system collection cache for get-by-id (no-include requests only)
             String tenantId = request.getHeader("X-Tenant-ID");
-            if (definition.systemCollection() && systemCollectionCache != null
-                    && includeNames.isEmpty()) {
+            if (cacheable(definition) && includeNames.isEmpty()) {
                 Optional<Map<String, Object>> cached = systemCollectionCache.getByIdResponse(
                         tenantId, collectionName, id);
                 if (cached.isPresent()) {
@@ -288,7 +287,7 @@ public class DynamicCollectionRouter {
             }
 
             // Cache the response for system collections (only when no includes)
-            if (definition.systemCollection() && systemCollectionCache != null && includeNames.isEmpty()) {
+            if (cacheable(definition) && includeNames.isEmpty()) {
                 systemCollectionCache.putByIdResponse(tenantId, collectionName, id, response);
             }
 
@@ -1760,6 +1759,18 @@ public class DynamicCollectionRouter {
      */
     private String buildQueryHash(QueryRequest queryRequest) {
         return queryRequest.toString();
+    }
+
+    /**
+     * Whether this collection's responses may be served from / stored in the
+     * {@link SystemCollectionCache}. Read-only system collections (record-versions,
+     * field-history, email-logs, login-history, audit logs, ...) are excluded:
+     * they are written by backend services via direct JDBC, never through this
+     * router, so no write path ever evicts their entries — caching them serves
+     * stale, per-pod results until the TTL expires.
+     */
+    private boolean cacheable(CollectionDefinition definition) {
+        return definition.systemCollection() && !definition.readOnly() && systemCollectionCache != null;
     }
 
     /**

--- a/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/router/DynamicCollectionRouterCacheTest.java
+++ b/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/router/DynamicCollectionRouterCacheTest.java
@@ -70,6 +70,17 @@ class DynamicCollectionRouterCacheTest {
                 .build();
     }
 
+    private CollectionDefinition buildReadOnlySystemCollection(String name) {
+        return new CollectionDefinitionBuilder()
+                .name(name)
+                .displayName(name)
+                .addField(FieldDefinition.requiredString("name"))
+                .systemCollection(true)
+                .tenantScoped(true)
+                .readOnly(true)
+                .build();
+    }
+
     private String jsonApiBody(Map<String, Object> attributes) throws Exception {
         Map<String, Object> data = new HashMap<>();
         data.put("type", "test");
@@ -147,6 +158,26 @@ class DynamicCollectionRouterCacheTest {
         }
 
         @Test
+        @DisplayName("Should NOT cache response for read-only system collections")
+        void list_doesNotCache_forReadOnlySystemCollection() throws Exception {
+            // record-versions / field-history / email-logs etc. are written by backend
+            // services via direct JDBC — no write path ever evicts their cache entries,
+            // so caching them serves stale per-pod results until the TTL.
+            CollectionDefinition def = buildReadOnlySystemCollection("record-versions");
+            when(registry.get("record-versions")).thenReturn(def);
+
+            QueryResult result = QueryResult.empty(Pagination.defaults());
+            when(queryEngine.executeQuery(eq(def), any(QueryRequest.class))).thenReturn(result);
+
+            mockMvc.perform(get("/api/record-versions")
+                            .header("X-Tenant-ID", "tenant-1"))
+                    .andExpect(status().isOk());
+
+            verify(cache, never()).getListResponse(any(), any(), any());
+            verify(cache, never()).putListResponse(any(), any(), any(), any());
+        }
+
+        @Test
         @DisplayName("Should NOT cache response when include parameter is present")
         void list_doesNotCache_whenIncludePresent() throws Exception {
             CollectionDefinition def = buildSystemCollection("collections");
@@ -209,6 +240,23 @@ class DynamicCollectionRouterCacheTest {
 
             // Verify the response was cached
             verify(cache).putByIdResponse(eq("tenant-1"), eq("collections"), eq("abc"), any());
+        }
+
+        @Test
+        @DisplayName("Should NOT consult or fill cache for read-only system collections")
+        void get_doesNotUseCache_forReadOnlySystemCollection() throws Exception {
+            CollectionDefinition def = buildReadOnlySystemCollection("record-versions");
+            when(registry.get("record-versions")).thenReturn(def);
+
+            Map<String, Object> record = Map.of("id", "abc", "name", "v1");
+            when(queryEngine.getById(def, "abc")).thenReturn(Optional.of(record));
+
+            mockMvc.perform(get("/api/record-versions/abc")
+                            .header("X-Tenant-ID", "tenant-1"))
+                    .andExpect(status().isOk());
+
+            verify(cache, never()).getByIdResponse(any(), any(), any());
+            verify(cache, never()).putByIdResponse(any(), any(), any(), any());
         }
 
         @Test

--- a/kelta-ui/app/src/components/ActivityTimeline/ActivityTimeline.test.tsx
+++ b/kelta-ui/app/src/components/ActivityTimeline/ActivityTimeline.test.tsx
@@ -7,16 +7,15 @@ import type { ActivityTimelineProps } from './ActivityTimeline'
 import type { ApiClient } from '../../services/apiClient'
 
 // Mock I18n — echo the key so assertions can target stable strings. Version
-// entry keys (the only ones interpolating a `user` param) append the resolved
-// author/fields so tests can assert getUserDisplay + display-name wiring.
+// update keys (the only ones interpolating a `fields` param) append the resolved
+// field display names so tests can assert schema display-name wiring.
 vi.mock('../../context/I18nContext', () => ({
   useI18n: vi.fn(() => ({
     locale: 'en',
     setLocale: vi.fn(),
     t: (key: string, params?: Record<string, string | number> | string) => {
-      if (params && typeof params === 'object' && 'user' in params) {
-        const fields = 'fields' in params ? ` fields=${params.fields}` : ''
-        return `${key} user=${params.user}${fields}`
+      if (params && typeof params === 'object' && 'fields' in params) {
+        return `${key} fields=${params.fields}`
       }
       return key
     },
@@ -252,18 +251,19 @@ describe('ActivityTimeline', () => {
       )
     }
 
-    it('renders one entry per version with the author and suppresses synthesized entries', async () => {
+    it('renders one entry per version with the author on its own line and suppresses synthesized entries', async () => {
       const getList = versionGetList()
 
       renderTimeline({ getList: getList as unknown as ApiClient['getList'] }, historyProps)
 
-      await waitFor(() =>
-        expect(screen.getByText('activity.versionCreated user=Jane Doe')).toBeInTheDocument()
-      )
-      // Changed fields render as schema display names.
-      expect(
-        screen.getByText('activity.versionUpdated user=Jane Doe fields=Full Name')
-      ).toBeInTheDocument()
+      await waitFor(() => expect(screen.getByText('activity.versionCreated')).toBeInTheDocument())
+      // Single changed field uses the singular key; fields render as schema display names.
+      expect(screen.getByText('activity.versionUpdatedOne fields=Full Name')).toBeInTheDocument()
+
+      // The author renders on its own line under the timestamp for each version entry.
+      const userLines = screen.getAllByTestId('activity-entry-user')
+      expect(userLines).toHaveLength(2)
+      expect(userLines[0]).toHaveTextContent('Jane Doe')
 
       // Synthesized created/updated entries are suppressed — the version feed covers them.
       expect(screen.queryByText('activity.recordCreated')).not.toBeInTheDocument()
@@ -289,7 +289,7 @@ describe('ActivityTimeline', () => {
 
       // Newest first: the first link is v2.
       const links = screen.getAllByTestId('activity-version-link')
-      expect(links[0]).toHaveTextContent('activity.versionUpdated')
+      expect(links[0]).toHaveTextContent('activity.versionUpdatedOne')
       fireEvent.click(links[0])
 
       expect(onOpenHistory).toHaveBeenCalledWith(2)

--- a/kelta-ui/app/src/components/ActivityTimeline/ActivityTimeline.tsx
+++ b/kelta-ui/app/src/components/ActivityTimeline/ActivityTimeline.tsx
@@ -147,6 +147,8 @@ interface TimelineEntry {
   timestamp: string
   /** Set on VERSION entries — click-through target for the History tab. */
   versionNumber?: number
+  /** Set on VERSION entries — author display name, rendered on its own line. */
+  user?: string
 }
 
 /**
@@ -500,17 +502,15 @@ export function ActivityTimeline({
         const user = getUserDisplay?.(version.changedBy)?.name ?? version.changedBy
         let description: string
         if (version.changeType === 'CREATED') {
-          description = t('activity.versionCreated', { version: version.versionNumber, user })
+          description = t('activity.versionCreated')
         } else if (version.changeType === 'DELETED') {
-          description = t('activity.versionDeleted', { version: version.versionNumber, user })
+          description = t('activity.versionDeleted')
         } else {
           const fields = version.changedFields.map((f) => displayNames.get(f) ?? f).join(', ')
-          description = t('activity.versionUpdated', {
-            version: version.versionNumber,
-            count: version.changedFields.length,
-            fields,
-            user,
-          })
+          description =
+            version.changedFields.length === 1
+              ? t('activity.versionUpdatedOne', { fields })
+              : t('activity.versionUpdated', { count: version.changedFields.length, fields })
         }
         allEntries.push({
           id: `version-${version.id}`,
@@ -518,6 +518,7 @@ export function ActivityTimeline({
           description,
           timestamp: version.changedAt,
           versionNumber: version.versionNumber,
+          user,
         })
       }
     }
@@ -761,6 +762,14 @@ export function ActivityTimeline({
                 <p className="m-0 text-xs text-muted-foreground leading-snug">
                   <time dateTime={entry.timestamp}>{formatRelativeTime(entry.timestamp)}</time>
                 </p>
+                {entry.user && (
+                  <p
+                    className="m-0 text-xs text-muted-foreground leading-snug break-all"
+                    data-testid="activity-entry-user"
+                  >
+                    {entry.user}
+                  </p>
+                )}
               </div>
             </div>
           ))}

--- a/kelta-ui/app/src/i18n/translations/ar.json
+++ b/kelta-ui/app/src/i18n/translations/ar.json
@@ -935,9 +935,10 @@
     "sections": "الأقسام"
   },
   "activity": {
-    "versionCreated": "تم إنشاء السجل (الإصدار {{version}}) — بواسطة {{user}}",
-    "versionUpdated": "تم تحديث السجل إلى الإصدار {{version}} — تم تغيير {{count}} من الحقول: {{fields}} — بواسطة {{user}}",
-    "versionDeleted": "تم حذف السجل (الإصدار {{version}}) — بواسطة {{user}}"
+    "versionCreated": "تم إنشاء السجل",
+    "versionUpdated": "تم تحديث {{count}} من الحقول: {{fields}}",
+    "versionUpdatedOne": "تم تحديث حقل واحد: {{fields}}",
+    "versionDeleted": "تم حذف السجل"
   },
   "history": {
     "tabTitle": "السجل التاريخي",

--- a/kelta-ui/app/src/i18n/translations/de.json
+++ b/kelta-ui/app/src/i18n/translations/de.json
@@ -1335,9 +1335,10 @@
     "recalled": "Zurückgerufen",
     "sharedWith": "Freigegeben für {{id}} ({{level}})",
     "loading": "Aktivität wird geladen...",
-    "versionCreated": "Datensatz erstellt (v{{version}}) — von {{user}}",
-    "versionUpdated": "Datensatz aktualisiert auf v{{version}} — {{count}} Felder geändert: {{fields}} — von {{user}}",
-    "versionDeleted": "Datensatz gelöscht (v{{version}}) — von {{user}}"
+    "versionCreated": "Datensatz erstellt",
+    "versionUpdated": "{{count}} Felder aktualisiert: {{fields}}",
+    "versionUpdatedOne": "1 Feld aktualisiert: {{fields}}",
+    "versionDeleted": "Datensatz gelöscht"
   },
   "history": {
     "tabTitle": "Verlauf",

--- a/kelta-ui/app/src/i18n/translations/en.json
+++ b/kelta-ui/app/src/i18n/translations/en.json
@@ -2042,9 +2042,10 @@
     "fieldChanged": "{{field}} changed from {{from}} to {{to}}",
     "fieldSet": "{{field}} set to {{value}}",
     "fieldCleared": "{{field}} cleared (was {{value}})",
-    "versionCreated": "Record created (v{{version}}) — by {{user}}",
-    "versionUpdated": "Record updated to v{{version}} — {{count}} fields changed: {{fields}} — by {{user}}",
-    "versionDeleted": "Record deleted (v{{version}}) — by {{user}}",
+    "versionCreated": "Record created",
+    "versionUpdated": "Updated {{count}} fields: {{fields}}",
+    "versionUpdatedOne": "Updated 1 field: {{fields}}",
+    "versionDeleted": "Record deleted",
     "loading": "Loading activity..."
   },
   "history": {

--- a/kelta-ui/app/src/i18n/translations/es.json
+++ b/kelta-ui/app/src/i18n/translations/es.json
@@ -1297,9 +1297,10 @@
     "recalled": "Retirado",
     "sharedWith": "Compartido con {{id}} ({{level}})",
     "loading": "Cargando actividad...",
-    "versionCreated": "Registro creado (v{{version}}) — por {{user}}",
-    "versionUpdated": "Registro actualizado a v{{version}} — {{count}} campos modificados: {{fields}} — por {{user}}",
-    "versionDeleted": "Registro eliminado (v{{version}}) — por {{user}}"
+    "versionCreated": "Registro creado",
+    "versionUpdated": "{{count}} campos modificados: {{fields}}",
+    "versionUpdatedOne": "1 campo modificado: {{fields}}",
+    "versionDeleted": "Registro eliminado"
   },
   "history": {
     "tabTitle": "Historial",

--- a/kelta-ui/app/src/i18n/translations/fr.json
+++ b/kelta-ui/app/src/i18n/translations/fr.json
@@ -1297,9 +1297,10 @@
     "recalled": "Rappelé",
     "sharedWith": "Partagé avec {{id}} ({{level}})",
     "loading": "Chargement de l'activité...",
-    "versionCreated": "Enregistrement créé (v{{version}}) — par {{user}}",
-    "versionUpdated": "Enregistrement mis à jour vers v{{version}} — {{count}} champs modifiés : {{fields}} — par {{user}}",
-    "versionDeleted": "Enregistrement supprimé (v{{version}}) — par {{user}}"
+    "versionCreated": "Enregistrement créé",
+    "versionUpdated": "{{count}} champs modifiés : {{fields}}",
+    "versionUpdatedOne": "1 champ modifié : {{fields}}",
+    "versionDeleted": "Enregistrement supprimé"
   },
   "history": {
     "tabTitle": "Historique",

--- a/kelta-ui/app/src/i18n/translations/pt.json
+++ b/kelta-ui/app/src/i18n/translations/pt.json
@@ -1335,9 +1335,10 @@
     "recalled": "Revogado",
     "sharedWith": "Compartilhado com {{id}} ({{level}})",
     "loading": "Carregando atividade...",
-    "versionCreated": "Registro criado (v{{version}}) — por {{user}}",
-    "versionUpdated": "Registro atualizado para v{{version}} — {{count}} campos alterados: {{fields}} — por {{user}}",
-    "versionDeleted": "Registro excluído (v{{version}}) — por {{user}}"
+    "versionCreated": "Registro criado",
+    "versionUpdated": "{{count}} campos atualizados: {{fields}}",
+    "versionUpdatedOne": "1 campo atualizado: {{fields}}",
+    "versionDeleted": "Registro excluído"
   },
   "history": {
     "tabTitle": "Histórico",


### PR DESCRIPTION
## Summary
- **Cache staleness (History vs Activity mismatch, flapping refreshes):** read-only system collections (`record-versions`, `field-history`, `email-logs`, `login-history`, audit logs) are written by backend services via direct JDBC — never through `DynamicCollectionRouter` — so no write path ever evicted their `SystemCollectionCache` entries. Each worker pod served stale per-pod cached lists until the Caffeine TTL, and the Activity feed (`page[size]=50`) and History tab (`page[size]=200`) hashed to different cache entries, showing different version counts that changed per refresh depending on the serving pod. The router now serves read-only system collections uncached (they are per-record, high-write, low-reuse queries — the cache bought nothing there).
- **Activity timeline version entries simplified:** "Record updated to v3 — 1 fields changed: IMDB Rating — by couchpicks-admin@kelta.local" becomes "Updated 1 field: IMDB Rating" (proper singular/plural via `versionUpdatedOne`/`versionUpdated` keys) with the author on its own line under the timestamp. Created/deleted entries likewise drop the version suffix and inline author. All six locales updated.

## Changes
- `runtime-core/.../router/DynamicCollectionRouter.java` — new `cacheable(definition)` guard: system collection && !readOnly && cache present
- `runtime-core/.../router/DynamicCollectionRouterCacheTest.java` — list + get-by-id never consult/fill cache for read-only system collections
- `kelta-ui/app/.../ActivityTimeline/ActivityTimeline.tsx` — version entry author moved to its own line (`activity-entry-user`), singular/plural key selection
- `kelta-ui/app/src/i18n/translations/{en,de,pt,fr,es,ar}.json` — reworded `versionCreated`/`versionUpdated`/`versionDeleted`, added `versionUpdatedOne`
- `e2e-tests/tests/end-user/record-history.spec.ts` — activity link assertion matches new text
- `.claude/docs/architecture.md` — documented the read-only-system-collection cache exclusion

## Testing
- `DynamicCollectionRouterCacheTest` 16/16 green (5 new assertions)
- Gateway 493 + worker 2062 tests green; kelta-web 983 green with coverage; kelta-ui 2639 green
- `npx vite build` green (prod-image typecheck escape guard); translation JSONs parse-validated

🤖 Generated with [Claude Code](https://claude.com/claude-code)