### PR TITLE
fix(e2e): force-delete test collections in teardown so they stop leaking into product tenants

### DIFF
--- a/.claude/docs/concerns.md
+++ b/.claude/docs/concerns.md
@@ -757,11 +757,20 @@ cleanable). The page-builder wizard specs leak the same way.
 Fixes applied: the cli-smoke round-trip now refuses to create schema unless the
 tenant slug is disposable (`/e2e|test|sandbox|ci/`) or
 `KELTA_E2E_ALLOW_SCHEMA_MUTATION=1` is set, and its teardown deletes data
-records before the collection. Still open (needs backend work / DB access, not
-freelanced against prod):
-1. Give the child-table FKs `ON DELETE CASCADE` (or add a cascade path to
-   `deleteCollection`) so a collection can be torn down. Audit the 15 above.
-2. Point the deploy-pipeline e2e at a disposable tenant, not `default`/a product
-   tenant, so the guard above doesn't just skip the round-trip in CI.
-3. Clean the 10 stuck collections already in couchpicks — requires the cascade
-   fix or direct control-plane DB deletion.
+records before the collection.
+1. **DONE (V181 + V182).** All owning `collection(id)` FKs now `ON DELETE CASCADE`
+   (V181 did 18; V182 added the one it missed, `record_version` — see the "FIXED (V181…)"
+   entry earlier).
+2. **DONE (force-delete teardown).** The deploy e2e still runs against `default` (a product
+   tenant — a dedicated disposable tenant would need its own `E2E_API_TOKEN` secret), but the
+   specs now clean up after themselves rather than leaking: `DataFactory.cleanup()` deletes
+   collections with `?force=true` (so the `CollectionDeletionGuardHook` lets it through and the
+   FK cascade removes the children) and surfaces failures via `console.warn` instead of
+   swallowing them. UI-created collections (the wizard spec had **no** teardown, the source of
+   the `e2e_wizard_*` litter) are registered with `DataFactory.trackCollectionByName(name)` so
+   the same force-delete cleans them. A dedicated disposable e2e tenant is still the ideal
+   (preserves the ability to run destructive specs without any product-tenant blast radius);
+   deferred on the secret.
+3. **DONE (2026-08-08).** The 11 stuck `e2e_*` collections (10 `e2e_test_*` + 1 `e2e_cli_*`,
+   plus 2 more that leaked mid-cleanup) were force-deleted from couchpicks once V181+V182 and
+   the guard were live; only the 14 real domain collections remain.

--- a/e2e-tests/helpers/data-factory.ts
+++ b/e2e-tests/helpers/data-factory.ts
@@ -583,12 +583,71 @@ export class DataFactory {
 
   async cleanup(): Promise<void> {
     for (const entity of this.createdEntities.reverse()) {
+      // Collections accumulate child rows (field_history, record_version, attachments…)
+      // that the server's CollectionDeletionGuardHook refuses to destroy without
+      // ?force=true — and that, before the V181/V182 FK cascades, made a used collection
+      // undeletable outright. An unforced (or silently swallowed) delete here leaked
+      // e2e_test_* collections into the target tenant — the litter that piled up in the
+      // couchpicks product tenant. Force the collection delete, and surface a failure
+      // instead of hiding it so a future leak is visible in the test log.
+      const path =
+        entity.type === "collections"
+          ? `/api/collections/${entity.id}?force=true`
+          : `/api/${entity.type}/${entity.id}`;
       try {
-        await this.request("DELETE", `/api/${entity.type}/${entity.id}`);
-      } catch {
-        // Ignore cleanup failures
+        await this.request("DELETE", path);
+      } catch (err) {
+        if (entity.type === "collections") {
+          console.warn(
+            `[data-factory] failed to delete collection ${entity.id} during cleanup — it may leak: ${String(err)}`,
+          );
+        }
+        // Non-collection cleanup failures are non-fatal and ignored.
       }
     }
     this.createdEntities = [];
+  }
+
+  /**
+   * Register an externally-created collection (e.g. one created through the admin UI
+   * in a wizard test) for force-delete at {@link cleanup}, resolving its id from the
+   * LIST endpoint by name. UI-created collections are not otherwise tracked, so without
+   * this they have no teardown and leak into the target tenant.
+   */
+  async trackCollectionByName(
+    name: string,
+    timeoutMs = STORAGE_READY_TIMEOUT_MS,
+  ): Promise<void> {
+    const url = `${this.api.baseUrl}/${this.api.tenantSlug}/api/collections?page[size]=1000`;
+    const deadline = Date.now() + timeoutMs;
+
+    while (Date.now() < deadline) {
+      try {
+        const response = await fetch(url, {
+          method: "GET",
+          headers: {
+            "Content-Type": "application/vnd.api+json",
+            Authorization: `Bearer ${this.currentToken}`,
+          },
+        });
+        if (response.ok) {
+          const body = (await response.json()) as JsonApiResponse;
+          const data = Array.isArray(body.data) ? body.data : [body.data];
+          const match = data.find((r) => r?.attributes?.name === name);
+          if (match?.id) {
+            this.createdEntities.push({ type: "collections", id: match.id });
+            return;
+          }
+        }
+      } catch {
+        // Network error — keep retrying
+      }
+      await new Promise((resolve) =>
+        setTimeout(resolve, STORAGE_READY_POLL_MS),
+      );
+    }
+    console.warn(
+      `[data-factory] trackCollectionByName('${name}') did not resolve an id within ${timeoutMs}ms — it may leak`,
+    );
   }
 }

--- a/e2e-tests/tests/admin/collections/collection-wizard.spec.ts
+++ b/e2e-tests/tests/admin/collections/collection-wizard.spec.ts
@@ -136,5 +136,10 @@ test.describe("Collection Wizard", () => {
 
     // Should redirect to collection detail or list page
     await expect(page).toHaveURL(new RegExp(`/${tenantSlug}/collections`));
+
+    // The wizard creates the collection through the UI, so nothing tracks it for
+    // teardown — that is what leaked e2e_wizard_* collections into the target tenant.
+    // Register it so the data-factory cleanup force-deletes it after the test.
+    await dataFactory.trackCollectionByName(uniqueName);
   });
 });


### PR DESCRIPTION
## Problem

The deploy-pipeline E2E runs against `E2E_TENANT_SLUG: default` — the same tenant the `couchpicks` CLI profile targets (all its collections carry tenant_id `…001`). Schema-mutating specs leaked test collections into it because teardown couldn't (or didn't) remove them:

- `DataFactory.cleanup()` deleted collections with a plain `DELETE` and **swallowed failures**. A used collection has child rows (`field_history`, `record_version`, attachments…), so the new `CollectionDeletionGuardHook` rejects an unforced delete with 400 — and before V181/V182 it failed 409 outright. Either way, ignored → `e2e_test_*` litter.
- The collection-wizard spec creates `e2e_wizard_*` **through the UI with no teardown at all**.

This is concern follow-up #2 ("point the deploy e2e at a disposable tenant"). It recurs every deploy that runs E2E — it re-leaked 2 collections into couchpicks during this very session's pipeline.

## Fix (teardown hygiene — keeps coverage, no new tenant/secret)

- `DataFactory.cleanup()` deletes collections with **`?force=true`** (guard lets it through, FK cascade removes children) and `console.warn`s on failure instead of hiding it.
- Adds `DataFactory.trackCollectionByName(name)` to register a UI-created collection for the same force-delete; the wizard spec now calls it after creating its collection.

## Verified

- `tsc --noEmit` clean on e2e-tests.
- Manually confirmed the mechanism against couchpicks: `DELETE /api/collections/{id}?force=true` cleanly removes a used collection (guard + V182 cascade), which is exactly what `cleanup()` now issues.

## Not covered (deferred)

A **dedicated disposable e2e tenant** is still the ideal — it removes all product-tenant blast radius, not just the leak. It needs its own `E2E_API_TOKEN` GitHub secret (can't provision here). Noted in concerns.md.
