### PR TITLE
fix(worker): watch criteria and channels were stored double-encoded

### DIFF
--- a/kelta-worker/src/main/java/io/kelta/worker/controller/WatchController.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/controller/WatchController.java
@@ -29,6 +29,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
+import tools.jackson.core.type.TypeReference;
 import tools.jackson.databind.ObjectMapper;
 
 import java.util.ArrayList;
@@ -159,8 +160,8 @@ public class WatchController implements SelfScopedController {
         data.put("tenantId", tenantId);
         data.put("memberId", subject);
         data.put("targetId", target.id());
-        data.put("criteria", criteria);
-        data.put("channels", toJsonArray(channels));
+        data.put("criteria", criteriaStructure(criteria));
+        data.put("channels", channels);
         data.put("status", Watch.STATUS_ACTIVE);
         if (body.expiresAt() != null) {
             data.put("expiresAt", body.expiresAt());
@@ -183,11 +184,11 @@ public class WatchController implements SelfScopedController {
 
         Map<String, Object> data = new LinkedHashMap<>();
         if (body != null && body.criteria() != null) {
-            data.put("criteria", validateCriteria(body.criteria()));
+            data.put("criteria", criteriaStructure(validateCriteria(body.criteria())));
         }
         if (body != null && body.channels() != null) {
-            data.put("channels", toJsonArray(
-                    intersectChannels(tenantId, existing.memberId(), body.channels())));
+            data.put("channels",
+                    intersectChannels(tenantId, existing.memberId(), body.channels()));
         }
         if (body != null && body.status() != null) {
             data.put("status", requirePausableStatus(body.status()));
@@ -347,10 +348,23 @@ public class WatchController implements SelfScopedController {
         return item;
     }
 
-    private String toJsonArray(List<String> values) {
-        var array = objectMapper.createArrayNode();
-        values.forEach(array::add);
-        return array.toString();
+    /**
+     * Criteria as a structure, not JSON text. The storage adapter JSON-encodes
+     * whatever it is handed, so passing the serialized form stored a JSON *string*
+     * wrapping the object — which then read back as a textual node, silently
+     * defeating criteria matching and channel selection.
+     */
+    private Map<String, Object> criteriaStructure(String json) {
+        if (json == null || json.isBlank()) {
+            return Map.of();
+        }
+        try {
+            return objectMapper.readValue(json, new TypeReference<Map<String, Object>>() { });
+        } catch (RuntimeException e) {
+            // validateCriteria already re-serialized this from a parsed structure,
+            // so failing here means a bug, not bad input.
+            throw new IllegalStateException("criteria could not be re-read as a structure", e);
+        }
     }
 
     private CollectionDefinition definition() {

--- a/kelta-worker/src/main/java/io/kelta/worker/service/availability/AlertDispatchService.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/service/availability/AlertDispatchService.java
@@ -186,6 +186,12 @@ public class AlertDispatchService {
         }
         try {
             JsonNode node = objectMapper.readTree(json);
+            // Rows written before the storage fix hold a JSON string wrapping the
+            // array; unwrap one level so an existing watch keeps its channels
+            // instead of silently falling back to the full entitlement.
+            if (node.isTextual()) {
+                node = objectMapper.readTree(node.stringValue());
+            }
             if (!node.isArray()) {
                 return List.of();
             }

--- a/kelta-worker/src/main/java/io/kelta/worker/service/availability/WatchCriteria.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/service/availability/WatchCriteria.java
@@ -72,6 +72,20 @@ public record WatchCriteria(
             errors.add("criteria is not valid JSON");
             return new ParseResult(ANY, errors);
         }
+        // Legacy rows carry the object as a JSON string (see the storage note in
+        // WatchController) — unwrap once so their date windows still match. Only
+        // when an object actually falls out: a plain string stays the malformed
+        // input it always was.
+        if (node.isTextual()) {
+            try {
+                JsonNode unwrapped = objectMapper.readTree(node.stringValue());
+                if (unwrapped.isObject()) {
+                    node = unwrapped;
+                }
+            } catch (RuntimeException e) {
+                // Not JSON inside — leave it textual for the object check below.
+            }
+        }
         if (!node.isObject()) {
             errors.add("criteria must be a JSON object");
             return new ParseResult(ANY, errors);

--- a/kelta-worker/src/test/java/io/kelta/worker/service/availability/WatchCriteriaTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/service/availability/WatchCriteriaTest.java
@@ -237,4 +237,15 @@ class WatchCriteriaTest {
             assertThat(json).isEqualTo("{\"v\":1}");
         }
     }
+
+    @Test
+    @DisplayName("unwraps a legacy double-encoded criteria string (storage regression)")
+    void unwrapsDoubleEncodedCriteria() {
+        // Rows written before the storage fix hold the object as a JSON *string*.
+        String legacy = "\"{\\\"v\\\":1,\\\"dateStart\\\":\\\"2026-09-01\\\"}\"";
+        WatchCriteria.ParseResult result = WatchCriteria.parse(legacy, objectMapper);
+
+        assertThat(result.isValid()).isTrue();
+        assertThat(result.criteria().dateStart()).isEqualTo(java.time.LocalDate.of(2026, 9, 1));
+    }
 }


### PR DESCRIPTION
Found while verifying #1325 end to end: with the member's watch finally visible, its `channels` came back as `"[\"email\"]"` — a JSON string wrapping the array, not an array.

`WatchController` handed the storage adapter **pre-serialized JSON text**. The adapter JSON-encodes whatever it is given (correctly — a bare `en` is not valid JSONB input, `"en"` is), so the text got encoded a second time.

Both readers then failed silently:

- `AlertDispatchService.parseChannels` sees a textual node → returns empty → `resolveChannels` treats that as "no preference" and **falls back to the member's full entitlement**. A member who unchecked SMS could still be texted — an A2P consent problem, not a cosmetic one.
- `WatchCriteria.parse` sees a textual node → `ANY` → **date windows never narrowed a match**, so watches alerted on slots outside their range.

Neither path threw; the values just stopped being honoured.

**Fix:** the controller stores structures (`List<String>`, `Map<String,Object>`) and lets the adapter do the single encoding it is designed to do. Both parsers unwrap one level of string encoding so rows already written keep working — the criteria unwrap applies only when an object actually falls out, so a genuinely malformed `"text"` is still reported as "must be a JSON object" (existing test pinned that).

51 tests green across `WatchCriteriaTest` (+1 regression for the legacy shape), `WatchControllerTest`, `AlertDispatchServiceTest`, `WatchGuardHookTest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)