### PR TITLE
fix(runtime,worker): deterministic ordering for unsorted queries and field lists

### DIFF
--- a/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/storage/PhysicalTableStorageAdapter.java
+++ b/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/storage/PhysicalTableStorageAdapter.java
@@ -322,10 +322,16 @@ public class PhysicalTableStorageAdapter implements StorageAdapter {
             sql.append(buildWhereClause(allFilters, definition, params));
         }
 
-        // Build ORDER BY clause
+        // Build ORDER BY clause. Unsorted queries get a deterministic creation-order
+        // fallback: without it Postgres returns rows in arbitrary heap order, which
+        // (a) makes LIMIT/OFFSET pagination skip or duplicate rows across pages and
+        // (b) leaks nondeterministic ordering into JSON:API include resolution
+        // (e.g. ?include=fields powering field lists in the layout editor).
         if (request.hasSorting()) {
             sql.append(" ORDER BY ");
             sql.append(buildOrderByClause(request.sorting(), definition));
+        } else {
+            sql.append(" ORDER BY created_at, id");
         }
 
         // Build LIMIT and OFFSET for pagination

--- a/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/storage/PhysicalTableStorageAdapterTest.java
+++ b/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/storage/PhysicalTableStorageAdapterTest.java
@@ -310,6 +310,44 @@ class PhysicalTableStorageAdapterTest {
     }
     
     @Nested
+    @DisplayName("Default Ordering Tests")
+    class DefaultOrderingTests {
+
+        @Test
+        @DisplayName("Unsorted queries fall back to deterministic creation order")
+        void unsortedQueriesUseCreationOrder() {
+            adapter.initializeCollection(testCollection);
+
+            // Insert out of creation-time order: ids chosen so neither insert order
+            // nor id order matches created_at order.
+            Instant base = Instant.parse("2026-01-01T00:00:00Z");
+            insertAt("z-third", "Third", base.plusSeconds(30));
+            insertAt("a-first", "First", base.plusSeconds(10));
+            insertAt("m-second", "Second", base.plusSeconds(20));
+
+            QueryRequest request = new QueryRequest(
+                new Pagination(1, 10), List.of(), List.of(), List.of());
+            QueryResult result = adapter.query(testCollection, request);
+
+            List<String> names = result.data().stream()
+                .map(r -> (String) r.get("name"))
+                .toList();
+            assertEquals(List.of("First", "Second", "Third"), names);
+        }
+
+        private void insertAt(String id, String name, Instant createdAt) {
+            Map<String, Object> data = new HashMap<>();
+            data.put("id", id);
+            data.put("name", name);
+            data.put("price", 1.0);
+            data.put("sku", "SKU-" + id);
+            data.put("createdAt", createdAt);
+            data.put("updatedAt", createdAt);
+            adapter.create(testCollection, data);
+        }
+    }
+
+    @Nested
     @DisplayName("Query Tests")
     class QueryTests {
         

--- a/kelta-worker/src/main/java/io/kelta/worker/service/CollectionLifecycleManager.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/service/CollectionLifecycleManager.java
@@ -72,7 +72,7 @@ public class CollectionLifecycleManager {
                    relationship_type, relationship_name, cascade_delete, field_order, column_name,
                    immutable, searchable, track_history
             FROM field WHERE collection_id = ? AND active = true
-            ORDER BY field_order
+            ORDER BY field_order, created_at, id
             """;
 
     private static final String SELECT_COLLECTION_NAME_BY_ID = """


### PR DESCRIPTION
## Summary
Root-cause fix for the two e2e failures on the main Build-and-Deploy run (object-detail dark-theme visual regression, related-list column order): **field order was nondeterministic**.

- `fieldOrder` is never auto-assigned, so API-created fields all carry NULL `field_order`. `CollectionLifecycleManager` ordered by `field_order` alone → NULL ties → the in-memory `CollectionDefinition` field order (record-detail cells, display-field auto-detect) changed run to run. The failing visual diff shows exactly this: SUMMARY rendered before TITLE and the record title picked up the summary value.
- `?include=fields` resolves through an **unsorted** query-engine call → arbitrary heap order fed the layout editor's column list (the related-list spec failed asserting natural order *before* any drag). Unsorted queries also paginate with LIMIT/OFFSET, which can skip/duplicate rows across pages without a stable order.

## Changes
- `PhysicalTableStorageAdapter.query`: unsorted queries fall back to `ORDER BY created_at, id` (verified: every adapter-served table has both columns; the six baseline tables lacking `created_at` are repository-owned, never adapter-served).
- `CollectionLifecycleManager`: field hydration orders by `field_order, created_at, id`.
- Regression test: inserts records out of creation order, asserts unsorted query returns creation order.

## Testing
- runtime-core: full suite green (real exit codes); worker `mvn verify` green.
- The two failing e2e specs should stabilize; they were passing-by-luck before (heap order frequently matches insertion order on fresh tables, which is why branch CI was green and the post-merge run wasn't).

🤖 Generated with [Claude Code](https://claude.com/claude-code)