### PR TITLE
fix(ui): edit form renders JSON fields as text instead of [object Object]

### DIFF
--- a/kelta-ui/app/src/pages/app/ObjectFormPage/ObjectFormPage.tsx
+++ b/kelta-ui/app/src/pages/app/ObjectFormPage/ObjectFormPage.tsx
@@ -60,6 +60,7 @@ import type { FieldDefinition, FieldType } from '@/hooks/useCollectionSchema'
 import type { PageLayoutDto } from '@/hooks/usePageLayout'
 import type { LookupOption } from '@/components/LookupSelect'
 import type { RecordType } from '@/types/collections'
+import { buildSaveAttributes, computeInitialFormData } from './formData'
 
 /** Picklist value returned from the API (field names match backend schema) */
 interface PicklistValueDto {
@@ -278,13 +279,22 @@ function FormField({
 
   // Textarea fields (rich_text, json)
   if (isTextareaField(field.type)) {
+    // JSON values can arrive as parsed objects/arrays — String() would render "[object Object],…"
+    const textValue =
+      value == null
+        ? ''
+        : typeof value === 'string'
+          ? value
+          : field.type === 'json'
+            ? JSON.stringify(value, null, 2)
+            : String(value)
     return (
       <div className="space-y-2">
         {labelEl}
         <Textarea
           id={fieldId}
           data-testid={fieldId}
-          value={value != null ? String(value) : ''}
+          value={textValue}
           onChange={(e) => onChange(field.name, e.target.value)}
           disabled={isReadOnly}
           rows={field.type === 'json' ? 6 : 4}
@@ -341,51 +351,6 @@ function FormField({
       {errorEl}
     </div>
   )
-}
-
-/**
- * Compute initial form data from record (edit) or field defaults (create).
- * Formats date/datetime values for HTML input compatibility.
- */
-function computeInitialFormData(
-  isNew: boolean,
-  record: Record<string, unknown> | undefined,
-  fields: FieldDefinition[],
-  queryDefaults?: Record<string, string>
-): Record<string, unknown> {
-  if (!isNew && record) {
-    const data: Record<string, unknown> = { ...record }
-    // Format date/datetime values for HTML inputs
-    for (const field of fields) {
-      const value = data[field.name]
-      if (value != null && typeof value === 'string') {
-        if (field.type === 'date') {
-          // HTML date input expects YYYY-MM-DD
-          data[field.name] = value.split('T')[0]
-        } else if (field.type === 'datetime') {
-          // HTML datetime-local input expects YYYY-MM-DDTHH:MM
-          data[field.name] = value.slice(0, 16)
-        }
-      }
-    }
-    return data
-  }
-  const defaults: Record<string, unknown> = {}
-  for (const field of fields) {
-    if (field.type === 'boolean') {
-      defaults[field.name] = false
-    }
-  }
-  // Apply query parameter defaults (e.g. ?order_ref=<id> from related list)
-  if (queryDefaults) {
-    const fieldNames = new Set(fields.map((f) => f.name))
-    for (const [key, value] of Object.entries(queryDefaults)) {
-      if (fieldNames.has(key)) {
-        defaults[key] = value
-      }
-    }
-  }
-  return defaults
 }
 
 interface ObjectFormBodyProps {
@@ -540,12 +505,11 @@ function ObjectFormBody({
       return
     }
 
-    const attributes: Record<string, unknown> = {}
-    for (const field of editableFields) {
-      const value = formData[field.name]
-      if (value !== undefined && value !== '') {
-        attributes[field.name] = value
-      }
+    const { attributes, errors } = buildSaveAttributes(editableFields, formData)
+    if (Object.keys(errors).length > 0) {
+      setFormErrors((prev) => ({ ...prev, ...errors }))
+      showToast('Fix invalid JSON before saving', 'error')
+      return
     }
 
     // Include record type ID if selected

--- a/kelta-ui/app/src/pages/app/ObjectFormPage/formData.test.ts
+++ b/kelta-ui/app/src/pages/app/ObjectFormPage/formData.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest'
+import { buildSaveAttributes, computeInitialFormData } from './formData'
+import type { FieldDefinition } from '@/hooks/useCollectionSchema'
+
+function field(over: Partial<FieldDefinition> = {}): FieldDefinition {
+  return { id: 'f1', name: 'name', displayName: 'Name', type: 'string', required: false, ...over }
+}
+
+describe('computeInitialFormData', () => {
+  it('pretty-prints JSON object values for the textarea editor', () => {
+    const fields = [field({ name: 'crew', type: 'json' })]
+    const crew = [{ job: 'Novel', name: 'Megan Maxwell', department: 'Writing' }]
+    const data = computeInitialFormData(false, { crew }, fields)
+    expect(data.crew).toBe(JSON.stringify(crew, null, 2))
+  })
+
+  it('leaves JSON string values untouched', () => {
+    const fields = [field({ name: 'config', type: 'json' })]
+    const data = computeInitialFormData(false, { config: '{"a":1}' }, fields)
+    expect(data.config).toBe('{"a":1}')
+  })
+
+  it('formats date and datetime strings for HTML inputs', () => {
+    const fields = [field({ name: 'day', type: 'date' }), field({ name: 'at', type: 'datetime' })]
+    const data = computeInitialFormData(
+      false,
+      { day: '2026-07-18T00:00:00Z', at: '2026-07-18T09:30:00Z' },
+      fields
+    )
+    expect(data.day).toBe('2026-07-18')
+    expect(data.at).toBe('2026-07-18T09:30')
+  })
+
+  it('applies boolean and query-param defaults for new records', () => {
+    const fields = [field({ name: 'active', type: 'boolean' }), field({ name: 'order_ref' })]
+    const data = computeInitialFormData(true, undefined, fields, { order_ref: 'abc' })
+    expect(data.active).toBe(false)
+    expect(data.order_ref).toBe('abc')
+  })
+})
+
+describe('buildSaveAttributes', () => {
+  it('parses JSON field text back to structured JSON', () => {
+    const fields = [field({ name: 'crew', type: 'json' })]
+    const crew = [{ job: 'Director', name: 'Lucía Alemany', department: 'Directing' }]
+    const { attributes, errors } = buildSaveAttributes(fields, {
+      crew: JSON.stringify(crew, null, 2),
+    })
+    expect(attributes.crew).toEqual(crew)
+    expect(errors).toEqual({})
+  })
+
+  it('reports invalid JSON as a field error instead of sending the raw string', () => {
+    const fields = [field({ name: 'crew', type: 'json' })]
+    const { attributes, errors } = buildSaveAttributes(fields, { crew: '{not json' })
+    expect(attributes).not.toHaveProperty('crew')
+    expect(errors.crew).toBe('Invalid JSON')
+  })
+
+  it('passes non-string JSON values through unchanged', () => {
+    const fields = [field({ name: 'crew', type: 'json' })]
+    const crew = [{ job: 'Screenplay' }]
+    const { attributes, errors } = buildSaveAttributes(fields, { crew })
+    expect(attributes.crew).toBe(crew)
+    expect(errors).toEqual({})
+  })
+
+  it('skips undefined and empty-string values', () => {
+    const fields = [field({ name: 'title' }), field({ name: 'crew', type: 'json' })]
+    const { attributes } = buildSaveAttributes(fields, { title: '', crew: undefined })
+    expect(attributes).toEqual({})
+  })
+})

--- a/kelta-ui/app/src/pages/app/ObjectFormPage/formData.ts
+++ b/kelta-ui/app/src/pages/app/ObjectFormPage/formData.ts
@@ -1,0 +1,82 @@
+/**
+ * Pure form-state helpers for ObjectFormPage: initial form data from a record
+ * (or defaults for a new one) and the reverse mapping back to a JSON:API
+ * attributes payload on save.
+ */
+import type { FieldDefinition } from '@/hooks/useCollectionSchema'
+
+/**
+ * Compute initial form data from record (edit) or field defaults (create).
+ * Formats date/datetime values for HTML input compatibility and JSON values
+ * as pretty-printed text for the textarea editor.
+ */
+export function computeInitialFormData(
+  isNew: boolean,
+  record: Record<string, unknown> | undefined,
+  fields: FieldDefinition[],
+  queryDefaults?: Record<string, string>
+): Record<string, unknown> {
+  if (!isNew && record) {
+    const data: Record<string, unknown> = { ...record }
+    for (const field of fields) {
+      const value = data[field.name]
+      if (value == null) continue
+      if (typeof value === 'string') {
+        if (field.type === 'date') {
+          // HTML date input expects YYYY-MM-DD
+          data[field.name] = value.split('T')[0]
+        } else if (field.type === 'datetime') {
+          // HTML datetime-local input expects YYYY-MM-DDTHH:MM
+          data[field.name] = value.slice(0, 16)
+        }
+      } else if (field.type === 'json' && typeof value === 'object') {
+        // JSON arrives parsed — edit it as text
+        data[field.name] = JSON.stringify(value, null, 2)
+      }
+    }
+    return data
+  }
+  const defaults: Record<string, unknown> = {}
+  for (const field of fields) {
+    if (field.type === 'boolean') {
+      defaults[field.name] = false
+    }
+  }
+  // Apply query parameter defaults (e.g. ?order_ref=<id> from related list)
+  if (queryDefaults) {
+    const fieldNames = new Set(fields.map((f) => f.name))
+    for (const [key, value] of Object.entries(queryDefaults)) {
+      if (fieldNames.has(key)) {
+        defaults[key] = value
+      }
+    }
+  }
+  return defaults
+}
+
+/**
+ * Build the JSON:API attributes payload from form state. JSON fields are edited as
+ * text — parse them back to structured JSON here; a parse failure becomes a field
+ * error so the raw string never overwrites structured data.
+ */
+export function buildSaveAttributes(
+  editableFields: FieldDefinition[],
+  formData: Record<string, unknown>
+): { attributes: Record<string, unknown>; errors: Record<string, string> } {
+  const attributes: Record<string, unknown> = {}
+  const errors: Record<string, string> = {}
+  for (const field of editableFields) {
+    const value = formData[field.name]
+    if (value === undefined || value === '') continue
+    if (field.type === 'json' && typeof value === 'string') {
+      try {
+        attributes[field.name] = JSON.parse(value)
+      } catch {
+        errors[field.name] = 'Invalid JSON'
+      }
+      continue
+    }
+    attributes[field.name] = value
+  }
+  return { attributes, errors }
+}


### PR DESCRIPTION
## Summary
- The end-user edit form (`/app/o/<collection>/<id>/edit`) coerced JSON field values with `String()`, so an array of objects rendered as `[object Object],[object Object],…` in the textarea (reported on couchpicks `titles` cast_members/crew)
- Worse, saving after touching the field would have committed that garbage string over the structured JSON data
- Fix mirrors the admin ResourceFormPage pattern: pretty-print parsed JSON into the textarea on load, parse the text back to structured JSON on save, and block save with an `Invalid JSON` field error when the text doesn't parse

## Changes
- `kelta-ui/app/src/pages/app/ObjectFormPage/formData.ts` — new pure helpers `computeInitialFormData` (moved from the page, now JSON-aware) and `buildSaveAttributes` (JSON parse + error collection)
- `kelta-ui/app/src/pages/app/ObjectFormPage/ObjectFormPage.tsx` — textarea renders non-string JSON values via `JSON.stringify` defensively; save path uses `buildSaveAttributes` and surfaces parse errors
- `kelta-ui/app/src/pages/app/ObjectFormPage/formData.test.ts` — unit tests for both helpers (stringify on load, parse on save, invalid-JSON error, date/datetime formatting, defaults)

## Testing
- New unit tests: 8/8 pass
- Full frontend suite: 221 files, 2649 tests pass
- `npm run lint` (0 errors), `npm run format:check` clean, `npx vite build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)