### PR TITLE
fix(runtime): reject a changed immutable field instead of dropping it

### DIFF
--- a/.claude/docs/conventions.md
+++ b/.claude/docs/conventions.md
@@ -75,6 +75,33 @@ sniff placeholder strings like `***`. Masked values are always JSON strings.
 distinguishable error would itself be a value-probing oracle. Do not "improve"
 it with specifics.
 
+#### Immutable fields on update
+
+Immutability is declared two ways and **both are loud** — an update that would
+change an immutable field fails with a `VALIDATION_FAILED` envelope naming the
+field (`constraint: "immutable"`), never a 200 for a write that did not happen
+(#1330):
+
+- **Field-level** (`FieldDefinition.immutable()`) — rejected by
+  `DefaultValidationEngine` whenever the field is present in an UPDATE payload.
+- **Collection-level** (`CollectionDefinition.immutableFields()`, e.g.
+  `watch-targets.source`/`externalId`) — rejected by `DefaultQueryEngine.update`
+  when the submitted value **differs** from the stored one. Re-sending the value
+  the record already holds is accepted and dropped from the patch, so a
+  full-record round-trip (read → edit one field → write the whole map back)
+  still works. A `null`/blank submission is treated as "not supplied", not as a
+  clear — generic forms coerce untouched inputs to `null`, and an immutable
+  field cannot be emptied anyway.
+
+Collection-level immutability is **not** exposed on the schema/describe API, so a
+generic client cannot pre-disable those inputs — it finds out by being rejected.
+A relationship field that is immutable also cannot be re-parented:
+`RecordMergeService` skips it and returns it under `skippedImmutable` instead of
+counting a write it cannot make.
+
+Prefer the field-level flag for new fields in the declared field list;
+collection-level covers fields outside it (`tenantId`, join keys).
+
 ### Javadoc
 - Required for public classes and methods
 - Include `@param`, `@returns`, `@throws`

--- a/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/query/DefaultQueryEngine.java
+++ b/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/query/DefaultQueryEngine.java
@@ -349,14 +349,35 @@ public class DefaultQueryEngine implements QueryEngine {
         recordData.remove("createdAt");
         recordData.remove("createdBy");
 
-        // Strip immutable fields from update data
+        // Reject writes that would change a collection-level immutable field.
+        // These used to be stripped silently, which returned 200 for a write that
+        // never happened (#1330). Only a real change is an error: a caller
+        // re-sending the value the record already holds — any full-record
+        // round-trip — still succeeds. Either way the field leaves the patch, so
+        // the stored value is never rewritten.
         if (!definition.immutableFields().isEmpty()) {
-            for (String immutableField : definition.immutableFields()) {
-                if (recordData.containsKey(immutableField)) {
-                    logger.debug("Stripping immutable field '{}' from update on collection '{}'",
-                            immutableField, definition.name());
-                    recordData.remove(immutableField);
+            List<FieldError> immutableErrors = new ArrayList<>();
+            Map<String, Object> existingRecord = existing.get();
+            // Sorted so a multi-field rejection reads the same on every call —
+            // immutableFields() is an unordered Set.
+            for (String immutableField : new TreeSet<>(definition.immutableFields())) {
+                if (!recordData.containsKey(immutableField)) {
+                    continue;
                 }
+                Object submitted = recordData.remove(immutableField);
+                if (isBlank(submitted)) {
+                    // An empty submission is not a change request. Forms round-trip a
+                    // whole record and coerce untouched inputs to null/"", and an
+                    // immutable field cannot be cleared anyway — failing here would
+                    // reject edits that never touched the field.
+                    continue;
+                }
+                if (!sameStoredValue(existingRecord.get(immutableField), submitted)) {
+                    immutableErrors.add(FieldError.immutable(immutableField));
+                }
+            }
+            if (!immutableErrors.isEmpty()) {
+                throw new ValidationException(ValidationResult.failure(immutableErrors));
             }
         }
 
@@ -672,6 +693,29 @@ public class DefaultQueryEngine implements QueryEngine {
             }
         }
         return changedFields;
+    }
+
+    /**
+     * Compares a submitted value against the value already stored, tolerantly
+     * enough that re-sending an unchanged field is not read as a change.
+     *
+     * <p>A read-back value does not always come back in the type it was written
+     * as — an id column may surface as a {@code UUID}, a timestamp as an
+     * {@code Instant} — so equal string forms count as equal. Only used to
+     * decide whether an immutable field is actually being changed.
+     */
+    private boolean isBlank(Object value) {
+        return value == null || (value instanceof String s && s.isBlank());
+    }
+
+    private boolean sameStoredValue(Object stored, Object submitted) {
+        if (Objects.equals(stored, submitted)) {
+            return true;
+        }
+        if (stored == null || submitted == null) {
+            return false;
+        }
+        return String.valueOf(stored).equals(String.valueOf(submitted));
     }
 
     /**

--- a/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/query/ReadOnlyCollectionTest.java
+++ b/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/query/ReadOnlyCollectionTest.java
@@ -5,6 +5,8 @@ import io.kelta.runtime.model.CollectionDefinitionBuilder;
 import io.kelta.runtime.model.FieldDefinition;
 import io.kelta.runtime.model.FieldType;
 import io.kelta.runtime.storage.StorageAdapter;
+import io.kelta.runtime.validation.FieldError;
+import io.kelta.runtime.validation.ValidationException;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -16,19 +18,21 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 /**
- * Tests for read-only collection enforcement and immutable field stripping
+ * Tests for read-only collection enforcement and immutable field handling
  * in DefaultQueryEngine.
  *
  * <p>Verifies that:
  * <ul>
  *   <li>Read-only collections reject create, update, and delete operations</li>
  *   <li>Read-only collections still allow query (read) operations</li>
- *   <li>Immutable fields are stripped from update data before persisting</li>
+ *   <li>An update that would change an immutable field is rejected, not silently dropped</li>
+ *   <li>An unchanged immutable field is accepted and left out of the persisted patch</li>
  *   <li>Non-immutable fields pass through normally</li>
  * </ul>
  */
@@ -164,15 +168,15 @@ class ReadOnlyCollectionTest {
         }
     }
 
-    // ==================== Immutable Field Stripping Tests ====================
+    // ==================== Immutable Field Tests ====================
 
     @Nested
-    @DisplayName("Immutable Field Stripping")
+    @DisplayName("Immutable Field Enforcement")
     class ImmutableFieldTests {
 
         @Test
-        @DisplayName("Should strip immutable fields from update data")
-        void update_stripsImmutableFields_fromUpdateData() {
+        @DisplayName("Should reject an update that changes immutable fields, naming each one")
+        void update_rejectsChangedImmutableFields() {
             CollectionDefinition usersDef = buildCollectionWithImmutableFields();
             String id = "user-1";
 
@@ -184,9 +188,44 @@ class ReadOnlyCollectionTest {
 
             // Attempt to update email (immutable), tenantId (immutable), and name (mutable)
             Map<String, Object> updateData = new HashMap<>();
-            updateData.put("email", "jane@example.com");      // immutable - should be stripped
-            updateData.put("tenantId", "tenant-2");            // immutable - should be stripped
-            updateData.put("name", "Jane");                     // mutable - should be kept
+            updateData.put("email", "jane@example.com");      // immutable - should be rejected
+            updateData.put("tenantId", "tenant-2");            // immutable - should be rejected
+            updateData.put("name", "Jane");                     // mutable
+
+            when(storageAdapter.getById(usersDef, id)).thenReturn(Optional.of(existingRecord));
+
+            ValidationException exception = assertThrows(ValidationException.class,
+                    () -> queryEngine.update(usersDef, id, updateData));
+
+            List<String> failedFields = exception.getValidationResult().errors().stream()
+                    .map(FieldError::fieldName)
+                    .toList();
+            assertTrue(failedFields.containsAll(List.of("email", "tenantId")),
+                    "Both immutable fields should be named in the error, was " + failedFields);
+            assertTrue(exception.getValidationResult().errors().stream()
+                            .allMatch(error -> "immutable".equals(error.constraint())),
+                    "Errors should carry the immutable constraint");
+
+            verify(storageAdapter, never()).update(eq(usersDef), eq(id), any());
+        }
+
+        @Test
+        @DisplayName("Should accept an unchanged immutable field and leave it out of the patch")
+        void update_acceptsUnchangedImmutableField() {
+            CollectionDefinition usersDef = buildCollectionWithImmutableFields();
+            String id = "user-1";
+
+            Map<String, Object> existingRecord = new HashMap<>();
+            existingRecord.put("id", id);
+            existingRecord.put("email", "john@example.com");
+            existingRecord.put("name", "John");
+            existingRecord.put("tenantId", "tenant-1");
+
+            // A full-record round-trip: immutable fields resent with the values they already hold
+            Map<String, Object> updateData = new HashMap<>();
+            updateData.put("email", "john@example.com");
+            updateData.put("tenantId", "tenant-1");
+            updateData.put("name", "Jane");
 
             when(storageAdapter.getById(usersDef, id)).thenReturn(Optional.of(existingRecord));
             when(storageAdapter.update(eq(usersDef), eq(id), any()))
@@ -194,19 +233,91 @@ class ReadOnlyCollectionTest {
 
             queryEngine.update(usersDef, id, updateData);
 
-            // Capture the data passed to storageAdapter.update()
             ArgumentCaptor<Map<String, Object>> dataCaptor = ArgumentCaptor.forClass(Map.class);
             verify(storageAdapter).update(eq(usersDef), eq(id), dataCaptor.capture());
 
             Map<String, Object> persistedData = dataCaptor.getValue();
-
             assertFalse(persistedData.containsKey("email"),
-                    "Immutable field 'email' should be stripped from update data");
+                    "Unchanged immutable field should not be rewritten");
             assertFalse(persistedData.containsKey("tenantId"),
-                    "Immutable field 'tenantId' should be stripped from update data");
-            assertTrue(persistedData.containsKey("name"),
-                    "Mutable field 'name' should be present in update data");
+                    "Unchanged immutable field should not be rewritten");
             assertEquals("Jane", persistedData.get("name"));
+        }
+
+        @Test
+        @DisplayName("Should treat a stored value that reads back as another type as unchanged")
+        void update_acceptsImmutableField_whenStoredTypeDiffers() {
+            CollectionDefinition usersDef = buildCollectionWithImmutableFields();
+            String id = "user-1";
+            UUID tenantId = UUID.fromString("11111111-2222-3333-4444-555555555555");
+
+            Map<String, Object> existingRecord = new HashMap<>();
+            existingRecord.put("id", id);
+            existingRecord.put("email", "john@example.com");
+            existingRecord.put("tenantId", tenantId);          // reads back as a UUID
+
+            Map<String, Object> updateData = new HashMap<>();
+            updateData.put("tenantId", tenantId.toString());   // resent as a String
+            updateData.put("name", "Jane");
+
+            when(storageAdapter.getById(usersDef, id)).thenReturn(Optional.of(existingRecord));
+            when(storageAdapter.update(eq(usersDef), eq(id), any()))
+                    .thenAnswer(invocation -> Optional.of(invocation.getArgument(2)));
+
+            assertDoesNotThrow(() -> queryEngine.update(usersDef, id, updateData));
+        }
+
+        @Test
+        @DisplayName("Should ignore a blank submission for an immutable field")
+        void update_ignoresBlankImmutableField() {
+            CollectionDefinition usersDef = buildCollectionWithImmutableFields();
+            String id = "user-1";
+
+            Map<String, Object> existingRecord = new HashMap<>();
+            existingRecord.put("id", id);
+            existingRecord.put("email", "john@example.com");
+            existingRecord.put("tenantId", "tenant-1");
+
+            // A form round-trip that coerced untouched inputs to null / ""
+            Map<String, Object> updateData = new HashMap<>();
+            updateData.put("email", null);
+            updateData.put("tenantId", "");
+            updateData.put("name", "Jane");
+
+            when(storageAdapter.getById(usersDef, id)).thenReturn(Optional.of(existingRecord));
+            when(storageAdapter.update(eq(usersDef), eq(id), any()))
+                    .thenAnswer(invocation -> Optional.of(invocation.getArgument(2)));
+
+            assertDoesNotThrow(() -> queryEngine.update(usersDef, id, updateData));
+
+            ArgumentCaptor<Map<String, Object>> dataCaptor = ArgumentCaptor.forClass(Map.class);
+            verify(storageAdapter).update(eq(usersDef), eq(id), dataCaptor.capture());
+
+            Map<String, Object> persistedData = dataCaptor.getValue();
+            assertFalse(persistedData.containsKey("email"),
+                    "A blank submission must not clear an immutable field");
+            assertFalse(persistedData.containsKey("tenantId"),
+                    "A blank submission must not clear an immutable field");
+            assertEquals("Jane", persistedData.get("name"));
+        }
+
+        @Test
+        @DisplayName("Should reject setting an immutable field that is currently null")
+        void update_rejectsImmutableField_whenStoredValueIsNull() {
+            CollectionDefinition usersDef = buildCollectionWithImmutableFields();
+            String id = "user-1";
+
+            Map<String, Object> existingRecord = new HashMap<>();
+            existingRecord.put("id", id);
+            existingRecord.put("name", "John");
+
+            Map<String, Object> updateData = new HashMap<>();
+            updateData.put("email", "jane@example.com");
+
+            when(storageAdapter.getById(usersDef, id)).thenReturn(Optional.of(existingRecord));
+
+            assertThrows(ValidationException.class, () -> queryEngine.update(usersDef, id, updateData));
+            verify(storageAdapter, never()).update(eq(usersDef), eq(id), any());
         }
 
         @Test

--- a/kelta-worker/src/main/java/io/kelta/worker/controller/RecordMergeController.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/controller/RecordMergeController.java
@@ -101,6 +101,14 @@ public class RecordMergeController {
                 rm.put("count", r.count());
                 return rm;
             }).toList());
+            // Relationships the merge could not move because the field is immutable —
+            // reported so the caller does not read a 200 as "everything was re-parented".
+            out.put("skippedImmutable", result.skippedImmutable().stream().map(s -> {
+                Map<String, Object> sm = new LinkedHashMap<>();
+                sm.put("collection", s.collection());
+                sm.put("field", s.field());
+                return sm;
+            }).toList());
             return ResponseEntity.ok(out);
         } catch (IllegalArgumentException | InvalidQueryException e) {
             // Unknown collection, missing record, or an invalid field → 400 (client error).

--- a/kelta-worker/src/main/java/io/kelta/worker/service/RecordMergeService.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/service/RecordMergeService.java
@@ -37,6 +37,10 @@ import java.util.Set;
  *   <li><b>Delete</b> the duplicate records.</li>
  * </ol>
  *
+ * <p>An inbound field its own collection declares immutable cannot be re-parented — an update
+ * naming it is rejected, not applied. Those relationships are skipped and returned in
+ * {@link Result#skippedImmutable()} rather than counted as moved.
+ *
  * <p>The whole operation is expected to run inside the caller's transaction so a mid-merge failure
  * rolls back cleanly (see {@code RecordMergeController}).
  *
@@ -60,11 +64,16 @@ public class RecordMergeService {
     public record ReparentedField(String collection, String field, int count) {
     }
 
+    /** An inbound relationship the merge could not re-parent because the field is immutable. */
+    public record SkippedField(String collection, String field) {
+    }
+
     /** Merge outcome: the surviving master, what was deleted, and the re-parenting breakdown. */
     public record Result(String masterId,
                          List<String> deletedIds,
                          int reparentedRecords,
-                         List<ReparentedField> reparented) {
+                         List<ReparentedField> reparented,
+                         List<SkippedField> skippedImmutable) {
     }
 
     /** A field in another collection whose LOOKUP/MASTER_DETAIL relationship targets the merged collection. */
@@ -127,8 +136,17 @@ public class RecordMergeService {
         // 2. Re-parent inbound FKs from each duplicate onto the master (before delete — see class doc).
         List<InboundRef> inbound = findInboundReferences(collectionName);
         List<ReparentedField> reparented = new ArrayList<>();
+        List<SkippedField> skippedImmutable = new ArrayList<>();
         int totalReparented = 0;
         for (InboundRef ref : inbound) {
+            // A field the owning collection declares immutable cannot be re-pointed by an
+            // update. That was always true — the write used to be dropped silently and
+            // still counted as re-parented (#1330). Report it instead of miscounting; the
+            // caller has to fix those children another way before deleting the duplicate.
+            if (ref.definition().immutableFields().contains(ref.fieldName())) {
+                skippedImmutable.add(new SkippedField(ref.definition().name(), ref.fieldName()));
+                continue;
+            }
             int fieldCount = 0;
             for (String dupId : dupes) {
                 fieldCount += reparent(ref, dupId, masterId);
@@ -147,7 +165,7 @@ public class RecordMergeService {
             }
         }
 
-        return new Result(masterId, deleted, totalReparented, reparented);
+        return new Result(masterId, deleted, totalReparented, reparented, skippedImmutable);
     }
 
     /**

--- a/kelta-worker/src/test/java/io/kelta/worker/service/RecordMergeServiceTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/service/RecordMergeServiceTest.java
@@ -134,6 +134,41 @@ class RecordMergeServiceTest {
     }
 
     @Test
+    @DisplayName("skips an immutable inbound FK instead of counting a write it cannot make")
+    void skipsImmutableInboundReference() {
+        // Same topology, except orders.contact is immutable on the orders collection.
+        CollectionDefinition immutableOrdersDef = CollectionDefinition.builder()
+                .name("orders")
+                .storageConfig(StorageConfig.physicalTable("orders"))
+                .addField(FieldDefinition.string("total"))
+                .addField(new FieldDefinition(
+                        "contact", FieldType.MASTER_DETAIL, false, false, false,
+                        null, null, null, ReferenceConfig.masterDetail("contacts", "Contact"), null))
+                .addImmutableField("contact")
+                .build();
+
+        when(collectionRegistry.get("contacts")).thenReturn(contactsDef);
+        when(collectionRegistry.get("orders")).thenReturn(immutableOrdersDef);
+        when(collectionRegistry.getAllCollectionNames()).thenReturn(Set.of("contacts", "orders"));
+        when(queryEngine.getById(any(), anyString()))
+                .thenAnswer(inv -> Optional.of(Map.of("id", inv.getArgument(1))));
+        when(queryEngine.delete(any(), anyString())).thenReturn(true);
+
+        Result result = service.merge("contacts", "master", List.of("dup1"), Map.of());
+
+        // No scan, no update attempt — the write would be rejected as immutable.
+        verify(queryEngine, never()).executeQuery(eq(immutableOrdersDef), any(QueryRequest.class));
+        verify(queryEngine, never()).update(eq(immutableOrdersDef), anyString(), any());
+
+        assertThat(result.reparentedRecords()).isZero();
+        assertThat(result.reparented()).isEmpty();
+        assertThat(result.skippedImmutable()).singleElement().satisfies(s -> {
+            assertThat(s.collection()).isEqualTo("orders");
+            assertThat(s.field()).isEqualTo("contact");
+        });
+    }
+
+    @Test
     @DisplayName("rejects blank master, empty duplicates, and the master listed as a duplicate")
     void inputValidation() {
         assertThatThrownBy(() -> service.merge("contacts", " ", List.of("d1"), Map.of()))


### PR DESCRIPTION
## Summary
Closes #1330.

Updating `watch-targets.source` or `externalId` returned **200**, bumped `updatedAt`, and left the value alone. The collection-level mechanism (`CollectionDefinition.immutableFields()`) stripped the field with a `logger.debug` and told the caller nothing, while the field-level one (`FieldDefinition.immutable()`) has always answered with a validation error. Two spellings of one intent, one of them silent — anything doing update-then-assume (a migration, a sync job, a backfill) diverges without noticing.

`DefaultQueryEngine.update` now compares the submitted value against the stored one and raises `FieldError.immutable` per field that would actually change, so the caller gets the same `VALIDATION_FAILED` envelope the field-level path produces.

**Only a real change is an error.** Re-sending the value the record already holds still succeeds, which is what keeps every full-record round-trip working — PUT, the generic admin form (`ResourceFormPage` submits all fields), `PackageImportService`, bulk upsert, offline replay. A `null`/blank submission counts as "not supplied" rather than a clear, because generic forms coerce untouched inputs to `null` and an immutable field cannot be emptied anyway. Comparison is string-tolerant so a column that reads back as a `UUID`/`Instant` is not mistaken for a change; fields are reported sorted so a multi-field rejection is deterministic.

Deliberately **laxer than the field-level rule**, which rejects the field merely for being present — matching that would break every whole-record write to a system collection.

### One caller did rely on the silence
`RecordMergeService` re-parents inbound FKs by updating them, and several of those are immutable (`chat-messages.senderId`, `chat-participants.conversationId`, `fields.collectionId`, `record-version.recordId`). Those updates never landed, yet were counted as re-parented — and with ≥1000 matching children the drain loop could not terminate. The merge now skips such relationships up front and returns them as `skippedImmutable` (also in the `/api/.../merge` response): same data outcome as today, but the response no longer claims children were moved when they were not.

Behaviour change for anyone currently getting a silent no-op — worth a release note.

## Changes
- `runtime-core/.../query/DefaultQueryEngine.java` — strip → compare-and-reject; blank submission ignored; string-tolerant comparison
- `kelta-worker/.../service/RecordMergeService.java` + `controller/RecordMergeController.java` — skip immutable inbound refs, report as `skippedImmutable`
- `.claude/docs/conventions.md` — documents the immutability contract (both mechanisms, the null rule, the merge caveat, and that collection-level immutability is not exposed on the describe API)
- Tests: `ReadOnlyCollectionTest`, `RecordMergeServiceTest`

## Testing
- `runtime-core` 1473 tests green — rejection names both fields and persists nothing, unchanged value accepted and dropped from the patch, blank submission ignored, `UUID` vs `String` tolerated, setting a currently-null immutable field rejected
- `kelta-worker` 2426 green (incl. the new merge-skip test), `kelta-gateway` 583 green
- `kelta-web` lint + typecheck + format + coverage green; `kelta-ui` untouched
- No e2e added: backend-only error behaviour, no UI surface changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)