### PR TITLE
fix(runtime): FORMULA has no physical column — unblock red main

### DIFF
--- a/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/model/FieldType.java
+++ b/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/model/FieldType.java
@@ -120,10 +120,19 @@ public enum FieldType {
 
     /**
      * Returns true if this type has a physical column in the database.
-     * ROLLUP_SUMMARY is computed on read; FORMULA fields have a materialized DB column.
+     * FORMULA and ROLLUP_SUMMARY are computed on read.
+     *
+     * <p>Both are evaluated after retrieval by {@code DefaultQueryEngine.computeDerivedFields},
+     * so neither needs storage. Returning true for FORMULA makes
+     * {@code PhysicalTableStorageAdapter.initializeCollection} create a column that is written
+     * on insert and then overwritten by the read-time evaluation — dead storage that can hold a
+     * stale value after an expression change, plus a spurious ALTER TABLE per FORMULA field in
+     * {@code SchemaMigrationEngine}. It also breaks {@code FormulaRecomputeService}, whose
+     * per-row UPDATE is deliberately the {@code SET updated_at = updated_at} no-op it documents
+     * *because* there is no column to refresh.
      */
     public boolean hasPhysicalColumn() {
-        return this != ROLLUP_SUMMARY;
+        return this != FORMULA && this != ROLLUP_SUMMARY;
     }
 
     /**


### PR DESCRIPTION
## `main` is red, and this unblocks it

`runtime-core` fails on a clean checkout of `origin/main` (verified in a separate worktree,
no other branch's code present):

```
FieldTypeTest.formulaHasNoPhysicalColumn:72 expected: <false> but was: <true>
Tests run: 1469, Failures: 1
```

A failing suite gates `build-and-push`, so no images are building and nothing is deploying —
the failure mode `concerns.md` describes as "a deploy outage, not a test nuisance."

## The test is right; the implementation is the defect

#1281 changed exactly one line and one Javadoc:

```java
- return this != FORMULA && this != ROLLUP_SUMMARY;
+ return this != ROLLUP_SUMMARY;
```

Nothing else moved with it. The rest of the formula design — including code in that same PR —
still assumes FORMULA has no column:

| Source | Says |
|---|---|
| `DefaultQueryEngine.computeDerivedFields` | evaluates FORMULA **after retrieval** — a formula value never needs storage |
| `FormulaComputeHook` javadoc | "Formula values are **not** persisted to physical columns" |
| `FormulaRecomputeService` javadoc | "FORMULA fields have **no** physical column today" |
| `FormulaRecomputeService` line 141 | `UPDATE … SET updated_at = updated_at` — a deliberate no-op |

The query engine is decisive: formula values are computed on read, so there is nothing to
store. And `FormulaRecomputeService`'s no-op UPDATE only makes sense when there is no column
to refresh.

I originally assumed the opposite — that `hasPhysicalColumn()`'s own javadoc ("FORMULA fields
have a materialized DB column") was authoritative and the test had gone stale. Checking the
read path first is what reversed it. Worth stating plainly, because "make the failing
assertion match the code" would have been the fast fix and the wrong one.

## What leaving it would cost

With `hasPhysicalColumn()` true for FORMULA, `hasPhysicalColumn()` is the gate for column
creation, the INSERT column list, and migration DDL. So today:

1. `PhysicalTableStorageAdapter.initializeCollection` creates a physical column per FORMULA
   field — written on insert, then overwritten by the read-time evaluation. Dead storage, free
   to hold a stale value after an expression change.
2. `SchemaMigrationEngine` emits a spurious `ALTER TABLE` per FORMULA field.
3. `FormulaRecomputeService` is silently broken — the service whose entire job is refreshing
   pre-existing rows after an expression change now bumps `updated_at` and refreshes nothing.

Any collection created since #1281 deployed carries the spurious columns. They are harmless
to leave (unused), so no migration is proposed here — flagging it so it is a decision rather
than an oversight.

## Verification

`runtime-core`: **1,469 tests, 0 failures** (the same suite that is 1469/1 on `main`). Run on
JDK 25 in the `maven:3.9-eclipse-temurin-25` container.

## If I've read the intent backwards

If #1281 *did* mean to materialize FORMULA, then this is the wrong direction and the real work
is larger than a one-liner: `FormulaRecomputeService` would need a genuine per-row UPDATE, the
read-time evaluation in `DefaultQueryEngine` would need to stop clobbering the stored value,
and both javadocs would need correcting. Say so and I'll do that instead — but `main` should
be made green either way, and this is the smaller, more reversible of the two.
