### PR TITLE
fix(gateway): member-controller routes shadowed by collection routes (portal 403)

### DIFF
--- a/.claude/docs/concerns.md
+++ b/.claude/docs/concerns.md
@@ -283,6 +283,24 @@ ids raw when they're not in the live page's `lookupDisplayMap` (no write-time di
 
 (No open bugs from the original audit. See Resolved → Bugs.)
 
+**FIXED (RouteRegistry authoritative member paths) — member-controller static routes were
+shadowed by their backing collection's generic route, 403-ing portal members.** A member
+resource served by a dedicated controller (e.g. `/api/watches` → `WatchController`, "API_ACCESS
+only, controller owner-scopes") is registered as a `static-` route so the gateway skips
+per-resource Cerbos (`RouteAuthorizationFilter` line ~153). But `watches`/`wins`/`devices`/
+`billing` are ALSO system collections, and each auto-registers a generic route at the **same
+path**. `RouteRegistry` keys by path (last-write-wins), and the collection route loads *after* the
+static routes, so it overwrote `static-watches` with a UUID-id route → per-resource collection
+Cerbos ran → a portal member (no collection role; base `resource_collection` policy is
+`roles:["*"]`, matches nothing) got `403 "Insufficient permissions for read on watches"`, breaking
+the whole consumer app. Never caught because the scenario tests exercise the DB/RLS layer, not the
+gateway authz path. Fix: `RouteRegistry.AUTHORITATIVE_STATIC_PATHS` (`/api/watches|wins|devices|
+billing/**`) — only a `static-` route may occupy those; a dynamic collection route for the same
+path is ignored. Deliberately NOT a blanket "static wins": config collections (flows, reports, …)
+are also `static-` bootstrap routes yet **rely** on their generic route's per-resource Cerbos and
+must keep it. Any NEW member-controller route that shares a path with a system collection must be
+added to that set.
+
 **FIXED (V181__collection_fk_cascade) — collections became permanently undeletable once
 used.** Deleting a collection is a generic record delete against the `collection` table
 (`DynamicCollectionRouter` → `QueryEngine.delete`); `PhysicalTableStorageAdapter` maps

--- a/kelta-gateway/src/main/java/io/kelta/gateway/route/RouteRegistry.java
+++ b/kelta-gateway/src/main/java/io/kelta/gateway/route/RouteRegistry.java
@@ -7,27 +7,66 @@ import org.springframework.stereotype.Component;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Thread-safe in-memory registry for route definitions.
- * 
+ *
  * Routes are indexed by their path pattern for efficient lookup.
  * All operations are thread-safe using ConcurrentHashMap.
- * 
+ *
  * This registry is updated dynamically through:
  * - Initial bootstrap from the worker service
  * - Real-time NATS events for configuration changes
  */
 @Component
 public class RouteRegistry {
-    
+
     private static final Logger logger = LoggerFactory.getLogger(RouteRegistry.class);
-    
+
+    /**
+     * Member-facing paths served by a dedicated controller (API_ACCESS-only at the
+     * gateway; the controller owner-scopes the data). Each ALSO backs a system
+     * collection whose auto-registered generic route shares this exact path — and,
+     * being loaded after the static routes, would overwrite the static override in
+     * {@link #routes} (keyed by path) and force per-resource collection Cerbos. A
+     * portal member holds no collection role, so that check denies with 403 and the
+     * member can never reach their own watches/wins/devices/billing (the dedicated
+     * controller they were meant to hit).
+     *
+     * <p>These paths are therefore authoritative: only a {@code static-} route may
+     * occupy them; a dynamic collection route for the same path is ignored. This is
+     * deliberately NOT a blanket "static always wins" — config collections
+     * (flows, reports, dashboards, …) are also registered as {@code static-} bootstrap
+     * routes yet rely on their generic route's per-resource Cerbos for protection, and
+     * must keep it. Only the member-controller routes below invert that.
+     */
+    private static final Set<String> AUTHORITATIVE_STATIC_PATHS = Set.of(
+            "/api/watches/**", "/api/wins/**", "/api/devices/**", "/api/billing/**");
+
     private final ConcurrentHashMap<String, RouteDefinition> routes;
-    
+
     public RouteRegistry() {
         this.routes = new ConcurrentHashMap<>();
+    }
+
+    private static boolean isStaticRoute(RouteDefinition route) {
+        return route.getId() != null && route.getId().startsWith("static-");
+    }
+
+    /**
+     * A dynamic (non-{@code static-}) route targeting an authoritative member path is
+     * a shadow of the intended controller override and must be dropped. Returns true
+     * when {@code route} should be ignored.
+     */
+    private boolean shadowsAuthoritativeStaticRoute(RouteDefinition route) {
+        if (AUTHORITATIVE_STATIC_PATHS.contains(route.getPath()) && !isStaticRoute(route)) {
+            logger.info("Ignoring dynamic route '{}' for authoritative member path '{}' — "
+                    + "the static controller route owns it", route.getId(), route.getPath());
+            return true;
+        }
+        return false;
     }
     
     /**
@@ -46,7 +85,11 @@ public class RouteRegistry {
             logger.error("Cannot add route with null or empty path: {}", route);
             return;
         }
-        
+
+        if (shadowsAuthoritativeStaticRoute(route)) {
+            return;
+        }
+
         RouteDefinition previous = routes.put(route.getPath(), route);
         if (previous != null) {
             logger.info("Updated existing route for path '{}': {}", route.getPath(), route);
@@ -95,6 +138,10 @@ public class RouteRegistry {
         }
         if (route.getPath() == null || route.getPath().isEmpty()) {
             logger.error("Cannot update route with null or empty path: {}", route);
+            return;
+        }
+
+        if (shadowsAuthoritativeStaticRoute(route)) {
             return;
         }
 

--- a/kelta-gateway/src/test/java/io/kelta/gateway/route/RouteRegistryTest.java
+++ b/kelta-gateway/src/test/java/io/kelta/gateway/route/RouteRegistryTest.java
@@ -390,6 +390,41 @@ class RouteRegistryTest {
         assertFalse(registry.findByPath("/api/inventory/1/2").isPresent());
     }
 
+    @Test
+    void dynamicCollectionRouteDoesNotShadowMemberStaticRoute() {
+        // Member-facing static route registered first (bootstrap)…
+        registry.addRoute(createRoute("static-watches", "/api/watches/**"));
+        // …then the 'watches' system collection's generic route tries to take the
+        // same path. It must be ignored so the API_ACCESS-only controller route wins
+        // (otherwise per-resource Cerbos runs and a portal member gets 403).
+        registry.addRoute(createRoute("3307cdef-collection-uuid", "/api/watches/**"));
+
+        RouteDefinition resolved = registry.findByPath("/api/watches").orElseThrow();
+        assertEquals("static-watches", resolved.getId(),
+            "the static member route must own /api/watches, not the collection route");
+    }
+
+    @Test
+    void updateRouteAlsoRejectsShadowOfMemberStaticRoute() {
+        registry.addRoute(createRoute("static-wins", "/api/wins/**"));
+        // NATS collection-update path must not clobber it either.
+        registry.updateRoute(createRoute("wins-collection-uuid", "/api/wins/**"));
+
+        assertEquals("static-wins", registry.findByPath("/api/wins").orElseThrow().getId());
+    }
+
+    @Test
+    void nonMemberStaticRouteIsStillOverwritableByCollectionRoute() {
+        // A config collection (e.g. flows) relies on its generic route's per-resource
+        // Cerbos check — the dynamic route may still replace the bootstrap static one.
+        registry.addRoute(createRoute("static-flows", "/api/flows/**"));
+        registry.addRoute(createRoute("flows-collection-uuid", "/api/flows/**"));
+
+        RouteDefinition resolved = registry.findByPath("/api/flows").orElseThrow();
+        assertEquals("flows-collection-uuid", resolved.getId(),
+            "non-member static routes keep last-write-wins so per-resource Cerbos still applies");
+    }
+
     private RouteDefinition createRoute(String id, String path) {
         return new RouteDefinition(
             id,


### PR DESCRIPTION
## Bug
The SpotOpened consumer app (and any portal member) got `403 "Insufficient permissions for read on watches"` on `/api/watches` — the dashboard couldn't load watches. Same latent bug on `/api/wins`, `/api/devices`, `/api/billing`.

## Root cause
`/api/watches` is served by a dedicated `WatchController` ("applies only the blanket API_ACCESS check — all member scoping is [in this controller]"), so it's registered as a `static-watches` route and `RouteAuthorizationFilter` skips per-resource Cerbos for `static-` routes.

But `watches` is **also** a system collection, and its generic route auto-registers at the **same path** `/api/watches/**`. `RouteRegistry` keys by path (last-write-wins) and the collection route loads *after* the static routes, so it **overwrote** `static-watches` with a UUID-id route. Per-resource collection Cerbos then ran; a portal member holds no collection role (base `resource_collection` policy is `roles:["*"]`, which matches nothing) → 403.

Confirmed from gateway logs:
```
Added new route for path '/api/watches/**': id='static-watches'
Updated existing route for path '/api/watches/**': id='3307cdef-…' collectionName='watches'
User …@rzware.com denied read on collection 'watches' (id=3307cdef-…)
```
Not caught earlier because the scenario tests exercise the DB/RLS layer, not the gateway authz path.

## Fix
`RouteRegistry.AUTHORITATIVE_STATIC_PATHS` = `/api/watches|wins|devices|billing/**`. For those paths only a `static-` route may register; a dynamic collection route for the same path is ignored (both `addRoute` and `updateRoute`).

**Deliberately narrow** — NOT "static always wins": config collections (flows, reports, dashboards, …) are also `static-` bootstrap routes but **rely** on their generic route's per-resource Cerbos and must keep it. A blanket flip would un-protect them.

## Tests
`RouteRegistryTest`: member route survives a shadowing add + update; a non-member route (`flows`) is still overwritable (per-resource Cerbos preserved). 25/25 green; route/listener/config suites green (60).

## Deploy note
Authz-adjacent — **not auto-merged**. After merge, the gateway image must be rebuilt/redeployed for it to take effect.