### PR TITLE
fix(cli): PAT name collision on same-day re-login broke browser login

### DIFF
--- a/.claude/docs/specs/kelta-cli/2-browser-login.md
+++ b/.claude/docs/specs/kelta-cli/2-browser-login.md
@@ -27,7 +27,10 @@ Flow (PR B):
    normal browser session.
 4. Callback → verify `state` → exchange code at `/oauth2/token` (public client, PKCE).
 5. With the access JWT: `POST {apiUrl}/{tenant}/api/me/tokens`
-   `{ name: "kelta-cli <hostname> <yyyy-mm-dd>", expiresInDays: <--expires-in, default 90> }`
+   `{ name: "kelta-cli <hostname> <yyyy-mm-ddThh-mm-ss>", expiresInDays: <--expires-in, default 90> }`
+   (second-precision stamp — `(user_id, name)` is unique on `user_api_token`, so a
+   date-only name collided on the second login of the day; the worker returns 409
+   `UNIQUE_VIOLATION` on a duplicate name instead of 500)
    → store returned `klt_` token + `tokenPrefix` + `expiresAt` in the profile; drop JWT.
 6. Browser tab shows a static "you can close this window" page; CLI prints profile summary.
 

--- a/kelta-web/packages/cli/src/auth/loginFlow.test.ts
+++ b/kelta-web/packages/cli/src/auth/loginFlow.test.ts
@@ -63,6 +63,9 @@ describe('browserLogin', () => {
     expect(minted.token).toBe('klt_new1234567890');
     expect(minted.expiresAt).toBe('2026-11-01T00:00:00Z');
     expect(minted.name).toContain(hostname());
+    // second-precision stamp — (user, name) is unique server-side, so a
+    // date-only name 409s on the second login of the day
+    expect(minted.name).toMatch(/ \d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}$/);
 
     // token exchange: form-encoded PKCE request to the auth server
     const [tokenUrl, tokenBody] = post.mock.calls[0] as [string, URLSearchParams];

--- a/kelta-web/packages/cli/src/auth/loginFlow.ts
+++ b/kelta-web/packages/cli/src/auth/loginFlow.ts
@@ -124,7 +124,10 @@ async function exchangeCode(
 }
 
 async function mintPat(params: BrowserLoginParams, accessToken: string): Promise<MintedPat> {
-  const name = `kelta-cli ${hostname()} ${new Date().toISOString().slice(0, 10)}`;
+  // Second-precision timestamp: PAT names are unique per (user, name), so a
+  // date-only name collides on the second login of the day (worker 409s).
+  const stamp = new Date().toISOString().slice(0, 19).replace(/:/g, '-');
+  const name = `kelta-cli ${hostname()} ${stamp}`;
   const response = await axios.post<{ token?: string; tokenPrefix?: string; expiresAt?: string }>(
     `${params.apiUrl.replace(/\/$/, '')}/${params.tenantSlug}/api/me/tokens`,
     { name, expiresInDays: params.expiresInDays },

--- a/kelta-web/packages/cli/src/commands/auth.ts
+++ b/kelta-web/packages/cli/src/commands/auth.ts
@@ -68,13 +68,23 @@ const login = defineCommand({
   handler: async (ctx, input) => {
     const name = activeProfileName(ctx);
     const existing = loadConfig().profiles[name];
-    const apiUrl = input.url ?? existing?.apiUrl;
+    let apiUrl = input.url ?? existing?.apiUrl;
     const tenantSlug = input.tenant ?? existing?.tenantSlug;
     if (!apiUrl || !tenantSlug) {
       throw new CliError(`Profile "${name}" has no saved connection — pass --url and --tenant`, {
         code: 'MISSING_CONNECTION',
         exitCode: EXIT.USAGE,
       });
+    }
+    // The API URL must be an origin: the CLI prepends /<tenant> itself, so a
+    // path here (e.g. --url https://api.kelta.io/spotopened) doubles the slug
+    // and 404s at the gateway.
+    const parsedApiUrl = new URL(apiUrl);
+    if (parsedApiUrl.pathname !== '/' && parsedApiUrl.pathname !== '') {
+      ctx.log(
+        `Ignoring path "${parsedApiUrl.pathname}" in the API URL — the tenant slug comes from --tenant`
+      );
+      apiUrl = parsedApiUrl.origin;
     }
 
     // Headless path: store the supplied token verbatim, exactly as before.

--- a/kelta-web/packages/cli/src/commands/authLogin.test.ts
+++ b/kelta-web/packages/cli/src/commands/authLogin.test.ts
@@ -100,6 +100,33 @@ describe('auth login — browser flow', () => {
     expect(JSON.stringify(result)).not.toContain('klt_minted1234567890');
   });
 
+  it('strips a path from --url with a warning — the CLI prepends the tenant slug itself', async () => {
+    browserLoginMock.mockResolvedValue({
+      token: 'klt_minted1234567890',
+      tokenPrefix: 'klt_mint',
+      expiresAt: '2026-11-04T00:00:00Z',
+      name: 'n',
+    });
+
+    const context = ctx('prod');
+    const def = command(authCommands, 'login');
+    await def.handler(
+      context,
+      def.input.parse({
+        url: 'https://api.kelta.io/acme',
+        tenant: 'acme',
+        expiresIn: '30',
+        browser: true,
+      }) as never
+    );
+
+    expect(browserLoginMock).toHaveBeenCalledWith(
+      expect.objectContaining({ apiUrl: 'https://api.kelta.io' })
+    );
+    expect(loadConfig().profiles.prod?.apiUrl).toBe('https://api.kelta.io');
+    expect(vi.mocked(context.log).mock.calls.flat().join('\n')).toContain('Ignoring path "/acme"');
+  });
+
   it('re-authenticates an existing profile with no flags', async () => {
     saveConfig({
       version: 1,

--- a/kelta-worker/src/main/java/io/kelta/worker/controller/PersonalAccessTokenController.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/controller/PersonalAccessTokenController.java
@@ -2,9 +2,11 @@ package io.kelta.worker.controller;
 
 import io.kelta.runtime.context.TenantContext;
 import io.kelta.runtime.router.UserIdResolver;
+import io.kelta.runtime.storage.UniqueConstraintViolationException;
 import io.kelta.worker.service.SecurityAuditLogger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.http.ResponseEntity;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -155,12 +157,16 @@ public class PersonalAccessTokenController {
                 : List.of("api");
         String scopesJson = "[" + String.join(",", scopes.stream().map(s -> "\"" + s + "\"").toList()) + "]";
 
-        // Insert token
-        jdbcTemplate.update(
-                "INSERT INTO user_api_token (user_id, tenant_id, name, token_prefix, token_hash, scopes, expires_at) " +
-                        "VALUES (?, ?, ?, ?, ?, ?::jsonb, ?)",
-                userId, tenantId, name.trim(), tokenPrefixDisplay, tokenHash, scopesJson,
-                Timestamp.from(expiresAt));
+        // Insert token — uq_user_api_token_name_per_user makes (user_id, name) unique
+        try {
+            jdbcTemplate.update(
+                    "INSERT INTO user_api_token (user_id, tenant_id, name, token_prefix, token_hash, scopes, expires_at) " +
+                            "VALUES (?, ?, ?, ?, ?, ?::jsonb, ?)",
+                    userId, tenantId, name.trim(), tokenPrefixDisplay, tokenHash, scopesJson,
+                    Timestamp.from(expiresAt));
+        } catch (DuplicateKeyException e) {
+            throw new UniqueConstraintViolationException("user_api_token", "name", name.trim());
+        }
 
         // Cache token metadata in Redis for gateway validation
         try {

--- a/kelta-worker/src/test/java/io/kelta/worker/controller/PersonalAccessTokenControllerTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/controller/PersonalAccessTokenControllerTest.java
@@ -2,10 +2,12 @@ package io.kelta.worker.controller;
 
 import io.kelta.runtime.context.TenantContext;
 import io.kelta.runtime.router.UserIdResolver;
+import io.kelta.runtime.storage.UniqueConstraintViolationException;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.http.HttpStatus;
@@ -15,6 +17,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
@@ -93,6 +96,22 @@ class PersonalAccessTokenControllerTest {
             String token = (String) body.get("token");
             assertThat(token).startsWith("klt_");
             assertThat(token).hasSize(44); // "klt_" + 40 chars
+        }
+
+        @Test
+        void shouldThrowUniqueViolationWhenNameAlreadyExists() {
+            when(jdbcTemplate.queryForList(contains("platform_user"), eq("user-1"), eq("tenant-1")))
+                    .thenReturn(List.of(Map.of("email", "user@test.com")));
+            when(jdbcTemplate.queryForList(contains("COUNT"), eq("user-1"), eq("tenant-1")))
+                    .thenReturn(List.of(Map.of("cnt", 0L)));
+            when(jdbcTemplate.update(contains("INSERT INTO user_api_token"), any(Object[].class)))
+                    .thenThrow(new DuplicateKeyException(
+                            "duplicate key value violates unique constraint \"uq_user_api_token_name_per_user\""));
+
+            assertThatThrownBy(() -> controller.createToken("user-1",
+                    Map.of("name", "My Token", "expiresInDays", 90)))
+                    .isInstanceOf(UniqueConstraintViolationException.class)
+                    .hasMessageContaining("name");
         }
 
         @Test


### PR DESCRIPTION
## Problem

`kelta auth login` failed live with `Error [INTERNAL_ERROR]: An unexpected error occurred` on the second login of the day (first live round-trip of the CLI browser login against prod).

Root cause: the CLI names the minted PAT `kelta-cli <hostname> <yyyy-mm-dd>` — deterministic per machine per day. `uq_user_api_token_name_per_user` makes `(user_id, name)` unique, so the second same-day login threw `DuplicateKeyException` in `PersonalAccessTokenController.createToken`, which fell through to the generic 500 handler.

A secondary foot-gun found in the same session: `--url https://api.kelta.io/<slug>` doubles the tenant slug (the CLI prepends `/<slug>` itself) and 404s at the gateway.

## Fix

- **cli**: PAT name now carries a second-precision timestamp (`kelta-cli <host> 2026-08-09T12-33-57`) — unique per login.
- **cli**: a path component in `--url` is stripped to the origin with a warning.
- **worker**: duplicate PAT name maps to 409 `UNIQUE_VIOLATION` (via existing `UniqueConstraintViolationException` handler) instead of 500, so any residual collision is self-explanatory.

## Testing

- New worker unit test: duplicate insert → `UniqueConstraintViolationException` (409 path).
- New/updated CLI tests: name format regex, `--url` path-strip + warning.
- `/verify` green: runtime build, gateway 583, worker 2407, kelta-web 1126 tests + lint/typecheck/format/coverage.

**No auto-merge** — touches the PAT-mint endpoint (auth-adjacent surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)