### PR TITLE
fix(cli): local MCP — stdout purity, hosted URL, and launchable install command

### DIFF
--- a/.claude/docs/specs/kelta-cli/5-local-mcp.md
+++ b/.claude/docs/specs/kelta-cli/5-local-mcp.md
@@ -10,6 +10,9 @@ a stdio MCP server (TypeScript `@modelcontextprotocol/sdk`) composing two tool s
 
 - **Remote bridge (default for platform tools)**: forwards JSON-RPC messages to hosted
   kelta-mcp at `{mcpUrl}/{tenantSlug}/mcp/{user|admin}` with the profile PAT as bearer.
+  **`mcpUrl` defaults to the profile's API origin** — kelta-mcp is not a separate public
+  host; the gateway routes `^/[a-z][a-z0-9-]+/mcp/(user|admin)` on the `api.*` host.
+  `--mcp-url` overrides it for deployments that do front kelta-mcp separately.
   The hosted server is **stateless HTTP** (one POST per message, no session) — the bridge
   is a thin per-message forwarder; pod restarts are invisible by design. `tools/list` is
   fetched from the remote and merged. This keeps the 38 platform tools single-sourced in

--- a/kelta-web/README.md
+++ b/kelta-web/README.md
@@ -100,6 +100,12 @@ kelta metadata export -n app -v 1.0 -o app.json        # file flag is -o/--out
 kelta sandbox create -n dev && kelta promote create -s <src> -t <dst>
 ```
 
+**Local MCP** — `kelta mcp serve` bridges the hosted kelta-mcp toolsets (via the gateway at
+`{apiUrl}/{slug}/mcp/{user|admin}`; override with `--mcp-url`) and adds `cli_`-prefixed local
+tools from the registry. `kelta mcp install claude-desktop|claude-code|cursor|generic` prints
+client config using the **resolved absolute binary path** — GUI clients are launched by the OS,
+not a login shell, so a bare `kelta` on PATH does not resolve.
+
 **Self-update & distribution** — released binaries (`kelta-cli-downloads` image,
 downloads.kelta.io) embed version/sha/target and self-update with `kelta update`
 (sha256-verified atomic swap; `--check` reports only; `KELTA_UPDATE_URL` overrides the

--- a/kelta-web/packages/cli/src/commands/mcp.ts
+++ b/kelta-web/packages/cli/src/commands/mcp.ts
@@ -5,8 +5,21 @@ import { CliError, EXIT } from '../errors.js';
 import { deriveMcpUrl, RemoteEndpoint, type Toolset } from '../mcp/remote.js';
 import { buildMcpServer, connectServer, type McpSource } from '../mcp/server.js';
 import { defineCommand, type RegisteredCommand } from '../registry/types.js';
+import { BUILD_TARGET } from '../version.js';
 
 const TOOLSETS: Toolset[] = ['user', 'admin'];
+
+/**
+ * Command a GUI MCP client should launch. Desktop clients (Claude Desktop,
+ * Cursor) are started by the OS launcher, NOT a login shell, so they do not
+ * inherit `~/.local/bin` on PATH — a bare `kelta` fails to spawn with no
+ * useful error. A released binary knows its own absolute path; a dev build
+ * (node running dist/) falls back to the bare name, since execPath there is
+ * the node interpreter.
+ */
+function launcherCommand(): string {
+  return BUILD_TARGET === 'dev' ? 'kelta' : process.execPath;
+}
 
 function resolveToolsets(toolset: string): Toolset[] {
   return toolset === 'all' ? TOOLSETS : [toolset as Toolset];
@@ -132,14 +145,15 @@ const install = defineCommand({
       return Promise.resolve({ text });
     }
 
+    const command = launcherCommand();
     const stdioConfig = JSON.stringify(
-      { mcpServers: { [name]: { command: 'kelta', args: serveArgs } } },
+      { mcpServers: { [name]: { command, args: serveArgs } } },
       null,
       2
     );
     const text =
       input.client === 'claude-code'
-        ? `claude mcp add ${name} -- kelta ${serveArgs.join(' ')}\n`
+        ? `claude mcp add ${name} -- ${command} ${serveArgs.join(' ')}\n`
         : input.client === 'claude-desktop'
           ? `# Merge into claude_desktop_config.json (Claude Desktop → Settings → Developer):\n${stdioConfig}\n`
           : input.client === 'cursor'

--- a/kelta-web/packages/cli/src/commands/mcp.ts
+++ b/kelta-web/packages/cli/src/commands/mcp.ts
@@ -50,6 +50,7 @@ const serve = defineCommand({
   name: 'serve',
   summary: 'Run a stdio MCP server: hosted kelta-mcp tools bridged + cli_ local tools',
   requiresAuth: false, // source=local works offline; remote sources check the profile themselves
+  ownsStdout: true, // stdout carries JSON-RPC frames only
   options: [
     { flag: '--toolset <set>', description: 'user|admin|all', default: 'all' },
     { flag: '--source <source>', description: 'auto|remote|local', default: 'auto' },

--- a/kelta-web/packages/cli/src/commands/mcpInstall.test.ts
+++ b/kelta-web/packages/cli/src/commands/mcpInstall.test.ts
@@ -6,6 +6,7 @@ import { setConfigDirForTesting, setLegacyRcForTesting } from '../config/paths.j
 import { saveConfig, setToken } from '../config/store.js';
 import type { CommandContext, RegisteredCommand } from '../registry/types.js';
 import { mcpCommands } from './mcp.js';
+import { BUILD_TARGET } from '../version.js';
 
 const TOKEN = 'klt_install1234567890';
 
@@ -44,7 +45,24 @@ async function run(input: Record<string, unknown>) {
 describe('kelta mcp install', () => {
   it('claude-code default recommends the stdio bridge', async () => {
     const result = await run({ client: 'claude-code' });
-    expect(result.text).toContain('claude mcp add kelta-prod -- kelta mcp serve --profile prod');
+    expect(result.text).toContain('claude mcp add kelta-prod --');
+    expect(result.text).toContain('mcp serve --profile prod');
+  });
+
+  it('emits a launcher GUI clients can actually spawn (absolute path when released)', async () => {
+    // Regression: desktop clients are started by the OS launcher, not a login
+    // shell, so ~/.local/bin is not on PATH and a bare `kelta` fails to spawn.
+    const desktop = await run({ client: 'claude-desktop' });
+    const parsed = JSON.parse(desktop.text?.slice(desktop.text.indexOf('{')) ?? '{}') as {
+      mcpServers: Record<string, { command: string }>;
+    };
+    const command = parsed.mcpServers['kelta-prod'].command;
+    if (BUILD_TARGET === 'dev') {
+      expect(command).toBe('kelta');
+    } else {
+      expect(command).toBe(process.execPath);
+      expect(command.startsWith('/')).toBe(true);
+    }
   });
 
   it('claude-desktop and cursor print mergeable stdio JSON', async () => {
@@ -68,7 +86,8 @@ describe('kelta mcp install', () => {
 
   it('--direct emits the hosted HTTP endpoint with a PAT placeholder, never the token', async () => {
     const result = await run({ client: 'claude-code', direct: true, toolset: 'user' });
-    expect(result.text).toContain('https://mcp.kelta.io/acme/mcp/user');
+    // gateway-routed, not a separate mcp.* host
+    expect(result.text).toContain('https://api.kelta.io/acme/mcp/user');
     expect(result.text).toContain('<YOUR_PAT>');
     expect(result.text).not.toContain(TOKEN);
   });

--- a/kelta-web/packages/cli/src/mcp/localTools.test.ts
+++ b/kelta-web/packages/cli/src/mcp/localTools.test.ts
@@ -99,8 +99,15 @@ describe('runLocalCommand', () => {
 });
 
 describe('deriveMcpUrl', () => {
-  it('swaps api. for mcp. and rejects non-conventional hosts', () => {
-    expect(deriveMcpUrl('https://api.kelta.io')).toBe('https://mcp.kelta.io');
-    expect(deriveMcpUrl('https://gateway.internal')).toBeUndefined();
+  it('uses the API origin — the gateway routes /{slug}/mcp/{toolset}', () => {
+    // Regression: an earlier version swapped api.->mcp., a host that does not
+    // exist. Every bridge request 404'd and the server silently degraded to
+    // local-only tools.
+    expect(deriveMcpUrl('https://api.kelta.io')).toBe('https://api.kelta.io');
+    expect(deriveMcpUrl('https://api.kelta.io/some/path')).toBe('https://api.kelta.io');
+    expect(deriveMcpUrl('http://localhost:8080')).toBe('http://localhost:8080');
+    // any reachable API origin works — no host-name convention is assumed
+    expect(deriveMcpUrl('https://gateway.internal')).toBe('https://gateway.internal');
+    expect(deriveMcpUrl('not a url')).toBeUndefined();
   });
 });

--- a/kelta-web/packages/cli/src/mcp/remote.ts
+++ b/kelta-web/packages/cli/src/mcp/remote.ts
@@ -16,21 +16,22 @@ interface JsonRpcResponse {
 }
 
 /**
- * Derive the hosted MCP base URL from the API URL by swapping a leading
- * `api.` host label for `mcp.` (api.kelta.io → mcp.kelta.io).
+ * Hosted MCP base URL for a profile: **the API origin itself**.
+ *
+ * kelta-mcp is not a separate public host — the gateway routes the MCP paths
+ * (`Host(api.…) && PathRegexp(^/[a-z][a-z0-9-]+/mcp/(user|admin)…)`), so
+ * `{apiUrl}/{slug}/mcp/{toolset}` is the real endpoint. An earlier version
+ * invented an `api.` → `mcp.` host swap by symmetry with the auth URL; that
+ * host does not exist, so every bridge request 404'd and the server silently
+ * degraded to local-only tools. Override with `--mcp-url` when a deployment
+ * really does front kelta-mcp on its own host.
  */
 export function deriveMcpUrl(apiUrl: string): string | undefined {
   try {
-    const url = new URL(apiUrl);
-    if (url.hostname.startsWith('api.')) {
-      url.hostname = 'mcp.' + url.hostname.slice(4);
-      url.pathname = '';
-      return url.origin;
-    }
+    return new URL(apiUrl).origin;
   } catch {
-    // fall through
+    return undefined;
   }
-  return undefined;
 }
 
 /**

--- a/kelta-web/packages/cli/src/registry/bind.ts
+++ b/kelta-web/packages/cli/src/registry/bind.ts
@@ -81,11 +81,13 @@ export async function dispatch(
     if (isDangerous) await confirmDangerous(def, global);
     const ctx: CommandContext = buildContext(global);
     const result = await def.handler(ctx, input as never);
+    // stdout-owning commands (the stdio MCP server) carry protocol bytes: a
+    // rendered result or an update hint would corrupt the JSON-RPC stream and
+    // the client rejects the whole connection.
+    if (def.ownsStdout) return;
     const format = pickFormat(global.output, process.stdout.isTTY ?? false);
     process.stdout.write(renderResult(result, { format, raw: global.raw, quiet: global.quiet }));
-    // stdio MCP servers must never write hints; everything else may nudge once/day
-    if (def.group !== 'mcp')
-      await maybeNotifyUpdate((message) => process.stderr.write(message + '\n'));
+    await maybeNotifyUpdate((message) => process.stderr.write(message + '\n'));
   } catch (error) {
     const mapped = mapError(error);
     const format = pickFormat(global.output, process.stderr.isTTY ?? false);

--- a/kelta-web/packages/cli/src/registry/stdoutOwnership.test.ts
+++ b/kelta-web/packages/cli/src/registry/stdoutOwnership.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Command } from 'commander';
+import { z } from 'zod';
+import { bindCommands } from './bind.js';
+import { defineCommand, type RegisteredCommand } from './types.js';
+
+/**
+ * stdout of `mcp serve` IS the JSON-RPC transport. Any extra byte the
+ * dispatcher writes — a rendered handler result, an update hint — corrupts the
+ * stream and the MCP client rejects the whole connection with a schema error.
+ *
+ * Regression: `mcp serve` returned {} and the dispatcher rendered it, appending
+ * {"message":"ok"} to the protocol stream on shutdown. Claude Desktop failed
+ * with invalid_union / unrecognized_keys ["message"].
+ */
+let written: string[];
+
+beforeEach(() => {
+  written = [];
+  vi.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown) => {
+    written.push(String(chunk));
+    return true;
+  });
+  vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+  process.exitCode = undefined;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  process.exitCode = undefined;
+});
+
+function run(def: RegisteredCommand, argv: string[]) {
+  const program = new Command();
+  program.name('kelta').exitOverride().option('--output <format>', 'format');
+  bindCommands(program, [def]);
+  return program.parseAsync(argv, { from: 'user' });
+}
+
+const serveLike = defineCommand({
+  group: 'mcp',
+  name: 'serve',
+  summary: 'owns stdout',
+  requiresAuth: false,
+  ownsStdout: true,
+  input: z.object({}),
+  // mirrors the real handler: returns an empty result after the transport closes
+  handler: () => Promise.resolve({}),
+});
+
+const normal = defineCommand({
+  group: 'things',
+  name: 'noop',
+  summary: 'ordinary command',
+  requiresAuth: false,
+  input: z.object({}),
+  handler: () => Promise.resolve({}),
+});
+
+describe('stdout ownership', () => {
+  it('writes NOTHING to stdout for an ownsStdout command', async () => {
+    await run(serveLike as RegisteredCommand, ['mcp', 'serve', '--output', 'json']);
+    expect(written.join('')).toBe('');
+  });
+
+  it('still renders ordinary commands (guard is not blanket-suppressing output)', async () => {
+    await run(normal as RegisteredCommand, ['things', 'noop', '--output', 'json']);
+    // this is the exact frame that corrupted the MCP stream — correct here, fatal there
+    expect(JSON.parse(written.join(''))).toEqual({ message: 'ok' });
+  });
+
+  it('the real mcp serve command is flagged ownsStdout', async () => {
+    const { mcpCommands } = await import('../commands/mcp.js');
+    const serve = mcpCommands.find((command) => command.name === 'serve');
+    expect(serve?.ownsStdout).toBe(true);
+    // install prints config for humans and must NOT be suppressed
+    expect(mcpCommands.find((command) => command.name === 'install')?.ownsStdout).toBeFalsy();
+  });
+});

--- a/kelta-web/packages/cli/src/registry/types.ts
+++ b/kelta-web/packages/cli/src/registry/types.ts
@@ -58,6 +58,13 @@ export interface CommandDef<I = unknown> {
   dangerous?: boolean | ((input: I) => boolean);
   /** Default true; false for local-only commands (profile, login). */
   requiresAuth?: boolean;
+  /**
+   * This command writes its own protocol bytes to stdout (the stdio MCP
+   * server). The dispatcher must NOT render a result or print any hint —
+   * a single stray line corrupts the JSON-RPC stream and the client rejects
+   * the connection.
+   */
+  ownsStdout?: boolean;
   // method syntax (not a property) — bivariant, so CommandDef<Specific>
   // stays assignable to the erased RegisteredCommand below
   handler(ctx: CommandContext, input: I): Promise<HandlerResult>;
@@ -78,6 +85,7 @@ export interface RegisteredCommand {
   input: { parse(raw: unknown): unknown };
   dangerous?: boolean | ((input: never) => boolean);
   requiresAuth?: boolean;
+  ownsStdout?: boolean;
   handler(ctx: CommandContext, input: never): Promise<HandlerResult>;
 }
 


### PR DESCRIPTION
## Three defects, all found running the local MCP against Claude Desktop and the live cluster

### 1. `mcp serve` corrupted its own protocol stream (the connection-killer)
Claude Desktop rejected the server outright:

```
invalid_union … "code": "unrecognized_keys", "keys": ["message"]
```

`mcp serve` is a registry command, so when its handler returned, the dispatcher **rendered the result to stdout** — the handler returns `{}`, which the JSON renderer turns into `{"message":"ok"}`. That frame lands inside the JSON-RPC transport the server exclusively owns, and the client's schema validation kills the session.

Fixed with an explicit `ownsStdout` marker on the command definition: the dispatcher skips both result rendering and the passive update hint for such commands. That also replaces a `def.group !== 'mcp'` guard on the update hint which was *right by accident* — it would have wrongly suppressed hints for `mcp install`, an ordinary command that should print.

### 2. `deriveMcpUrl` pointed at a host that doesn't exist
I derived the hosted MCP base by swapping `api.` → `mcp.`, by symmetry with the auth URL. There is no `mcp.kelta.io`; the gateway routes the MCP paths itself:

```
Host(`api.kelta.io`) && PathRegexp(`^/[a-z][a-z0-9-]+/mcp/(user|admin)(/.*)?$`)
```

Every bridge request 404'd. Because `--source auto` degrades gracefully by design, the server came up "fine" serving **17 local tools instead of 56**, visible only as a stderr warning no GUI client shows. Now the base URL is the profile's **API origin**; `--mcp-url` still overrides.

### 3. `mcp install` emitted a command GUI clients can't spawn
It printed `"command": "kelta"`. Desktop clients are launched by the OS (launchd), not a login shell, so `~/.local/bin` isn't on PATH and the server fails to start with no useful error. Released binaries now emit their own absolute path via `process.execPath`; dev builds keep the bare name, since `execPath` there is the node interpreter.

## Verification
Compiled a release-style binary and drove a real MCP session against the live cluster:

- stdout across a full session **including shutdown**: 2 frames, both valid JSON-RPC, zero stray bytes (previously line 2 was `{"message":"ok"}`)
- with **no `--mcp-url` flag**: `tools/list` → **56 tools** (39 hosted + 17 local), zero warnings — previously 17 and two 404 warnings
- `mcp install claude-desktop` emits an absolute `command` path

1124 tests green; lint/typecheck/format clean.

**The stdout test was validated by breaking the fix.** My first attempt spawned a subprocess and passed even with the fix reverted — vacuous, because node couldn't resolve `.js`→`.ts` imports and it hit an early return. I threw it away and tested the dispatcher directly; that version fails without the fix, which I confirmed before committing.

## How these got in
Same root cause as the tenant-slug bug in #1304: I inferred conventions (`api.`→`mcp.` by symmetry, `kelta` will be on PATH) and wrote unit tests that asserted my inference back at me. The stdout bug is a variant — the MCP server tests used an in-memory transport, which never exercises the real process stdout the dispatcher writes to. All three only surfaced against the real system.

🤖 Generated with [Claude Code](https://claude.com/claude-code)