### PR TITLE
feat(auth): kelta-cli public client + RFC 8252 loopback redirect (kelta-cli slice 2, PR A)

### DIFF
--- a/kelta-auth/CLAUDE.md
+++ b/kelta-auth/CLAUDE.md
@@ -35,6 +35,14 @@ io.kelta.auth/
    authenticate it as method NONE; the refresh token is the credential and is
    rotated on every use (`reuseRefreshTokens(false)`). Confidential clients that
    omit their secret are rejected, never silently authenticated.
+7. CLI login: `kelta-cli` (public client, PKCE, **no refresh grant**) uses an
+   RFC 8252 loopback redirect — `http://127.0.0.1:<any port>/callback` or
+   `[::1]` — accepted port-agnostically by `PlatformRedirectUriValidator` for
+   this client ONLY (loopback IP literals, never `localhost`; path exactly
+   `/callback`; no userinfo/query/fragment). The 15-min access token exists
+   solely for the CLI to mint a PAT (`POST /api/me/tokens`) and is then
+   discarded. Registered by `ConnectedAppRegistrar.registerCliClient()`.
+   Spec: `specs/kelta-cli/2-browser-login.md`.
 
 ### Identity Brokering (SSO)
 - `DynamicClientRegistrationRepository` — loads OIDC provider configs from worker at runtime

--- a/kelta-auth/src/main/java/io/kelta/auth/config/ConnectedAppRegistrar.java
+++ b/kelta-auth/src/main/java/io/kelta/auth/config/ConnectedAppRegistrar.java
@@ -41,6 +41,7 @@ public class ConnectedAppRegistrar implements ApplicationRunner {
     @Override
     public void run(ApplicationArguments args) {
         registerPlatformClient();
+        registerCliClient();
         registerSupersetClient();
     }
 
@@ -102,6 +103,46 @@ public class ConnectedAppRegistrar implements ApplicationRunner {
             log.info("Updated Platform OAuth2 client '{}' redirect URI to '{}' (was '{}')",
                     clientId, expectedRedirectUri, existing.getRedirectUris());
         }
+    }
+
+    /**
+     * Registers the kelta CLI as a public OAuth2 client (spec: specs/kelta-cli/2-browser-login.md).
+     * <p>
+     * The CLI runs authorization_code + PKCE with an RFC 8252 loopback redirect —
+     * {@code http://127.0.0.1:<os-assigned port>/callback} — validated port-agnostically by
+     * {@code PlatformRedirectUriValidator}; the URI registered here is only the
+     * template/documentation value. No refresh token is issued on purpose: the access token
+     * lives just long enough for the CLI to mint a PAT via {@code POST /api/me/tokens} and is
+     * then discarded, so the PAT is the only durable credential on the developer's machine.
+     */
+    private void registerCliClient() {
+        String clientId = "kelta-cli";
+
+        if (clientRepository.findByClientId(clientId) != null) {
+            log.info("CLI OAuth2 client '{}' already registered", clientId);
+            return;
+        }
+
+        RegisteredClient cliClient = RegisteredClient.withId(UUID.randomUUID().toString())
+                .clientId(clientId)
+                .clientName("Kelta CLI")
+                .clientAuthenticationMethod(ClientAuthenticationMethod.NONE)
+                .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+                .redirectUri("http://127.0.0.1/callback")
+                .scope(OidcScopes.OPENID)
+                .scope(OidcScopes.PROFILE)
+                .scope("email")
+                .clientSettings(ClientSettings.builder()
+                        .requireAuthorizationConsent(false)
+                        .requireProofKey(true)
+                        .build())
+                .tokenSettings(TokenSettings.builder()
+                        .accessTokenTimeToLive(Duration.ofMinutes(15))
+                        .build())
+                .build();
+
+        clientRepository.save(cliClient);
+        log.info("Registered CLI OAuth2 client '{}' (PKCE public client, loopback redirect)", clientId);
     }
 
     private void registerSupersetClient() {

--- a/kelta-auth/src/main/java/io/kelta/auth/config/PlatformRedirectUriValidator.java
+++ b/kelta-auth/src/main/java/io/kelta/auth/config/PlatformRedirectUriValidator.java
@@ -65,6 +65,18 @@ public class PlatformRedirectUriValidator
             }
         }
 
+        // For the CLI client ONLY: RFC 8252 §7.3 loopback redirect. Native apps
+        // cannot pre-register a port, so the OS assigns one at login time and the
+        // port MUST be ignored during comparison. Everything else stays strict:
+        // scheme http, host a loopback IP LITERAL (never "localhost" — a hosts-file
+        // or DNS entry can point it anywhere), path exactly /callback, and no
+        // userinfo/query/fragment. No other client gets this rule.
+        if ("kelta-cli".equals(registeredClient.getClientId())) {
+            if (isLoopbackCallback(requestedRedirectUri)) {
+                return;
+            }
+        }
+
         // For connected apps with multiple redirect URIs, validate that the
         // requested URI matches a registered origin + exact path. This supports
         // apps that register multiple callback paths for different environments.
@@ -123,6 +135,32 @@ public class PlatformRedirectUriValidator
             }
         } catch (IllegalArgumentException e) {
             // Invalid URI
+        }
+        return false;
+    }
+
+    /**
+     * RFC 8252 §7.3 loopback-interface redirect for the {@code kelta-cli} client:
+     * {@code http://127.0.0.1:<any port>/callback} or {@code http://[::1]:<any port>/callback}.
+     * The port is deliberately not compared; host must be a loopback IP literal
+     * (NOT {@code localhost}); the path must be exactly {@code /callback}; and the
+     * URI must carry no userinfo, query, or fragment.
+     */
+    private boolean isLoopbackCallback(String requestedRedirectUri) {
+        try {
+            URI uri = URI.create(requestedRedirectUri);
+            boolean loopbackHost = "127.0.0.1".equals(uri.getHost()) || "[::1]".equals(uri.getHost());
+            if ("http".equals(uri.getScheme())
+                    && loopbackHost
+                    && "/callback".equals(uri.getPath())
+                    && uri.getUserInfo() == null
+                    && uri.getQuery() == null
+                    && uri.getFragment() == null) {
+                log.debug("Allowing RFC 8252 loopback redirect_uri for kelta-cli: {}", requestedRedirectUri);
+                return true;
+            }
+        } catch (IllegalArgumentException ignored) {
+            // fall through to false
         }
         return false;
     }

--- a/kelta-auth/src/test/java/io/kelta/auth/config/ConnectedAppRegistrarTest.java
+++ b/kelta-auth/src/test/java/io/kelta/auth/config/ConnectedAppRegistrarTest.java
@@ -1,0 +1,77 @@
+package io.kelta.auth.config;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("ConnectedAppRegistrar — kelta-cli client")
+class ConnectedAppRegistrarTest {
+
+    private RegisteredClientRepository clientRepository;
+    private ConnectedAppRegistrar registrar;
+
+    @BeforeEach
+    void setUp() {
+        clientRepository = Mockito.mock(RegisteredClientRepository.class);
+        PasswordEncoder passwordEncoder = Mockito.mock(PasswordEncoder.class);
+        AuthProperties properties = new AuthProperties();
+        registrar = new ConnectedAppRegistrar(clientRepository, passwordEncoder, properties);
+    }
+
+    @Test
+    @DisplayName("registers kelta-cli as a PKCE public client with no refresh grant")
+    void shouldRegisterCliClient() {
+        registrar.run(null);
+
+        ArgumentCaptor<RegisteredClient> captor = ArgumentCaptor.forClass(RegisteredClient.class);
+        Mockito.verify(clientRepository, Mockito.atLeastOnce()).save(captor.capture());
+        List<RegisteredClient> saved = captor.getAllValues();
+
+        RegisteredClient cli = saved.stream()
+                .filter(c -> "kelta-cli".equals(c.getClientId()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("kelta-cli client was not registered"));
+
+        assertThat(cli.getClientAuthenticationMethods())
+                .containsExactly(ClientAuthenticationMethod.NONE);
+        assertThat(cli.getAuthorizationGrantTypes())
+                .containsExactly(AuthorizationGrantType.AUTHORIZATION_CODE);
+        // No refresh token by design: the access token only lives long enough to mint a PAT.
+        assertThat(cli.getAuthorizationGrantTypes())
+                .doesNotContain(AuthorizationGrantType.REFRESH_TOKEN);
+        assertThat(cli.getRedirectUris()).containsExactly("http://127.0.0.1/callback");
+        assertThat(cli.getClientSettings().isRequireProofKey()).isTrue();
+        assertThat(cli.getClientSettings().isRequireAuthorizationConsent()).isFalse();
+        assertThat(cli.getClientSecret()).isNull();
+    }
+
+    @Test
+    @DisplayName("is idempotent — an existing kelta-cli registration is left untouched")
+    void shouldSkipWhenCliClientExists() {
+        RegisteredClient existing = RegisteredClient.withId(UUID.randomUUID().toString())
+                .clientId("kelta-cli")
+                .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+                .redirectUri("http://127.0.0.1/callback")
+                .build();
+        Mockito.when(clientRepository.findByClientId("kelta-cli")).thenReturn(existing);
+
+        registrar.run(null);
+
+        ArgumentCaptor<RegisteredClient> captor = ArgumentCaptor.forClass(RegisteredClient.class);
+        Mockito.verify(clientRepository, Mockito.atLeastOnce()).save(captor.capture());
+        assertThat(captor.getAllValues())
+                .noneMatch(c -> "kelta-cli".equals(c.getClientId()));
+    }
+}

--- a/kelta-auth/src/test/java/io/kelta/auth/config/PlatformRedirectUriValidatorTest.java
+++ b/kelta-auth/src/test/java/io/kelta/auth/config/PlatformRedirectUriValidatorTest.java
@@ -113,6 +113,99 @@ class PlatformRedirectUriValidatorTest {
     }
 
     @Nested
+    @DisplayName("CLI client RFC 8252 loopback redirect")
+    class CliLoopback {
+
+        private static final String CLI_REGISTERED_URI = "http://127.0.0.1/callback";
+
+        @Test
+        @DisplayName("accepts 127.0.0.1 with any OS-assigned port")
+        void shouldAllowIpv4LoopbackAnyPort() {
+            var context = buildContext("kelta-cli",
+                    "http://127.0.0.1:49152/callback", CLI_REGISTERED_URI);
+            assertThatCode(() -> validator.accept(context)).doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("accepts [::1] with any OS-assigned port")
+        void shouldAllowIpv6LoopbackAnyPort() {
+            var context = buildContext("kelta-cli",
+                    "http://[::1]:60321/callback", CLI_REGISTERED_URI);
+            assertThatCode(() -> validator.accept(context)).doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("rejects the localhost hostname — DNS/hosts-file poisonable")
+        void shouldRejectLocalhostHostname() {
+            var context = buildContext("kelta-cli",
+                    "http://localhost:49152/callback", CLI_REGISTERED_URI);
+            assertThatThrownBy(() -> validator.accept(context))
+                    .isInstanceOf(OAuth2AuthorizationCodeRequestAuthenticationException.class);
+        }
+
+        @Test
+        @DisplayName("rejects a non-loopback host")
+        void shouldRejectNonLoopbackHost() {
+            var context = buildContext("kelta-cli",
+                    "http://192.168.0.10:49152/callback", CLI_REGISTERED_URI);
+            assertThatThrownBy(() -> validator.accept(context))
+                    .isInstanceOf(OAuth2AuthorizationCodeRequestAuthenticationException.class);
+        }
+
+        @Test
+        @DisplayName("rejects a path other than /callback")
+        void shouldRejectOtherPaths() {
+            var context = buildContext("kelta-cli",
+                    "http://127.0.0.1:49152/other", CLI_REGISTERED_URI);
+            assertThatThrownBy(() -> validator.accept(context))
+                    .isInstanceOf(OAuth2AuthorizationCodeRequestAuthenticationException.class);
+        }
+
+        @Test
+        @DisplayName("rejects https-scheme loopback (RFC 8252 loopback is http)")
+        void shouldRejectHttpsScheme() {
+            var context = buildContext("kelta-cli",
+                    "https://127.0.0.1:49152/callback", CLI_REGISTERED_URI);
+            assertThatThrownBy(() -> validator.accept(context))
+                    .isInstanceOf(OAuth2AuthorizationCodeRequestAuthenticationException.class);
+        }
+
+        @Test
+        @DisplayName("rejects userinfo, query, and fragment decorations")
+        void shouldRejectDecoratedUris() {
+            for (String uri : new String[]{
+                    "http://user@127.0.0.1:49152/callback",
+                    "http://127.0.0.1:49152/callback?x=1",
+                    "http://127.0.0.1:49152/callback#frag"}) {
+                var context = buildContext("kelta-cli", uri, CLI_REGISTERED_URI);
+                assertThatThrownBy(() -> validator.accept(context))
+                        .as("should reject %s", uri)
+                        .isInstanceOf(OAuth2AuthorizationCodeRequestAuthenticationException.class);
+            }
+        }
+
+        @Test
+        @DisplayName("the loopback rule does NOT apply to kelta-platform")
+        void shouldNotApplyLoopbackRuleToPlatformClient() {
+            var context = buildContext("kelta-platform",
+                    "http://127.0.0.1:49152/callback",
+                    "http://localhost:5173/auth/callback");
+            assertThatThrownBy(() -> validator.accept(context))
+                    .isInstanceOf(OAuth2AuthorizationCodeRequestAuthenticationException.class);
+        }
+
+        @Test
+        @DisplayName("the loopback rule does NOT apply to arbitrary clients")
+        void shouldNotApplyLoopbackRuleToOtherClients() {
+            var context = buildContext("other-client",
+                    "http://127.0.0.1:49152/callback",
+                    "https://myapp.com/oauth/callback");
+            assertThatThrownBy(() -> validator.accept(context))
+                    .isInstanceOf(OAuth2AuthorizationCodeRequestAuthenticationException.class);
+        }
+    }
+
+    @Nested
     @DisplayName("Connected app with multiple redirect URIs")
     class ConnectedAppClient {
         @Test


### PR DESCRIPTION
## Summary
- PR A of `specs/kelta-cli/2-browser-login.md` — the kelta-auth half of CLI browser login. **Security-typed: do NOT enable auto-merge** (reviewer sign-off required per SECURITY.md).
- Registers `kelta-cli` as a public OAuth2 client: `authorization_code` + PKCE (`requireProofKey`), method NONE, consent skipped, 15-minute access token, **no refresh grant** — the JWT exists only for the CLI to mint a PAT via `POST /api/me/tokens` and is then discarded, so the PAT stays the only durable credential on a developer machine.
- `PlatformRedirectUriValidator` gains an RFC 8252 §7.3 loopback rule **scoped to `kelta-cli` only**: `http://127.0.0.1:<any port>/callback` or `http://[::1]:<any port>/callback`. The port is ignored (native apps get an OS-assigned port); everything else is strict — loopback IP literals only (`localhost` rejected: hosts-file/DNS poisonable), path exactly `/callback`, https-scheme loopback rejected, no userinfo/query/fragment.

## Reviewer checklist (the security-critical diff is the validator)
- [ ] Loopback branch is reachable only when `registeredClient.getClientId()` is exactly `kelta-cli`
- [ ] `localhost` hostname rejected; only `127.0.0.1` / `[::1]` literals pass
- [ ] Path must equal `/callback` (no suffix matching); userinfo/query/fragment rejected
- [ ] `kelta-platform` and connected-app validation paths unchanged (regression tests pin both directions)
- [ ] No refresh grant on the client; registrar is add-if-absent (idempotent across pods/restarts — DB-backed `RegisteredClientRepository`, no NATS concern)

## Changes
- `kelta-auth/.../config/ConnectedAppRegistrar.java` — `registerCliClient()`
- `kelta-auth/.../config/PlatformRedirectUriValidator.java` — `isLoopbackCallback()` + scoped branch
- Tests: `PlatformRedirectUriValidatorTest` +9 loopback cases (accept/reject both directions, non-applicability to other clients), new `ConnectedAppRegistrarTest` (client shape + idempotency)
- `kelta-auth/CLAUDE.md` — OAuth2 flow section documents the CLI login flow

## Testing
- `mvn test -f kelta-auth/pom.xml`: 341 tests, 0 failures

PR B (the CLI side: loopback server, PKCE flow, PAT mint, token lifecycle commands) follows separately and depends on this landing + deploying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)