### PR TITLE
fix(ui): scroll detail tab bar into view when activity opens History

### DIFF
--- a/e2e-tests/tests/end-user/record-history.spec.ts
+++ b/e2e-tests/tests/end-user/record-history.spec.ts
@@ -97,11 +97,16 @@ test.describe("Record History", () => {
     await expect(detailPage.versionRows).toHaveCount(2);
 
     // The activity timeline shows a click-through entry for the update
-    await expect(
-      detailPage.activityVersionLinks.filter({
-        hasText: "Updated 1 field:",
-      }),
-    ).toBeVisible();
+    const activityLink = detailPage.activityVersionLinks.filter({
+      hasText: "Updated 1 field:",
+    });
+    await expect(activityLink).toBeVisible();
+
+    // Clicking it opens the History tab at that version and scrolls the tab
+    // bar into view (the switch used to happen off-screen and look like a no-op)
+    await activityLink.click();
+    await expect(detailPage.versionDetail).toBeVisible();
+    await expect(detailPage.versionDetail).toBeInViewport();
   });
 
   test("shows no History tab for a collection without trackHistory", async ({

--- a/kelta-ui/app/src/pages/ResourceDetailPage/DetailTabBar.test.tsx
+++ b/kelta-ui/app/src/pages/ResourceDetailPage/DetailTabBar.test.tsx
@@ -14,6 +14,7 @@ import { MemoryRouter } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import React from 'react'
 import { DetailTabBar, HISTORY_TAB } from './DetailTabBar'
+import { scrollDetailTabBarIntoView } from './detailTabBarScroll'
 import type { DetailTabBarProps } from './DetailTabBar'
 import type { ApiClient } from '@/services/apiClient'
 
@@ -133,6 +134,27 @@ describe('DetailTabBar', () => {
       await user.click(screen.getByTestId('detail-tab-notes'))
 
       expect(onTabChange).toHaveBeenCalledWith('__notes__')
+    })
+  })
+
+  describe('scrollDetailTabBarIntoView', () => {
+    it('scrolls the rendered tab bar into view on the next frame', async () => {
+      renderTabBar()
+      const tabBar = screen.getByTestId('detail-tab-bar')
+      const scrollIntoView = vi.fn()
+      Object.defineProperty(tabBar, 'scrollIntoView', { value: scrollIntoView })
+
+      scrollDetailTabBarIntoView()
+
+      // Deferred a frame — nothing yet.
+      expect(scrollIntoView).not.toHaveBeenCalled()
+      await new Promise((resolve) => requestAnimationFrame(() => resolve(undefined)))
+      expect(scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth', block: 'start' })
+    })
+
+    it('does not throw when no tab bar is mounted', async () => {
+      expect(() => scrollDetailTabBarIntoView()).not.toThrow()
+      await new Promise((resolve) => requestAnimationFrame(() => resolve(undefined)))
     })
   })
 })

--- a/kelta-ui/app/src/pages/ResourceDetailPage/ResourceDetailPage.tsx
+++ b/kelta-ui/app/src/pages/ResourceDetailPage/ResourceDetailPage.tsx
@@ -28,6 +28,7 @@ import { useRecordContext } from '../../hooks/useRecordContext'
 import { usePageLayout } from '../../hooks/usePageLayout'
 import { useLookupDisplayMap } from '../../hooks/useLookupDisplayMap'
 import { DetailTabBar, HISTORY_TAB } from './DetailTabBar'
+import { scrollDetailTabBarIntoView } from './detailTabBarScroll'
 import { RecordHistoryTab } from '../../components/RecordHistory/RecordHistoryTab'
 import { RecordShell } from '../../components/record/RecordShell'
 import { RecordDetailBody } from '../../components/record/RecordDetailBody'
@@ -382,6 +383,7 @@ export function ResourceDetailPage({
         },
         { replace: true }
       )
+      scrollDetailTabBarIntoView()
     },
     [setSearchParams]
   )

--- a/kelta-ui/app/src/pages/ResourceDetailPage/detailTabBarScroll.ts
+++ b/kelta-ui/app/src/pages/ResourceDetailPage/detailTabBarScroll.ts
@@ -1,0 +1,14 @@
+/**
+ * Scrolls the detail tab bar into view. The activity timeline's version links
+ * switch to the History tab via a `?tab=` search param, but the tab bar sits
+ * below the (often long) record body — without this the switch happens
+ * off-screen and the click looks like a no-op. Deferred a frame so the newly
+ * selected tab panel has mounted before the scroll.
+ */
+export function scrollDetailTabBarIntoView(): void {
+  requestAnimationFrame(() => {
+    document
+      .querySelector('[data-testid="detail-tab-bar"]')
+      ?.scrollIntoView?.({ behavior: 'smooth', block: 'start' })
+  })
+}

--- a/kelta-ui/app/src/pages/app/ObjectDetailPage/ObjectDetailPage.tsx
+++ b/kelta-ui/app/src/pages/app/ObjectDetailPage/ObjectDetailPage.tsx
@@ -55,6 +55,7 @@ import { buildIncludedDisplayMap } from '@/utils/jsonapi'
 import { FieldRenderer } from '@/components/FieldRenderer'
 import { InsufficientPrivileges } from '@/components/InsufficientPrivileges'
 import { DetailTabBar, HISTORY_TAB } from '@/pages/ResourceDetailPage/DetailTabBar'
+import { scrollDetailTabBarIntoView } from '@/pages/ResourceDetailPage/detailTabBarScroll'
 import { RecordHistoryTab } from '@/components/RecordHistory/RecordHistoryTab'
 import { RecordShell } from '@/components/record/RecordShell'
 import { RecordDetailBody } from '@/components/record/RecordDetailBody'
@@ -302,6 +303,7 @@ export function ObjectDetailPage(): React.ReactElement {
         },
         { replace: true }
       )
+      scrollDetailTabBarIntoView()
     },
     [setSearchParams]
   )


### PR DESCRIPTION
## Summary
- Clicking a version entry in the Activity timeline correctly switched to the History tab (`?tab=__history__&version=N` → controlled `DetailTabBar`), but the tab bar renders below the record body grid — on large screens with the docked left-panel Activity (#1269) the switch happened entirely off-screen, so the click looked like a dead link.
- `openHistoryAtVersion` in both record stacks (end-user `ObjectDetailPage`, admin `ResourceDetailPage`) now calls `scrollDetailTabBarIntoView()` after setting the search params — smooth-scrolls the tab bar into view one frame later (so the History panel has mounted).

## Changes
- `kelta-ui/app/src/pages/ResourceDetailPage/detailTabBarScroll.ts` — new helper (own file; the fast-refresh lint rule bars function exports from component files)
- `kelta-ui/app/src/pages/ResourceDetailPage/ResourceDetailPage.tsx`, `kelta-ui/app/src/pages/app/ObjectDetailPage/ObjectDetailPage.tsx` — call it from `openHistoryAtVersion`
- `kelta-ui/app/src/pages/ResourceDetailPage/DetailTabBar.test.tsx` — helper unit tests (deferred-frame scroll, no-op when unmounted)
- `e2e-tests/tests/end-user/record-history.spec.ts` — now actually clicks the activity link and asserts the version detail is visible **and in viewport** (the missing regression guard)

## Testing
- kelta-ui 2641 tests green (2 new); lint/format clean; `npx vite build` green
- Full /verify: gateway 493, worker 2062, kelta-web 983 + coverage — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)