### PR TITLE
fix(worker): web push could never be enabled on the native image

### DIFF
--- a/kelta-worker/src/main/java/io/kelta/worker/service/push/WebPushProvider.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/service/push/WebPushProvider.java
@@ -8,7 +8,6 @@ import com.nimbusds.jwt.SignedJWT;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -49,7 +48,6 @@ import java.util.Date;
  * as it does for a stale FCM/APNs token.
  */
 @Component
-@ConditionalOnProperty(name = "kelta.push.vapid.public-key")
 public class WebPushProvider implements PushProvider {
 
     private static final Logger log = LoggerFactory.getLogger(WebPushProvider.class);
@@ -76,13 +74,25 @@ public class WebPushProvider implements PushProvider {
         this.publicKey = publicKey;
         this.subject = subject == null || subject.isBlank() ? "mailto:admin@kelta.io" : subject;
         this.privateKey = parsePrivateKey(privateKey);
-        log.info("WebPushProvider active (VAPID subject {})", this.subject);
+        // Always a bean: on the native image @ConditionalOnProperty is fixed at
+        // AOT build time, so a key configured at deploy time could never enable
+        // web push. Configuration is judged at runtime instead (supports()).
+        if (configured()) {
+            log.info("WebPushProvider active (VAPID subject {})", this.subject);
+        } else {
+            log.info("WebPushProvider idle — no VAPID key pair configured");
+        }
     }
 
-    /** Only handles browser subscriptions; native platforms fall through. */
+    /** True when a usable VAPID key pair is present. */
+    private boolean configured() {
+        return publicKey != null && !publicKey.isBlank() && privateKey != null;
+    }
+
+    /** Only handles browser subscriptions, and only once a key pair is configured. */
     @Override
     public boolean supports(String platform) {
-        return PLATFORM.equalsIgnoreCase(platform);
+        return PLATFORM.equalsIgnoreCase(platform) && configured();
     }
 
     /** The key a frontend passes to {@code pushManager.subscribe}. */

--- a/kelta-worker/src/test/java/io/kelta/worker/service/push/PushProviderWiringTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/service/push/PushProviderWiringTest.java
@@ -69,12 +69,18 @@ class PushProviderWiringTest {
     }
 
     @Test
-    @DisplayName("web push stays absent when no VAPID key is configured")
-    void webProviderAbsentWithoutKeys() {
+    @DisplayName("web push stays inert when no VAPID key is configured")
+    void webProviderInertWithoutKeys() {
+        // The bean must exist unconditionally — on the native image a
+        // @ConditionalOnProperty is fixed at AOT build time and a deploy-time
+        // key could never enable it — but an unconfigured provider must not
+        // claim web devices or advertise a public key.
         runner.run(context -> {
             assertThat(context).hasNotFailed();
-            assertThat(context).doesNotHaveBean(WebPushProvider.class);
-            assertThat(context.getBeansOfType(PushProvider.class)).hasSize(1);
+            assertThat(context).hasSingleBean(WebPushProvider.class);
+            WebPushProvider web = context.getBean(WebPushProvider.class);
+            assertThat(web.supports("web")).isFalse();
+            assertThat(web.publicKey()).isEmpty();
         });
     }
 


### PR DESCRIPTION
Deploying VAPID keys to prod (homelab-argo#185) did nothing: `GET /api/devices/vapid-public-key` kept 404ing after the configmap rolled and the worker restarted. Root cause: `WebPushProvider`'s `@ConditionalOnProperty(kelta.push.vapid.public-key)` is evaluated at **AOT build time** for the native image — the CI build environment has no VAPID key, so the shipped binary permanently excludes the bean; runtime env can never resurrect it. (Same failure class as the fcm/apns `@Autowired` startup gap: only visible on the deployed artifact.)

Fix: the bean is unconditional; configuration is a runtime judgment —
- unconfigured: logs idle, `supports()` returns false for every platform (never claims web devices), `publicKey()` blank so the endpoint's existing 404 path holds
- configured: identical behavior to before

`PushProviderWiringTest` updated: absent-bean expectation → present-but-inert. 18 push tests green.

After merge+deploy the already-rolled VAPID configmap (homelab-argo#185) takes effect with no further action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)