### PR TITLE
fix(worker): make collections deletable once used (ON DELETE CASCADE on collection FKs)

### DIFF
--- a/.claude/docs/concerns.md
+++ b/.claude/docs/concerns.md
@@ -269,6 +269,32 @@ ids raw when they're not in the live page's `lookupDisplayMap` (no write-time di
 
 (No open bugs from the original audit. See Resolved → Bugs.)
 
+**FIXED (V181__collection_fk_cascade) — collections became permanently undeletable once
+used.** Deleting a collection is a generic record delete against the `collection` table
+(`DynamicCollectionRouter` → `QueryEngine.delete`); `PhysicalTableStorageAdapter` maps
+Postgres FK violation 23503 to a 409 `REFERENCED_RECORD`. 14 tables referenced
+`collection(id)` with **no** `ON DELETE` action (approval_process, bulk_job, field_history,
+file_attachment, layout_assignment, layout_related_list.related_collection_id, list_view,
+note, page_layout, record_type, report.primary_collection_id, script_trigger,
+validation_rule, email_template.related_collection_id). Several (field_history,
+file_attachment, bulk_job, script_trigger) have no delete API, so once a collection had any
+record written that emitted a `field_history` row it could never be deleted via API/CLI.
+V181 sets `ON DELETE CASCADE` on the 13 that are *owned by* the collection (same semantics
+as the V173 field-delete cascade), `ON DELETE SET NULL` on `email_template.related_collection_id`
+(a reusable template only tagged against the collection; nullable), and cascades four
+intermediate children on the delete tree so the recursive cascade completes
+(approval_instance→approval_process, dashboard_component→report,
+layout_assignment→{page_layout,record_type}). `field.reference_collection_id` (a lookup in
+collection B pointing at A) already had `ON DELETE SET NULL` — left as-is (nulling the
+target beats silently deleting B's field). Regression guard:
+`CollectionDeletionScenarioTest` (kelta-test-harness) writes a record (→ field_history) +
+a list view, then deletes the collection end to end and asserts the cascade.
+**Residual open gap:** collection delete still does **not** `DROP` the physical user-data
+table (no `DROP TABLE` exists in `src/main`; `CollectionLifecycleManager.teardownCollection`
+is explicit that "data is not dropped"), nor does it purge S3 objects behind cascaded
+`file_attachment` rows — both leak storage after a delete. Tracked as follow-up (needs an
+ordered teardown in the delete service, not an FK).
+
 **FIXED (fix/gateway-rate-limiter-fixed-window) — gateway rate limiter never reset its
 window under continuous traffic → tenant-wide self-sustaining 429 lockout; root cause of
 the "storage-ready" e2e flake (found 2026-07-11 from PR #1240's failing run).**

--- a/kelta-test-harness/src/test/java/io/kelta/testharness/scenarios/CollectionDeletionScenarioTest.java
+++ b/kelta-test-harness/src/test/java/io/kelta/testharness/scenarios/CollectionDeletionScenarioTest.java
@@ -1,0 +1,192 @@
+package io.kelta.testharness.scenarios;
+
+import io.kelta.testharness.ScenarioBase;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestClient;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression guard for "collections become undeletable once used" (concerns.md). A
+ * collection is deleted as a generic record delete against the {@code collection} table;
+ * before V181, 14 FKs referenced {@code collection(id)} with no ON DELETE action, so any
+ * dependent row — including {@code field_history} rows written automatically on the first
+ * record write, and metadata rows (a saved list view) with no delete API — turned the
+ * delete into a permanent 409 REFERENCED_RECORD.
+ *
+ * <p>This exercises the real stack (gateway → worker → per-tenant Postgres): create a
+ * collection, add a {@code trackHistory} field, write a record (→ a {@code field_history}
+ * row), and create a {@code list_view} — two distinct FK blockers with no delete API — then
+ * DELETE the collection and assert it returns 204 and every dependent row cascaded away.
+ * This is the DB-constraint regression the "test-gap" lesson demands: Mockito worker tests
+ * cannot exercise a real ON DELETE CASCADE.
+ */
+@DisplayName("Collection Deletion Scenario")
+class CollectionDeletionScenarioTest extends ScenarioBase {
+
+    @Test
+    @DisplayName("a used collection (field_history + list view) deletes end to end, cascading dependents")
+    @SuppressWarnings("unchecked")
+    void usedCollectionCanBeDeleted() throws Exception {
+        String token = auth.loginAsAdmin();
+        String tenantId = auth.extractTenantId(token);
+        String slug = tenants.slugForTenantId(tenantId);
+        RestClient client = gatewayClientWithToken(token);
+
+        String collectionName = "deltest";
+
+        // Collections route is live for the tenant.
+        waitForStatus(client, "/" + slug + "/api/collections", HttpStatus.OK, 20);
+
+        // 1. Create a user collection.
+        Map<String, Object> collectionBody = Map.of("data", Map.of(
+                "type", "collections",
+                "attributes", Map.of(
+                        "name", collectionName,
+                        "displayName", "Deletion Test",
+                        "tenantScoped", true)));
+        ResponseEntity<Map> createdCollection = client.post().uri("/" + slug + "/api/collections")
+                .contentType(MediaType.APPLICATION_JSON).body(collectionBody)
+                .retrieve().toEntity(Map.class);
+        assertThat(createdCollection.getStatusCode().is2xxSuccessful()).isTrue();
+        String collectionId = (String) ((Map<String, Object>) createdCollection.getBody().get("data")).get("id");
+        assertThat(collectionId).isNotBlank();
+
+        // The dynamic route for the new collection propagates via NATS — wait for it.
+        waitForStatus(client, "/" + slug + "/api/" + collectionName, HttpStatus.OK, 30);
+
+        // 2. Add a history-tracked field so a record write produces a field_history row.
+        addTrackedField(client, slug, collectionId, "title");
+        waitForField(client, slug, collectionId, "title");
+
+        // 3. Write a record — FieldHistoryHook inserts a field_history row (collection_id →
+        //    collection(id)). field_history has no delete API, so this is what historically
+        //    made the collection permanently undeletable.
+        Map<String, Object> recordBody = Map.of("data", Map.of(
+                "type", collectionName,
+                "attributes", Map.of("title", "keep-me")));
+        ResponseEntity<Map> createdRecord = client.post().uri("/" + slug + "/api/" + collectionName)
+                .contentType(MediaType.APPLICATION_JSON).body(recordBody)
+                .retrieve().toEntity(Map.class);
+        assertThat(createdRecord.getStatusCode().is2xxSuccessful()).isTrue();
+
+        // 4. Create a saved list view — a second FK blocker (list_view.collection_id) with
+        //    no delete API of its own.
+        Map<String, Object> listViewBody = Map.of("data", Map.of(
+                "type", "list-views",
+                "attributes", Map.of(
+                        "collectionId", collectionId,
+                        "name", "All " + collectionName,
+                        "columns", List.of(Map.of("field", "title")))));
+        ResponseEntity<Map> createdListView = client.post().uri("/" + slug + "/api/list-views")
+                .contentType(MediaType.APPLICATION_JSON).body(listViewBody)
+                .retrieve().toEntity(Map.class);
+        assertThat(createdListView.getStatusCode().is2xxSuccessful()).isTrue();
+
+        // Sanity: both blockers really exist before the delete (else the test proves nothing).
+        assertThat(countByCollectionId("field_history", collectionId))
+                .as("record write should have produced a field_history row").isPositive();
+        assertThat(countByCollectionId("list_view", collectionId))
+                .as("a list view should exist for the collection").isPositive();
+
+        // 5. Delete the collection. Before V181 this returned 409 REFERENCED_RECORD forever.
+        HttpStatusCode deleteStatus = client.delete()
+                .uri("/" + slug + "/api/collections/" + collectionId)
+                .retrieve()
+                .onStatus(s -> true, (req, resp) -> {})
+                .toBodilessEntity()
+                .getStatusCode();
+        assertThat(deleteStatus)
+                .as("used collection should delete (204), not 409 REFERENCED_RECORD")
+                .isEqualTo(HttpStatus.NO_CONTENT);
+
+        // 6. The collection row and every cascaded dependent are gone.
+        assertThat(countById("collection", collectionId)).as("collection row removed").isZero();
+        assertThat(countByCollectionId("field_history", collectionId))
+                .as("field_history rows cascaded").isZero();
+        assertThat(countByCollectionId("list_view", collectionId))
+                .as("list_view rows cascaded").isZero();
+        assertThat(countByCollectionId("field", collectionId))
+                .as("field rows cascaded (existing fk_field_collection)").isZero();
+    }
+
+    /** Adds a STRING field with {@code trackHistory=true} so writes emit field_history rows. */
+    private void addTrackedField(RestClient client, String slug, String collectionId, String fieldName) {
+        Map<String, Object> body = Map.of("data", Map.of(
+                "type", "fields",
+                "attributes", Map.of(
+                        "collectionId", collectionId,
+                        "name", fieldName,
+                        "type", "STRING",
+                        "trackHistory", true)));
+        ResponseEntity<Map> response = client.post().uri("/" + slug + "/api/fields")
+                .contentType(MediaType.APPLICATION_JSON).body(body)
+                .retrieve().toEntity(Map.class);
+        assertThat(response.getStatusCode().is2xxSuccessful())
+                .as("field '%s' create should succeed", fieldName).isTrue();
+    }
+
+    /** Polls the fields list until {@code fieldName} is present (route + registry propagation). */
+    @SuppressWarnings("unchecked")
+    private void waitForField(RestClient client, String slug, String collectionId, String fieldName) {
+        for (int i = 0; i < 30; i++) {
+            try {
+                ResponseEntity<Map> fields = client.get()
+                        .uri("/" + slug + "/api/fields?filter[collectionId][eq]=" + collectionId)
+                        .retrieve().toEntity(Map.class);
+                List<Map<String, Object>> data = (List<Map<String, Object>>) fields.getBody().get("data");
+                boolean present = data != null && data.stream().anyMatch(f -> {
+                    Map<String, Object> a = (Map<String, Object>) f.get("attributes");
+                    return a != null && fieldName.equals(a.get("name"));
+                });
+                if (present) {
+                    return;
+                }
+            } catch (RuntimeException ignored) {
+                // not ready yet
+            }
+            sleep();
+        }
+        throw new AssertionError("Field '" + fieldName + "' expected present but timed out");
+    }
+
+    /** Counts rows in a system (public-schema) table by their {@code collection_id} column. */
+    private int countByCollectionId(String table, String collectionId) throws Exception {
+        return count("SELECT count(*) FROM " + table + " WHERE collection_id = ?", collectionId);
+    }
+
+    /** Counts rows in a table by primary key {@code id}. */
+    private int countById(String table, String id) throws Exception {
+        return count("SELECT count(*) FROM " + table + " WHERE id = ?", id);
+    }
+
+    private int count(String sql, String param) throws Exception {
+        try (Connection admin = openDbConnection();
+             PreparedStatement ps = admin.prepareStatement(sql)) {
+            ps.setString(1, param);
+            try (ResultSet rs = ps.executeQuery()) {
+                rs.next();
+                return rs.getInt(1);
+            }
+        }
+    }
+
+    private void sleep() {
+        try {
+            Thread.sleep(500);
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/kelta-worker/src/main/resources/db/migration/V181__collection_fk_cascade.sql
+++ b/kelta-worker/src/main/resources/db/migration/V181__collection_fk_cascade.sql
@@ -1,0 +1,120 @@
+-- Collections became permanently undeletable once used. Deleting a collection is a
+-- generic record delete against the `collection` table (DynamicCollectionRouter →
+-- QueryEngine.delete); PhysicalTableStorageAdapter maps Postgres FK violation 23503 to
+-- a 409 REFERENCED_RECORD. 14 FKs referenced collection(id) with NO ON DELETE action,
+-- so any dependent row (a list view, a validation rule, and — for tables with no delete
+-- API such as field_history / file_attachment / bulk_job / script_trigger — rows written
+-- automatically) restricted the delete forever.
+--
+-- Deleting a collection is inherently destructive (its whole data table and every record
+-- go away), so metadata and data OWNED BY the collection must go with it. This mirrors the
+-- field(id) cascade precedent in V173 (a field's dependent UI/metadata rows cascade on
+-- field delete). Two exceptions where the dependent is a reusable/standalone artifact only
+-- loosely associated with the collection get ON DELETE SET NULL instead of CASCADE:
+--   * email_template.related_collection_id — a template outlives the collection it was
+--     tagged against (nullable; the seeded system templates already carry NULL here).
+--   * field.reference_collection_id — a lookup field in collection B pointing at collection
+--     A. Cascading would silently delete B's field; instead the target is nulled so the
+--     field survives (dangling). This FK ALREADY had ON DELETE SET NULL in the baseline —
+--     left as-is, documented here for completeness.
+--
+-- Note (out of scope, tracked in concerns.md): collection delete still does NOT DROP the
+-- physical user-data table, nor purge S3 objects behind cascaded file_attachment rows.
+
+-- ── Direct collection(id) references → CASCADE (owned by the collection) ──────────────
+ALTER TABLE approval_process
+    DROP CONSTRAINT approval_process_collection_id_fkey,
+    ADD CONSTRAINT approval_process_collection_id_fkey
+        FOREIGN KEY (collection_id) REFERENCES collection(id) ON DELETE CASCADE;
+
+ALTER TABLE bulk_job
+    DROP CONSTRAINT bulk_job_collection_id_fkey,
+    ADD CONSTRAINT bulk_job_collection_id_fkey
+        FOREIGN KEY (collection_id) REFERENCES collection(id) ON DELETE CASCADE;
+
+ALTER TABLE field_history
+    DROP CONSTRAINT field_history_collection_id_fkey,
+    ADD CONSTRAINT field_history_collection_id_fkey
+        FOREIGN KEY (collection_id) REFERENCES collection(id) ON DELETE CASCADE;
+
+ALTER TABLE file_attachment
+    DROP CONSTRAINT file_attachment_collection_id_fkey,
+    ADD CONSTRAINT file_attachment_collection_id_fkey
+        FOREIGN KEY (collection_id) REFERENCES collection(id) ON DELETE CASCADE;
+
+ALTER TABLE layout_assignment
+    DROP CONSTRAINT layout_assignment_collection_id_fkey,
+    ADD CONSTRAINT layout_assignment_collection_id_fkey
+        FOREIGN KEY (collection_id) REFERENCES collection(id) ON DELETE CASCADE;
+
+ALTER TABLE layout_related_list
+    DROP CONSTRAINT layout_related_list_related_collection_id_fkey,
+    ADD CONSTRAINT layout_related_list_related_collection_id_fkey
+        FOREIGN KEY (related_collection_id) REFERENCES collection(id) ON DELETE CASCADE;
+
+ALTER TABLE list_view
+    DROP CONSTRAINT list_view_collection_id_fkey,
+    ADD CONSTRAINT list_view_collection_id_fkey
+        FOREIGN KEY (collection_id) REFERENCES collection(id) ON DELETE CASCADE;
+
+ALTER TABLE note
+    DROP CONSTRAINT note_collection_id_fkey,
+    ADD CONSTRAINT note_collection_id_fkey
+        FOREIGN KEY (collection_id) REFERENCES collection(id) ON DELETE CASCADE;
+
+ALTER TABLE page_layout
+    DROP CONSTRAINT page_layout_collection_id_fkey,
+    ADD CONSTRAINT page_layout_collection_id_fkey
+        FOREIGN KEY (collection_id) REFERENCES collection(id) ON DELETE CASCADE;
+
+ALTER TABLE record_type
+    DROP CONSTRAINT record_type_collection_id_fkey,
+    ADD CONSTRAINT record_type_collection_id_fkey
+        FOREIGN KEY (collection_id) REFERENCES collection(id) ON DELETE CASCADE;
+
+ALTER TABLE report
+    DROP CONSTRAINT report_primary_collection_id_fkey,
+    ADD CONSTRAINT report_primary_collection_id_fkey
+        FOREIGN KEY (primary_collection_id) REFERENCES collection(id) ON DELETE CASCADE;
+
+ALTER TABLE script_trigger
+    DROP CONSTRAINT script_trigger_collection_id_fkey,
+    ADD CONSTRAINT script_trigger_collection_id_fkey
+        FOREIGN KEY (collection_id) REFERENCES collection(id) ON DELETE CASCADE;
+
+ALTER TABLE validation_rule
+    DROP CONSTRAINT validation_rule_collection_id_fkey,
+    ADD CONSTRAINT validation_rule_collection_id_fkey
+        FOREIGN KEY (collection_id) REFERENCES collection(id) ON DELETE CASCADE;
+
+-- ── Direct collection(id) reference → SET NULL (reusable, nullable) ───────────────────
+ALTER TABLE email_template
+    DROP CONSTRAINT email_template_related_collection_id_fkey,
+    ADD CONSTRAINT email_template_related_collection_id_fkey
+        FOREIGN KEY (related_collection_id) REFERENCES collection(id) ON DELETE SET NULL;
+
+-- ── Intermediate children on the cascade path → CASCADE ──────────────────────────────
+-- These do NOT reference collection(id) directly, but a collection delete cascades into
+-- approval_process / report / page_layout / record_type, and those cascades would in turn
+-- hit these RESTRICTing children (trigger firing order within one DELETE is not
+-- guaranteed, so relying on the sibling collection-path delete is unsafe). Give every edge
+-- on the tree an ON DELETE action so the recursive cascade completes.
+ALTER TABLE approval_instance
+    DROP CONSTRAINT approval_instance_approval_process_id_fkey,
+    ADD CONSTRAINT approval_instance_approval_process_id_fkey
+        FOREIGN KEY (approval_process_id) REFERENCES approval_process(id) ON DELETE CASCADE;
+
+ALTER TABLE dashboard_component
+    DROP CONSTRAINT dashboard_component_report_id_fkey,
+    ADD CONSTRAINT dashboard_component_report_id_fkey
+        FOREIGN KEY (report_id) REFERENCES report(id) ON DELETE CASCADE;
+
+ALTER TABLE layout_assignment
+    DROP CONSTRAINT layout_assignment_layout_id_fkey,
+    ADD CONSTRAINT layout_assignment_layout_id_fkey
+        FOREIGN KEY (layout_id) REFERENCES page_layout(id) ON DELETE CASCADE;
+
+ALTER TABLE layout_assignment
+    DROP CONSTRAINT layout_assignment_record_type_id_fkey,
+    ADD CONSTRAINT layout_assignment_record_type_id_fkey
+        FOREIGN KEY (record_type_id) REFERENCES record_type(id) ON DELETE CASCADE;


### PR DESCRIPTION
## Summary
- Collections became permanently undeletable once used: 14 FKs referenced `collection(id)` with no `ON DELETE` action, so any dependent row turned a collection delete into a permanent **409 REFERENCED_RECORD**. Several dependent tables (`field_history`, `file_attachment`, `bulk_job`, `script_trigger`) have no delete API, so once a collection had a record written (which can emit a `field_history` row) it could never be deleted via API/CLI.
- `V181__collection_fk_cascade.sql` fixes it by giving every FK on the collection-delete tree an `ON DELETE` action.

## Changes
- **`kelta-worker/.../db/migration/V181__collection_fk_cascade.sql`** (new):
  - **13 → `ON DELETE CASCADE`** (rows owned by the collection, same semantics as the V173 field-delete cascade): approval_process, bulk_job, field_history, file_attachment, layout_assignment, layout_related_list.related_collection_id, list_view, note, page_layout, record_type, report.primary_collection_id, script_trigger, validation_rule.
  - **1 → `ON DELETE SET NULL`**: `email_template.related_collection_id` (a reusable, nullable, loosely-associated template).
  - **4 intermediate children → CASCADE** so the recursive cascade completes regardless of trigger ordering: approval_instance→approval_process, dashboard_component→report, layout_assignment→{page_layout, record_type}.
  - `field.reference_collection_id` (a lookup in B pointing at A) already had `ON DELETE SET NULL` — left as-is (null the target, don't delete B's field).
- **`kelta-test-harness/.../CollectionDeletionScenarioTest.java`** (new): full-stack scenario — create collection + `trackHistory` field → write a record (→ `field_history`) + a `list_view`, then DELETE the collection and assert 204 + every dependent row cascaded.
- **`.claude/docs/concerns.md`**: documents the fix and the residual open gap (collection delete still doesn't `DROP` the physical data table or purge S3 objects behind cascaded `file_attachment` rows — needs an ordered teardown, tracked as follow-up).

## Testing
- FK coverage is exhaustive: 20 FKs → `collection(id)` = 6 already had actions + 14 fixed here; cascade tree fully closed.
- Migration applies clean against `V1__baseline` (18 ALTERs, zero errors) on ephemeral Postgres 15.
- **DB-level cascade proof**: without V181, `DELETE FROM collection` fails with `23503` on `field_history_collection_id_fkey`; with V181, the same rows delete and collection/field/field_history/list_view all cascade to 0.
- `CollectionDeletionScenarioTest` compiles clean. The full Testcontainers stack run failed only on worker-container HTTP readiness (environmental — 200MB JVM jar boot timeout on the dev box), not on the migration or test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)