### PR TITLE
feat(ai): guard against unbounded AI chat conversation growth

### DIFF
--- a/docs/superpowers/specs/2026-07-27-ai-chat-length-guard-design.md
+++ b/docs/superpowers/specs/2026-07-27-ai-chat-length-guard-design.md
@@ -1,0 +1,109 @@
+# AI chat conversation-length guard
+
+2026-07-27
+
+## Problem
+
+`ChatService.buildMessageHistory` reloads a conversation's *entire* message
+history from the DB and resends it to Claude on every turn, with no cap. A
+long-lived conversation thread (same `conversationId`, resumed over many
+sessions) grows unbounded until a turn's input exceeds the model's context
+window. At that point Anthropic's API rejects the request outright (a clean
+400 `invalid_request_error` — the model never runs, never sees the request).
+
+Today that failure surfaces cleanly on the streaming path (`chatStream`
+already catches all exceptions and emits an `error` SSE event) but not on the
+non-streaming path (`chat()` has no error handling at all, so it would 500
+raw). Either way, once a thread crosses the line, it's dead — no recovery, no
+guidance to the user.
+
+This is not a rare pathological case: tool results (schema dumps, sampled
+records) accumulate across a session on top of normal chat text, and a single
+productive builder session can plausibly approach the limit well before
+"hundreds of messages."
+
+## Non-goals
+
+Full automatic compaction (summarize-and-continue *within* the same thread,
+threading the summary back into every future turn via the system prompt) was
+considered and explicitly deferred — real cost/complexity (new `Conversation`
+columns, a compaction marker, rewritten history-loading), open-ended benefit.
+This spec covers a smaller, contained stopgap instead: detect the danger,
+stop before it becomes a hard failure, and hand the user a summary to carry
+into a fresh conversation manually. No schema migration, no change to how any
+other turn is built or threaded.
+
+## Design
+
+**Threshold.** Default model is `claude-sonnet-5` (200,000-token context
+window); `default-max-tokens` is 32,768 and Anthropic reserves that full
+budget against the context window on every call, so the real ceiling for
+input is ~167,000 tokens. Guard threshold: **160,000 tokens** — close enough
+to avoid tripping while there's still real room (per-turn growth is normally
+small; tool results are already size-capped), far enough to leave margin
+before the actual wall.
+
+**Signal.** No new token-counting logic needed. `ChatMessage.tokensInput()`
+already stores the exact input-token count Anthropic reported for that turn —
+i.e., the true size of history + system prompt actually sent. New repository
+method `ChatMessageRepository.findMostRecentAssistantTokensInput(conversationId,
+tenantId)` returns the most recent assistant message's `tokensInput` (0 if
+none). `ChatService.isConversationTooLarge(...)` compares it to the
+threshold.
+
+**Check placement.** In both `chat()` and `chatStream()`, immediately after
+`buildMessageHistory` and *before* `SystemPromptService.buildSystemPrompt`
+(which makes a live schema-fetch call to the worker — skip it entirely on the
+guard-trip path, nothing to save it for). Cost when it doesn't trip: one
+`int` comparison against data already loaded for other reasons — no new I/O,
+no new network call. Cost is zero on the common path.
+
+**On trip:** one extra non-streaming Anthropic call, prompted specifically
+for a structured handoff summary (not generic narrative):
+
+> Summarize this conversation for someone continuing it in a new session.
+> Cover, briefly: (1) what collections/fields/objects were discussed,
+> created, or proposed, (2) decisions made and why, (3) any stated
+> preferences or constraints ("don't do X", "always Y"), (4) open questions
+> or unfinished next steps. Be concise — this is a handoff note, not a
+> transcript.
+
+The reply sent to the user is `<summary>` + a fixed redirect line telling
+them to start a new conversation and paste the summary in if they want
+continuity. This is persisted as a normal assistant `ChatMessage` (no new
+columns, no special role) and returned/streamed exactly like any other
+assistant turn — `chat()` returns it in the normal response shape (plus a
+`conversationTooLarge: true` flag); `chatStream()` emits it as a single
+`delta` event (matching `StreamAssembler`'s existing event shape,
+`{"text": ...}`) followed by `done` (also flagged).
+
+**Failure inside the guard itself.** If the summarization call errors, catch
+it and fall back to the plain redirect line with no summary — the guard's
+core job (never let the turn hard-fail) holds regardless of whether the
+extra call succeeds. No new tokens are recorded to `TokenTrackingService` in
+that case.
+
+**Separately: non-streaming error handling.** `chat()` gets the same
+try/catch shape `chatStream()` already has, wrapping the tool-loop call and
+translating any Anthropic API exception into a clean
+`{"error": {"code": "AI_PROVIDER_ERROR", "message": ...}}` result instead of
+an unhandled 500. Small, independent, closes an existing asymmetry between
+the two entry points.
+
+## Testing
+
+- `ChatMessageRepositoryTest`: new test for
+  `findMostRecentAssistantTokensInput` (found row / no rows).
+- `ChatServiceTest` (new — none existed before): guard trips above threshold
+  and skips the tool loop entirely; guard does not trip at/under threshold;
+  summarization failure falls back to the plain redirect with zero recorded
+  tokens; non-streaming `chat()` returns a clean error map instead of
+  throwing on an Anthropic exception.
+
+## Out of scope / later
+
+- Full automatic compaction (see Non-goals).
+- Surfacing a live "context used" indicator in the AiChat UI.
+- Governed agent runs (`AgentRuntimeService`) are already bounded per-run
+  (8 iterations / 100k tokens) and are not a growing conversation — untouched
+  here.

--- a/kelta-ai/CLAUDE.md
+++ b/kelta-ai/CLAUDE.md
@@ -42,8 +42,10 @@ public SseEmitter chatStream(@RequestHeader("X-Tenant-ID") String tenantId, ...)
 ### Anthropic API Integration
 - `AnthropicService` wraps the `anthropic-java` SDK
 - Model configurable via `AiConfigProperties` — see `kelta-platform/pom.xml` for the current default model ID
-- Rate limit errors (429) retried with exponential backoff
 - Context built via `SystemPromptService` using schema from `WorkerApiClient`
+
+### Conversation-length guard
+`ChatService.buildMessageHistory` resends a conversation's *entire* message history every turn — unbounded, since a thread can be resumed indefinitely. Before that (and before the schema-fetching `SystemPromptService.buildSystemPrompt` call), both `chat()` and `chatStream()` check `isConversationTooLarge` — the most recent assistant message's recorded `tokensInput` against `MAX_CONVERSATION_INPUT_TOKENS` (160k; claude-sonnet-5's 200k window minus the reserved max-tokens budget, with margin). If tripped, one extra non-streaming call asks Claude for a structured handoff summary, which is returned/streamed to the user with a message to start a new conversation — no schema change, no automatic compaction of the thread itself. See `docs/superpowers/specs/2026-07-27-ai-chat-length-guard-design.md`.
 
 ### Config Properties
 ```java
@@ -56,8 +58,8 @@ public record AiConfigProperties(
 ```
 
 ### Error Handling
-- Anthropic 429 → exponential backoff retry
-- Map SDK errors to HTTP status codes
+- No retry/backoff around Anthropic calls — a 429/5xx/context-length error surfaces to the caller on that turn
+- `ChatService.chat()` and `chatStream()` both catch any exception from the tool loop and return/emit a clean `{"code": "AI_PROVIDER_ERROR", "message": ...}` shape instead of letting it propagate as a raw 500 — `chatStream()` as an `error` SSE event, `chat()` as an `error` key in the response map
 - No custom exception classes — uses standard Spring exceptions
 
 ## When Adding a New Endpoint

--- a/kelta-ai/src/main/java/io/kelta/ai/repository/ChatMessageRepository.java
+++ b/kelta-ai/src/main/java/io/kelta/ai/repository/ChatMessageRepository.java
@@ -58,6 +58,26 @@ public class ChatMessageRepository {
                 this::mapRow, conversationId, tenantId);
     }
 
+    /**
+     * The most recent assistant turn's recorded input-token count — i.e. the
+     * true size of history + system prompt actually sent to Anthropic on
+     * that turn. Used as a cheap proxy for "how big is this conversation
+     * right now" without any new token-counting logic. Returns 0 if the
+     * conversation has no assistant turns yet.
+     */
+    public int findMostRecentAssistantTokensInput(UUID conversationId, String tenantId) {
+        List<Integer> result = jdbc.query(
+                """
+                SELECT tokens_input FROM ai_message
+                 WHERE conversation_id = ? AND tenant_id = ? AND role = 'assistant'
+                 ORDER BY created_at DESC
+                 LIMIT 1
+                """,
+                (rs, rowNum) -> rs.getInt("tokens_input"),
+                conversationId, tenantId);
+        return result.isEmpty() ? 0 : result.getFirst();
+    }
+
     public Optional<ChatMessage> findById(UUID id, String tenantId) {
         List<ChatMessage> results = jdbc.query(
                 "SELECT * FROM ai_message WHERE id = ? AND tenant_id = ?",

--- a/kelta-ai/src/main/java/io/kelta/ai/service/ChatService.java
+++ b/kelta-ai/src/main/java/io/kelta/ai/service/ChatService.java
@@ -23,6 +23,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * Orchestrates the AI chat flow: builds context, drives Anthropic's multi-turn
@@ -35,6 +36,29 @@ public class ChatService {
     private static final Logger log = LoggerFactory.getLogger(ChatService.class);
     private static final int MAX_TOOL_ITERATIONS = 8;
     private static final long TOKEN_BUDGET = 100_000L;
+
+    /**
+     * Guard against unbounded conversation-history growth (see
+     * docs/superpowers/specs/2026-07-27-ai-chat-length-guard-design.md).
+     * claude-sonnet-5's context window is 200k tokens and Anthropic reserves
+     * the full requested max-tokens budget (32,768 default) against it on
+     * every call, so the real ceiling is ~167k input tokens. This threshold
+     * leaves enough margin to trip before that wall without firing while
+     * there's still real room left.
+     */
+    private static final int MAX_CONVERSATION_INPUT_TOKENS = 160_000;
+
+    private static final String LENGTH_GUARD_SUMMARY_PROMPT = """
+            Summarize this conversation for someone continuing it in a new session. Cover, briefly:
+            (1) what collections/fields/objects were discussed, created, or proposed,
+            (2) decisions made and why,
+            (3) any stated preferences or constraints ("don't do X", "always Y"),
+            (4) open questions or unfinished next steps.
+            Be concise — this is a handoff note, not a transcript.""";
+
+    private static final String LENGTH_GUARD_REDIRECT =
+            "This conversation has gotten long enough that I can't reliably keep working in it. "
+            + "Start a new conversation and paste the summary above if you'd like me to pick up where we left off.";
 
     private final AnthropicService anthropicService;
     private final SystemPromptService systemPromptService;
@@ -68,15 +92,30 @@ public class ChatService {
         Conversation conversation = getOrCreateConversation(tenantId, userId, conversationId, userMessage);
         messageRepository.save(ChatMessage.user(tenantId, conversation.id(), userMessage));
 
-        String systemPrompt = systemPromptService.buildSystemPrompt(tenantId, contextType, contextId);
         List<MessageParam> conversationParams = new ArrayList<>(buildMessageHistory(conversation.id(), tenantId));
 
+        if (isConversationTooLarge(conversation.id(), tenantId)) {
+            LengthGuardReply guard = buildLengthGuardReply(tenantId, conversationParams);
+            return persistLengthGuardReply(tenantId, conversation, guard);
+        }
+
+        String systemPrompt = systemPromptService.buildSystemPrompt(tenantId, contextType, contextId);
         List<AiProposal> proposals = new ArrayList<>();
         int[] tokenCounts = {0, 0};
         StringBuilder lastText = new StringBuilder();
 
-        runSyncToolLoop(tenantId, userId, conversation, systemPrompt, conversationParams,
-                proposals, tokenCounts, lastText);
+        try {
+            runSyncToolLoop(tenantId, userId, conversation, systemPrompt, conversationParams,
+                    proposals, tokenCounts, lastText);
+        } catch (Exception e) {
+            log.error("Error in chat: {}", e.getMessage(), e);
+            Map<String, Object> errorResult = new LinkedHashMap<>();
+            errorResult.put("conversationId", conversation.id().toString());
+            errorResult.put("error", Map.of(
+                    "code", "AI_PROVIDER_ERROR",
+                    "message", e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName()));
+            return errorResult;
+        }
 
         conversationRepository.updateTimestamp(conversation.id(), tenantId);
 
@@ -95,9 +134,15 @@ public class ChatService {
             Conversation conversation = getOrCreateConversation(tenantId, userId, conversationId, userMessage);
             messageRepository.save(ChatMessage.user(tenantId, conversation.id(), userMessage));
 
-            String systemPrompt = systemPromptService.buildSystemPrompt(tenantId, contextType, contextId);
             List<MessageParam> conversationParams = new ArrayList<>(buildMessageHistory(conversation.id(), tenantId));
 
+            if (isConversationTooLarge(conversation.id(), tenantId)) {
+                LengthGuardReply guard = buildLengthGuardReply(tenantId, conversationParams);
+                streamLengthGuardReply(tenantId, conversation, guard, emitter);
+                return;
+            }
+
+            String systemPrompt = systemPromptService.buildSystemPrompt(tenantId, contextType, contextId);
             List<AiProposal> proposals = new ArrayList<>();
             int[] tokenCounts = {0, 0};
 
@@ -128,6 +173,90 @@ public class ChatService {
             }
             emitter.complete();
         }
+    }
+
+    // =========================================================================
+    // Conversation-length guard
+    // =========================================================================
+
+    private record LengthGuardReply(String text, int tokensInput, int tokensOutput) {}
+
+    private boolean isConversationTooLarge(UUID conversationId, String tenantId) {
+        return messageRepository.findMostRecentAssistantTokensInput(conversationId, tenantId)
+                > MAX_CONVERSATION_INPUT_TOKENS;
+    }
+
+    /**
+     * One extra non-streaming call asking Claude to summarize the
+     * conversation so far into a handoff note, so the user has something to
+     * carry into a fresh conversation. If the call itself fails, falls back
+     * to the plain redirect with no summary and no recorded token usage —
+     * the guard's job (never let the turn hard-fail) holds either way.
+     */
+    private LengthGuardReply buildLengthGuardReply(String tenantId, List<MessageParam> conversationParams) {
+        try {
+            MessageCreateParams params = anthropicService
+                    .buildRequest(tenantId, LENGTH_GUARD_SUMMARY_PROMPT, conversationParams).build();
+            Message response = anthropicService.sendMessage(params);
+
+            String summary = response.content().stream()
+                    .flatMap(block -> block.text().stream())
+                    .map(TextBlock::text)
+                    .collect(Collectors.joining("\n"));
+
+            String text = (summary.isBlank() ? "" : summary + "\n\n---\n") + LENGTH_GUARD_REDIRECT;
+            return new LengthGuardReply(text,
+                    (int) response.usage().inputTokens(), (int) response.usage().outputTokens());
+        } catch (Exception e) {
+            log.warn("Length-guard summarization failed, falling back to plain redirect: {}", e.getMessage());
+            return new LengthGuardReply(LENGTH_GUARD_REDIRECT, 0, 0);
+        }
+    }
+
+    private Map<String, Object> persistLengthGuardReply(String tenantId, Conversation conversation,
+                                                          LengthGuardReply guard) {
+        messageRepository.save(ChatMessage.assistant(
+                tenantId, conversation.id(), List.of(textBlock(guard.text())),
+                guard.tokensInput(), guard.tokensOutput()));
+        if (guard.tokensInput() > 0 || guard.tokensOutput() > 0) {
+            tokenTrackingService.recordUsage(tenantId, guard.tokensInput(), guard.tokensOutput());
+        }
+        conversationRepository.updateTimestamp(conversation.id(), tenantId);
+
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("conversationId", conversation.id().toString());
+        result.put("content", guard.text());
+        result.put("proposals", List.of());
+        result.put("tokensUsed", Map.of("input", guard.tokensInput(), "output", guard.tokensOutput()));
+        result.put("conversationTooLarge", true);
+        return result;
+    }
+
+    private void streamLengthGuardReply(String tenantId, Conversation conversation, LengthGuardReply guard,
+                                         SseEmitter emitter) throws IOException {
+        messageRepository.save(ChatMessage.assistant(
+                tenantId, conversation.id(), List.of(textBlock(guard.text())),
+                guard.tokensInput(), guard.tokensOutput()));
+        if (guard.tokensInput() > 0 || guard.tokensOutput() > 0) {
+            tokenTrackingService.recordUsage(tenantId, guard.tokensInput(), guard.tokensOutput());
+        }
+        conversationRepository.updateTimestamp(conversation.id(), tenantId);
+
+        emitter.send(SseEmitter.event().name("delta").data(objectMapper.writeValueAsString(Map.of("text", guard.text()))));
+
+        Map<String, Object> doneData = new LinkedHashMap<>();
+        doneData.put("conversationId", conversation.id().toString());
+        doneData.put("tokensUsed", Map.of("input", guard.tokensInput(), "output", guard.tokensOutput()));
+        doneData.put("conversationTooLarge", true);
+        emitter.send(SseEmitter.event().name("done").data(objectMapper.writeValueAsString(doneData)));
+        emitter.complete();
+    }
+
+    private static Map<String, Object> textBlock(String text) {
+        Map<String, Object> block = new LinkedHashMap<>();
+        block.put("type", "text");
+        block.put("text", text);
+        return block;
     }
 
     // =========================================================================

--- a/kelta-ai/src/test/java/io/kelta/ai/repository/ChatMessageRepositoryTest.java
+++ b/kelta-ai/src/test/java/io/kelta/ai/repository/ChatMessageRepositoryTest.java
@@ -1,0 +1,60 @@
+package io.kelta.ai.repository;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ChatMessageRepository")
+class ChatMessageRepositoryTest {
+
+    private static final String TENANT = "tenant-1";
+
+    @Mock
+    private JdbcTemplate jdbc;
+
+    private final ObjectMapper objectMapper = JsonMapper.builder().build();
+
+    @Test
+    @DisplayName("findMostRecentAssistantTokensInput returns the most recent assistant turn's tokens_input")
+    void returnsRecordedTokensInput() {
+        UUID conversationId = UUID.randomUUID();
+        ChatMessageRepository repository = new ChatMessageRepository(jdbc, objectMapper);
+
+        when(jdbc.query(anyString(), any(RowMapper.class), eq(conversationId), eq(TENANT)))
+                .thenReturn(List.of(87_432));
+
+        int result = repository.findMostRecentAssistantTokensInput(conversationId, TENANT);
+
+        assertThat(result).isEqualTo(87_432);
+    }
+
+    @Test
+    @DisplayName("findMostRecentAssistantTokensInput returns 0 when the conversation has no assistant turns yet")
+    void returnsZeroWhenNoAssistantTurns() {
+        UUID conversationId = UUID.randomUUID();
+        ChatMessageRepository repository = new ChatMessageRepository(jdbc, objectMapper);
+
+        when(jdbc.query(anyString(), any(RowMapper.class), eq(conversationId), eq(TENANT)))
+                .thenReturn(List.of());
+
+        int result = repository.findMostRecentAssistantTokensInput(conversationId, TENANT);
+
+        assertThat(result).isZero();
+    }
+}

--- a/kelta-ai/src/test/java/io/kelta/ai/service/ChatServiceTest.java
+++ b/kelta-ai/src/test/java/io/kelta/ai/service/ChatServiceTest.java
@@ -1,0 +1,173 @@
+package io.kelta.ai.service;
+
+import com.anthropic.models.messages.ContentBlock;
+import com.anthropic.models.messages.Message;
+import com.anthropic.models.messages.MessageCreateParams;
+import com.anthropic.models.messages.MessageParam;
+import com.anthropic.models.messages.TextBlock;
+import com.anthropic.models.messages.Usage;
+import io.kelta.ai.TestFixtures;
+import io.kelta.ai.model.Conversation;
+import io.kelta.ai.repository.ChatMessageRepository;
+import io.kelta.ai.repository.ConversationRepository;
+import io.kelta.ai.service.tools.ToolDispatcher;
+import io.kelta.ai.service.tools.ToolRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ChatService length guard")
+class ChatServiceTest {
+
+    private static final String TENANT = TestFixtures.TENANT_ID;
+    private static final String USER = TestFixtures.USER_ID;
+
+    @Mock private AnthropicService anthropicService;
+    @Mock private SystemPromptService systemPromptService;
+    @Mock private ToolDispatcher toolDispatcher;
+    @Mock private ToolRegistry toolRegistry;
+    @Mock private TokenTrackingService tokenTrackingService;
+    @Mock private ConversationRepository conversationRepository;
+    @Mock private ChatMessageRepository messageRepository;
+
+    private final ObjectMapper objectMapper = JsonMapper.builder().build();
+
+    private ChatService chatService;
+    private Conversation conversation;
+
+    @BeforeEach
+    void setUp() {
+        chatService = new ChatService(anthropicService, systemPromptService, toolDispatcher, toolRegistry,
+                tokenTrackingService, conversationRepository, messageRepository, objectMapper);
+        conversation = TestFixtures.conversation();
+        when(conversationRepository.findById(conversation.id(), TENANT)).thenReturn(Optional.of(conversation));
+        when(messageRepository.findByConversation(conversation.id(), TENANT)).thenReturn(List.of());
+    }
+
+    private static MessageCreateParams.Builder minimalRequestBuilder() {
+        return MessageCreateParams.builder()
+                .model("claude-sonnet-5")
+                .maxTokens(1024)
+                .system("system prompt")
+                .addMessage(MessageParam.builder().role(MessageParam.Role.USER).content("hi").build());
+    }
+
+    private static Message assistantMessage(String text, long inputTokens, long outputTokens) {
+        Usage usage = Usage.builder()
+                .inputTokens(inputTokens)
+                .outputTokens(outputTokens)
+                .cacheCreation(Optional.empty())
+                .cacheCreationInputTokens(Optional.empty())
+                .cacheReadInputTokens(Optional.empty())
+                .inferenceGeo(Optional.empty())
+                .serverToolUse(Optional.empty())
+                .serviceTier(Optional.empty())
+                .build();
+        return Message.builder()
+                .id("msg_test")
+                .container(Optional.empty())
+                .model("claude-sonnet-5")
+                .stopReason(Optional.empty())
+                .stopSequence(Optional.empty())
+                .content(List.of(ContentBlock.ofText(
+                        TextBlock.builder().text(text).citations(List.of()).build())))
+                .usage(usage)
+                .build();
+    }
+
+    @Test
+    @DisplayName("below threshold: guard does not trip, normal flow proceeds")
+    void guardDoesNotTripBelowThreshold() {
+        when(messageRepository.findMostRecentAssistantTokensInput(conversation.id(), TENANT)).thenReturn(1_000);
+        when(systemPromptService.buildSystemPrompt(eq(TENANT), any(), any())).thenReturn("system prompt");
+        when(anthropicService.buildRequest(eq(TENANT), anyString(), anyList())).thenReturn(minimalRequestBuilder());
+        when(anthropicService.sendMessage(any())).thenReturn(assistantMessage("Sure, happy to help.", 500, 50));
+
+        Map<String, Object> result = chatService.chat(TENANT, USER, conversation.id(), "hello", null, null);
+
+        assertThat(result.get("content")).isEqualTo("Sure, happy to help.");
+        assertThat(result).doesNotContainKey("conversationTooLarge");
+        verify(systemPromptService).buildSystemPrompt(eq(TENANT), any(), any());
+    }
+
+    @Test
+    @DisplayName("above threshold: guard trips, skips system prompt + tool loop entirely, returns summary + redirect")
+    void guardTripsAboveThreshold() {
+        when(messageRepository.findMostRecentAssistantTokensInput(conversation.id(), TENANT)).thenReturn(170_000);
+        when(anthropicService.buildRequest(eq(TENANT), anyString(), anyList())).thenReturn(minimalRequestBuilder());
+        when(anthropicService.sendMessage(any()))
+                .thenReturn(assistantMessage("Key points: created 'customers' collection with email field.", 165_000, 120));
+
+        Map<String, Object> result = chatService.chat(TENANT, USER, conversation.id(), "keep going", null, null);
+
+        String content = (String) result.get("content");
+        assertThat(content).contains("Key points: created 'customers' collection");
+        assertThat(content).contains("Start a new conversation");
+        assertThat(result.get("conversationTooLarge")).isEqualTo(true);
+        assertThat(result.get("tokensUsed")).isEqualTo(Map.of("input", 165_000, "output", 120));
+
+        verifyNoInteractions(systemPromptService);
+        verify(tokenTrackingService).recordUsage(TENANT, 165_000, 120);
+        verify(messageRepository).save(argThatAssistantRole());
+    }
+
+    @Test
+    @DisplayName("above threshold + summarization call fails: falls back to plain redirect, records no tokens")
+    void guardFallsBackWhenSummarizationFails() {
+        when(messageRepository.findMostRecentAssistantTokensInput(conversation.id(), TENANT)).thenReturn(170_000);
+        when(anthropicService.buildRequest(eq(TENANT), anyString(), anyList())).thenReturn(minimalRequestBuilder());
+        when(anthropicService.sendMessage(any())).thenThrow(new RuntimeException("upstream 500"));
+
+        Map<String, Object> result = chatService.chat(TENANT, USER, conversation.id(), "keep going", null, null);
+
+        String content = (String) result.get("content");
+        assertThat(content).doesNotContain("---");
+        assertThat(content).contains("Start a new conversation");
+        assertThat(result.get("tokensUsed")).isEqualTo(Map.of("input", 0, "output", 0));
+
+        verifyNoInteractions(systemPromptService);
+        verify(tokenTrackingService, never()).recordUsage(anyString(), any(Integer.class), any(Integer.class));
+    }
+
+    @Test
+    @DisplayName("non-streaming chat() returns a clean error instead of throwing when Anthropic errors")
+    void chatReturnsCleanErrorOnProviderException() {
+        when(messageRepository.findMostRecentAssistantTokensInput(conversation.id(), TENANT)).thenReturn(0);
+        when(systemPromptService.buildSystemPrompt(eq(TENANT), any(), any())).thenReturn("system prompt");
+        when(anthropicService.buildRequest(eq(TENANT), anyString(), anyList())).thenReturn(minimalRequestBuilder());
+        when(anthropicService.sendMessage(any())).thenThrow(new RuntimeException("prompt is too long: 210000 tokens > 200000 maximum"));
+
+        Map<String, Object> result = chatService.chat(TENANT, USER, conversation.id(), "one more thing", null, null);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> error = (Map<String, Object>) result.get("error");
+        assertThat(error).isNotNull();
+        assertThat(error.get("code")).isEqualTo("AI_PROVIDER_ERROR");
+        assertThat(error.get("message")).isEqualTo("prompt is too long: 210000 tokens > 200000 maximum");
+    }
+
+    private static io.kelta.ai.model.ChatMessage argThatAssistantRole() {
+        return org.mockito.ArgumentMatchers.argThat(m -> "assistant".equals(m.role()));
+    }
+}


### PR DESCRIPTION
## Summary
- `ChatService.buildMessageHistory` resends a conversation's *entire* history on every turn with no cap — a long-lived thread eventually hits a hard context-window failure from Anthropic with no recovery path (and on the non-streaming `chat()` path today, that surfaces as a raw unhandled 500).
- Adds a threshold guard (`MAX_CONVERSATION_INPUT_TOKENS = 160_000`), using the exact `tokensInput` Anthropic already reported on the last turn (no new token-counting logic). Checked before the schema-fetching `SystemPromptService.buildSystemPrompt` call in both `chat()` and `chatStream()` — free on the common path (an `int` comparison on data already loaded), skips the schema fetch entirely when it does trip.
- On trip: one extra non-streaming call asks Claude for a structured handoff summary (what was discussed/created, decisions, stated preferences, open questions), returned to the user with a redirect to start a new conversation. Falls back to a plain redirect with zero recorded tokens if the summarization call itself fails.
- Separately: brought `chat()`'s error handling up to `chatStream()`'s existing standard — both now return a clean `{"error": {"code": "AI_PROVIDER_ERROR", ...}}` shape instead of an unhandled exception.
- No schema migration, no change to how any other turn is built/threaded — full design rationale (including the threshold math and the two-approaches discussion) in `docs/superpowers/specs/2026-07-27-ai-chat-length-guard-design.md`.

## Test plan
- [x] `mvn test -f kelta-ai/pom.xml` — 141/141 pass
- [x] New `ChatMessageRepositoryTest`: `findMostRecentAssistantTokensInput` (row found / no rows)
- [x] New `ChatServiceTest`: guard trips above threshold and skips the tool loop + system prompt entirely; guard does not trip at/under threshold; summarization failure falls back to the plain redirect with zero recorded tokens; non-streaming `chat()` returns a clean error instead of throwing
- [ ] Manual: confirm the redirect message renders correctly in the AiChat UI for both the streaming and non-streaming entry points

🤖 Generated with [Claude Code](https://claude.com/claude-code)