### PR TITLE
fix(watches): allow re-targeting a watch, and let support staff write

### DIFF
--- a/kelta-worker/src/main/java/io/kelta/worker/controller/WatchController.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/controller/WatchController.java
@@ -173,16 +173,37 @@ public class WatchController implements SelfScopedController {
         return ResponseEntity.status(HttpStatus.CREATED).body(Map.of("data", created));
     }
 
-    /** Updates criteria, channels, or status (pause/resume) on the caller's own watch. */
+    /**
+     * Updates target, criteria, channels, or status (pause/resume) on a watch.
+     *
+     * <p>Normally the caller's own watch; support staff holding
+     * {@link #SUPPORT_PERMISSION} may name a member, exactly as {@code list} and
+     * {@code create} already allow. Without that, correcting a member's watch
+     * needs direct database access, which skips the entitlement and validation
+     * guards below.
+     */
     @PatchMapping("/{id}")
     public Map<String, Object> update(@PathVariable String id,
                                       @RequestBody UpdateWatchRequest body,
                                       HttpServletRequest request) {
         String tenantId = requireTenant();
-        String subject = requireActor(request, tenantId);
+        String subject = resolveSubject(request, tenantId,
+                body == null ? null : body.memberId());
         Watch existing = requireOwnWatch(tenantId, id, subject);
 
         Map<String, Object> data = new LinkedHashMap<>();
+        if (body != null && body.targetId() != null && !body.targetId().isBlank()) {
+            // Same checks as create: an unknown or retired target must not be
+            // reachable by re-pointing an existing watch either.
+            WatchTarget target = targetRepository.findById(tenantId, body.targetId())
+                    .orElseThrow(() -> new ResponseStatusException(
+                            HttpStatus.NOT_FOUND, "Unknown target"));
+            if (!target.active()) {
+                throw new ResponseStatusException(HttpStatus.CONFLICT,
+                        "Target is not currently watchable");
+            }
+            data.put("targetId", target.id());
+        }
         if (body != null && body.criteria() != null) {
             data.put("criteria", criteriaStructure(validateCriteria(body.criteria())));
         }
@@ -202,11 +223,13 @@ public class WatchController implements SelfScopedController {
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Not found"));
     }
 
-    /** Deletes the caller's own watch. */
+    /** Deletes a watch — the caller's own, or a named member's for support staff. */
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> delete(@PathVariable String id, HttpServletRequest request) {
+    public ResponseEntity<Void> delete(@PathVariable String id,
+                                       @RequestParam(required = false) String memberId,
+                                       HttpServletRequest request) {
         String tenantId = requireTenant();
-        String subject = requireActor(request, tenantId);
+        String subject = resolveSubject(request, tenantId, memberId);
         requireOwnWatch(tenantId, id, subject);
 
         queryEngine.delete(definition(), id);
@@ -402,6 +425,7 @@ public class WatchController implements SelfScopedController {
     }
 
     /** Request body for {@code PATCH /api/watches/{id}}. */
-    public record UpdateWatchRequest(Object criteria, List<String> channels, String status) {
+    public record UpdateWatchRequest(String targetId, Object criteria, List<String> channels,
+                                     String status, String memberId) {
     }
 }

--- a/kelta-worker/src/test/java/io/kelta/worker/controller/WatchControllerTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/controller/WatchControllerTest.java
@@ -1,0 +1,221 @@
+package io.kelta.worker.controller;
+
+import tools.jackson.databind.ObjectMapper;
+import io.kelta.runtime.context.TenantContext;
+import io.kelta.runtime.model.CollectionDefinition;
+import io.kelta.runtime.query.QueryEngine;
+import io.kelta.runtime.registry.CollectionRegistry;
+import io.kelta.runtime.router.UserIdResolver;
+import io.kelta.worker.controller.WatchController.UpdateWatchRequest;
+import io.kelta.worker.repository.BootstrapRepository;
+import io.kelta.worker.repository.Watch;
+import io.kelta.worker.repository.WatchRepository;
+import io.kelta.worker.repository.WatchTarget;
+import io.kelta.worker.repository.WatchTargetRepository;
+import io.kelta.worker.service.CerbosPermissionResolver;
+import io.kelta.worker.service.billing.EntitlementService;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Covers re-pointing a watch at another target, and support staff acting on a
+ * member's watch.
+ *
+ * <p>Both were previously impossible: {@code targetId} was absent from the update
+ * contract, and {@code update}/{@code delete} ignored the support permission that
+ * {@code list} and {@code create} already honoured — so correcting a member's
+ * watch meant a direct database write, skipping every guard asserted here.
+ */
+@DisplayName("WatchController — retarget and support writes")
+class WatchControllerTest {
+
+    private static final String TENANT = "t1";
+    private static final String OWNER = "member-1";
+    private static final String OTHER = "member-2";
+    private static final String STAFF = "staff-1";
+    private static final String WATCH_ID = "watch-1";
+
+    private WatchRepository watchRepository;
+    private WatchTargetRepository targetRepository;
+    private QueryEngine queryEngine;
+    private CerbosPermissionResolver permissionResolver;
+    private BootstrapRepository bootstrapRepository;
+    private WatchController controller;
+
+    @BeforeEach
+    void setUp() {
+        watchRepository = mock(WatchRepository.class);
+        targetRepository = mock(WatchTargetRepository.class);
+        queryEngine = mock(QueryEngine.class);
+        permissionResolver = mock(CerbosPermissionResolver.class);
+        bootstrapRepository = mock(BootstrapRepository.class);
+
+        CollectionRegistry registry = mock(CollectionRegistry.class);
+        when(registry.get(WatchController.COLLECTION)).thenReturn(mock(CollectionDefinition.class));
+
+        UserIdResolver userIdResolver = mock(UserIdResolver.class);
+        when(userIdResolver.resolve(anyString(), any())).thenAnswer(i -> i.getArgument(0));
+
+        EntitlementService entitlements = mock(EntitlementService.class);
+        when(entitlements.intLimit(anyString(), anyString(), anyString(), anyInt()))
+                .thenAnswer(i -> (int) i.getArgument(3));
+
+        controller = new WatchController(watchRepository, targetRepository, queryEngine,
+                registry, entitlements, userIdResolver, permissionResolver,
+                bootstrapRepository, new ObjectMapper());
+        TenantContext.set(TENANT);
+
+        when(queryEngine.update(any(), anyString(), any()))
+                .thenAnswer(i -> Optional.of(Map.of("id", i.getArgument(1))));
+    }
+
+    @AfterEach
+    void tearDown() {
+        TenantContext.clear();
+    }
+
+    private HttpServletRequest requestFrom(String actor, boolean staff) {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getHeader("X-User-Id")).thenReturn(actor);
+        when(request.getHeader("X-User-Type")).thenReturn(staff ? "INTERNAL" : "PORTAL");
+        when(permissionResolver.getProfileId(request)).thenReturn(staff ? "profile-staff" : "profile-member");
+        when(bootstrapRepository.findProfileSystemPermissions(anyString())).thenReturn(
+                staff
+                        ? List.of(Map.of("permission_name", WatchController.SUPPORT_PERMISSION,
+                                         "granted", Boolean.TRUE))
+                        : List.of());
+        return request;
+    }
+
+    private void watchOwnedBy(String member) {
+        Watch watch = new Watch(WATCH_ID, TENANT, member, "target-old",
+                null, null, Watch.STATUS_ACTIVE, null);
+        when(watchRepository.findByMember(TENANT, member)).thenReturn(List.of(watch));
+    }
+
+    private void targetExists(String id, boolean active) {
+        when(targetRepository.findById(TENANT, id))
+                .thenReturn(Optional.of(
+                        new WatchTarget(id, TENANT, "src", "ext", "Name", "cat", null, active)));
+    }
+
+    @Test
+    @DisplayName("re-points a watch at another active target")
+    void retargets() {
+        watchOwnedBy(OWNER);
+        targetExists("target-new", true);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Map<String, Object>> data =
+                ArgumentCaptor.forClass((Class<Map<String, Object>>) (Class<?>) Map.class);
+
+        controller.update(WATCH_ID,
+                new UpdateWatchRequest("target-new", null, null, null, null),
+                requestFrom(OWNER, false));
+
+        verify(queryEngine).update(any(), eq(WATCH_ID), data.capture());
+        assertThat(data.getValue()).containsEntry("targetId", "target-new");
+    }
+
+    @Test
+    @DisplayName("rejects an unknown target rather than storing a dangling id")
+    void unknownTarget() {
+        watchOwnedBy(OWNER);
+        when(targetRepository.findById(TENANT, "nope")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> controller.update(WATCH_ID,
+                new UpdateWatchRequest("nope", null, null, null, null),
+                requestFrom(OWNER, false)))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("Unknown target");
+        verify(queryEngine, never()).update(any(), anyString(), any());
+    }
+
+    @Test
+    @DisplayName("rejects a retired target — the same guard create applies")
+    void retiredTarget() {
+        watchOwnedBy(OWNER);
+        targetExists("target-retired", false);
+
+        assertThatThrownBy(() -> controller.update(WATCH_ID,
+                new UpdateWatchRequest("target-retired", null, null, null, null),
+                requestFrom(OWNER, false)))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("not currently watchable");
+        verify(queryEngine, never()).update(any(), anyString(), any());
+    }
+
+    @Test
+    @DisplayName("a member naming someone else is refused")
+    void memberCannotNameAnother() {
+        assertThatThrownBy(() -> controller.update(WATCH_ID,
+                new UpdateWatchRequest(null, null, null, "PAUSED", OTHER),
+                requestFrom(OWNER, false)))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("Not permitted");
+    }
+
+    @Test
+    @DisplayName("support staff may update a named member's watch")
+    void supportCanUpdate() {
+        watchOwnedBy(OTHER);
+        targetExists("target-new", true);
+
+        controller.update(WATCH_ID,
+                new UpdateWatchRequest("target-new", null, null, null, OTHER),
+                requestFrom(STAFF, true));
+
+        verify(queryEngine).update(any(), eq(WATCH_ID), any());
+    }
+
+    @Test
+    @DisplayName("support staff may delete a named member's watch")
+    void supportCanDelete() {
+        watchOwnedBy(OTHER);
+
+        controller.delete(WATCH_ID, OTHER, requestFrom(STAFF, true));
+
+        verify(queryEngine).delete(any(), eq(WATCH_ID));
+    }
+
+    @Test
+    @DisplayName("a member naming someone else on delete is refused")
+    void memberCannotDeleteAnothers() {
+        assertThatThrownBy(() -> controller.delete(WATCH_ID, OTHER, requestFrom(OWNER, false)))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("Not permitted");
+        verify(queryEngine, never()).delete(any(), anyString());
+    }
+
+    @Test
+    @DisplayName("an omitted targetId leaves the target alone")
+    void omittedTargetIdIsNotAChange() {
+        watchOwnedBy(OWNER);
+
+        controller.update(WATCH_ID,
+                new UpdateWatchRequest(null, null, null, "PAUSED", null),
+                requestFrom(OWNER, false));
+
+        verify(targetRepository, never()).findById(anyString(), anyString());
+    }
+}


### PR DESCRIPTION
Closes #1331.

**Security-typed (member-surface authorization) — not auto-merging.** Please review the
`resolveSubject` change on `delete` in particular.

## The problem

Two gaps meant a watch could not be moved between targets by *anyone*:

1. `targetId` was absent from `UpdateWatchRequest`, so not even the owner could re-point.
2. `update` and `delete` called `requireActor` + `requireOwnWatch` directly, ignoring the
   `MANAGE_DATA` support path that `list` and `create` already honoured — so support staff
   could **see** a member's watches but not act on them.

Correcting one therefore required a direct `UPDATE` against the `watch` table, which skips
the entitlement checks, criteria validation, and the support audit line this controller
exists to enforce.

## The change

**`targetId` on update**, validated exactly as `create` does — unknown target → 404,
retired target → 409. Deliberately mirroring `create` rather than inventing a second
convention. This is a legitimate member action too ("I meant the other campground"), not
only an operator one.

**`update` and `delete` resolve their subject through `resolveSubject`**, so a
`MANAGE_DATA` holder can fix a member's watch and it lands in the audit log
(`Support actor acting on watches of member …`) rather than in someone's psql history.

Authorization behaviour that stays unchanged, and is now pinned by tests:

- a member naming another member is refused **without revealing whether they exist**
- a `PORTAL` actor short-circuits to non-support before any permission lookup
- `requireOwnWatch` still scopes to the resolved subject, so support access is per-member,
  not global

## Why it came up

An audit found five `watch-targets` whose upstream ids pointed at the wrong object — the
two Global Entry targets labelled "Denver" were actually **Atlanta** and **Dallas-Fort
Worth**, and had been sending a member alerts for the wrong city. Correcting the catalog
orphaned the watches on the retired rows, and there was no supported way to move them.

Compounds with #1330: an immutable `externalId` forces a *replacement* target rather than
an edit, which is precisely what orphans the watches.

## Tests

8 new (`WatchControllerTest`, the first for this controller), covering both directions:

- re-points to an active target, and the update map actually carries `targetId`
- unknown target → 404, retired target → 409, neither reaching `queryEngine`
- member naming another member refused, on **both** update and delete
- support staff may update and delete a named member's watch
- an omitted `targetId` never touches `targetRepository`

`Watch*Test` suite: 44 tests, green. Worker compiles clean.