### PR TITLE
feat(mcp): send orienting instructions on MCP server initialize

### DIFF
--- a/kelta-mcp/CLAUDE.md
+++ b/kelta-mcp/CLAUDE.md
@@ -73,6 +73,14 @@ MCP content, and maps gateway 4xx/5xx via `McpErrorMapper`. Translate friendly c
 args → native JSON:API at this boundary (see `.claude/docs/conventions.md`). Full recipe:
 `.claude/docs/playbooks.md` → "Add an MCP tool".
 
+### Server instructions
+Each server's `.instructions(...)` call in `McpServerConfig` (`USER_INSTRUCTIONS` /
+`ADMIN_INSTRUCTIONS`) is sent once, in the `initialize` response, before any tool call —
+it's the front door that orients a client (discovery order, filter/formula gotchas, build
+order for admin) instead of making it reconstruct the operating model tool-by-tool every
+session. **Update it in the same PR** whenever a tool is added, removed, renamed, or its
+documented behavior changes in a way that affects the recommended usage order.
+
 ### No DB
 kelta-mcp is stateless. The runtime-core auto-configurations (`KeltaRuntimeAutoConfiguration`, `EncryptionAutoConfiguration`) are excluded in `McpApplication`. Component scan is restricted to `io.kelta.mcp` so we only depend on runtime-core for type definitions (CollectionDefinition, FieldDefinition, FieldType).
 

--- a/kelta-mcp/src/main/java/io/kelta/mcp/config/McpServerConfig.java
+++ b/kelta-mcp/src/main/java/io/kelta/mcp/config/McpServerConfig.java
@@ -58,6 +58,74 @@ public class McpServerConfig {
     private static final String SERVER_NAME = "kelta-mcp";
     private static final String SERVER_VERSION = "1.0.0";
 
+    /**
+     * Sent once, in the {@code initialize} response, before any tool call —
+     * the one place a client (or a human reading the connection handshake)
+     * gets oriented instead of reconstructing the operating model tool-by-tool
+     * every session. Keep this in sync with the tool surface: update it in
+     * the same PR that adds/removes/renames a tool. See kelta-mcp/CLAUDE.md.
+     */
+    private static final String USER_INSTRUCTIONS = """
+            Kelta data-plane MCP server: CRUD records, run flows, approvals, and search \
+            over the current tenant's collections.
+
+            Discovery order: list_collections -> get_collection_schema (field names + \
+            types for one collection) -> query_collection / get_record.
+
+            Reading: query_collection lists/filters (ops: EQ NEQ GT GTE LT LTE CONTAINS \
+            STARTS ENDS ICONTAINS ISTARTS IENDS IEQ ISNULL; fields AND together, NO OR — \
+            run multiple queries and union client-side for OR/IN). get_record fetches one \
+            row by id. search is keyword full-text; semantic_search is vector/meaning-based. \
+            describe_api returns the full OpenAPI 3.0 spec for exact request/response shapes, \
+            but only covers plain collection CRUD — flows, approvals, and bulk are NOT in it; \
+            use the dedicated tools below for those.
+
+            Writing: create_record / update_record / delete_record / bulk_apply. Check each \
+            tool's annotations (readOnlyHint / destructiveHint / idempotentHint) before \
+            assuming a call is safe to retry — destructive writes are flagged so a caller \
+            can confirm before running them.
+
+            Automation: execute_flow starts a flow asynchronously (not idempotent — each \
+            call starts a new run); poll get_flow_run with the returned execution id for \
+            status. submit_for_approval / list_approvals drive approval-gated records.
+
+            Conventions: tool arguments are friendly camelCase; the tool boundary translates \
+            them into the platform's native JSON:API shape (kebab-case collection/attribute \
+            names on the wire) — pass names as given in list_collections / \
+            get_collection_schema, don't pre-convert casing yourself.""";
+
+    private static final String ADMIN_INSTRUCTIONS = """
+            Kelta control-plane MCP server: define collections, fields, layouts, flows, \
+            picklists, and validation rules for the current tenant.
+
+            Typical build order for a new object: create_collection (optionally with an \
+            inline initial field set) -> add_field (repeat per additional field) -> \
+            create_validation_rule / create_unique_constraint as needed -> for picklist \
+            fields, create_picklist + add_picklist_value first, then reference it from \
+            add_field via picklistSourceId -> create_layout / create_listview for the admin \
+            UI -> create_flow for automation. update_/delete_ counterparts exist for every \
+            create_ tool.
+
+            Field types: add_field's `type` argument accepts friendly aliases (text, number, \
+            picklist, reference, ...) that map onto the native uppercase FieldType enum — see \
+            that tool's own description for the full alias table. Every uppercase enum name is \
+            also accepted verbatim.
+
+            Validation rules: create_validation_rule's errorConditionFormula is an ERROR \
+            condition — the record is REJECTED when it evaluates TRUE (not a must-hold \
+            condition). Read the tool description before writing a formula; getting this \
+            backwards silently inverts the rule.
+
+            Shared read tools (also callable from /mcp/user): list_collections, \
+            get_collection_schema — use these to look up ids/names before a create_/update_ \
+            call rather than guessing.
+
+            Bringing in external data: import_api_spec + materialize_api_collection wire up \
+            an API-backed collection from an OpenAPI spec.
+
+            Every mutating tool declares destructiveHint / idempotentHint in its annotations \
+            — check them before retrying a failed call or assuming a create_ is safe to repeat.""";
+
     @Bean(name = "userTransportProvider")
     public HttpServletStatelessServerTransportProvider userTransportProvider() {
         return new HttpServletStatelessServerTransportProvider(
@@ -82,6 +150,7 @@ public class McpServerConfig {
             PatPropagatingToolDecorator patPropagator) {
         McpStatelessSyncServer server = McpServer.sync(transport)
                 .serverInfo(SERVER_NAME + "-user", SERVER_VERSION)
+                .instructions(USER_INSTRUCTIONS)
                 .capabilities(ServerCapabilities.builder()
                         .tools(true)
                         .resources(false, false)  // (subscribe, listChanged): both off in stateless
@@ -117,6 +186,7 @@ public class McpServerConfig {
             PatPropagatingToolDecorator patPropagator) {
         McpStatelessSyncServer server = McpServer.sync(transport)
                 .serverInfo(SERVER_NAME + "-admin", SERVER_VERSION)
+                .instructions(ADMIN_INSTRUCTIONS)
                 .capabilities(ServerCapabilities.builder().tools(true).build())
                 .build();
         server.addTool(wrap(pingTool("admin"), "admin", decorator, rateLimiter, patPropagator));

--- a/kelta-mcp/src/test/java/io/kelta/mcp/McpApplicationTest.java
+++ b/kelta-mcp/src/test/java/io/kelta/mcp/McpApplicationTest.java
@@ -4,6 +4,7 @@ import io.kelta.mcp.resource.UserResource;
 import io.kelta.mcp.resource.UserResourceTemplate;
 import io.kelta.mcp.tool.AdminTool;
 import io.kelta.mcp.tool.UserTool;
+import io.kelta.mcp.transport.HttpServletStatelessServerTransportProvider;
 import io.kelta.mcp.transport.KeltaMcpController;
 import io.modelcontextprotocol.server.McpStatelessSyncServer;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
@@ -12,6 +13,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.context.TestPropertySource;
 
 import java.util.List;
@@ -53,6 +56,14 @@ class McpApplicationTest {
 
     @Autowired
     private List<AdminTool> adminTools;
+
+    @Autowired
+    @Qualifier("userTransportProvider")
+    private HttpServletStatelessServerTransportProvider userTransport;
+
+    @Autowired
+    @Qualifier("adminTransportProvider")
+    private HttpServletStatelessServerTransportProvider adminTransport;
 
     @Test
     void bothMcpServersAreWired() {
@@ -235,6 +246,41 @@ class McpApplicationTest {
             assertThat(t.annotations().readOnlyHint()).as("%s readOnlyHint=false", t.name()).isFalse();
             assertThat(t.annotations().destructiveHint()).as("%s destructiveHint=true", t.name()).isTrue();
         }
+    }
+
+    @Test
+    void userServerSendsOrientingInstructionsOnInitialize() throws Exception {
+        // The `instructions` field of the initialize response is the one
+        // place a client is oriented before making any tool call — assert
+        // it's actually populated (not left as the SDK default of null/blank)
+        // and mentions the discovery path a fresh client needs.
+        MockHttpServletResponse res = initialize(userTransport, "/threadline-clothing/mcp/user");
+        assertThat(res.getStatus()).isEqualTo(200);
+        String body = res.getContentAsString();
+        assertThat(body).contains("list_collections").contains("get_collection_schema");
+    }
+
+    @Test
+    void adminServerSendsOrientingInstructionsOnInitialize() throws Exception {
+        MockHttpServletResponse res = initialize(adminTransport, "/threadline-clothing/mcp/admin");
+        assertThat(res.getStatus()).isEqualTo(200);
+        String body = res.getContentAsString();
+        assertThat(body).contains("create_collection").contains("add_field");
+    }
+
+    private static MockHttpServletResponse initialize(
+            HttpServletStatelessServerTransportProvider transport, String path) throws Exception {
+        MockHttpServletRequest req = new MockHttpServletRequest("POST", path);
+        req.addHeader("Content-Type", "application/json");
+        req.setContent("""
+                {"jsonrpc":"2.0","id":1,"method":"initialize","params":{
+                  "protocolVersion":"2025-11-25",
+                  "capabilities":{},
+                  "clientInfo":{"name":"test-client","version":"1.0"}
+                }}""".getBytes());
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        transport.service(req, res);
+        return res;
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Both the user (`/mcp/user`) and admin (`/mcp/admin`) MCP servers built via `McpServer.sync(...)` never called `.instructions(...)`, so the `initialize` response had no orientation text — a client had to reconstruct the operating model (discovery order, filter/formula gotchas, admin build order) tool-by-tool, every session.
- Adds `USER_INSTRUCTIONS` and `ADMIN_INSTRUCTIONS` in `McpServerConfig`, covering: discovery path (`list_collections` → `get_collection_schema` → `query_collection`/`get_record`), key gotchas already documented on individual tools (validation-rule formula polarity, `query_collection`'s operator set and no-OR limitation, camelCase-to-JSON:API translation at the tool boundary), and the typical admin build order (`create_collection` → `add_field` → validation/picklist → `create_layout`/`create_listview` → `create_flow`).
- Individual tool descriptions were already thorough (not the gap) — this fixes the missing "front door" that orients a client before its first tool call.
- Updated `kelta-mcp/CLAUDE.md` with a note to keep the instructions text in sync with the tool surface going forward.

## Test plan
- [x] `mvn test -f kelta-mcp/pom.xml` — 221/221 pass
- [x] New tests in `McpApplicationTest` drive a real `initialize` JSON-RPC handshake through each transport and assert the response carries the orienting text
- [ ] Manual: connect a Claude Code session to the local MCP server and confirm the instructions surface in the client

🤖 Generated with [Claude Code](https://claude.com/claude-code)