### PR TITLE
chore(DevEnv): Add JVM-mode compose overlay for low-memory local builds

### DIFF
--- a/.claude/docs/concerns.md
+++ b/.claude/docs/concerns.md
@@ -422,6 +422,15 @@ for removal ("inline the current value"). Findings:
 
 ## Dependency Risks
 
+- **`make up` needs ~24 GB allocated to Docker.** Compose builds `kelta-auth`, `kelta-worker` and
+  `kelta-gateway` concurrently from their native `Dockerfile`s, and `native-image` sizes its heap to
+  ~80% of whatever the cgroup reports — so on a 12 GB Docker Desktop three builders each claim ~9 GB
+  and one dies with `ResourceExhausted: ... cannot allocate memory`. It reads like a build break but
+  is purely a resource ceiling. Fix: `make up-jvm` (overlay `docker-compose.jvm.yml` swaps the three
+  services to their `Dockerfile.jvm` variants; ports, container names, healthchecks and env are
+  unchanged), or raise the Docker Desktop memory allocation. Use native locally only when debugging
+  native-specific behavior — reachability metadata, `reflect-config.json` gaps, build-time init
+  (see the entry below).
 - **Gateway is a GraalVM native image — every DTO deserialized from `/internal/bootstrap` MUST be
   in `reflect-config.json`.** Root cause of the 2026-07-02 total-API outage: V148 added
   `ipAllowlists: Map<String,TenantIpConfig>` to `kelta-gateway/.../config/BootstrapConfig` + the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -253,6 +253,7 @@ runtime/runtime-messaging-nats -am -B
 | Frontend lint/type/test | `/test-frontend` · or in `kelta-web`/`kelta-ui/app`: `npm run lint && npm run typecheck && npm run test:run` |
 | Single Java test | `mvn test -f kelta-<svc>/pom.xml -Dtest=ClassName` |
 | Run full local stack | `make up` (then `make seed`) — see `README.md` |
+| Local stack, low-memory box | `make up-jvm` — JVM images instead of GraalVM native. `make up` builds 3 native images concurrently and needs ~24 GB allocated to Docker, else `cannot allocate memory` |
 
 Java tests: surefire runs `*Test`/`*Tests`/`*Properties` in parallel; failsafe runs
 `*IntegrationTest` only under `-Pintegration-tests`. Frontend coverage gate: 80% in

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,18 @@ COMPOSE_AI    := docker compose --profile ai
 COMPOSE_FULL  := docker compose --profile ai --profile tools
 COMPOSE_TELE  := docker compose --profile telehealth
 
-.PHONY: setup gen-keys copy-env up up-ai up-full up-telehealth down reset seed rebuild logs debug ps help
+# JVM-mode overlay: builds the Java services from their Dockerfile.jvm variants
+# instead of GraalVM native-image. Three concurrent native builds need ~24 GB
+# allocated to Docker; the JVM path fits a default allocation and is ~5x faster.
+# See the header of docker-compose.jvm.yml.
+JVM_FILES         := -f docker-compose.yml -f docker-compose.jvm.yml
+COMPOSE_JVM       := docker compose $(JVM_FILES)
+COMPOSE_JVM_AI    := docker compose $(JVM_FILES) --profile ai
+COMPOSE_JVM_FULL  := docker compose $(JVM_FILES) --profile ai --profile tools
+
+.PHONY: setup gen-keys copy-env up up-ai up-full up-telehealth \
+        up-jvm up-jvm-ai up-jvm-full rebuild-jvm \
+        down reset seed rebuild logs debug ps help
 
 # ─── First-time setup ────────────────────────────────────────────────────────
 
@@ -70,6 +81,23 @@ up-full: setup
 up-telehealth: setup
 	$(COMPOSE_TELE) up -d
 
+# ─── JVM mode (faster local builds, low memory) ──────────────────────────────
+# Same stack as `up`, but Java services build from Dockerfile.jvm. Use these if
+# `make up` dies with "cannot allocate memory" — that's GraalVM native-image
+# running out of room, not a code failure. See docker-compose.jvm.yml.
+
+## up-jvm: start default stack using JVM images (fast build, low memory)
+up-jvm: setup
+	$(COMPOSE_JVM) up -d
+
+## up-jvm-ai: start JVM stack + AI service
+up-jvm-ai: setup
+	$(COMPOSE_JVM_AI) up -d
+
+## up-jvm-full: start full JVM stack (default + ai + tools)
+up-jvm-full: setup
+	$(COMPOSE_JVM_FULL) up -d
+
 ## down: stop and remove containers (keeps volumes)
 down:
 	$(COMPOSE) --profile ai --profile tools --profile observability --profile telehealth down
@@ -91,6 +119,12 @@ rebuild:
 	@[ -n "$(SVC)" ] || (echo "Usage: make rebuild SVC=<service-name>"; exit 1)
 	$(COMPOSE) build $(SVC)
 	$(COMPOSE) up -d --no-deps $(SVC)
+
+## rebuild-jvm SVC=<name>: same as rebuild, but builds the JVM image variant
+rebuild-jvm:
+	@[ -n "$(SVC)" ] || (echo "Usage: make rebuild-jvm SVC=<service-name>"; exit 1)
+	$(COMPOSE_JVM) build $(SVC)
+	$(COMPOSE_JVM) up -d --no-deps $(SVC)
 
 ## logs SVC=<name>: tail logs for a service (omit SVC for all)
 logs:

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ provided by the internal `kelta-auth` service — no external identity server re
 - Maven 3.9+
 - Node.js 18+
 - Docker & Docker Compose
+  - `make up` builds GraalVM native images and needs **~24 GB allocated to Docker**.
+    With less, use `make up-jvm` — see [Native vs JVM images](#native-vs-jvm-images).
 
 ## Local Development
 
@@ -63,6 +65,9 @@ make setup   # first time only: copies .env, generates RSA JWK + AES key
 make up      # starts postgres, redis, nats, cerbos, auth, worker, gateway, ui
 make seed    # waits for healthy stack, then prints credentials
 ```
+
+> **Build fails with `cannot allocate memory`?** That's GraalVM native-image, not a
+> code error. Run `make up-jvm` instead — see [Native vs JVM images](#native-vs-jvm-images).
 
 Default credentials (seeded by Flyway migrations):
 
@@ -100,7 +105,45 @@ make rebuild SVC=kelta-worker   # rebuild + restart one service
 make logs SVC=kelta-gateway     # tail logs
 make down            # stop all containers
 make reset           # wipe volumes and restart clean
+
+make up-jvm          # default stack, JVM images (fast build, low memory)
+make up-jvm-ai       # JVM stack + kelta-ai
+make up-jvm-full     # JVM stack + ai + tools
+make rebuild-jvm SVC=kelta-worker   # rebuild one service as a JVM image
 ```
+
+`make help` lists every target.
+
+### Native vs JVM images
+
+`kelta-auth`, `kelta-worker` and `kelta-gateway` ship two Dockerfiles: `Dockerfile`
+(GraalVM native-image, what production runs) and `Dockerfile.jvm` (plain JRE).
+
+`make up` uses the native path. Compose builds those three **concurrently**, and
+`native-image` sizes its heap to ~80% of whatever the cgroup reports — so three
+builders on a 12 GB Docker Desktop each try to claim ~9 GB and the build dies with:
+
+```
+ResourceExhausted: ... "mvn -Pnative native:compile ..." did not complete
+successfully: cannot allocate memory
+```
+
+Two ways to fix it:
+
+| | `make up` (native) | `make up-jvm` |
+|---|---|---|
+| Docker memory needed | ~24 GB (Settings → Resources) | fits a default allocation |
+| Build time | ~10 min per service | ~2–3 min per service |
+| Startup | ~50 ms | ~20–40 s |
+| Production parity | yes | behaviorally equivalent for dev |
+
+JVM mode is the right default for day-to-day work. Reach for native when you're
+debugging something native-specific — reachability metadata, `reflect-config.json`
+gaps, or build-time initialization (see `.claude/docs/concerns.md`).
+
+Ports, container names, healthchecks and env are identical in both modes — the
+overlay (`docker-compose.jvm.yml`) only swaps `build.dockerfile`. Switching modes
+recreates the containers but keeps volumes, so your data survives.
 
 ### Debugging a service in the IDE (hybrid mode)
 

--- a/docker-compose.jvm.yml
+++ b/docker-compose.jvm.yml
@@ -1,0 +1,39 @@
+# Local-dev override: JVM images instead of GraalVM native images.
+#
+# Why this exists
+# ---------------
+# The base compose builds kelta-auth, kelta-worker and kelta-gateway from their
+# native `Dockerfile`s, which end in `mvn -Pnative native:compile`. Compose builds
+# those three concurrently, and GraalVM's `native-image` sizes its heap to ~80% of
+# whatever the cgroup reports — so on a Docker Desktop with, say, 12 GB allocated,
+# three builders each try to claim ~9 GB and the build dies with:
+#
+#     ResourceExhausted: ... did not complete successfully: cannot allocate memory
+#
+# Running native locally needs ~24 GB allocated to Docker and ~10 min per service.
+# For day-to-day work the JVM variants are equivalent in behavior, build in a few
+# minutes, and fit comfortably in a default Docker Desktop allocation.
+#
+# Unlike docker-compose.ci.yml (which also strips host ports and container_names
+# for the shared CI daemon), this override touches ONLY the build stanzas, so
+# localhost ports, container names, healthchecks and env all stay as in base.
+#
+# Usage:  make up-jvm       (or up-jvm-ai / up-jvm-full)
+# Native: make up           (unchanged — still the production-parity path)
+
+services:
+  kelta-auth:
+    build:
+      dockerfile: kelta-auth/Dockerfile.jvm
+
+  kelta-worker:
+    build:
+      dockerfile: kelta-worker/Dockerfile.jvm
+
+  kelta-gateway:
+    build:
+      dockerfile: kelta-gateway/Dockerfile.jvm
+
+  kelta-ai:
+    build:
+      dockerfile: kelta-ai/Dockerfile.jvm


### PR DESCRIPTION
## Problem

`make up` fails on a machine with a default Docker Desktop memory allocation:

```
Dockerfile:84
  84 | >>> RUN mvn -Pnative native:compile -DskipTests -B
target kelta-auth: failed to solve: ResourceExhausted: process
"/bin/sh -c mvn -Pnative native:compile -DskipTests -B" did not complete
successfully: cannot allocate memory
```

This reads like a build break but is purely a resource ceiling. Compose builds
`kelta-auth`, `kelta-worker` and `kelta-gateway` **concurrently** from their native
GraalVM Dockerfiles, and `native-image` sizes its heap to ~80% of whatever the cgroup
reports. So on a 12 GB Docker Desktop, three builders each try to claim ~9 GB and
whichever loses the race dies. Native mode needs ~24 GB allocated to Docker.

## Change

Adds `docker-compose.jvm.yml`, an overlay that swaps **only** `build.dockerfile` to the
`Dockerfile.jvm` variants that already exist for each Java service.

This is deliberately narrower than the existing `docker-compose.ci.yml`, which also
strips host ports and `container_name`s for the shared CI daemon and therefore isn't
usable for local dev. Ports, container names, healthchecks and env are all untouched
here, so `localhost:5173` / `:8080` / `:8081` / `:8083` work exactly as before.

New targets — `make up` is unchanged and remains the production-parity path:

| Target | Purpose |
|---|---|
| `make up-jvm` | default stack, JVM images |
| `make up-jvm-ai` | + kelta-ai |
| `make up-jvm-full` | + ai + tools |
| `make rebuild-jvm SVC=…` | rebuild one service as a JVM image |

|  | `make up` (native) | `make up-jvm` |
|---|---|---|
| Docker memory | ~24 GB | fits a default allocation |
| Build time | ~10 min/service | ~2–3 min/service |
| Startup | ~50 ms | ~20–40 s |

## Two things checked rather than assumed

- **Healthchecks.** The `.jvm` images carry no `HEALTHCHECK`, unlike the native ones.
  This is fine: the base compose defines `healthcheck:` per service, which takes
  precedence over the Dockerfile, and `start_period` is 60–90s — ample for JVM boot
  versus native's ~50 ms.
- **`wget` availability.** Those healthchecks shell out to `wget`. The `.jvm` runtime
  stage is Alpine, where busybox provides it.

## Verification

- `docker compose -f docker-compose.yml -f docker-compose.jvm.yml config -q` → valid;
  confirmed the three services resolve to `Dockerfile.jvm` while `kelta-ui` keeps its own
  Dockerfile and all ports/container names are preserved.
- Built `kelta-auth` through the overlay end to end → `emf-kelta-auth:latest` (396 MB),
  exit 0. The Maven package step took **3.6 s**, against the ~10 min native-image was
  spending before it OOM'd.
- `make help` lists the new targets; `make -n up-jvm` expands to the correct command.

**Not run: `/verify`.** This change touches no Java or TypeScript source — it's compose
YAML, the Makefile, and three docs — so the build/test pipeline can't exercise it. The
Docker build above is the meaningful check. Flagging explicitly rather than implying a
green run.

## Docs

Updated in the same PR per the repo's docs rule:

- `README.md` — "Native vs JVM images" section, prerequisite note, and a callout keyed to
  the exact error string so the next person searching for it lands on the fix.
- `CLAUDE.md` — row in the Build/Test/Verify table.
- `.claude/docs/concerns.md` — entry under Dependency Risks, so this is recorded as a
  known resource ceiling rather than rediscovered as a build failure.
