### PR TITLE
feat(gateway): multi-origin CORS (comma-separated list)

### DIFF
--- a/kelta-gateway/src/main/java/io/kelta/gateway/config/SecurityConfig.java
+++ b/kelta-gateway/src/main/java/io/kelta/gateway/config/SecurityConfig.java
@@ -59,12 +59,19 @@ public class SecurityConfig {
                     "Set it to your UI domain (e.g., 'https://app.example.com'). " +
                     "Wildcard '*' is not permitted with allowCredentials=true.");
         }
-        if ("*".equals(corsAllowedOriginPattern)) {
-            log.warn("CORS_ALLOWED_ORIGIN_PATTERN is set to '*' which allows any origin " +
+        // Comma-separated so several product frontends (e.g. app.kelta.io +
+        // app.spotopened.com) can each call the gateway from the browser. Each
+        // trimmed entry is a Spring allowedOriginPattern.
+        List<String> originPatterns = Arrays.stream(corsAllowedOriginPattern.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isBlank())
+                .toList();
+        if (originPatterns.contains("*")) {
+            log.warn("CORS_ALLOWED_ORIGIN_PATTERN includes '*' which allows any origin " +
                     "to make credentialed requests. This is insecure for production.");
         }
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOriginPatterns(List.of(corsAllowedOriginPattern));
+        configuration.setAllowedOriginPatterns(originPatterns);
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(List.of(
                 "Authorization", "Content-Type", "Accept", "X-Correlation-ID",

--- a/kelta-gateway/src/test/java/io/kelta/gateway/config/SecurityConfigTest.java
+++ b/kelta-gateway/src/test/java/io/kelta/gateway/config/SecurityConfigTest.java
@@ -1,0 +1,59 @@
+package io.kelta.gateway.config;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.cors.CorsConfiguration;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("SecurityConfig CORS")
+class SecurityConfigTest {
+
+    private SecurityConfig withOriginPattern(String pattern) {
+        SecurityConfig config = new SecurityConfig();
+        ReflectionTestUtils.setField(config, "corsAllowedOriginPattern", pattern);
+        return config;
+    }
+
+    private CorsConfiguration corsFor(SecurityConfig config) {
+        var source = config.corsConfigurationSource();
+        var exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/api/watches"));
+        return source.getCorsConfiguration(exchange);
+    }
+
+    @Test
+    @DisplayName("a single origin is honored")
+    void singleOrigin() {
+        assertThat(corsFor(withOriginPattern("https://app.kelta.io")).getAllowedOriginPatterns())
+                .containsExactly("https://app.kelta.io");
+    }
+
+    @Test
+    @DisplayName("a comma-separated list allows several frontends (trimmed, blanks dropped)")
+    void multipleOrigins() {
+        List<String> patterns = corsFor(withOriginPattern(
+                "https://app.kelta.io, https://app.spotopened.com , ")).getAllowedOriginPatterns();
+        assertThat(patterns).containsExactly("https://app.kelta.io", "https://app.spotopened.com");
+    }
+
+    @Test
+    @DisplayName("credentials are allowed and the origin is a pattern (never a wildcard '*')")
+    void credentialsAllowed() {
+        CorsConfiguration cfg = corsFor(withOriginPattern("https://app.spotopened.com"));
+        assertThat(cfg.getAllowCredentials()).isTrue();
+        assertThat(cfg.getAllowedOrigins()).isNull(); // uses allowedOriginPatterns, never allowedOrigins
+    }
+
+    @Test
+    @DisplayName("blank config fails fast (misconfiguration must not silently allow nothing)")
+    void blankThrows() {
+        assertThatThrownBy(() -> withOriginPattern("  ").corsConfigurationSource())
+                .isInstanceOf(IllegalStateException.class);
+    }
+}


### PR DESCRIPTION
The gateway CORS wrapped a **single** origin pattern in `List.of(...)`, so only one browser frontend could call `api.kelta.io` cross-origin (currently `https://app.kelta.io`). The telehealth/atlantico consumer frontends dodge this with a BFF; the new **spotopened-web** app calls the gateway directly, so it needs its origin allowed too.

## Change
`SecurityConfig.corsConfigurationSource()` now splits `CORS_ALLOWED_ORIGIN_PATTERN` on comma (trim, drop blanks) into multiple `allowedOriginPatterns`. Blank still fails fast; `'*'` still warns (insecure with `allowCredentials=true`). `kelta-auth` already accepts a comma-list — this brings the gateway in line.

## Deploy (homelab-argo, separate)
- `emf/gateway-configmap.yaml`: `CORS_ALLOWED_ORIGIN_PATTERN: "https://app.kelta.io,https://app.spotopened.com"`
- `emf/auth-deployment.yaml`: append `,https://app.spotopened.com` to `CORS_ALLOWED_ORIGINS`

## Tests
`SecurityConfigTest` — single origin, comma-list (trimmed, blanks dropped), credentials + pattern (never `allowedOrigins`), blank throws. Gateway verify: **580 green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)