### PR TITLE
fix(billing): subscription period end was never recorded

### DIFF
--- a/kelta-worker/src/main/java/io/kelta/worker/service/billing/BillingWebhookService.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/service/billing/BillingWebhookService.java
@@ -199,7 +199,7 @@ public class BillingWebhookService {
         String status = text(subscription, "status");
         subscriptionRepository.upsert(tenantId, userId, planId, stripeSubscriptionId,
                 stripeCustomerId, status,
-                epochSeconds(subscription, "current_period_end"),
+                currentPeriodEnd(subscription),
                 subscription.path("cancel_at_period_end").asBoolean(false),
                 epochSeconds(subscription, "canceled_at"));
 
@@ -289,6 +289,33 @@ public class BillingWebhookService {
         }
         String s = value.stringValue();
         return s.isBlank() ? null : s;
+    }
+
+    /**
+     * The subscription's period end, from wherever the event renders it.
+     *
+     * <p>Stripe moved {@code current_period_end} off the subscription and onto
+     * each subscription item in 2025-03-31.basil. Webhook payloads are rendered
+     * with the <b>account's</b> API version (or the endpoint's), not the version
+     * this client pins for its own calls, so both shapes reach us and reading only
+     * the old one silently left the column null — which is what the member-facing
+     * "renews on" and "cancels on" lines read.
+     */
+    private static Instant currentPeriodEnd(JsonNode subscription) {
+        Instant topLevel = epochSeconds(subscription, "current_period_end");
+        if (topLevel != null) {
+            return topLevel;
+        }
+        // Items can carry different periods; the subscription's own period end is
+        // the latest of them.
+        Instant latest = null;
+        for (JsonNode item : subscription.path("items").path("data")) {
+            Instant itemEnd = epochSeconds(item, "current_period_end");
+            if (itemEnd != null && (latest == null || itemEnd.isAfter(latest))) {
+                latest = itemEnd;
+            }
+        }
+        return latest;
     }
 
     private static Instant epochSeconds(JsonNode node, String field) {

--- a/kelta-worker/src/test/java/io/kelta/worker/service/billing/BillingWebhookServiceTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/service/billing/BillingWebhookServiceTest.java
@@ -307,6 +307,54 @@ class BillingWebhookServiceTest {
         }
 
         @Test
+        @DisplayName("reads current_period_end from the item when the event omits it top-level")
+        void readsPeriodEndFromItem() {
+            when(planRepository.findByStripePriceId(TENANT, "price_1"))
+                    .thenReturn(Optional.of(plan("plan-paid", "paid", null)));
+            when(planRepository.findById(TENANT, "plan-paid"))
+                    .thenReturn(Optional.of(plan("plan-paid", "paid", null)));
+
+            // Stripe moved the field onto items in 2025-03-31.basil, and webhook
+            // payloads render with the ACCOUNT's version, not the pinned client
+            // version — so a live account emits this shape and the old reader left
+            // the column null.
+            service.process(TENANT, """
+                    {"id":"evt_period_item","type":"customer.subscription.updated","data":{"object":{
+                      "id":"sub_9","customer":"cus_9","status":"active",
+                      "cancel_at_period_end":false,
+                      "metadata":{"userId":"user-1"},
+                      "items":{"data":[{"price":{"id":"price_1"},
+                        "current_period_end":1788969546}]}}}}
+                    """);
+
+            verify(subscriptionRepository).upsert(eq(TENANT), eq(USER), eq("plan-paid"),
+                    eq("sub_9"), eq("cus_9"), eq("active"),
+                    eq(Instant.ofEpochSecond(1788969546L)), eq(false), eq(null));
+        }
+
+        @Test
+        @DisplayName("takes the latest item period when items differ")
+        void takesLatestItemPeriod() {
+            when(planRepository.findByStripePriceId(TENANT, "price_1"))
+                    .thenReturn(Optional.of(plan("plan-paid", "paid", null)));
+            when(planRepository.findById(TENANT, "plan-paid"))
+                    .thenReturn(Optional.of(plan("plan-paid", "paid", null)));
+
+            service.process(TENANT, """
+                    {"id":"evt_period_multi","type":"customer.subscription.updated","data":{"object":{
+                      "id":"sub_10","customer":"cus_10","status":"active",
+                      "cancel_at_period_end":false,
+                      "metadata":{"userId":"user-1"},
+                      "items":{"data":[{"price":{"id":"price_1"},"current_period_end":1788969546},
+                                       {"price":{"id":"price_2"},"current_period_end":1790000000}]}}}}
+                    """);
+
+            verify(subscriptionRepository).upsert(eq(TENANT), eq(USER), eq("plan-paid"),
+                    eq("sub_10"), eq("cus_10"), eq("active"),
+                    eq(Instant.ofEpochSecond(1790000000L)), eq(false), eq(null));
+        }
+
+        @Test
         @DisplayName("an unmapped price still mirrors the subscription with a null plan")
         void unmappedPriceStillMirrors() {
             when(planRepository.findByStripePriceId(anyString(), any()))


### PR DESCRIPTION
Caught verifying a real test-mode purchase end to end: the subscription mirrored correctly (status `active`, plan mapped, entitlements applied) but `currentPeriodEnd` came back `null`.

Confirmed against the live object — top-level `current_period_end` is absent, `items.data[0].current_period_end` is `1788969546`. Stripe moved the field onto subscription items in **2025-03-31.basil**. `StripeApiClient` pins `2024-06-20`, but that governs *outbound* calls; **webhook payloads render with the account's (or the endpoint's) API version**, so a current account delivers the new shape regardless of what the client pins.

Failure mode was silent: no exception, no log — the column just stayed empty, so the member-facing "renews on" / "cancels on" lines had nothing to render and any renewal logic reading the column saw no date.

**Fix:** read top-level first, then fall back to the latest item period. Both shapes work, and no version pin becomes load-bearing — when the old field disappears entirely, this keeps working.

Tests: two new cases (item-shape payload, multi-item picking the latest); 21 green in `BillingWebhookServiceTest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)