### PR TITLE
test(e2e): stop CLI round-trip leaking undeletable collections into product tenants

### DIFF
--- a/.claude/docs/concerns.md
+++ b/.claude/docs/concerns.md
@@ -677,3 +677,34 @@ existing `asyncUtilTimeout: 5000` in `vitest.setup.ts`), and the composer tests 
 `fireEvent.change` + a committed-value assertion instead of per-keystroke typing.
 Still open: the underlying starvation (consider giving the frontend job its own runner
 or serialising it against the native builds).
+
+## Collections become undeletable once used; e2e leaked litter into a product tenant (2026-08-06)
+
+`PhysicalTableStorageAdapter.delete` issues a raw `DELETE` on the `collection`
+row and maps Postgres FK violation 23503 to 409 `REFERENCED_RECORD`. **15 tables
+reference `collection(id)` with NO `ON DELETE CASCADE`** — `field_history`,
+`file_attachment`, `bulk_job`, `validation_rule`, `list_view`, `page_layout`,
+`record_type`, `report`, `note`, `script_trigger`, `layout_assignment`,
+`layout_related_list`, `email_template.related_collection_id`,
+`approval_process`, `field.reference_collection_id`. Several (`field_history`,
+`file_attachment`, `script_trigger`, `bulk_job`) have **no delete API**. So once
+a collection has been used — any record write creates `field_history` rows — it
+can no longer be deleted through the API/CLI at all. (`field.collection_id`,
+`collection_version`, `search_index`, profile permissions DO cascade.)
+
+Surfaced when the CLI e2e round-trip (`e2e-tests/tests/admin/cli-smoke.spec.ts`)
+ran against the **couchpicks product tenant** and left 10 undeletable
+`e2e_cli_*` / `e2e_test_*` collections (plus 5 `e2e_wizard_*` that were
+cleanable). The page-builder wizard specs leak the same way.
+
+Fixes applied: the cli-smoke round-trip now refuses to create schema unless the
+tenant slug is disposable (`/e2e|test|sandbox|ci/`) or
+`KELTA_E2E_ALLOW_SCHEMA_MUTATION=1` is set, and its teardown deletes data
+records before the collection. Still open (needs backend work / DB access, not
+freelanced against prod):
+1. Give the child-table FKs `ON DELETE CASCADE` (or add a cascade path to
+   `deleteCollection`) so a collection can be torn down. Audit the 15 above.
+2. Point the deploy-pipeline e2e at a disposable tenant, not `default`/a product
+   tenant, so the guard above doesn't just skip the round-trip in CI.
+3. Clean the 10 stuck collections already in couchpicks — requires the cascade
+   fix or direct control-plane DB deletion.

--- a/e2e-tests/tests/admin/cli-smoke.spec.ts
+++ b/e2e-tests/tests/admin/cli-smoke.spec.ts
@@ -108,7 +108,26 @@ test.describe("kelta CLI smoke", () => {
     expect(payload.error.code).toBe("CONFIRMATION_REQUIRED");
   });
 
+  // This round-trip CREATES a collection, adds a field + validation rule, and
+  // WRITES records. It must never touch a real product tenant: the platform
+  // cannot delete a collection once it has been used (child rows in tables like
+  // field_history / validation_rule reference collection(id) with no
+  // ON DELETE CASCADE and no delete API), so teardown is inherently
+  // best-effort and any run leaves a permanent, undeletable collection behind.
+  // An earlier version ran against `couchpicks` and littered it with
+  // undeletable e2e_cli_* / e2e_test_* collections.
+  //
+  // Guard: run only against a tenant whose slug is clearly disposable, or when
+  // the operator explicitly opts in. Default is skip.
+  const disposableTenant = /(^|[-_])(e2e|test|sandbox|ci)([-_]|$)/i.test(TENANT ?? "");
+  const mutationOptIn = process.env.KELTA_E2E_ALLOW_SCHEMA_MUTATION === "1";
+  const mayMutate = disposableTenant || mutationOptIn;
+
   test("admin round-trip: collection → field → validation rule → rejected record → delete", () => {
+    test.skip(
+      !mayMutate,
+      `refusing to create schema in tenant "${TENANT ?? "?"}" — set KELTA_E2E_ALLOW_SCHEMA_MUTATION=1 or use a disposable tenant`
+    );
     test.setTimeout(120_000);
     const name = `e2e_cli_${String(Date.now())}`;
     try {
@@ -151,6 +170,13 @@ test.describe("kelta CLI smoke", () => {
       ]);
       expect(accepted.status, accepted.stderr).toBe(0);
     } finally {
+      // Best-effort teardown in dependency order. The collection itself may
+      // survive (see the guard comment above) — clear what the API allows so a
+      // disposable tenant stays as clean as possible.
+      const ids = runCli(["records", "list", name, "--quiet"]).stdout.split("\n").filter(Boolean);
+      for (const id of ids) {
+        runCli(["records", "delete", name, id, "--yes", "--output", "json"]);
+      }
       runCli(["collections", "delete", name, "--yes", "--output", "json"]);
     }
   });


### PR DESCRIPTION
## What you asked me to fix
The couchpicks collection list was cluttered with `e2e_test_*` / `e2e_wizard_*` / `e2e_cli_*` collections. Root cause + prevention below; cleanup status is honest.

## Why the litter is undeletable
`collections delete` does a raw `DELETE` on the `collection` row. **15 tables reference `collection(id)` with no `ON DELETE CASCADE`** (`field_history`, `file_attachment`, `bulk_job`, `validation_rule`, `list_view`, `page_layout`, `record_type`, `report`, `note`, `script_trigger`, …), and several have **no delete API**. Any record write creates `field_history` rows — so once a collection is used, it can never be deleted through the API. My CLI round-trip writes records, so every run it leaves a permanent collection behind, and it ran against **couchpicks, a product tenant**.

## This PR (prevention — the part I own)
- The schema-mutating round-trip now **skips unless the tenant is disposable** (`/e2e|test|sandbox|ci/`) or `KELTA_E2E_ALLOW_SCHEMA_MUTATION=1` is set. It will never silently create schema in a product tenant again.
- Teardown deletes data records before the collection (best-effort; the collection def may still survive per the platform gap).
- `concerns.md` documents the 15 non-cascade FKs and the follow-ups.

## Not in this PR — flagged, not freelanced
1. **Platform fix**: give those child-table FKs `ON DELETE CASCADE` (or a cascade path in `deleteCollection`). Without it, no used collection is ever deletable — a latent problem well beyond e2e.
2. **Pipeline**: point the deploy e2e at a disposable tenant instead of `default`, else the guard above just skips this round-trip in CI (coverage lost, but that beats polluting prod).
3. **Cleanup of the 10 stuck couchpicks collections**: needs the cascade fix or direct control-plane DB deletion. I deleted the 5 that were cleanable; I will not run raw `DELETE`s against the production app DB on inference. Happy to do it with you, or once the cascade fix lands.

## Testing
e2e spec typechecks; guard verified to skip against a non-disposable tenant name and run under the opt-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)