### PR TITLE
fix(auth): CLI loopback redirect must carry the tenant slug (kelta-cli slice 2 follow-up)

### DIFF
--- a/.claude/docs/specs/kelta-cli/2-browser-login.md
+++ b/.claude/docs/specs/kelta-cli/2-browser-login.md
@@ -18,7 +18,10 @@ Flow (PR B):
 1. `kelta login --url https://api.kelta.io --tenant acme [--profile prod]` (flags optional
    when re-authenticating an existing profile).
 2. CLI binds a one-shot HTTP listener on `127.0.0.1:<random port>`, generates
-   `state` + PKCE verifier/S256 challenge.
+   `state` + PKCE verifier/S256 challenge. The callback path is
+   **`/{tenantSlug}/auth/callback`** — kelta-auth's `TenantContextFilter` derives the
+   login's tenant from the `redirect_uri` path, so a slug-less path authorizes and then
+   fails with "no tenant context in session".
 3. Opens `<authUrl>/oauth2/authorize?client_id=kelta-cli&redirect_uri=http://127.0.0.1:<port>/callback&code_challenge=…&state=…&scope=openid`
    via OS opener (`open`/`xdg-open`/`start`); prints the URL as fallback. MFA/SSO ride the
    normal browser session.
@@ -58,9 +61,10 @@ Opening browser… (or visit: https://auth.kelta.io/oauth2/authorize?…)
   credential), `requireProofKey(true)`, `requireAuthorizationConsent(false)`, redirect URI
   template `http://127.0.0.1/callback`.
 - `PlatformRedirectUriValidator`: for client `kelta-cli` **only**, accept
-  `http://127.0.0.1:<any port>/callback` and `http://[::1]:<any port>/callback` per
-  RFC 8252 §7.3 (exact path match, loopback literal only — **not** `localhost`, which can
-  be DNS-poisoned). All other clients keep exact-match semantics.
+  `http://127.0.0.1:<any port>/{slug}/auth/callback` and the `[::1]` equivalent per
+  RFC 8252 §7.3 (port ignored; loopback literal only — **not** `localhost`, which can
+  be DNS-poisoned; slug shape `[a-z][a-z0-9-]*` mirrors the gateway). All other clients
+  keep exact-match semantics.
 
 **PR B — CLI**: consumes existing `POST/GET/DELETE /api/me/tokens` (worker) through the
 gateway. No server change. Note: create requires the JWT path (`X-User-Id` derived by

--- a/kelta-auth/CLAUDE.md
+++ b/kelta-auth/CLAUDE.md
@@ -36,12 +36,16 @@ io.kelta.auth/
    rotated on every use (`reuseRefreshTokens(false)`). Confidential clients that
    omit their secret are rejected, never silently authenticated.
 7. CLI login: `kelta-cli` (public client, PKCE, **no refresh grant**) uses an
-   RFC 8252 loopback redirect — `http://127.0.0.1:<any port>/callback` or
-   `[::1]` — accepted port-agnostically by `PlatformRedirectUriValidator` for
-   this client ONLY (loopback IP literals, never `localhost`; path exactly
-   `/callback`; no userinfo/query/fragment). The 15-min access token exists
-   solely for the CLI to mint a PAT (`POST /api/me/tokens`) and is then
-   discarded. Registered by `ConnectedAppRegistrar.registerCliClient()`.
+   RFC 8252 loopback redirect — `http://127.0.0.1:<any port>/<tenant-slug>/auth/callback`
+   (or `[::1]`) — accepted port-agnostically by `PlatformRedirectUriValidator`
+   for this client ONLY (loopback IP literals, never `localhost`; path must match
+   `/{slug}/auth/callback`; no userinfo/query/fragment). **The tenant slug in the
+   path is load-bearing, not cosmetic**: `TenantContextFilter` derives the login's
+   tenant from the `redirect_uri` path for every client, so a slug-less
+   `/callback` passes OAuth validation and then fails authentication with
+   "no tenant context in session" (`KeltaUserDetailsService`). The 15-min access
+   token exists solely for the CLI to mint a PAT (`POST /api/me/tokens`) and is
+   then discarded. Registered by `ConnectedAppRegistrar.registerCliClient()`.
    Spec: `specs/kelta-cli/2-browser-login.md`.
 
 ### Identity Brokering (SSO)

--- a/kelta-auth/src/main/java/io/kelta/auth/config/ConnectedAppRegistrar.java
+++ b/kelta-auth/src/main/java/io/kelta/auth/config/ConnectedAppRegistrar.java
@@ -109,11 +109,15 @@ public class ConnectedAppRegistrar implements ApplicationRunner {
      * Registers the kelta CLI as a public OAuth2 client (spec: specs/kelta-cli/2-browser-login.md).
      * <p>
      * The CLI runs authorization_code + PKCE with an RFC 8252 loopback redirect —
-     * {@code http://127.0.0.1:<os-assigned port>/callback} — validated port-agnostically by
-     * {@code PlatformRedirectUriValidator}; the URI registered here is only the
-     * template/documentation value. No refresh token is issued on purpose: the access token
-     * lives just long enough for the CLI to mint a PAT via {@code POST /api/me/tokens} and is
-     * then discarded, so the PAT is the only durable credential on the developer's machine.
+     * {@code http://127.0.0.1:<os-assigned port>/<tenant-slug>/auth/callback} — validated
+     * port-agnostically by {@code PlatformRedirectUriValidator}. The URI registered here is
+     * only a template: the validator's loopback branch does the real matching, so an existing
+     * registration from an earlier release keeps working without a migration. The tenant slug
+     * is part of the path because {@code TenantContextFilter} derives the login's tenant from
+     * exactly that shape, the same way it does for the SPA. No refresh token is issued on
+     * purpose: the access token lives just long enough for the CLI to mint a PAT via
+     * {@code POST /api/me/tokens} and is then discarded, so the PAT is the only durable
+     * credential on the developer's machine.
      */
     private void registerCliClient() {
         String clientId = "kelta-cli";
@@ -128,7 +132,7 @@ public class ConnectedAppRegistrar implements ApplicationRunner {
                 .clientName("Kelta CLI")
                 .clientAuthenticationMethod(ClientAuthenticationMethod.NONE)
                 .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
-                .redirectUri("http://127.0.0.1/callback")
+                .redirectUri("http://127.0.0.1/tenant/auth/callback")
                 .scope(OidcScopes.OPENID)
                 .scope(OidcScopes.PROFILE)
                 .scope("email")

--- a/kelta-auth/src/main/java/io/kelta/auth/config/PlatformRedirectUriValidator.java
+++ b/kelta-auth/src/main/java/io/kelta/auth/config/PlatformRedirectUriValidator.java
@@ -12,6 +12,7 @@ import org.springframework.security.oauth2.server.authorization.client.Registere
 
 import java.net.URI;
 import java.util.function.Consumer;
+import java.util.regex.Pattern;
 
 /**
  * Custom redirect URI validator for the multi-tenant platform.
@@ -26,6 +27,14 @@ public class PlatformRedirectUriValidator
         implements Consumer<OAuth2AuthorizationCodeRequestAuthenticationContext> {
 
     private static final Logger log = LoggerFactory.getLogger(PlatformRedirectUriValidator.class);
+
+    /**
+     * Loopback callback path for {@code kelta-cli}: {@code /{tenant-slug}/auth/callback}.
+     * The slug shape mirrors the gateway's TenantSlugExtractionFilter so a URI accepted
+     * here resolves to the same tenant everywhere else.
+     */
+    private static final Pattern LOOPBACK_CALLBACK_PATH =
+            Pattern.compile("^/[a-z][a-z0-9-]*/auth/callback$");
 
     private final AuthDomainResolver domainResolver;
 
@@ -141,18 +150,25 @@ public class PlatformRedirectUriValidator
 
     /**
      * RFC 8252 §7.3 loopback-interface redirect for the {@code kelta-cli} client:
-     * {@code http://127.0.0.1:<any port>/callback} or {@code http://[::1]:<any port>/callback}.
+     * {@code http://127.0.0.1:<any port>/<tenant-slug>/auth/callback} (or {@code [::1]}).
      * The port is deliberately not compared; host must be a loopback IP literal
-     * (NOT {@code localhost}); the path must be exactly {@code /callback}; and the
-     * URI must carry no userinfo, query, or fragment.
+     * (NOT {@code localhost}); and the URI must carry no userinfo, query, or fragment.
+     * <p>
+     * The path MUST carry the tenant slug in the same shape every other client uses
+     * ({@code /{slug}/auth/callback}), because {@link TenantContextFilter} derives the
+     * login's tenant from exactly that pattern. A slug-less {@code /callback} is
+     * accepted by OAuth but then fails at authentication with "no tenant context in
+     * session" — which is precisely the bug this shape prevents.
      */
     private boolean isLoopbackCallback(String requestedRedirectUri) {
         try {
             URI uri = URI.create(requestedRedirectUri);
             boolean loopbackHost = "127.0.0.1".equals(uri.getHost()) || "[::1]".equals(uri.getHost());
+            String path = uri.getPath();
             if ("http".equals(uri.getScheme())
                     && loopbackHost
-                    && "/callback".equals(uri.getPath())
+                    && path != null
+                    && LOOPBACK_CALLBACK_PATH.matcher(path).matches()
                     && uri.getUserInfo() == null
                     && uri.getQuery() == null
                     && uri.getFragment() == null) {

--- a/kelta-auth/src/test/java/io/kelta/auth/config/ConnectedAppRegistrarTest.java
+++ b/kelta-auth/src/test/java/io/kelta/auth/config/ConnectedAppRegistrarTest.java
@@ -51,7 +51,7 @@ class ConnectedAppRegistrarTest {
         // No refresh token by design: the access token only lives long enough to mint a PAT.
         assertThat(cli.getAuthorizationGrantTypes())
                 .doesNotContain(AuthorizationGrantType.REFRESH_TOKEN);
-        assertThat(cli.getRedirectUris()).containsExactly("http://127.0.0.1/callback");
+        assertThat(cli.getRedirectUris()).containsExactly("http://127.0.0.1/tenant/auth/callback");
         assertThat(cli.getClientSettings().isRequireProofKey()).isTrue();
         assertThat(cli.getClientSettings().isRequireAuthorizationConsent()).isFalse();
         assertThat(cli.getClientSecret()).isNull();
@@ -63,7 +63,7 @@ class ConnectedAppRegistrarTest {
         RegisteredClient existing = RegisteredClient.withId(UUID.randomUUID().toString())
                 .clientId("kelta-cli")
                 .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
-                .redirectUri("http://127.0.0.1/callback")
+                .redirectUri("http://127.0.0.1/tenant/auth/callback")
                 .build();
         Mockito.when(clientRepository.findByClientId("kelta-cli")).thenReturn(existing);
 

--- a/kelta-auth/src/test/java/io/kelta/auth/config/PlatformRedirectUriValidatorTest.java
+++ b/kelta-auth/src/test/java/io/kelta/auth/config/PlatformRedirectUriValidatorTest.java
@@ -116,13 +116,13 @@ class PlatformRedirectUriValidatorTest {
     @DisplayName("CLI client RFC 8252 loopback redirect")
     class CliLoopback {
 
-        private static final String CLI_REGISTERED_URI = "http://127.0.0.1/callback";
+        private static final String CLI_REGISTERED_URI = "http://127.0.0.1/tenant/auth/callback";
 
         @Test
         @DisplayName("accepts 127.0.0.1 with any OS-assigned port")
         void shouldAllowIpv4LoopbackAnyPort() {
             var context = buildContext("kelta-cli",
-                    "http://127.0.0.1:49152/callback", CLI_REGISTERED_URI);
+                    "http://127.0.0.1:49152/acme/auth/callback", CLI_REGISTERED_URI);
             assertThatCode(() -> validator.accept(context)).doesNotThrowAnyException();
         }
 
@@ -130,7 +130,7 @@ class PlatformRedirectUriValidatorTest {
         @DisplayName("accepts [::1] with any OS-assigned port")
         void shouldAllowIpv6LoopbackAnyPort() {
             var context = buildContext("kelta-cli",
-                    "http://[::1]:60321/callback", CLI_REGISTERED_URI);
+                    "http://[::1]:60321/acme/auth/callback", CLI_REGISTERED_URI);
             assertThatCode(() -> validator.accept(context)).doesNotThrowAnyException();
         }
 
@@ -138,7 +138,7 @@ class PlatformRedirectUriValidatorTest {
         @DisplayName("rejects the localhost hostname — DNS/hosts-file poisonable")
         void shouldRejectLocalhostHostname() {
             var context = buildContext("kelta-cli",
-                    "http://localhost:49152/callback", CLI_REGISTERED_URI);
+                    "http://localhost:49152/acme/auth/callback", CLI_REGISTERED_URI);
             assertThatThrownBy(() -> validator.accept(context))
                     .isInstanceOf(OAuth2AuthorizationCodeRequestAuthenticationException.class);
         }
@@ -147,7 +147,7 @@ class PlatformRedirectUriValidatorTest {
         @DisplayName("rejects a non-loopback host")
         void shouldRejectNonLoopbackHost() {
             var context = buildContext("kelta-cli",
-                    "http://192.168.0.10:49152/callback", CLI_REGISTERED_URI);
+                    "http://192.168.0.10:49152/acme/auth/callback", CLI_REGISTERED_URI);
             assertThatThrownBy(() -> validator.accept(context))
                     .isInstanceOf(OAuth2AuthorizationCodeRequestAuthenticationException.class);
         }
@@ -165,7 +165,7 @@ class PlatformRedirectUriValidatorTest {
         @DisplayName("rejects https-scheme loopback (RFC 8252 loopback is http)")
         void shouldRejectHttpsScheme() {
             var context = buildContext("kelta-cli",
-                    "https://127.0.0.1:49152/callback", CLI_REGISTERED_URI);
+                    "https://127.0.0.1:49152/acme/auth/callback", CLI_REGISTERED_URI);
             assertThatThrownBy(() -> validator.accept(context))
                     .isInstanceOf(OAuth2AuthorizationCodeRequestAuthenticationException.class);
         }
@@ -174,9 +174,38 @@ class PlatformRedirectUriValidatorTest {
         @DisplayName("rejects userinfo, query, and fragment decorations")
         void shouldRejectDecoratedUris() {
             for (String uri : new String[]{
-                    "http://user@127.0.0.1:49152/callback",
-                    "http://127.0.0.1:49152/callback?x=1",
-                    "http://127.0.0.1:49152/callback#frag"}) {
+                    "http://user@127.0.0.1:49152/acme/auth/callback",
+                    "http://127.0.0.1:49152/acme/auth/callback?x=1",
+                    "http://127.0.0.1:49152/acme/auth/callback#frag"}) {
+                var context = buildContext("kelta-cli", uri, CLI_REGISTERED_URI);
+                assertThatThrownBy(() -> validator.accept(context))
+                        .as("should reject %s", uri)
+                        .isInstanceOf(OAuth2AuthorizationCodeRequestAuthenticationException.class);
+            }
+        }
+
+        @Test
+        @DisplayName("rejects a slug-less /callback — TenantContextFilter would find no tenant")
+        void shouldRejectSlugLessCallback() {
+            // Regression: this shape authorized fine, then failed the actual
+            // login with "no tenant context in session" (the tenant is derived
+            // from the redirect_uri path).
+            var context = buildContext("kelta-cli",
+                    "http://127.0.0.1:49152/callback", CLI_REGISTERED_URI);
+            assertThatThrownBy(() -> validator.accept(context))
+                    .isInstanceOf(OAuth2AuthorizationCodeRequestAuthenticationException.class);
+        }
+
+        @Test
+        @DisplayName("rejects malformed or traversing slugs")
+        void shouldRejectMalformedSlugs() {
+            for (String uri : new String[]{
+                    "http://127.0.0.1:49152//auth/callback",
+                    "http://127.0.0.1:49152/../auth/callback",
+                    "http://127.0.0.1:49152/Acme/auth/callback",
+                    "http://127.0.0.1:49152/9acme/auth/callback",
+                    "http://127.0.0.1:49152/acme/x/auth/callback",
+                    "http://127.0.0.1:49152/acme/auth/callback/extra"}) {
                 var context = buildContext("kelta-cli", uri, CLI_REGISTERED_URI);
                 assertThatThrownBy(() -> validator.accept(context))
                         .as("should reject %s", uri)
@@ -188,7 +217,7 @@ class PlatformRedirectUriValidatorTest {
         @DisplayName("the loopback rule does NOT apply to kelta-platform")
         void shouldNotApplyLoopbackRuleToPlatformClient() {
             var context = buildContext("kelta-platform",
-                    "http://127.0.0.1:49152/callback",
+                    "http://127.0.0.1:49152/acme/auth/callback",
                     "http://localhost:5173/auth/callback");
             assertThatThrownBy(() -> validator.accept(context))
                     .isInstanceOf(OAuth2AuthorizationCodeRequestAuthenticationException.class);
@@ -198,7 +227,7 @@ class PlatformRedirectUriValidatorTest {
         @DisplayName("the loopback rule does NOT apply to arbitrary clients")
         void shouldNotApplyLoopbackRuleToOtherClients() {
             var context = buildContext("other-client",
-                    "http://127.0.0.1:49152/callback",
+                    "http://127.0.0.1:49152/acme/auth/callback",
                     "https://myapp.com/oauth/callback");
             assertThatThrownBy(() -> validator.accept(context))
                     .isInstanceOf(OAuth2AuthorizationCodeRequestAuthenticationException.class);

--- a/kelta-web/packages/cli/src/auth/loginFlow.test.ts
+++ b/kelta-web/packages/cli/src/auth/loginFlow.test.ts
@@ -71,7 +71,13 @@ describe('browserLogin', () => {
     expect(tokenBody.get('client_id')).toBe('kelta-cli');
     expect(tokenBody.get('code')).toBe('auth-code-1');
     expect(tokenBody.get('code_verifier')).toMatch(/^[A-Za-z0-9_-]{43}$/);
-    expect(tokenBody.get('redirect_uri')).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/callback$/);
+    // the tenant slug MUST ride in the callback path — kelta-auth's
+    // TenantContextFilter reads it from here to scope the login (regression:
+    // a slug-less /callback authorized fine then failed with "no tenant
+    // context in session")
+    expect(tokenBody.get('redirect_uri')).toMatch(
+      /^http:\/\/127\.0\.0\.1:\d+\/acme\/auth\/callback$/
+    );
 
     // PAT mint: tenant-scoped endpoint, JWT bearer, requested lifetime
     const [patUrl, patBody, patConfig] = post.mock.calls[1] as [
@@ -121,6 +127,25 @@ describe('browserLogin', () => {
     await expect(browserLogin({ ...PARAMS, navigate: completeInBrowser })).rejects.toMatchObject({
       code: 'PAT_MINT_FAILED',
     });
+  });
+
+  it('builds an authorize URL whose redirect_uri carries the tenant slug', async () => {
+    let authorizeUrl = '';
+    post
+      .mockResolvedValueOnce({ data: { access_token: 'jwt-1' } })
+      .mockResolvedValueOnce({ data: { token: 'klt_x1234567890' } });
+
+    await browserLogin({
+      ...PARAMS,
+      tenantSlug: 'couchpicks',
+      navigate: (url) => {
+        authorizeUrl = url;
+        completeInBrowser(url);
+      },
+    });
+
+    const redirectUri = new URL(authorizeUrl).searchParams.get('redirect_uri') ?? '';
+    expect(new URL(redirectUri).pathname).toBe('/couchpicks/auth/callback');
   });
 
   it('aborts on a forged state without calling the token endpoint', async () => {

--- a/kelta-web/packages/cli/src/auth/loginFlow.ts
+++ b/kelta-web/packages/cli/src/auth/loginFlow.ts
@@ -55,10 +55,15 @@ export function deriveAuthUrl(apiUrl: string): string | undefined {
 export async function browserLogin(params: BrowserLoginParams): Promise<MintedPat> {
   const verifier = generateVerifier();
   const state = generateState();
-  const server = await startLoopbackServer(state, params.timeoutMs);
+  // The tenant slug MUST be in the callback path: kelta-auth's
+  // TenantContextFilter reads it from the redirect_uri to scope the user
+  // lookup. A slug-less path authorizes fine, then fails the actual login
+  // with "no tenant context in session".
+  const callbackPath = `/${params.tenantSlug}/auth/callback`;
+  const server = await startLoopbackServer(state, callbackPath, params.timeoutMs);
 
   try {
-    const redirectUri = `http://127.0.0.1:${String(server.port)}/callback`;
+    const redirectUri = `http://127.0.0.1:${String(server.port)}${callbackPath}`;
     const authorizeUrl =
       `${params.authUrl.replace(/\/$/, '')}/oauth2/authorize?` +
       new URLSearchParams({

--- a/kelta-web/packages/cli/src/auth/loopbackServer.test.ts
+++ b/kelta-web/packages/cli/src/auth/loopbackServer.test.ts
@@ -11,45 +11,48 @@ async function hit(port: number, path: string): Promise<number> {
 
 describe('startLoopbackServer', () => {
   it('resolves the code on a matching-state callback and serves the close page', async () => {
-    const server = await startLoopbackServer('state-1');
-    const status = await hit(server.port, '/callback?code=abc123&state=state-1');
+    const server = await startLoopbackServer('state-1', '/acme/auth/callback');
+    const status = await hit(server.port, '/acme/auth/callback?code=abc123&state=state-1');
     expect(status).toBe(200);
     await expect(server.code).resolves.toBe('abc123');
   });
 
   it('rejects on state mismatch (CSRF)', async () => {
-    const server = await startLoopbackServer('expected');
-    await hit(server.port, '/callback?code=abc123&state=forged');
+    const server = await startLoopbackServer('expected', '/acme/auth/callback');
+    await hit(server.port, '/acme/auth/callback?code=abc123&state=forged');
     await expect(server.code).rejects.toMatchObject({ code: 'STATE_MISMATCH', exitCode: 3 });
   });
 
   it('rejects when the IdP returns an error', async () => {
-    const server = await startLoopbackServer('state-1');
-    await hit(server.port, '/callback?error=access_denied&error_description=nope&state=state-1');
+    const server = await startLoopbackServer('state-1', '/acme/auth/callback');
+    await hit(
+      server.port,
+      '/acme/auth/callback?error=access_denied&error_description=nope&state=state-1'
+    );
     await expect(server.code).rejects.toMatchObject({ code: 'AUTHORIZATION_DENIED' });
   });
 
   it('rejects a callback with no code', async () => {
-    const server = await startLoopbackServer('state-1');
-    await hit(server.port, '/callback?state=state-1');
+    const server = await startLoopbackServer('state-1', '/acme/auth/callback');
+    await hit(server.port, '/acme/auth/callback?state=state-1');
     await expect(server.code).rejects.toMatchObject({ code: 'NO_AUTHORIZATION_CODE' });
   });
 
   it('404s other paths without settling', async () => {
-    const server = await startLoopbackServer('state-1', 5_000);
+    const server = await startLoopbackServer('state-1', '/acme/auth/callback', 5_000);
     expect(await hit(server.port, '/favicon.ico')).toBe(404);
     // still waiting — now complete it properly
-    await hit(server.port, '/callback?code=ok&state=state-1');
+    await hit(server.port, '/acme/auth/callback?code=ok&state=state-1');
     await expect(server.code).resolves.toBe('ok');
   });
 
   it('times out when the browser never comes back', async () => {
-    const server = await startLoopbackServer('state-1', 50);
+    const server = await startLoopbackServer('state-1', '/acme/auth/callback', 50);
     await expect(server.code).rejects.toMatchObject({ code: 'LOGIN_TIMEOUT', exitCode: 3 });
   });
 
   it('rejects CliError instances (mapped, not generic)', async () => {
-    const server = await startLoopbackServer('state-1', 50);
+    const server = await startLoopbackServer('state-1', '/acme/auth/callback', 50);
     await expect(server.code).rejects.toBeInstanceOf(CliError);
   });
 });

--- a/kelta-web/packages/cli/src/auth/loopbackServer.ts
+++ b/kelta-web/packages/cli/src/auth/loopbackServer.ts
@@ -17,12 +17,15 @@ export interface LoopbackServer {
 
 /**
  * One-shot RFC 8252 loopback listener. Binds 127.0.0.1 on an OS-assigned port
- * and waits for exactly one authorization callback on /callback. The state
- * parameter MUST match or the code is rejected (CSRF). Times out after
- * `timeoutMs` so an abandoned login never hangs the terminal.
+ * and waits for exactly one authorization callback on `callbackPath` — which is
+ * tenant-scoped (`/{slug}/auth/callback`) because kelta-auth derives the login's
+ * tenant from the redirect_uri path. The state parameter MUST match or the code
+ * is rejected (CSRF). Times out after `timeoutMs` so an abandoned login never
+ * hangs the terminal.
  */
 export function startLoopbackServer(
   expectedState: string,
+  callbackPath: string,
   timeoutMs = 120_000
 ): Promise<LoopbackServer> {
   return new Promise((resolveServer, rejectServer) => {
@@ -35,7 +38,7 @@ export function startLoopbackServer(
 
     const server: Server = createServer((req, res) => {
       const url = new URL(req.url ?? '/', 'http://127.0.0.1');
-      if (url.pathname !== '/callback') {
+      if (url.pathname !== callbackPath) {
         res.writeHead(404).end();
         return;
       }


### PR DESCRIPTION
## The bug
`kelta auth login` reached the login page, then failed. kelta-auth logs:

```
WARN io.kelta.auth.service.KeltaUserDetailsService --
  Refusing to authenticate 'couchpicks-admin@kelta.local': no tenant context in session
```

`TenantContextFilter` derives the login's tenant from the **redirect_uri path** (`^/([^/]+)/auth/callback$`) for every client — the SPA sends `https://app.kelta.io/couchpicks/auth/callback`, so the slug lands in the session and `KeltaUserDetailsService` scopes the user lookup. Slice 2's CLI sent `http://127.0.0.1:<port>/callback`: no slug → no session tenant → authentication refused. The redirect_uri does double duty as the tenant carrier, and I missed that when adding the loopback shape.

My slice-2 tests asserted the redirect was *accepted by OAuth validation*; none asserted a login could *complete*. That gap is why this reached deploy.

## The fix
Change the shape, not the filter: `kelta-cli` loopback redirects are now
`http://127.0.0.1:<port>/<tenant-slug>/auth/callback` (or `[::1]`).

- **`TenantContextFilter` needs no change** — its existing pattern already matches, so the CLI now behaves exactly like the SPA instead of via a parallel mechanism.
- `PlatformRedirectUriValidator` accepts `/{slug}/auth/callback` for `kelta-cli` only, slug pattern `[a-z][a-z0-9-]*` mirroring the gateway's `TenantSlugExtractionFilter`. Port still ignored (RFC 8252), loopback IP literals only (`localhost` still rejected), no userinfo/query/fragment.
- The registered redirect URI is only a template — the validator's loopback branch does the matching — so **the already-registered client keeps working with no DB migration**; the template string is updated for accuracy.
- CLI builds the tenant-scoped path and its one-shot listener serves it.

## Reviewer checklist
- [ ] Loopback branch still reachable only for client id `kelta-cli`
- [ ] Slug regex rejects traversal and malformed shapes (`//`, `..`, uppercase, leading digit, extra path segments) — covered by a new test
- [ ] Slug-less `/callback` now **rejected** (regression test) — this is the shape that broke
- [ ] `kelta-platform` / connected-app validation paths untouched

## Testing
- kelta-auth: 343 tests green. `CliLoopback` grew 9 → 11 (slug-less rejection, malformed slugs); registrar test updated.
- CLI: 199 green, including a new assertion that the authorize URL's `redirect_uri` path equals `/<slug>/auth/callback`.
- Docs updated (`kelta-auth/CLAUDE.md`, slice-2 spec) to state that the slug in the path is load-bearing, not cosmetic.

**Security-typed (redirect URI validation) — not auto-merged.** After merge + deploy I'll run the real login against couchpicks and report the result rather than assume it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)