### PR TITLE
fix(auth,ui): silent token refresh for the SPA public client

### DIFF
--- a/kelta-auth/CLAUDE.md
+++ b/kelta-auth/CLAUDE.md
@@ -28,6 +28,13 @@ io.kelta.auth/
 3. `KeltaUserDetailsService` loads user from worker via `WorkerClient`
 4. `KeltaTokenCustomizer` adds custom claims (tenantId, profileId, groups)
 5. Token issued and returned to client
+6. Silent refresh: the SPA (`kelta-platform`, public client, PKCE) refreshes with
+   `grant_type=refresh_token` + `client_id` only. Spring AS has no built-in
+   client-auth path for that request, so
+   `PublicClientRefreshTokenAuthenticationConverter`/`-Provider` (in `config/`)
+   authenticate it as method NONE; the refresh token is the credential and is
+   rotated on every use (`reuseRefreshTokens(false)`). Confidential clients that
+   omit their secret are rejected, never silently authenticated.
 
 ### Identity Brokering (SSO)
 - `DynamicClientRegistrationRepository` — loads OIDC provider configs from worker at runtime

--- a/kelta-auth/src/main/java/io/kelta/auth/config/AuthorizationServerConfig.java
+++ b/kelta-auth/src/main/java/io/kelta/auth/config/AuthorizationServerConfig.java
@@ -82,7 +82,8 @@ public class AuthorizationServerConfig {
     @Order(1)
     public SecurityFilterChain authorizationServerSecurityFilterChain(
             HttpSecurity http,
-            AuthDomainResolver authDomainResolver) throws Exception {
+            AuthDomainResolver authDomainResolver,
+            RegisteredClientRepository registeredClientRepository) throws Exception {
         // Configure OIDC on the configurer BEFORE capturing endpoint matchers,
         // so that OIDC discovery endpoints (/.well-known/openid-configuration)
         // are included in the security matcher for this chain.
@@ -90,6 +91,15 @@ public class AuthorizationServerConfig {
                 new OAuth2AuthorizationServerConfigurer();
         authorizationServerConfigurer
                 .oidc(Customizer.withDefaults())
+                // Spring AS has no built-in client-authentication path for public-client
+                // refresh_token requests (PublicClientAuthenticationConverter matches PKCE
+                // authorization_code only), so the SPA's silent refresh would 302 to the
+                // HTML login page. These custom converter/provider close that gap; the
+                // refresh token itself is the credential and is rotated on every use.
+                .clientAuthentication(clientAuth -> clientAuth
+                        .authenticationConverter(new PublicClientRefreshTokenAuthenticationConverter())
+                        .authenticationProvider(new PublicClientRefreshTokenAuthenticationProvider(
+                                registeredClientRepository)))
                 .authorizationEndpoint(endpoint -> endpoint
                         .consentPage("/oauth2/consent")
                         .authenticationProviders(configureRedirectUriValidator(authDomainResolver)));

--- a/kelta-auth/src/main/java/io/kelta/auth/config/PublicClientRefreshTokenAuthenticationConverter.java
+++ b/kelta-auth/src/main/java/io/kelta/auth/config/PublicClientRefreshTokenAuthenticationConverter.java
@@ -1,0 +1,71 @@
+package io.kelta.auth.config;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2ErrorCodes;
+import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
+import org.springframework.security.oauth2.server.authorization.authentication.OAuth2ClientAuthenticationToken;
+import org.springframework.security.web.authentication.AuthenticationConverter;
+import org.springframework.util.StringUtils;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Authenticates public clients (e.g. the platform SPA) on {@code grant_type=refresh_token}
+ * token requests.
+ *
+ * <p>Spring Authorization Server's built-in {@code PublicClientAuthenticationConverter}
+ * only matches PKCE {@code authorization_code} token requests, so a public client
+ * presenting a refresh token has no client-authentication path at all: the request
+ * falls through the client-auth filter unauthenticated and is redirected to the HTML
+ * login page. This converter closes that gap by producing an unauthenticated
+ * {@link OAuth2ClientAuthenticationToken} with method {@link ClientAuthenticationMethod#NONE}
+ * for refresh-token requests that carry a {@code client_id} and no client secret.
+ *
+ * <p>Requests that present any secret material (an {@code Authorization} header or a
+ * {@code client_secret} parameter) are left to the confidential-client converters, so
+ * connected apps and Superset are unaffected.
+ *
+ * @see PublicClientRefreshTokenAuthenticationProvider
+ */
+public final class PublicClientRefreshTokenAuthenticationConverter implements AuthenticationConverter {
+
+    @Override
+    public Authentication convert(HttpServletRequest request) {
+        if (!AuthorizationGrantType.REFRESH_TOKEN.getValue()
+                .equals(request.getParameter(OAuth2ParameterNames.GRANT_TYPE))) {
+            return null;
+        }
+        // Confidential clients authenticate with their secret — not our concern.
+        if (request.getHeader(HttpHeaders.AUTHORIZATION) != null
+                || request.getParameter(OAuth2ParameterNames.CLIENT_SECRET) != null) {
+            return null;
+        }
+
+        Map<String, String[]> parameterMap = request.getParameterMap();
+        String[] clientIdValues = parameterMap.get(OAuth2ParameterNames.CLIENT_ID);
+        if (clientIdValues == null || !StringUtils.hasText(clientIdValues[0])) {
+            return null;
+        }
+        if (clientIdValues.length != 1) {
+            throw new OAuth2AuthenticationException(OAuth2ErrorCodes.INVALID_REQUEST);
+        }
+        String clientId = clientIdValues[0];
+
+        Map<String, Object> additionalParameters = new HashMap<>();
+        parameterMap.forEach((key, values) -> {
+            if (!OAuth2ParameterNames.CLIENT_ID.equals(key)) {
+                additionalParameters.put(key, values.length == 1 ? values[0] : List.of(values));
+            }
+        });
+
+        return new OAuth2ClientAuthenticationToken(
+                clientId, ClientAuthenticationMethod.NONE, null, additionalParameters);
+    }
+}

--- a/kelta-auth/src/main/java/io/kelta/auth/config/PublicClientRefreshTokenAuthenticationProvider.java
+++ b/kelta-auth/src/main/java/io/kelta/auth/config/PublicClientRefreshTokenAuthenticationProvider.java
@@ -1,0 +1,87 @@
+package io.kelta.auth.config;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.OAuth2ErrorCodes;
+import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
+import org.springframework.security.oauth2.server.authorization.authentication.OAuth2ClientAuthenticationToken;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository;
+
+/**
+ * Completes client authentication for public-client refresh-token requests converted by
+ * {@link PublicClientRefreshTokenAuthenticationConverter}.
+ *
+ * <p>A public client has no secret to verify; the refresh token itself is the credential
+ * and is validated (and rotated — {@code reuseRefreshTokens(false)}) downstream by
+ * {@code OAuth2RefreshTokenAuthenticationProvider}. This provider therefore only verifies
+ * that the client exists, is registered as public ({@link ClientAuthenticationMethod#NONE}),
+ * and is allowed the {@code refresh_token} grant. Confidential clients that omit their
+ * secret are rejected here — never silently authenticated.
+ *
+ * <p>Returns {@code null} for anything that is not a public-client refresh-token request
+ * so the built-in providers (e.g. PKCE) keep handling their cases.
+ */
+public final class PublicClientRefreshTokenAuthenticationProvider implements AuthenticationProvider {
+
+    private static final Logger log =
+            LoggerFactory.getLogger(PublicClientRefreshTokenAuthenticationProvider.class);
+
+    private final RegisteredClientRepository registeredClientRepository;
+
+    public PublicClientRefreshTokenAuthenticationProvider(RegisteredClientRepository registeredClientRepository) {
+        this.registeredClientRepository = registeredClientRepository;
+    }
+
+    @Override
+    public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+        OAuth2ClientAuthenticationToken clientAuthentication =
+                (OAuth2ClientAuthenticationToken) authentication;
+
+        if (!ClientAuthenticationMethod.NONE.equals(clientAuthentication.getClientAuthenticationMethod())) {
+            return null;
+        }
+        Object grantType = clientAuthentication.getAdditionalParameters()
+                .get(OAuth2ParameterNames.GRANT_TYPE);
+        if (!AuthorizationGrantType.REFRESH_TOKEN.getValue().equals(grantType)) {
+            // PKCE authorization_code requests are handled by PublicClientAuthenticationProvider.
+            return null;
+        }
+
+        String clientId = clientAuthentication.getPrincipal().toString();
+        RegisteredClient registeredClient = this.registeredClientRepository.findByClientId(clientId);
+        if (registeredClient == null) {
+            throw invalidClient("client_id");
+        }
+        if (!registeredClient.getClientAuthenticationMethods().contains(ClientAuthenticationMethod.NONE)) {
+            // Confidential client attempting a secret-less refresh — reject.
+            log.debug("Rejected secret-less refresh_token request for confidential client '{}'", clientId);
+            throw invalidClient("authentication_method");
+        }
+        if (!registeredClient.getAuthorizationGrantTypes().contains(AuthorizationGrantType.REFRESH_TOKEN)) {
+            throw invalidClient("authorization_grant_type");
+        }
+
+        return new OAuth2ClientAuthenticationToken(
+                registeredClient, ClientAuthenticationMethod.NONE, null);
+    }
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return OAuth2ClientAuthenticationToken.class.isAssignableFrom(authentication);
+    }
+
+    private static OAuth2AuthenticationException invalidClient(String parameterName) {
+        OAuth2Error error = new OAuth2Error(OAuth2ErrorCodes.INVALID_CLIENT,
+                "Client authentication failed: " + parameterName,
+                "https://datatracker.ietf.org/doc/html/rfc6749#section-3.2.1");
+        return new OAuth2AuthenticationException(error);
+    }
+}

--- a/kelta-auth/src/test/java/io/kelta/auth/config/PublicClientRefreshTokenAuthenticationTest.java
+++ b/kelta-auth/src/test/java/io/kelta/auth/config/PublicClientRefreshTokenAuthenticationTest.java
@@ -1,0 +1,215 @@
+package io.kelta.auth.config;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.http.HttpHeaders;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2ErrorCodes;
+import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
+import org.springframework.security.oauth2.server.authorization.authentication.OAuth2ClientAuthenticationToken;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository;
+
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("Public-client refresh_token client authentication")
+class PublicClientRefreshTokenAuthenticationTest {
+
+    private static final String CLIENT_ID = "kelta-platform";
+
+    @Nested
+    @DisplayName("Converter")
+    class Converter {
+
+        private final PublicClientRefreshTokenAuthenticationConverter converter =
+                new PublicClientRefreshTokenAuthenticationConverter();
+
+        private MockHttpServletRequest refreshRequest() {
+            MockHttpServletRequest request = new MockHttpServletRequest("POST", "/oauth2/token");
+            request.setParameter(OAuth2ParameterNames.GRANT_TYPE,
+                    AuthorizationGrantType.REFRESH_TOKEN.getValue());
+            request.setParameter(OAuth2ParameterNames.CLIENT_ID, CLIENT_ID);
+            request.setParameter(OAuth2ParameterNames.REFRESH_TOKEN, "some-refresh-token");
+            return request;
+        }
+
+        @Test
+        @DisplayName("converts a secret-less refresh_token request to an unauthenticated NONE token")
+        void convertsRefreshRequest() {
+            var authentication = (OAuth2ClientAuthenticationToken) converter.convert(refreshRequest());
+
+            assertThat(authentication).isNotNull();
+            assertThat(authentication.getPrincipal()).isEqualTo(CLIENT_ID);
+            assertThat(authentication.getClientAuthenticationMethod())
+                    .isEqualTo(ClientAuthenticationMethod.NONE);
+            assertThat(authentication.getAdditionalParameters())
+                    .containsEntry(OAuth2ParameterNames.GRANT_TYPE,
+                            AuthorizationGrantType.REFRESH_TOKEN.getValue())
+                    .containsEntry(OAuth2ParameterNames.REFRESH_TOKEN, "some-refresh-token")
+                    .doesNotContainKey(OAuth2ParameterNames.CLIENT_ID);
+        }
+
+        @Test
+        @DisplayName("ignores non-refresh grant types")
+        void ignoresOtherGrantTypes() {
+            MockHttpServletRequest request = refreshRequest();
+            request.setParameter(OAuth2ParameterNames.GRANT_TYPE,
+                    AuthorizationGrantType.AUTHORIZATION_CODE.getValue());
+            assertThat(converter.convert(request)).isNull();
+        }
+
+        @Test
+        @DisplayName("ignores requests with an Authorization header (confidential client)")
+        void ignoresAuthorizationHeader() {
+            MockHttpServletRequest request = refreshRequest();
+            request.addHeader(HttpHeaders.AUTHORIZATION, "Basic Y2xpZW50OnNlY3JldA==");
+            assertThat(converter.convert(request)).isNull();
+        }
+
+        @Test
+        @DisplayName("ignores requests with a client_secret parameter (confidential client)")
+        void ignoresClientSecretParam() {
+            MockHttpServletRequest request = refreshRequest();
+            request.setParameter(OAuth2ParameterNames.CLIENT_SECRET, "s3cret");
+            assertThat(converter.convert(request)).isNull();
+        }
+
+        @Test
+        @DisplayName("ignores requests without client_id")
+        void ignoresMissingClientId() {
+            MockHttpServletRequest request = refreshRequest();
+            request.removeParameter(OAuth2ParameterNames.CLIENT_ID);
+            assertThat(converter.convert(request)).isNull();
+        }
+
+        @Test
+        @DisplayName("rejects duplicate client_id values")
+        void rejectsDuplicateClientId() {
+            MockHttpServletRequest request = refreshRequest();
+            request.setParameter(OAuth2ParameterNames.CLIENT_ID, CLIENT_ID, "other-client");
+            assertThatThrownBy(() -> converter.convert(request))
+                    .isInstanceOf(OAuth2AuthenticationException.class)
+                    .extracting(ex -> ((OAuth2AuthenticationException) ex).getError().getErrorCode())
+                    .isEqualTo(OAuth2ErrorCodes.INVALID_REQUEST);
+        }
+    }
+
+    @Nested
+    @DisplayName("Provider")
+    class Provider {
+
+        private RegisteredClientRepository repository;
+        private PublicClientRefreshTokenAuthenticationProvider provider;
+
+        @BeforeEach
+        void setUp() {
+            repository = Mockito.mock(RegisteredClientRepository.class);
+            provider = new PublicClientRefreshTokenAuthenticationProvider(repository);
+        }
+
+        private RegisteredClient publicClient() {
+            return RegisteredClient.withId(UUID.randomUUID().toString())
+                    .clientId(CLIENT_ID)
+                    .clientAuthenticationMethod(ClientAuthenticationMethod.NONE)
+                    .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+                    .authorizationGrantType(AuthorizationGrantType.REFRESH_TOKEN)
+                    .redirectUri("http://localhost:5173/auth/callback")
+                    .build();
+        }
+
+        private OAuth2ClientAuthenticationToken refreshAuthentication(String clientId) {
+            return new OAuth2ClientAuthenticationToken(clientId, ClientAuthenticationMethod.NONE, null,
+                    Map.of(OAuth2ParameterNames.GRANT_TYPE,
+                            AuthorizationGrantType.REFRESH_TOKEN.getValue()));
+        }
+
+        @Test
+        @DisplayName("authenticates a registered public client for the refresh grant")
+        void authenticatesPublicClient() {
+            Mockito.when(repository.findByClientId(CLIENT_ID)).thenReturn(publicClient());
+
+            var result = (OAuth2ClientAuthenticationToken) provider
+                    .authenticate(refreshAuthentication(CLIENT_ID));
+
+            assertThat(result).isNotNull();
+            assertThat(result.isAuthenticated()).isTrue();
+            assertThat(result.getRegisteredClient()).isNotNull();
+            assertThat(result.getRegisteredClient().getClientId()).isEqualTo(CLIENT_ID);
+            assertThat(result.getClientAuthenticationMethod()).isEqualTo(ClientAuthenticationMethod.NONE);
+        }
+
+        @Test
+        @DisplayName("passes through non-NONE client authentication methods")
+        void passesThroughConfidentialMethods() {
+            var authentication = new OAuth2ClientAuthenticationToken(CLIENT_ID,
+                    ClientAuthenticationMethod.CLIENT_SECRET_BASIC, "secret",
+                    Map.of(OAuth2ParameterNames.GRANT_TYPE,
+                            AuthorizationGrantType.REFRESH_TOKEN.getValue()));
+            assertThat(provider.authenticate(authentication)).isNull();
+        }
+
+        @Test
+        @DisplayName("passes through PKCE authorization_code requests to the built-in provider")
+        void passesThroughPkceRequests() {
+            var authentication = new OAuth2ClientAuthenticationToken(CLIENT_ID,
+                    ClientAuthenticationMethod.NONE, null,
+                    Map.of(OAuth2ParameterNames.GRANT_TYPE,
+                            AuthorizationGrantType.AUTHORIZATION_CODE.getValue(),
+                            OAuth2ParameterNames.CODE, "abc"));
+            assertThat(provider.authenticate(authentication)).isNull();
+        }
+
+        @Test
+        @DisplayName("rejects an unknown client_id")
+        void rejectsUnknownClient() {
+            Mockito.when(repository.findByClientId("nope")).thenReturn(null);
+            assertInvalidClient(refreshAuthentication("nope"));
+        }
+
+        @Test
+        @DisplayName("rejects a confidential client attempting a secret-less refresh")
+        void rejectsConfidentialClientWithoutSecret() {
+            RegisteredClient confidential = RegisteredClient.withId(UUID.randomUUID().toString())
+                    .clientId("superset")
+                    .clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_BASIC)
+                    .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+                    .authorizationGrantType(AuthorizationGrantType.REFRESH_TOKEN)
+                    .redirectUri("https://superset.example.com/callback")
+                    .build();
+            Mockito.when(repository.findByClientId("superset")).thenReturn(confidential);
+
+            assertInvalidClient(refreshAuthentication("superset"));
+        }
+
+        @Test
+        @DisplayName("rejects a public client without the refresh_token grant")
+        void rejectsClientWithoutRefreshGrant() {
+            RegisteredClient noRefresh = RegisteredClient.withId(UUID.randomUUID().toString())
+                    .clientId(CLIENT_ID)
+                    .clientAuthenticationMethod(ClientAuthenticationMethod.NONE)
+                    .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+                    .redirectUri("http://localhost:5173/auth/callback")
+                    .build();
+            Mockito.when(repository.findByClientId(CLIENT_ID)).thenReturn(noRefresh);
+
+            assertInvalidClient(refreshAuthentication(CLIENT_ID));
+        }
+
+        private void assertInvalidClient(OAuth2ClientAuthenticationToken authentication) {
+            assertThatThrownBy(() -> provider.authenticate(authentication))
+                    .isInstanceOf(OAuth2AuthenticationException.class)
+                    .extracting(ex -> ((OAuth2AuthenticationException) ex).getError().getErrorCode())
+                    .isEqualTo(OAuth2ErrorCodes.INVALID_CLIENT);
+        }
+    }
+}

--- a/kelta-ui/app/src/context/AuthContext.test.tsx
+++ b/kelta-ui/app/src/context/AuthContext.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { act, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { AuthProvider, useAuth } from './AuthContext'
 import { clearBootstrapCache } from '../utils/bootstrapCache'
@@ -572,6 +572,92 @@ describe('AuthContext', () => {
       // Stored PROVIDER_ID is the internal provider so refresh and callback
       // always target kelta-auth, never the external IdP.
       expect(mockSessionStorage['kelta_auth_provider_id']).toBe('internal-1')
+    })
+  })
+
+  describe('Proactive Refresh (Requirement 2.4)', () => {
+    const tokenEndpointCalls = () =>
+      (global.fetch as ReturnType<typeof vi.fn>).mock.calls.filter(
+        ([input]) => String(input) === mockDiscoveryDoc.token_endpoint
+      ).length
+
+    function storeValidTokens(expiresInMs: number) {
+      const payload = {
+        sub: 'user-123',
+        email: 'test@example.com',
+        exp: Math.floor((Date.now() + expiresInMs) / 1000),
+      }
+      const mockToken = createMockJwt(payload)
+      mockSessionStorage['kelta_auth_tokens'] = JSON.stringify({
+        accessToken: mockToken,
+        idToken: mockToken,
+        refreshToken: 'stored-refresh-token',
+        expiresAt: Date.now() + expiresInMs,
+      })
+    }
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('retries after a failed proactive refresh instead of abandoning the session', async () => {
+      vi.useFakeTimers()
+      storeValidTokens(5 * 60 * 1000) // expires in 5 minutes
+
+      // Token endpoint fails with a network error (transient)
+      const baseFetch = createMockFetch()
+      global.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        if (String(input) === mockDiscoveryDoc.token_endpoint) {
+          throw new Error('network down')
+        }
+        return baseFetch(input, init)
+      }) as typeof fetch
+
+      renderWithAuth()
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0)
+      })
+      expect(screen.getByTestId('authenticated')).toHaveTextContent('authenticated')
+
+      // Advance past the refresh point (expiry - 60s): first attempt fails
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(4 * 60 * 1000 + 1000)
+      })
+      expect(tokenEndpointCalls()).toBe(1)
+
+      // A retry is scheduled after the failure cooldown
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(31 * 1000)
+      })
+      expect(tokenEndpointCalls()).toBe(2)
+
+      // Transient failure must not discard the refresh token
+      const stored = JSON.parse(mockSessionStorage['kelta_auth_tokens'])
+      expect(stored.refreshToken).toBe('stored-refresh-token')
+    })
+
+    it('refreshes immediately when the tab wakes inside the expiry window', async () => {
+      vi.useFakeTimers()
+      storeValidTokens(5 * 60 * 1000)
+
+      renderWithAuth()
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0)
+      })
+      expect(screen.getByTestId('authenticated')).toHaveTextContent('authenticated')
+      expect(tokenEndpointCalls()).toBe(0)
+
+      // Simulate a long sleep: wall clock jumps past expiry without timers firing
+      vi.setSystemTime(Date.now() + 60 * 60 * 1000)
+
+      await act(async () => {
+        document.dispatchEvent(new Event('visibilitychange'))
+        await vi.advanceTimersByTimeAsync(0)
+      })
+
+      expect(tokenEndpointCalls()).toBe(1)
+      const stored = JSON.parse(mockSessionStorage['kelta_auth_tokens'])
+      expect(stored.accessToken).toBe('new-access-token')
     })
   })
 

--- a/kelta-ui/app/src/context/AuthContext.tsx
+++ b/kelta-ui/app/src/context/AuthContext.tsx
@@ -366,14 +366,23 @@ export function AuthProvider({
 
     refreshTimerRef.current = setTimeout(async () => {
       refreshTimerRef.current = null
+      let refreshed: StoredTokens | null = null
       try {
-        const refreshed = await refreshAccessToken()
-        if (refreshed) {
-          // Schedule the next refresh after this one succeeds
-          scheduleTokenRefresh()
-        }
+        refreshed = await refreshAccessToken()
       } catch (err) {
         console.warn('[Auth] Proactive token refresh failed:', err)
+      }
+      if (refreshed) {
+        // Schedule the next refresh after this one succeeds
+        scheduleTokenRefresh()
+      } else if (getStoredTokens()?.refreshToken) {
+        // Transient failure (network blip, cooldown) but the refresh token is
+        // still there — retry after the cooldown instead of abandoning the
+        // session to die at token expiry.
+        refreshTimerRef.current = setTimeout(() => {
+          refreshTimerRef.current = null
+          scheduleTokenRefresh()
+        }, REFRESH_FAILURE_COOLDOWN_MS)
       }
     }, delay)
   }, [refreshAccessToken])
@@ -814,6 +823,29 @@ export function AuthProvider({
       }
     }
   }, [isAuthenticated, scheduleTokenRefresh])
+
+  /**
+   * Browsers throttle or suspend timers in background tabs and across machine
+   * sleep, so the proactive timer can fire long after the token expired. When
+   * the tab becomes visible again, refresh immediately if we're inside the
+   * expiry window and re-arm the timer.
+   */
+  useEffect(() => {
+    if (!isAuthenticated) return
+    const onVisibilityChange = () => {
+      if (document.visibilityState !== 'visible') return
+      const tokens = getStoredTokens()
+      if (tokens?.refreshToken && isTokenExpired(tokens.expiresAt)) {
+        refreshAccessToken()
+          .then((refreshed) => {
+            if (refreshed) scheduleTokenRefresh()
+          })
+          .catch((err) => console.warn('[Auth] Refresh on tab wake failed:', err))
+      }
+    }
+    document.addEventListener('visibilitychange', onVisibilityChange)
+    return () => document.removeEventListener('visibilitychange', onVisibilityChange)
+  }, [isAuthenticated, refreshAccessToken, scheduleTokenRefresh])
 
   // Memoize context value to prevent unnecessary re-renders
   const contextValue = useMemo<AuthContextValue>(


### PR DESCRIPTION
## Problem

Leave the UI idle past the access-token TTL (8h) and it logs you out, even though it holds a refresh token and schedules a proactive refresh.

## Root cause

Spring Authorization Server has **no client-authentication path for `grant_type=refresh_token` from a public client**. Its `PublicClientAuthenticationConverter` only matches PKCE `authorization_code` token requests (verified in SAS 7.0.4 bytecode: default converter chain is JwtAssertion / SecretBasic / SecretPost / PublicClient(PKCE-only) / X509). The SPA's refresh POST (`client_id` only, no secret) matches nothing, falls through the client-auth filter unauthenticated, and gets 302-redirected to the HTML login page.

Confirmed against the live server:

```
POST /oauth2/token grant_type=refresh_token&client_id=kelta-platform → 302 /login
POST /oauth2/token grant_type=authorization_code&...&code_verifier=x → 400 {"error":"invalid_grant"}  (client auth OK)
```

So silent refresh has never worked: the UI's `fetch` follows the redirect, gets 200 HTML, `response.json()` throws, refresh returns null, and the session dies at token expiry.

## Fix

**kelta-auth** — `PublicClientRefreshTokenAuthenticationConverter` + `-Provider`, wired via `clientAuthentication` on the authorization-server configurer (custom converters/providers are prepended to the defaults):

- Converter matches only `grant_type=refresh_token` with a `client_id` and **no** secret material (no `Authorization` header, no `client_secret` param) — confidential clients (Superset, connected apps) keep their existing secret-verified path.
- Provider verifies the registered client exists, is registered as public (`ClientAuthenticationMethod.NONE`), and is allowed the `refresh_token` grant; otherwise `invalid_client`. A confidential client omitting its secret is rejected, never silently authenticated.
- The refresh token itself is the credential, validated and **rotated on every use** downstream (`reuseRefreshTokens(false)` already set — OAuth 2.1 pattern for public clients). PKCE requests pass through untouched to the built-in provider.

**kelta-ui** — two hardening fixes in `AuthContext`:

- Proactive refresh now retries after the 30s failure cooldown instead of permanently giving up after one transient failure.
- A `visibilitychange` handler refreshes immediately when the tab wakes inside the expiry window (background-tab timer throttling / machine sleep would otherwise delay the timer past expiry).

## Tests

- kelta-auth: 12 new unit tests (converter matching/skip rules, provider accept/reject incl. confidential-client-without-secret and missing-refresh-grant). Full suite 252 green.
- kelta-ui: 2 new AuthContext tests (retry-after-failed-proactive-refresh with fake timers; tab-wake refresh after simulated sleep). Suite 2654 green.
- /verify fully green (runtime, gateway, worker, kelta-web, kelta-ui).

## Notes

- **No auto-merge** — auth/security change per SECURITY.md.
- Docs: kelta-auth/CLAUDE.md OAuth2 Flow section updated in this PR.
- Deploy note: kelta-auth runs on JVM (no native reflect-config concern); no migration, no NATS changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)