### PR TITLE
fix(worker): cascade record_version FK so history-tracked collections are deletable (V182)

### DIFF
--- a/.claude/docs/concerns.md
+++ b/.claude/docs/concerns.md
@@ -286,9 +286,16 @@ intermediate children on the delete tree so the recursive cascade completes
 (approval_instance→approval_process, dashboard_component→report,
 layout_assignment→{page_layout,record_type}). `field.reference_collection_id` (a lookup in
 collection B pointing at A) already had `ON DELETE SET NULL` — left as-is (nulling the
-target beats silently deleting B's field). Regression guard:
-`CollectionDeletionScenarioTest` (kelta-test-harness) writes a record (→ field_history) +
-a list view, then deletes the collection end to end and asserts the cascade.
+target beats silently deleting B's field). **Follow-up V182__record_version_fk_cascade:**
+V181's enumeration predated one FK — `record_version.collection_id` (added by record
+versioning #1266) — so a collection with `trackHistory` on stayed undeletable (a
+`record_version` snapshot row per record write, no delete API). V182 gives it
+`ON DELETE CASCADE` (owned by the collection, same bucket as `field_history`; it is a leaf,
+so no intermediate edges). Regression guard: a second test in `CollectionDeletionScenarioTest`
+(kelta-test-harness) creates a collection with `trackHistory=true`, writes a record (→ a
+`record_version` snapshot), then deletes the collection and asserts the version rows cascaded.
+It needs its own collection because collection-level history supersedes per-field
+`field_history` (`FieldHistoryHook`), so one collection can't exercise both FKs at once.
 **Residual open gap:** collection delete still does **not** `DROP` the physical user-data
 table (no `DROP TABLE` exists in `src/main`; `CollectionLifecycleManager.teardownCollection`
 is explicit that "data is not dropped"), nor does it purge S3 objects behind cascaded
@@ -726,11 +733,15 @@ cleanable). The page-builder wizard specs leak the same way.
 Fixes applied: the cli-smoke round-trip now refuses to create schema unless the
 tenant slug is disposable (`/e2e|test|sandbox|ci/`) or
 `KELTA_E2E_ALLOW_SCHEMA_MUTATION=1` is set, and its teardown deletes data
-records before the collection. Still open (needs backend work / DB access, not
-freelanced against prod):
-1. Give the child-table FKs `ON DELETE CASCADE` (or add a cascade path to
-   `deleteCollection`) so a collection can be torn down. Audit the 15 above.
+records before the collection.
+1. **DONE (V181 + V182).** All owning FKs now `ON DELETE CASCADE` (V181 covered 13 +
+   `email_template` SET NULL + 4 intermediate edges; V182 added the one V181's hand-count
+   missed, `record_version.collection_id` from #1266). Note the audit above was written from
+   memory and is wrong in two ways — trust the catalog, not this prose: `field.reference_collection_id`
+   was already `SET NULL` (never a blocker), and `record_version` was omitted. See the
+   canonical "FIXED (V181…)" entry earlier in this doc.
 2. Point the deploy-pipeline e2e at a disposable tenant, not `default`/a product
-   tenant, so the guard above doesn't just skip the round-trip in CI.
-3. Clean the 10 stuck collections already in couchpicks — requires the cascade
-   fix or direct control-plane DB deletion.
+   tenant, so the guard above doesn't just skip the round-trip in CI. *(still open)*
+3. **DONE (2026-08-08).** The 11 stuck `e2e_cli_*` / `e2e_test_*` collections were cleaned
+   from couchpicks via the CLI once V181+V182 deployed (no raw prod DELETE) — the 14 real
+   domain collections remain.

--- a/kelta-test-harness/src/test/java/io/kelta/testharness/scenarios/CollectionDeletionScenarioTest.java
+++ b/kelta-test-harness/src/test/java/io/kelta/testharness/scenarios/CollectionDeletionScenarioTest.java
@@ -25,12 +25,20 @@ import static org.assertj.core.api.Assertions.assertThat;
  * record write, and metadata rows (a saved list view) with no delete API — turned the
  * delete into a permanent 409 REFERENCED_RECORD.
  *
- * <p>This exercises the real stack (gateway → worker → per-tenant Postgres): create a
- * collection, add a {@code trackHistory} field, write a record (→ a {@code field_history}
- * row), and create a {@code list_view} — two distinct FK blockers with no delete API — then
- * DELETE the collection and assert it returns 204 and every dependent row cascaded away.
- * This is the DB-constraint regression the "test-gap" lesson demands: Mockito worker tests
- * cannot exercise a real ON DELETE CASCADE.
+ * <p>The first test exercises the real stack (gateway → worker → per-tenant Postgres):
+ * create a collection, add a {@code trackHistory} field, write a record (→ a
+ * {@code field_history} row), and create a {@code list_view} — two distinct FK blockers with
+ * no delete API — then DELETE the collection and assert it returns 204 and every dependent
+ * row cascaded away. This is the DB-constraint regression the "test-gap" lesson demands:
+ * Mockito worker tests cannot exercise a real ON DELETE CASCADE.
+ *
+ * <p>The second test guards V182: V181 enumerated the FKs known at the time and missed
+ * {@code record_version.collection_id} (added later by record versioning #1266), so a
+ * collection with collection-level history ({@code trackHistory=true} on the collection)
+ * stayed undeletable — one {@code record_version} snapshot per record write, no delete API.
+ * Collection-level history supersedes per-field {@code field_history} (see
+ * {@code FieldHistoryHook}), so this case needs its own collection rather than folding into
+ * the first test.
  */
 @DisplayName("Collection Deletion Scenario")
 class CollectionDeletionScenarioTest extends ScenarioBase {
@@ -119,6 +127,74 @@ class CollectionDeletionScenarioTest extends ScenarioBase {
                 .as("list_view rows cascaded").isZero();
         assertThat(countByCollectionId("field", collectionId))
                 .as("field rows cascaded (existing fk_field_collection)").isZero();
+    }
+
+    @Test
+    @DisplayName("a used history-tracked collection (record_version) deletes end to end, cascading versions")
+    @SuppressWarnings("unchecked")
+    void versionedCollectionCanBeDeleted() throws Exception {
+        String token = auth.loginAsAdmin();
+        String tenantId = auth.extractTenantId(token);
+        String slug = tenants.slugForTenantId(tenantId);
+        RestClient client = gatewayClientWithToken(token);
+
+        String collectionName = "delvertest";
+
+        waitForStatus(client, "/" + slug + "/api/collections", HttpStatus.OK, 20);
+
+        // 1. Create a collection with collection-level history enabled. RecordVersionHook then
+        //    mints a record_version snapshot on every record write (record_version.collection_id
+        //    → collection(id)) — the FK V181 missed and V182 gives ON DELETE CASCADE.
+        Map<String, Object> collectionBody = Map.of("data", Map.of(
+                "type", "collections",
+                "attributes", Map.of(
+                        "name", collectionName,
+                        "displayName", "Versioned Deletion Test",
+                        "tenantScoped", true,
+                        "trackHistory", true)));
+        ResponseEntity<Map> createdCollection = client.post().uri("/" + slug + "/api/collections")
+                .contentType(MediaType.APPLICATION_JSON).body(collectionBody)
+                .retrieve().toEntity(Map.class);
+        assertThat(createdCollection.getStatusCode().is2xxSuccessful()).isTrue();
+        String collectionId = (String) ((Map<String, Object>) createdCollection.getBody().get("data")).get("id");
+        assertThat(collectionId).isNotBlank();
+
+        waitForStatus(client, "/" + slug + "/api/" + collectionName, HttpStatus.OK, 30);
+
+        // 2. A field to carry a value, then a record write — RecordVersionHook inserts a
+        //    record_version row (collection-level history supersedes field_history, so no
+        //    field_history row is written here).
+        addTrackedField(client, slug, collectionId, "title");
+        waitForField(client, slug, collectionId, "title");
+
+        Map<String, Object> recordBody = Map.of("data", Map.of(
+                "type", collectionName,
+                "attributes", Map.of("title", "keep-me")));
+        ResponseEntity<Map> createdRecord = client.post().uri("/" + slug + "/api/" + collectionName)
+                .contentType(MediaType.APPLICATION_JSON).body(recordBody)
+                .retrieve().toEntity(Map.class);
+        assertThat(createdRecord.getStatusCode().is2xxSuccessful()).isTrue();
+
+        // Sanity: the record_version blocker really exists before the delete.
+        assertThat(countByCollectionId("record_version", collectionId))
+                .as("a record write on a history-tracked collection should produce a record_version row")
+                .isPositive();
+
+        // 3. Delete the collection. Before V182 this returned 409 REFERENCED_RECORD forever.
+        HttpStatusCode deleteStatus = client.delete()
+                .uri("/" + slug + "/api/collections/" + collectionId)
+                .retrieve()
+                .onStatus(s -> true, (req, resp) -> {})
+                .toBodilessEntity()
+                .getStatusCode();
+        assertThat(deleteStatus)
+                .as("used history-tracked collection should delete (204), not 409 REFERENCED_RECORD")
+                .isEqualTo(HttpStatus.NO_CONTENT);
+
+        // 4. The collection row and every cascaded record_version are gone.
+        assertThat(countById("collection", collectionId)).as("collection row removed").isZero();
+        assertThat(countByCollectionId("record_version", collectionId))
+                .as("record_version rows cascaded (V182)").isZero();
     }
 
     /** Adds a STRING field with {@code trackHistory=true} so writes emit field_history rows. */

--- a/kelta-worker/src/main/resources/db/migration/V182__record_version_fk_cascade.sql
+++ b/kelta-worker/src/main/resources/db/migration/V182__record_version_fk_cascade.sql
@@ -1,0 +1,16 @@
+-- V181 gave every FK that referenced collection(id) an ON DELETE action so a used
+-- collection could finally be deleted — but it enumerated the 14 FKs known at the time and
+-- missed one added later by the record-versioning feature (#1266): record_version.
+-- record_version.collection_id references collection(id) with NO ON DELETE action, so a
+-- collection with collection-level history enabled (trackHistory=true) accumulates a
+-- record_version snapshot row per record write and becomes undeletable again with the same
+-- 409 REFERENCED_RECORD — the exact failure V181 set out to fix, for versioned collections.
+--
+-- record_version is OWNED BY the collection (it is that collection's history), and it has no
+-- delete API of its own, so it must cascade on collection delete just like field_history —
+-- same reasoning as V181's CASCADE bucket. record_version is a leaf (nothing references
+-- record_version(id)), so no intermediate cascade edges are needed.
+ALTER TABLE record_version
+    DROP CONSTRAINT record_version_collection_id_fkey,
+    ADD CONSTRAINT record_version_collection_id_fkey
+        FOREIGN KEY (collection_id) REFERENCES collection(id) ON DELETE CASCADE;


### PR DESCRIPTION
## What

V181 (#1308) made used collections deletable by giving `collection(id)` FKs `ON DELETE CASCADE`, but its FK enumeration was hand-written and **missed one** added later by record versioning (#1266): `record_version.collection_id`, still `NO ACTION`. A collection with **collection-level `trackHistory`** on writes one `record_version` snapshot per record write (no delete API), so it still hit `409 REFERENCED_RECORD` — the exact failure V181 set out to fix, for versioned collections.

## Change

- **`V182__record_version_fk_cascade.sql`** — `ON DELETE CASCADE` on `record_version.collection_id` (owned by the collection, same bucket as `field_history`; `record_version` is a leaf, so no intermediate cascade edges).
- **`CollectionDeletionScenarioTest`** — second test covering a `trackHistory=true` collection end to end (record_version written on write → cascaded on delete). Separate collection required because collection-level history supersedes per-field `field_history` (`FieldHistoryHook`), so one collection can't exercise both FKs.
- **`concerns.md`** — marks the gap closed; corrects the V181 audit prose (it was wrong twice — `field.reference_collection_id` was already `SET NULL`, `record_version` was omitted; trust the catalog, not the prose).

## Verification

- Reproduced + fixed in an isolated Postgres 15: pre-V182 `DELETE collection` → `foreign_key_violation`; after the V182 `ALTER`, the delete cascades and `record_version` rows go to 0.
- Constraint name/table/column confirmed against the live control-plane catalog (`record_version_collection_id_fkey`).
- Full Testcontainers harness scenario runs in CI (local run blocked by an unrelated OTEL-SDK boot issue in the worker image, not this change).

## Context

Unblocks cleanup of 10 leftover `e2e_test_*` collections stuck in the couchpicks tenant (the 11th, unversioned, already deleted via CLI once #1308 deployed). Once this deploys, those delete cleanly via `kelta collections delete` — no raw prod DB writes.
