### PR TITLE
feat(sms): Twilio API-key (key-sid) auth alongside account Auth Token

### DIFF
--- a/.claude/docs/integrations.md
+++ b/.claude/docs/integrations.md
@@ -462,8 +462,8 @@ FAILED SMS delivery, not a dead service.
 
 | Piece | Detail |
 |---|---|
-| Config | `kelta.sms.provider` (`log`\|`twilio`); `kelta.sms.twilio.{account-sid,auth-token,from-number}` (env `TWILIO_*`, from the deployment secret; `from-number` E.164) |
-| Send | `POST https://api.twilio.com/2010-04-01/Accounts/{sid}/Messages.json`, `application/x-www-form-urlencoded` `From`/`To`/`Body`, HTTP Basic auth. Non-2xx → `SmsDeliveryException` carrying Twilio's error body (never the token) |
+| Config | `kelta.sms.provider` (`log`\|`twilio`); `kelta.sms.twilio.{account-sid,key-sid,auth-token,from-number}` (env `TWILIO_*`, from the deployment secret; `from-number` E.164). **Two auth modes:** API key (recommended, revocable) = `key-sid` (`SK…`) + `auth-token` (the key secret); or account = leave `key-sid` blank, `auth-token` = the account Auth Token. `account-sid` (`AC…`) is always required |
+| Send | `POST https://api.twilio.com/2010-04-01/Accounts/{account-sid}/Messages.json`, `application/x-www-form-urlencoded` `From`/`To`/`Body`, HTTP Basic auth (**user = `key-sid` if set, else `account-sid`**; password = `auth-token`). Non-2xx → `SmsDeliveryException` carrying Twilio's error body (never the token) |
 | Alert channel | `sms` must be in the watch channels ∩ the member's plan entitlement (keep `sms` a paid-tier entitlement so free members can't burn credits); one alert per opening bounds volume |
 | Recipient | `platform_user.phone_number`; no number on file ⇒ FAILED sms delivery, other channels unaffected |
 | Owed | Live round-trip verification needs a real Twilio account (native-image `RestClient` + Basic-auth path is what CI can't reach); per-tenant Twilio credentials would move to the credential vault (`StripeCredentialType` precedent) |

--- a/.claude/docs/specs/consumer-alerting/10-sms-channel.md
+++ b/.claude/docs/specs/consumer-alerting/10-sms-channel.md
@@ -38,8 +38,9 @@ Config keys (from the deployment secret):
 | Key | Meaning |
 |-----|---------|
 | `kelta.sms.provider` | `log` (default) or `twilio` |
-| `kelta.sms.twilio.account-sid` | Twilio Account SID |
-| `kelta.sms.twilio.auth-token` | Twilio auth token |
+| `kelta.sms.twilio.account-sid` | Twilio Account SID (`AC…`) — always used in the request URL |
+| `kelta.sms.twilio.key-sid` | API Key SID (`SK…`), Basic-auth user — recommended; blank ⇒ use the account SID |
+| `kelta.sms.twilio.auth-token` | API Key secret (with `key-sid`) or the account Auth Token (without) |
 | `kelta.sms.twilio.from-number` | Sending number (E.164) |
 
 ## 4. DB migrations

--- a/kelta-worker/src/main/java/io/kelta/worker/service/sms/TwilioSmsProvider.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/service/sms/TwilioSmsProvider.java
@@ -28,8 +28,10 @@ import org.springframework.web.client.RestClientResponseException;
  * {@link #send}, not at construction. If it threw in the constructor, selecting
  * {@code provider=twilio} without secrets would leave no {@code SmsProvider} bean and the whole
  * worker would fail to boot — a missing credential must degrade to a failed SMS delivery, not a
- * dead service. To go live, set {@code kelta.sms.twilio.account-sid}, {@code .auth-token}, and
- * {@code .from-number} (E.164) from the deployment secret.
+ * dead service. To go live, set {@code kelta.sms.twilio.account-sid} ({@code AC…}),
+ * {@code .from-number} (E.164), and either an API key ({@code .key-sid} = {@code SK…} +
+ * {@code .auth-token} = its secret, recommended) or the account Auth Token ({@code .auth-token},
+ * leaving {@code .key-sid} blank) — from the deployment secret.
  */
 @Component
 @ConditionalOnProperty(name = "kelta.sms.provider", havingValue = "twilio")
@@ -42,6 +44,7 @@ public class TwilioSmsProvider implements SmsProvider {
 
     private final RestClient restClient;
     private final String accountSid;
+    private final String keySid;
     private final String authToken;
     private final String fromNumber;
 
@@ -50,19 +53,27 @@ public class TwilioSmsProvider implements SmsProvider {
      * a second (test-seam) constructor, and with more than one candidate Spring will not guess —
      * it falls back to a no-arg constructor and fails bean creation outright (the same trap the
      * payment client documents).
+     *
+     * <p><b>Two auth modes, both supported.</b> The URL always carries the {@code account-sid}
+     * ({@code AC…}). Basic auth uses {@code key-sid} ({@code SK…}) + {@code auth-token} = the API
+     * Key Secret when a {@code key-sid} is set (the recommended, revocable path), else the
+     * {@code account-sid} + {@code auth-token} = the account Auth Token.
      */
     @Autowired
     public TwilioSmsProvider(
             @Value("${kelta.sms.twilio.account-sid:}") String accountSid,
+            @Value("${kelta.sms.twilio.key-sid:}") String keySid,
             @Value("${kelta.sms.twilio.auth-token:}") String authToken,
             @Value("${kelta.sms.twilio.from-number:}") String fromNumber) {
-        this(RestClient.create(), accountSid, authToken, fromNumber);
+        this(RestClient.create(), accountSid, keySid, authToken, fromNumber);
     }
 
     /** Test seam: lets a unit test bind a mock-server-backed client. */
-    TwilioSmsProvider(RestClient restClient, String accountSid, String authToken, String fromNumber) {
+    TwilioSmsProvider(RestClient restClient, String accountSid, String keySid, String authToken,
+                      String fromNumber) {
         this.restClient = restClient;
         this.accountSid = accountSid;
+        this.keySid = keySid;
         this.authToken = authToken;
         this.fromNumber = fromNumber;
     }
@@ -86,7 +97,7 @@ public class TwilioSmsProvider implements SmsProvider {
         try {
             restClient.post()
                     .uri(BASE_URL + MESSAGES_PATH, accountSid)
-                    .headers(h -> h.setBasicAuth(accountSid, authToken))
+                    .headers(h -> h.setBasicAuth(basicAuthUser(), authToken))
                     .contentType(MediaType.APPLICATION_FORM_URLENCODED)
                     .body(form)
                     .retrieve()
@@ -99,6 +110,11 @@ public class TwilioSmsProvider implements SmsProvider {
         } catch (RuntimeException e) {
             throw new SmsDeliveryException("Twilio send failed: " + e.getMessage(), e);
         }
+    }
+
+    /** Basic-auth username: the API Key SID when configured (recommended), else the Account SID. */
+    private String basicAuthUser() {
+        return isBlank(keySid) ? accountSid : keySid;
     }
 
     private static boolean isBlank(String value) {

--- a/kelta-worker/src/main/resources/application.yml
+++ b/kelta-worker/src/main/resources/application.yml
@@ -69,7 +69,10 @@ kelta:
   sms:
     provider: ${KELTA_SMS_PROVIDER:log}   # log | twilio
     twilio:
-      account-sid: ${TWILIO_ACCOUNT_SID:}
+      account-sid: ${TWILIO_ACCOUNT_SID:}   # AC… — always used in the request URL
+      # API key (recommended, revocable): key-sid = SK… + auth-token = its secret.
+      # Or leave key-sid blank and set auth-token to the account Auth Token.
+      key-sid: ${TWILIO_KEY_SID:}
       auth-token: ${TWILIO_AUTH_TOKEN:}
       from-number: ${TWILIO_FROM_NUMBER:}
   worker:

--- a/kelta-worker/src/test/java/io/kelta/worker/service/sms/TwilioSmsProviderTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/service/sms/TwilioSmsProviderTest.java
@@ -23,9 +23,13 @@ class TwilioSmsProviderTest {
     }
 
     private Harness twilio(String sid, String token, String from) {
+        return twilioWithKey(sid, "", token, from);
+    }
+
+    private Harness twilioWithKey(String sid, String keySid, String token, String from) {
         RestClient.Builder builder = RestClient.builder();
         MockRestServiceServer server = MockRestServiceServer.bindTo(builder).build();
-        return new Harness(new TwilioSmsProvider(builder.build(), sid, token, from), server);
+        return new Harness(new TwilioSmsProvider(builder.build(), sid, keySid, token, from), server);
     }
 
     @Test
@@ -43,6 +47,24 @@ class TwilioSmsProviderTest {
                         .body("{\"sid\":\"SM1\"}").contentType(MediaType.APPLICATION_JSON));
 
         h.provider().send(new SmsMessage("+14155551234", "A spot just opened. Book now."));
+
+        h.server().verify();
+    }
+
+    @Test
+    @DisplayName("uses the API Key SID as the Basic-auth user when key-sid is configured")
+    void usesApiKeyForBasicAuth() {
+        Harness h = twilioWithKey(SID, "SKtestkey", "keysecret", FROM);
+        String expected = "Basic " + java.util.Base64.getEncoder()
+                .encodeToString("SKtestkey:keysecret".getBytes(java.nio.charset.StandardCharsets.UTF_8));
+        // The URL still carries the Account SID; only the Basic-auth user switches to the key.
+        h.server().expect(requestTo(
+                        "https://api.twilio.com/2010-04-01/Accounts/" + SID + "/Messages.json"))
+                .andExpect(header("Authorization", expected))
+                .andRespond(withStatus(HttpStatus.CREATED)
+                        .body("{\"sid\":\"SM1\"}").contentType(MediaType.APPLICATION_JSON));
+
+        h.provider().send(new SmsMessage("+14155551234", "hi"));
 
         h.server().verify();
     }


### PR DESCRIPTION
Lands the previously-unmerged key-sid support (was stranded on feat/twilio-sms-alerts as ca115b20) so the deployed worker can authenticate with a **revocable Twilio API Key (SK…)** instead of the account master Auth Token.

- `kelta.sms.twilio.key-sid` (`TWILIO_KEY_SID`): when set, becomes the Basic-auth username (recommended); blank → falls back to account-sid (Auth Token mode). URL always carries the account-sid.
- `auth-token` = the API Key Secret (key-sid mode) or the account Auth Token (fallback).
- Backward compatible: existing account-token config keeps working.

Unblocks SpotOpened SMS alerts (homelab-argo #179 already wires `TWILIO_KEY_SID`). After merge: worker native image rebuild/redeploy, then seal the API-key secret + flip `KELTA_SMS_PROVIDER=twilio`.

Tests: TwilioSmsProviderTest (asserts API-key Basic-auth header) + SmsProviderWiringTest — 9/9 green.

Not auto-merged — auth-credential path, manual review.