### PR TITLE
chore(ci): stop the cli-downloads smoke false-rollbacking good deploys

### DIFF
--- a/.claude/docs/ci-cd.md
+++ b/.claude/docs/ci-cd.md
@@ -88,3 +88,13 @@ target), and nginx serves `/cli/manifest.json`, `/cli/latest.txt`,
 Service, asserts the manifest version equals this run's, downloads the linux binary, and
 executes `kelta version` — warning-skipping only while the homelab-argo manifests don't
 exist yet. Ingress/Service/Deployment live in homelab-argo (`downloads.kelta.io`).
+
+**Smoke waits for ArgoCD (do not revert to a one-shot check).** ArgoCD applies the image
+bump asynchronously, so `kubectl rollout status` returns immediately against the still-old
+ReplicaSet and a single version check races the sync — a stale-version false failure that
+auto-rollback then turns into a needless revert of a good deploy (happened repeatedly:
+runs 31110044147, 31116131086, 31276755616). The step now **polls `/cli/manifest.json`
+until it reports `1.0.<run_number>` (≤5 min)** before asserting, and runs **only when
+`cli_downloads == 'true'`** (the image is only rebuilt then; the old `|| workflows == 'true'`
+ran the strict `EXPECT == run_number` check on runs where the image was not rebuilt, so it
+could never match).

--- a/.github/workflows/build-and-publish-containers.yml
+++ b/.github/workflows/build-and-publish-containers.yml
@@ -489,8 +489,12 @@ jobs:
       # The runner itself runs in-cluster, so it can hit the Service directly,
       # download the linux binary, and execute it — proving the whole chain:
       # compile → manifest → serve → self-describing binary.
+      # Only when the cli-downloads image was actually rebuilt this run. EXPECT is
+      # 1.0.<run_number>, which only matches a fresh build — on a workflows-only change the
+      # image is not rebuilt and the served version would never equal EXPECT (that stale
+      # `|| workflows` condition guaranteed a false failure + auto-rollback).
       - name: Verify CLI downloads service (when built)
-        if: needs.changes.outputs.cli_downloads == 'true' || needs.changes.outputs.workflows == 'true'
+        if: needs.changes.outputs.cli_downloads == 'true'
         run: |
           NS=${{ steps.k8s.outputs.ns }}
           DEPLOY=emf-cli-downloads
@@ -498,17 +502,32 @@ jobs:
             echo "::warning::${DEPLOY} not deployed in ${NS} yet (argo manifests pending) — skipping CLI downloads smoke."
             exit 0
           fi
-          kubectl -n ${NS} rollout status deploy/${DEPLOY} --timeout=180s
           BASE="http://${DEPLOY}.${NS}.svc.cluster.local"
           EXPECT="1.0.${{ github.run_number }}"
 
-          curl -fsS "${BASE}/health" | grep -q '"status":"UP"'
-          MANIFEST=$(curl -fsS "${BASE}/cli/manifest.json")
-          GOT=$(echo "${MANIFEST}" | sed -n 's/.*"version": *"\([^"]*\)".*/\1/p' | head -1)
+          # ArgoCD applies the image bump we just pushed asynchronously, so `rollout status`
+          # returns immediately against the still-old ReplicaSet and a one-shot version check
+          # races the sync. Poll the served manifest until it reports EXPECT (i.e. ArgoCD has
+          # rolled the new image) before asserting — up to ~5 min.
+          DEADLINE=$(( $(date +%s) + 300 ))
+          GOT=""
+          until [ "$(date +%s)" -ge "${DEADLINE}" ]; do
+            MANIFEST=$(curl -fsS "${BASE}/cli/manifest.json" 2>/dev/null || true)
+            GOT=$(echo "${MANIFEST}" | sed -n 's/.*"version": *"\([^"]*\)".*/\1/p' | head -1)
+            if [ "${GOT}" = "${EXPECT}" ]; then
+              break
+            fi
+            echo "waiting for ArgoCD to serve ${EXPECT} (currently '${GOT:-unreachable}')…"
+            sleep 10
+          done
           if [ "${GOT}" != "${EXPECT}" ]; then
-            echo "::error::Manifest version ${GOT} != expected ${EXPECT} — stale image served?"
+            echo "::error::Manifest version ${GOT:-unreachable} != expected ${EXPECT} after 5m — ArgoCD sync stalled or stale image served."
             exit 1
           fi
+
+          # Version has converged; the deployment is now the new ReplicaSet.
+          kubectl -n ${NS} rollout status deploy/${DEPLOY} --timeout=180s
+          curl -fsS "${BASE}/health" | grep -q '"status":"UP"'
 
           curl -fsS "${BASE}/cli/releases/${EXPECT}/kelta-linux-x64" -o /tmp/kelta-smoke
           chmod +x /tmp/kelta-smoke


### PR DESCRIPTION
## Problem

The `Verify CLI downloads service` smoke in `build-and-publish-containers.yml` false-fails and triggers `auto-rollback`, needlessly reverting good deploys. It just did this to **#1309** (the collection-delete guard) in run `31276755616`, and the same pattern reverted runs `31110044147` and `31116131086`.

Two root causes:

1. **Races ArgoCD.** The deploy job pushes an image bump to `homelab-argo`; ArgoCD applies it asynchronously. The smoke ran `kubectl rollout status` (returns immediately against the *old* ReplicaSet, since ArgoCD hasn't changed it yet) then did a **one-shot** manifest version check → reads the previous version → fails. (In 31276755616 it saw `1.0.1211`; `downloads.kelta.io` served the correct `1.0.1214` a minute later.)
2. **Runs when the image wasn't rebuilt.** `if: cli_downloads == 'true' || workflows == 'true'` — on a workflows-only change the cli-downloads image is not rebuilt, but the step still asserted `served == 1.0.<run_number>`, which can never match.

## Fix

- **Poll** `/cli/manifest.json` until it reports `1.0.<run_number>` (≤5 min) before asserting — waits for ArgoCD to converge instead of racing it. `rollout status` + health + binary-exec checks run *after* the version converges.
- Gate on **`cli_downloads == 'true'`** only (drop `|| workflows`), so the strict version assertion runs only when the image was actually rebuilt.

Docs: `ci-cd.md` updated with a "do not revert to a one-shot check" note.

## Not covered

Doesn't change the version scheme (`1.0.<run_number>`) or the auto-rollback mechanism — only stops this smoke from firing false negatives. The #1309 deploy it rolled back is being re-landed by re-running run 31276755616 (run_number preserved, 1214 already served).
