### PR TITLE
fix(test): stop frontend suite timing out under CI load and blocking deploys

### DIFF
--- a/.claude/docs/concerns.md
+++ b/.claude/docs/concerns.md
@@ -657,3 +657,23 @@ Regression guard: `TenantAwareDataSourceTest` asserts tenant connections use tra
 - **Password reset sends no email** — `PasswordController.sendPasswordResetEmail` (line 212) calls `WorkerClient.sendTemplateEmail` with the `user.password_reset` template.
 - **Unhandled EmptyResultDataAccessException** — `PasswordController.changePassword` (line 82) catches `EmptyResultDataAccessException` and returns the generic 400 to prevent username enumeration.
 - **NPE on null `reset_token_expires_at`** — `PasswordController.resetPassword` (line 185) explicitly null-checks `expiresTs` before the `Timestamp.toInstant()` cast.
+
+## Frontend suite starves under concurrent image builds (2026-08-06)
+
+`Test Frontend` in Build-and-Deploy shares the runner with three concurrent GraalVM
+native image builds. Under that contention the suite reported `environment 594s`
+cumulative and a test **body** exceeded vitest's 5s default `testTimeout` —
+`Chat.test.tsx > MessageComposer` died on a `userEvent.type` of ~15 chars (~15 React
+renders). It failed 4 of 5 consecutive main runs and read like a deterministic break.
+
+**Operational severity is the real point:** `build-and-push` is gated on
+`test-frontend.result != 'failure'`, so a frontend flake silently stops every image
+build, the deploy job then correctly refuses to bump tags, and **nothing ships** —
+including urgent fixes. A red frontend suite on main is a deploy outage, not a test
+nuisance.
+
+Mitigations applied: `testTimeout`/`hookTimeout` raised to 20s (same rationale as the
+existing `asyncUtilTimeout: 5000` in `vitest.setup.ts`), and the composer tests use
+`fireEvent.change` + a committed-value assertion instead of per-keystroke typing.
+Still open: the underlying starvation (consider giving the frontend job its own runner
+or serialising it against the native builds).

--- a/kelta-web/packages/components/src/Chat/Chat.test.tsx
+++ b/kelta-web/packages/components/src/Chat/Chat.test.tsx
@@ -60,7 +60,11 @@ describe('MessageComposer', () => {
     render(<MessageComposer onSend={onSend} />);
     const input = screen.getByTestId('kelta-message-composer-input');
 
-    await userEvent.type(input, '  hello there  ');
+    // fireEvent.change over userEvent.type: one render instead of ~15, and the
+    // committed value is asserted before Enter so the keydown handler cannot
+    // close over a stale draft. This test is about trimming, not keystrokes.
+    fireEvent.change(input, { target: { value: '  hello there  ' } });
+    await waitFor(() => expect(input).toHaveValue('  hello there  '));
     fireEvent.keyDown(input, { key: 'Enter' });
 
     await waitFor(() => expect(onSend).toHaveBeenCalledWith('hello there'));
@@ -72,7 +76,8 @@ describe('MessageComposer', () => {
     render(<MessageComposer onSend={onSend} />);
     const input = screen.getByTestId('kelta-message-composer-input');
 
-    await userEvent.type(input, 'line one');
+    fireEvent.change(input, { target: { value: 'line one' } });
+    await waitFor(() => expect(input).toHaveValue('line one'));
     fireEvent.keyDown(input, { key: 'Enter', shiftKey: true });
 
     expect(onSend).not.toHaveBeenCalled();
@@ -83,7 +88,8 @@ describe('MessageComposer', () => {
     render(<MessageComposer onSend={onSend} />);
     const input = screen.getByTestId('kelta-message-composer-input');
 
-    await userEvent.type(input, 'important note');
+    fireEvent.change(input, { target: { value: 'important note' } });
+    await waitFor(() => expect(input).toHaveValue('important note'));
     fireEvent.click(screen.getByTestId('kelta-message-composer-send'));
 
     await waitFor(() => expect(onSend).toHaveBeenCalled());

--- a/kelta-web/vitest.config.ts
+++ b/kelta-web/vitest.config.ts
@@ -16,6 +16,16 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     setupFiles: ['./vitest.setup.ts'],
+    // The Build-and-Deploy workflow runs this suite on the same runner as three
+    // concurrent GraalVM native image builds. Under that contention a test BODY
+    // (not just a waitFor) can exceed vitest's 5s default — a userEvent.type of
+    // ~15 chars is ~15 React renders. That surfaced as a deterministic-looking
+    // "Test timed out in 5000ms" on main that blocked every image build and
+    // therefore every deploy. Same rationale as asyncUtilTimeout in
+    // vitest.setup.ts; kept well below the job timeout so a genuine hang still
+    // fails fast.
+    testTimeout: 20_000,
+    hookTimeout: 20_000,
     include: ['packages/**/*.{test,spec}.{ts,tsx}', 'packages/**/*.property.test.{ts,tsx}'],
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
## Impact first
This is a **deploy outage**, not a test nuisance. `build-and-push` is gated on `test-frontend.result != 'failure'`, so this flake stopped every image build on main; the deploy job then correctly refused to bump tags against images that were never pushed, and **nothing has shipped since 13:38** — including the CLI login fix (#1304) that users are currently blocked on.

Failed **4 of the last 5** main runs: 162033d, 37620b3, dd79326, a6ae63c (c6f888f squeaked through).

## Root cause
Not an assertion failure — `Test timed out in 5000ms` on
`Chat.test.tsx > MessageComposer > sends the trimmed draft on Enter and clears it`.

The Build-and-Deploy runner executes this suite alongside **three concurrent GraalVM native image builds**. The failing run reported `environment 594.52s` cumulative. Under that contention a test *body* (not just a `waitFor`) blows vitest's 5s default `testTimeout`: `userEvent.type(input, '  hello there  ')` is ~15 keystrokes, each a React render.

It reproduces on neither an idle nor a CPU-saturated laptop (0/8 and 0/6), because the trigger is the runner's specific starvation profile — which is exactly why it looked deterministic in CI and invisible locally.

## Fix
- `testTimeout`/`hookTimeout` → 20s, with the rationale in a comment. This mirrors the precedent already in `vitest.setup.ts` (`asyncUtilTimeout: 5000`, added for this same "concurrent with heavy container image builds" reason). Kept well under the job timeout so a genuine hang still fails fast.
- Composer tests use `fireEvent.change` + a committed-value assertion instead of per-keystroke typing — one render instead of ~15. Test body 374ms → 218ms.
- That assertion also closes a **latent stale-closure race**: `handleKeyDown` closes over `draft`, and firing Enter immediately after typing could capture a draft from before the last keystroke committed. Asserting the value first makes the ordering explicit rather than incidental.

## Testing
- Full workspace suite green (1120 tests, 56 files); lint/typecheck/format clean.
- Chat file: 9/9, duration 3.57s → 1.65s.

## Still open (documented in `concerns.md`)
The underlying starvation is untouched — the frontend job shares a runner with the native builds. Worth giving it its own runner or serialising it, otherwise the next slow test rediscovers this. Filed as a known risk rather than silently absorbed by a bigger timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)