### PR TITLE
fix(cli): warn when records list hits a caller-scoped endpoint

### DIFF
--- a/kelta-web/packages/cli/src/commands/records.test.ts
+++ b/kelta-web/packages/cli/src/commands/records.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import type { CommandContext } from '../registry/types.js';
-import { recordCommands } from './records.js';
+import { recordCommands, warnIfCallerScoped } from './records.js';
 
 function command(name: string) {
   const def = recordCommands.find((c) => c.name === name);
@@ -118,5 +118,87 @@ describe('records get/create/update/delete', () => {
     const result = await def.handler(ctx, def.input.parse({ collection: 'x', id: 'n1' }) as never);
     expect(del).toHaveBeenCalledWith('n1');
     expect(result.ids).toEqual(['n1']);
+  });
+});
+
+describe('warnIfCallerScoped', () => {
+  const paginated = { metadata: { totalCount: 0 }, data: [], meta: { totalCount: 0 }, links: {} };
+
+  it('warns when the response carries no pagination metadata', () => {
+    const log = vi.fn();
+    warnIfCallerScoped({ data: [] }, 'watches', log);
+    expect(log).toHaveBeenCalledTimes(1);
+    expect(log.mock.calls[0][0]).toContain('watches');
+    expect(log.mock.calls[0][0]).toContain('caller-scoped');
+  });
+
+  it('warns even when the caller-scoped endpoint returned rows', () => {
+    // The view is partial whether or not it is empty; an operator paging through
+    // "all" the rows of a scoped endpoint is just as misled.
+    const log = vi.fn();
+    warnIfCallerScoped({ data: [{ id: '1' }] }, 'watches', log);
+    expect(log).toHaveBeenCalledTimes(1);
+  });
+
+  it('stays quiet for a genuinely empty generic-route result', () => {
+    // This is the case that must not be flagged: totalCount 0 with a full
+    // envelope really does mean the collection is empty.
+    const log = vi.fn();
+    warnIfCallerScoped(paginated, 'watch-targets', log);
+    expect(log).not.toHaveBeenCalled();
+  });
+
+  it('stays quiet for a populated generic-route result', () => {
+    const log = vi.fn();
+    warnIfCallerScoped({ ...paginated, data: [{ id: '1' }] }, 'watch-targets', log);
+    expect(log).not.toHaveBeenCalled();
+  });
+
+  it('accepts either metadata key as proof of the generic route', () => {
+    const log = vi.fn();
+    warnIfCallerScoped({ data: [], metadata: { totalCount: 0 } }, 'x', log);
+    warnIfCallerScoped({ data: [], meta: { totalCount: 0 } }, 'x', log);
+    expect(log).not.toHaveBeenCalled();
+  });
+
+  it('ignores responses whose data is not an array', () => {
+    const log = vi.fn();
+    warnIfCallerScoped({ data: undefined }, 'x', log);
+    warnIfCallerScoped({ data: { id: '1' } as unknown as unknown[] }, 'x', log);
+    expect(log).not.toHaveBeenCalled();
+  });
+});
+
+describe('records list caller-scope warning', () => {
+  it('fires for a bare envelope', async () => {
+    const list = vi.fn().mockResolvedValue({ data: [] });
+    const { ctx } = fakeCtx({ list });
+    const def = command('list');
+    await def.handler(ctx, def.input.parse({ collection: 'watches', filter: [] }) as never);
+    expect(ctx.log).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fire for a paginated envelope', async () => {
+    const list = vi.fn().mockResolvedValue({ data: [], metadata: { totalCount: 0 } });
+    const { ctx } = fakeCtx({ list });
+    const def = command('list');
+    await def.handler(ctx, def.input.parse({ collection: 'watch-targets', filter: [] }) as never);
+    expect(ctx.log).not.toHaveBeenCalled();
+  });
+
+  it('warns once under --all, not once per page', async () => {
+    const page = Array.from({ length: 200 }, (_, i) => ({ id: String(i) }));
+    const list = vi
+      .fn()
+      .mockResolvedValueOnce({ data: page })
+      .mockResolvedValueOnce({ data: [{ id: 'last' }] });
+    const { ctx } = fakeCtx({ list });
+    const def = command('list');
+    await def.handler(
+      ctx,
+      def.input.parse({ collection: 'watches', filter: [], all: true }) as never
+    );
+    expect(list).toHaveBeenCalledTimes(2);
+    expect(ctx.log).toHaveBeenCalledTimes(1);
   });
 });

--- a/kelta-web/packages/cli/src/commands/records.ts
+++ b/kelta-web/packages/cli/src/commands/records.ts
@@ -25,6 +25,33 @@ interface ListEnvelope {
   [key: string]: unknown;
 }
 
+/**
+ * Warns when a list response did not come from the generic collection route.
+ *
+ * Some collections are served by a hand-written controller mounted at the same
+ * path — `/api/watches` is `WatchController`, which scopes rows to the calling
+ * user. A tenant admin listing that collection gets an empty array even when it
+ * is full, and the CLI renders that identically to a genuinely empty collection,
+ * so `0 rows` reads as fact. Operators have acted on that false negative.
+ *
+ * The two cases are distinguishable on the wire: the generic route always
+ * carries pagination metadata, even for an empty result, while these controllers
+ * return a bare `{ data: [...] }`. Absence of that metadata is the signal.
+ */
+export function warnIfCallerScoped(
+  body: ListEnvelope,
+  collection: string,
+  log: (message: string) => void
+): void {
+  if (!Array.isArray(body.data)) return;
+  if (body.metadata !== undefined || body.meta !== undefined) return;
+  log(
+    `Note: "${collection}" is served by a caller-scoped endpoint, so these results are ` +
+      `limited to what the signed-in user owns. An empty result does not mean the ` +
+      `collection is empty.`
+  );
+}
+
 const list = defineCommand({
   group: 'records',
   name: 'list',
@@ -59,6 +86,7 @@ const list = defineCommand({
         page: input.page,
         size: input.size,
       })) as ListEnvelope;
+      warnIfCallerScoped(body, input.collection, ctx.log);
       return { data: body };
     }
 
@@ -70,6 +98,7 @@ const list = defineCommand({
         page,
         size: MAX_HTTP_PAGE_SIZE,
       })) as ListEnvelope;
+      if (page === 1) warnIfCallerScoped(body, input.collection, ctx.log);
       const batch = Array.isArray(body.data) ? body.data : [];
       rows.push(...batch);
       if (batch.length < MAX_HTTP_PAGE_SIZE) break;


### PR DESCRIPTION
Closes #1328.

## The problem

Some collections are served by a hand-written controller mounted at the generic
collection path. `/api/watches` is `WatchController`, which scopes rows to the calling
user — so a tenant admin listing that collection gets an empty array even when it is
full. The CLI rendered that identically to a genuinely empty collection.

Operators have acted on the false negative. I nearly retired a `watch-targets` row after
`0 watches`, and only distrusted the result because I'd watched alerts fire for that
member minutes earlier. A SQL query confirmed the rows existed.

## The signal

The two cases are distinguishable on the wire. The generic route always carries
pagination metadata, **even for an empty result**:

```json
{ "metadata": { "totalCount": 0, ... }, "data": [], "meta": { ... }, "links": { ... } }
```

while these controllers return a bare envelope:

```json
{ "data": [] }
```

## The change

`records list` checks for that absence and notes on **stderr** that the result is
caller-scoped and an empty result does not mean the collection is empty. stderr, not
stdout, so `--output json` stays pipeable (matching how `ctx.log` is already used). Under
`--all` it fires once rather than once per page.

The warning fires whether or not rows came back — a partial view misleads just as much
when it is non-empty, and an operator paging `--all` through a scoped endpoint is
arguably worse off.

## Why a shape heuristic

Deliberately a check on response shape rather than a hardcoded list of collection names:
it costs nothing, needs no server change, and covers any future controller with the same
shape. Normalising those controllers' envelopes (option 2 in #1328) is still worth doing
and would make this warning dormant rather than wrong — the check keys off metadata being
present, so a normalised endpoint simply stops triggering it.

## Tests

9 new (16 in the file, 214 across the CLI package, all passing). Both directions covered,
since a warning that always fires is as useless as one that never does:

- fires for a bare envelope, empty **and** populated
- silent for a genuinely empty generic-route result (`totalCount: 0` with a full
  envelope) — the case that must not be flagged
- silent for a populated generic-route result
- either `metadata` or `meta` counts as proof of the generic route
- ignores responses whose `data` is not an array
- end-to-end through the command handler, including "warns once under `--all`, not once
  per page"

Typecheck, eslint and prettier clean.