### PR TITLE
fix(worker): record-level filter emptied every portal member's own data

### DIFF
--- a/kelta-worker/src/main/java/io/kelta/worker/controller/BillingController.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/controller/BillingController.java
@@ -11,6 +11,7 @@ import io.kelta.worker.repository.BillingSubscriptionRepository;
 import io.kelta.worker.service.billing.BillingCheckoutService;
 import io.kelta.worker.service.billing.EntitlementService;
 import io.kelta.worker.service.billing.MemberEntitlements;
+import io.kelta.worker.interceptor.SelfScopedController;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -43,7 +44,7 @@ import java.util.Optional;
  */
 @RestController
 @RequestMapping("/api/billing")
-public class BillingController {
+public class BillingController implements SelfScopedController {
 
     private final BillingPlanRepository planRepository;
     private final BillingSubscriptionRepository subscriptionRepository;

--- a/kelta-worker/src/main/java/io/kelta/worker/controller/PushDeviceController.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/controller/PushDeviceController.java
@@ -3,6 +3,7 @@ package io.kelta.worker.controller;
 import io.kelta.runtime.context.TenantContext;
 import io.kelta.worker.service.push.DefaultPushService;
 import io.kelta.worker.service.push.WebPushProvider;
+import io.kelta.worker.interceptor.SelfScopedController;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.ObjectProvider;
@@ -23,7 +24,7 @@ import java.util.Map;
  * @since 1.0.0
  */
 @RestController
-public class PushDeviceController {
+public class PushDeviceController implements SelfScopedController {
 
     private static final Logger log = LoggerFactory.getLogger(PushDeviceController.class);
     private static final int ADMIN_NOTIFICATION_RATE_LIMIT = 10; // per hour

--- a/kelta-worker/src/main/java/io/kelta/worker/controller/WatchController.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/controller/WatchController.java
@@ -13,6 +13,7 @@ import io.kelta.worker.repository.WatchTarget;
 import io.kelta.worker.repository.WatchTargetRepository;
 import io.kelta.worker.service.availability.WatchCriteria;
 import io.kelta.worker.service.billing.EntitlementService;
+import io.kelta.worker.interceptor.SelfScopedController;
 import jakarta.servlet.http.HttpServletRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -59,7 +60,7 @@ import java.util.Optional;
  */
 @RestController
 @RequestMapping("/api/watches")
-public class WatchController {
+public class WatchController implements SelfScopedController {
 
     private static final Logger log = LoggerFactory.getLogger(WatchController.class);
 

--- a/kelta-worker/src/main/java/io/kelta/worker/controller/WinController.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/controller/WinController.java
@@ -7,6 +7,7 @@ import io.kelta.runtime.registry.CollectionRegistry;
 import io.kelta.runtime.router.UserIdResolver;
 import io.kelta.worker.repository.WinRepository;
 import io.kelta.worker.repository.WinRepository.Win;
+import io.kelta.worker.interceptor.SelfScopedController;
 import jakarta.servlet.http.HttpServletRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,7 +44,7 @@ import java.util.Map;
  */
 @RestController
 @RequestMapping("/api/wins")
-public class WinController {
+public class WinController implements SelfScopedController {
 
     private static final Logger log = LoggerFactory.getLogger(WinController.class);
 

--- a/kelta-worker/src/main/java/io/kelta/worker/interceptor/CerbosRecordAuthorizationAdvice.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/interceptor/CerbosRecordAuthorizationAdvice.java
@@ -68,6 +68,16 @@ public class CerbosRecordAuthorizationAdvice implements ResponseBodyAdvice<Objec
             return body;
         }
 
+        // A controller that scopes its own data to the caller is exempt: portal
+        // members hold no record grants, so the filter below would empty their own
+        // watches/wins/devices/billing while every write still succeeded. Checked on
+        // the handler, not the path, so the generic collection route on those same
+        // paths keeps full record-level filtering.
+        if (returnType != null
+                && SelfScopedController.class.isAssignableFrom(returnType.getContainingClass())) {
+            return body;
+        }
+
         HttpServletRequest httpRequest = servletRequest.getServletRequest();
         String path = httpRequest.getRequestURI();
 

--- a/kelta-worker/src/main/java/io/kelta/worker/interceptor/SelfScopedController.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/interceptor/SelfScopedController.java
@@ -1,0 +1,23 @@
+package io.kelta.worker.interceptor;
+
+/**
+ * Marks a controller that scopes its own response data to the calling member,
+ * exempting it from {@link CerbosRecordAuthorizationAdvice}'s record-level filter.
+ *
+ * <p>The advice removes any record the caller's <em>profile</em> is not granted at
+ * the record level. A portal member holds no record grants at all, so applying it
+ * to a member-facing endpoint empties the response — the member's own watches, wins,
+ * devices, and billing state vanish while every write still succeeds, which reads as
+ * data loss rather than a permission error. The same failure hit the telehealth
+ * portal in July 2026 and was patched there with a path exclusion.
+ *
+ * <p>A marker <b>interface</b>, not an annotation: the check is then a plain type
+ * test with no reflection, which the native image cannot silently drop.
+ *
+ * <p>Implementing this is a promise: the controller resolves the acting member from
+ * the request itself and returns only that member's rows (a foreign id must 404).
+ * It exempts only this controller's own handlers — the generic collection route on
+ * the same path keeps full record-level filtering.
+ */
+public interface SelfScopedController {
+}

--- a/kelta-worker/src/test/java/io/kelta/worker/interceptor/CerbosRecordAuthorizationAdviceTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/interceptor/CerbosRecordAuthorizationAdviceTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.MethodParameter;
 import org.springframework.http.MediaType;
 import org.springframework.http.server.ServletServerHttpRequest;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -47,6 +48,62 @@ class CerbosRecordAuthorizationAdviceTest {
         lenient().when(permissionResolver.getProfileId(request)).thenReturn("profile-1");
         lenient().when(permissionResolver.getTenantId(request)).thenReturn("tenant-1");
         return new ServletServerHttpRequest(request);
+    }
+
+    @Nested
+    @DisplayName("self-scoped controllers")
+    class SelfScoped {
+
+        /** Stands in for WatchController/WinController/PushDeviceController/BillingController. */
+        static class MemberController implements SelfScopedController {
+            public Map<String, Object> list() {
+                return Map.of();
+            }
+        }
+
+        static class GenericController {
+            public Map<String, Object> list() {
+                return Map.of();
+            }
+        }
+
+        private MethodParameter returnTypeOf(Class<?> controller) throws Exception {
+            return new MethodParameter(controller.getDeclaredMethod("list"), -1);
+        }
+
+        @Test
+        @DisplayName("keeps a member's own records — the filter would otherwise empty them")
+        void keepsSelfScopedRecords() throws Exception {
+            // A portal member holds no record grants, so Cerbos denies every record.
+            var request = createRequest("/api/watches");
+            Map<String, Object> body = Map.of("data",
+                    List.of(Map.of("id", "watch-1", "targetId", "t-1")));
+
+            Object result = advice.beforeBodyWrite(body, returnTypeOf(MemberController.class),
+                    MediaType.APPLICATION_JSON, null, request, null);
+
+            @SuppressWarnings("unchecked")
+            List<Map<String, Object>> data = (List<Map<String, Object>>) ((Map<String, Object>) result).get("data");
+            assertThat(data).hasSize(1);
+            verifyNoInteractions(authzService);
+        }
+
+        @Test
+        @DisplayName("still filters the generic collection route on the same path")
+        void filtersGenericRouteOnSamePath() throws Exception {
+            var request = createRequest("/api/watches");
+            when(authzService.batchCheckRecordAccess(any(), any(), any(), any(), anyList(), eq("read")))
+                    .thenReturn(Set.of());
+            Map<String, Object> body = Map.of("data",
+                    List.of(Map.of("id", "watch-1", "targetId", "t-1")));
+
+            Object result = advice.beforeBodyWrite(body, returnTypeOf(GenericController.class),
+                    MediaType.APPLICATION_JSON, null, request, null);
+
+            @SuppressWarnings("unchecked")
+            List<Map<String, Object>> data = (List<Map<String, Object>>) ((Map<String, Object>) result).get("data");
+            assertThat(data).isEmpty();
+        }
     }
 
     @Test


### PR DESCRIPTION
## The bug

A SpotOpened member's dashboard said *"No watches yet"* while the watch plainly existed. The write path was fine — it was the read that lied:

| call | result |
|---|---|
| `POST /api/watches` | 201, row created |
| quota pre-check on the next POST | `plan limit (1/1)` — **counted the row** |
| `GET /api/watches/{id}/alerts` | 200, **resolved the row** (same `findByMember`) |
| `GET /api/watches` | 200 `{"data":[]}` |
| `GET`/`PATCH /api/watches/{id}` | 200 `{"data":null}` (the PATCH still applied) |

Nothing was wrong with the query. `CerbosRecordAuthorizationAdvice` strips from every `/api/**` response any record the caller's **profile** lacks a record-level grant for — and a portal member holds no record grants at all, so it deleted the rows the member controllers had already owner-scoped. `/api/wins/recent` survived only because its redacted payload carries no `id`.

The advice's own comment documents this identical failure for the telehealth portal in July 2026 ("emptied every portal user's appointment list"), fixed there with a path exclusion. The consumer-alerting member controllers (slices 1/5/6/9) were never added.

## The fix

Exempt by **handler**, not path. A path exclusion for `/api/watches/**` would also unfilter the generic collection route on those paths — a member could then read another member's watch by id.

`WatchController`, `WinController`, `PushDeviceController`, `BillingController` implement the new marker `SelfScopedController`; the advice skips a handler whose controller implements it. A marker **interface** rather than an annotation, deliberately: the check is a plain type test with no reflection, which the native image cannot silently drop — the same class of trap as the AOT-evaluated `@ConditionalOnProperty` fixed in #1323.

## Tests

`CerbosRecordAuthorizationAdviceTest` gains a nested `SelfScoped` group: a self-scoped handler's records survive with Cerbos denying everything (and the authz service is never called), while an unmarked handler on the same path still filters to empty. 33 tests green across the advice + `WatchControllerTest` + `WinControllerTest`.

Reproduced against the live spotopened tenant before the fix; will verify the member list end-to-end after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)