### PR TITLE
fix(worker): win claimant lookup used nonexistent platform_user.display_name

### DIFF
--- a/kelta-worker/src/main/java/io/kelta/worker/repository/WinRepository.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/repository/WinRepository.java
@@ -94,12 +94,12 @@ public class WinRepository {
     }
 
     /**
-     * The member's first name (falling back to display name) for the public claimant label set
+     * The member's first name (falling back to username) for the public claimant label set
      * server-side at create time. Empty when the user has neither.
      */
     public Optional<String> findMemberDisplayFirstName(String tenantId, String memberId) {
         List<String> names = jdbc.query(
-                "SELECT COALESCE(NULLIF(first_name, ''), display_name) AS label"
+                "SELECT COALESCE(NULLIF(first_name, ''), username) AS label"
                         + " FROM platform_user WHERE tenant_id = ? AND id = ?",
                 (rs, i) -> rs.getString("label"), tenantId, memberId);
         return names.isEmpty() ? Optional.empty() : Optional.ofNullable(names.get(0));


### PR DESCRIPTION
POST /api/wins returned 500 for every member: `WinRepository.findMemberDisplayFirstName` selected `display_name`, a column `platform_user` has never had (V1 baseline defines `first_name`/`last_name`/`username`, no `display_name`). BadSqlGrammarException on every win create — the claim step behind the live-wins ticker (consumer-alerting slice 9) was dead on arrival.

Fix: fall back to `username` (existing column, same one-fragment-of-identity intent). Doc comment updated.

Verified: `WinControllerTest` + `WinGuardHookTest` green; reproduced the 500 against the live spotopened tenant before the fix (requestId 7719c37f).

🤖 Generated with [Claude Code](https://claude.com/claude-code)