### PR TITLE
fix(runtime): stop three DDL bugs from permanently breaking a collection

### DIFF
--- a/.claude/docs/ci-cd.md
+++ b/.claude/docs/ci-cd.md
@@ -74,6 +74,13 @@ auto-merged** (see `SECURITY.md`).
 - Registry: `harbor.rzware.com/emf/emf-<service>`.
 - Manifests: `homelab-argo` (kustomize), synced by **ArgoCD** to the local K8s cluster,
   namespace **`kelta`**. In-cluster service DNS is `emf-<service>` (e.g. `emf-gateway`).
+- **Schema gate.** `emf/worker-migrate-job.yaml` is an ArgoCD `PreSync` hook with
+  `backoffLimit: 0`, so the sync halts before any Deployment is touched if it fails. It runs, in
+  order: Flyway migrations → `SystemCollectionSeeder` (`@Order(5)`) → `SchemaBootstrapRunner`
+  (`@Order(10)`, applies every active collection's DDL) → `MigrateShutdownRunner`
+  (`@Order(MAX_VALUE)`, `System.exit(0)`). A schema failure throws before that exit, so the Job
+  exits non-zero and workers never roll out against an incomplete schema. Worker pods themselves
+  run no Flyway and no collection DDL.
 - Local dev never touches CI: `make up` / `docker-compose.yml`. CI overrides live in
   `docker-compose.ci.yml` (no fixed host ports, JVM Dockerfiles, CI-only cerbos image).
 

--- a/.claude/docs/concerns.md
+++ b/.claude/docs/concerns.md
@@ -507,6 +507,32 @@ keep the raw name via `TableRef` quoting. Watch-out for future DDL: never pass a
 name into `sanitizeIdentifier` directly — names go through `identifierPart`, references
 through `TableRef`.
 
+**FIXED (fix/schema-bootstrap-in-migrate-job) — three ways `initializeCollection` could abort a
+collection permanently.** All three were found in Loki: seven couchpicks collections threw
+`StorageException: Failed to initialize table` on *every* worker boot for months. Because the
+throw happens before `reconcileSchema`, an affected collection never picks up later field
+additions either — the physical table silently drifts from its metadata.
+- **(a) Column identifiers were emitted unquoted.** A field named `user` (or `order`, `group`,
+  `default`, …) produced `ERROR: syntax error at or near "user"` and killed the whole
+  `CREATE TABLE`. Fix: `PhysicalTableStorageAdapter.quoteIdentifier` — used for column
+  *references* in DDL **and** DML (and mirrored in `SchemaMigrationEngine` +
+  `CompositeUniqueConstraintService`). Constraint/index *names* keep bare `sanitizeIdentifier`:
+  they are matched against `pg_constraint.conname` as string literals. Column names are already
+  lower-cased by `toSnakeCase`, so quoting changes nothing for non-reserved names.
+- **(b) FK targets were assumed to live in the source's schema.** A tenant collection with a
+  LOOKUP to a *system* collection resolved to `"<tenant>"."users"` → `relation does not exist`.
+  Fix: `resolveTargetTable` probes the source schema then `public` via `to_regclass`, and a
+  target found in neither is skipped with a warning instead of failing the collection.
+- **(c) One orphaned row blocked the FK forever.** `ADD CONSTRAINT` validated existing rows, so a
+  single dangling reference failed the statement on every boot — leaving the column with *no*
+  integrity at all. Fix: add `NOT VALID` (enforced for all new writes immediately), then a
+  separate `VALIDATE CONSTRAINT` that only warns, naming the table and the exact fix-up command.
+
+**Test-harness note:** the runtime-core storage tests now build H2 with `DATABASE_TO_LOWER=TRUE`
+(as `ExternalJdbcStorageAdapterTest` already did). H2 folds unquoted identifiers to *upper* case
+while PostgreSQL folds to *lower*; without the flag, quoted-lowercase DDL wouldn't match the
+column H2 creates unquoted — a test-only divergence that made the suite disagree with production.
+
 **FIXED (PR #1174) — record-policy `collectionId` was UUID-keyed but checked by name.**
 `CerbosPolicyGenerator.generateRecordPolicy` emitted `R.attr.collectionId == "<UUID>"` (from
 `profile_object_permission.collection_id` + `collection.id`, both UUIDs), but

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -272,7 +272,16 @@ Java tests: surefire runs `*Test`/`*Tests`/`*Properties` in parallel; failsafe r
 - Location: `kelta-worker/src/main/resources/db/migration/`
 - Naming: `V<n>__<snake_description>.sql`. **Baseline file is V1__baseline (#1189 flatten) — deployed flyway_schema_history retains pre-flatten numbering, so a lower-numbered migration is silently skipped on existing databases.** The directory head moves often; always take head+1.
   Check the directory for the true highest number before creating one — never reuse/skip.
-- Flyway runs at worker startup. Migrations execute under the platform sentinel tenant.
+- Flyway runs in the **migrate Job**, not in worker pods (`spring.flyway.enabled=false` in the
+  default profile; `application-migrate.yml` re-enables it). Migrations execute under the platform
+  sentinel tenant.
+- **Collection DDL is deploy-time, not pod-startup.** The same Job (ArgoCD `PreSync` hook,
+  `backoffLimit: 0`) also runs `SchemaBootstrapRunner`, which applies every active collection's
+  `CREATE TABLE`/reconcile once and **throws on failure** — failing the hook so the worker rollout
+  never starts against a half-applied schema. Worker pods only *register* collections at startup
+  (`kelta.storage.schema-bootstrap.enabled=false`); N replicas each running the same DDL was
+  duplicated work racing itself. Collections created **at runtime** still get their table on the
+  pod, via the NATS `collection.changed` path.
 
 ---
 

--- a/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/storage/CompositeUniqueConstraintService.java
+++ b/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/storage/CompositeUniqueConstraintService.java
@@ -65,8 +65,10 @@ public class CompositeUniqueConstraintService {
         String baseTable = PhysicalTableStorageAdapter.getBaseTableName(definition);
         String indexName = buildIndexName(baseTable, columns);
 
+        // Quote the column refs (reserved words like `user` are legal field names);
+        // the index NAME stays unquoted so catalog lookups by name still match.
         String columnList = columns.stream()
-                .map(PhysicalTableStorageAdapter::sanitizeIdentifier)
+                .map(PhysicalTableStorageAdapter::quoteIdentifier)
                 .reduce((a, b) -> a + ", " + b)
                 .orElseThrow();
 

--- a/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/storage/PhysicalTableStorageAdapter.java
+++ b/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/storage/PhysicalTableStorageAdapter.java
@@ -146,6 +146,7 @@ public class PhysicalTableStorageAdapter implements StorageAdapter {
         sql.append("record_type_id VARCHAR(36)");
 
         List<String> postCreateStatements = new ArrayList<>();
+        List<PendingForeignKey> pendingForeignKeys = new ArrayList<>();
 
         for (FieldDefinition field : definition.fields()) {
             if (!field.type().hasPhysicalColumn()) {
@@ -161,7 +162,7 @@ public class PhysicalTableStorageAdapter implements StorageAdapter {
 
             String sqlType = mapFieldTypeToSql(field.type(), field);
             sql.append(", ");
-            sql.append(sanitizeIdentifier(columnName)).append(" ").append(sqlType);
+            sql.append(quoteIdentifier(columnName)).append(" ").append(sqlType);
 
             if (!field.nullable()) {
                 sql.append(" NOT NULL");
@@ -174,11 +175,11 @@ public class PhysicalTableStorageAdapter implements StorageAdapter {
             // Companion columns (use resolved column name for consistency)
             if (field.type() == FieldType.CURRENCY) {
                 sql.append(", ");
-                sql.append(sanitizeIdentifier(columnName + "_currency_code")).append(" VARCHAR(3)");
+                sql.append(quoteIdentifier(columnName + "_currency_code")).append(" VARCHAR(3)");
             }
             if (field.type() == FieldType.GEOLOCATION) {
                 sql.append(", ");
-                sql.append(sanitizeIdentifier(columnName + "_longitude")).append(" DOUBLE PRECISION");
+                sql.append(quoteIdentifier(columnName + "_longitude")).append(" DOUBLE PRECISION");
             }
 
             // Unique index for EXTERNAL_ID
@@ -188,7 +189,7 @@ public class PhysicalTableStorageAdapter implements StorageAdapter {
                         sanitizeIdentifier(columnName));
                 postCreateStatements.add(
                     "CREATE UNIQUE INDEX IF NOT EXISTS " + idxName
-                    + " ON " + qualifiedName + "(" + sanitizeIdentifier(columnName) + ")"
+                    + " ON " + qualifiedName + "(" + quoteIdentifier(columnName) + ")"
                 );
             }
 
@@ -209,25 +210,15 @@ public class PhysicalTableStorageAdapter implements StorageAdapter {
                 // Raw name: kebab-case targets are legal — TableRef validates and
                 // quotes the reference. Only the generated fk NAME must be strict.
                 String targetTableName = field.referenceConfig().targetCollection();
-                // Target table is in the same schema as the source table
-                TableRef targetRef = tableRef.isPublicSchema()
-                        ? TableRef.publicSchema(targetTableName)
-                        : TableRef.tenantSchema(tableRef.schema(), targetTableName);
-                String targetCol = sanitizeIdentifier(field.referenceConfig().targetField());
+                String targetCol = quoteIdentifier(field.referenceConfig().targetField());
                 String fkName = buildBoundedIdentifier(
                         "fk_", identifierPart(baseName), sanitizeIdentifier(columnName));
                 String onDelete = field.type() == FieldType.MASTER_DETAIL
                         ? "ON DELETE CASCADE" : "ON DELETE SET NULL";
 
-                postCreateStatements.add(
-                    "DO $$ BEGIN " +
-                    "IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = '" + fkName + "') THEN " +
-                    "ALTER TABLE " + qualifiedName +
-                    " ADD CONSTRAINT " + fkName +
-                    " FOREIGN KEY (" + sanitizeIdentifier(columnName) + ")" +
-                    " REFERENCES " + targetRef.toSql() + "(" + targetCol + ") " + onDelete + "; " +
-                    "END IF; END $$"
-                );
+                pendingForeignKeys.add(new PendingForeignKey(
+                        fkName, qualifiedName, quoteIdentifier(columnName),
+                        tableRef, targetTableName, targetCol, onDelete));
             }
         }
 
@@ -289,6 +280,10 @@ public class PhysicalTableStorageAdapter implements StorageAdapter {
                 jdbcTemplate.execute(stmt);
             }
 
+            for (PendingForeignKey fk : pendingForeignKeys) {
+                applyForeignKey(fk, definition.name());
+            }
+
             // Record the migration in history
             migrationEngine.recordMigration(definition.name(),
                 SchemaMigrationEngine.MigrationType.CREATE_TABLE, sql.toString());
@@ -297,6 +292,101 @@ public class PhysicalTableStorageAdapter implements StorageAdapter {
         } catch (DataAccessException e) {
             throw new StorageException("Failed to initialize table for collection: " + definition.name(), e);
         }
+    }
+
+    /**
+     * A LOOKUP/MASTER_DETAIL foreign key whose target table must be located before the
+     * constraint can be written. Held until after {@code CREATE TABLE} + schema reconcile,
+     * because resolving the target needs a DB round-trip and the referencing column has to
+     * exist first.
+     *
+     * @param fkName the generated (length-bounded, unquoted) constraint name
+     * @param sourceTable the schema-qualified table the constraint is added to
+     * @param sourceColumn the quoted referencing column
+     * @param sourceRef the source table's ref, used to derive the candidate target schema
+     * @param targetTableName the target collection's raw (possibly kebab-case) table name
+     * @param targetColumn the quoted referenced column, typically {@code "id"}
+     * @param onDelete the {@code ON DELETE …} clause
+     */
+    private record PendingForeignKey(
+            String fkName,
+            String sourceTable,
+            String sourceColumn,
+            TableRef sourceRef,
+            String targetTableName,
+            String targetColumn,
+            String onDelete) {
+    }
+
+    /**
+     * Adds one foreign key, resolving the target table's schema first.
+     *
+     * <p><b>Schema resolution.</b> The target is <em>not</em> necessarily co-located with the
+     * source: a tenant collection may hold a LOOKUP to a <em>system</em> collection, whose
+     * Flyway-managed table lives in {@code public}. Assuming the source's schema produced
+     * {@code relation "<tenant>.users" does not exist} and aborted initialization for the whole
+     * collection. So try the source schema first, then fall back to {@code public}, and skip
+     * the constraint with an actionable warning when the target exists in neither — a dangling
+     * reference is a metadata problem to fix, not a reason to leave the collection tableless.
+     *
+     * <p><b>{@code NOT VALID}.</b> The constraint is added without validating rows already in
+     * the table. A single orphaned legacy row would otherwise fail the {@code ALTER TABLE} on
+     * every worker boot, forever, leaving the column with <em>no</em> referential integrity at
+     * all. {@code NOT VALID} enforces the FK for all subsequent inserts and updates
+     * immediately; the follow-up {@code VALIDATE CONSTRAINT} then promotes it to fully valid
+     * when the existing data is clean, and only warns (naming the table) when it is not.
+     */
+    private void applyForeignKey(PendingForeignKey fk, String collectionName) {
+        TableRef targetRef = resolveTargetTable(fk);
+        if (targetRef == null) {
+            log.warn("Skipping foreign key '{}' on collection '{}': target table '{}' does not exist "
+                    + "in schema '{}' or 'public'. The reference field points at a collection with no "
+                    + "physical table — fix or remove the reference; the rest of the collection is "
+                    + "initialized normally.",
+                    fk.fkName(), collectionName, fk.targetTableName(), fk.sourceRef().schema());
+            return;
+        }
+
+        jdbcTemplate.execute(
+                "DO $$ BEGIN "
+                + "IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = '" + fk.fkName() + "') THEN "
+                + "ALTER TABLE " + fk.sourceTable()
+                + " ADD CONSTRAINT " + fk.fkName()
+                + " FOREIGN KEY (" + fk.sourceColumn() + ")"
+                + " REFERENCES " + targetRef.toSql() + "(" + fk.targetColumn() + ") "
+                + fk.onDelete() + " NOT VALID; "
+                + "END IF; END $$");
+
+        try {
+            jdbcTemplate.execute("ALTER TABLE " + fk.sourceTable()
+                    + " VALIDATE CONSTRAINT " + fk.fkName());
+        } catch (DataAccessException e) {
+            log.warn("Foreign key '{}' on '{}' is enforced for new writes but could not be validated "
+                    + "against existing rows — the table holds orphaned references to '{}'. Clean them "
+                    + "up (or null them out), then run: ALTER TABLE {} VALIDATE CONSTRAINT {}. Cause: {}",
+                    fk.fkName(), fk.sourceTable(), fk.targetTableName(),
+                    fk.sourceTable(), fk.fkName(), e.getMostSpecificCause().getMessage());
+        }
+    }
+
+    /**
+     * Locates the table a foreign key should reference: the source's own schema first, then
+     * {@code public} (where system collections live). Returns {@code null} when neither holds it.
+     */
+    private TableRef resolveTargetTable(PendingForeignKey fk) {
+        List<TableRef> candidates = fk.sourceRef().isPublicSchema()
+                ? List.of(TableRef.publicSchema(fk.targetTableName()))
+                : List.of(TableRef.tenantSchema(fk.sourceRef().schema(), fk.targetTableName()),
+                          TableRef.publicSchema(fk.targetTableName()));
+
+        for (TableRef candidate : candidates) {
+            Boolean exists = jdbcTemplate.queryForObject(
+                    "SELECT to_regclass(?) IS NOT NULL", Boolean.class, candidate.toSql());
+            if (Boolean.TRUE.equals(exists)) {
+                return candidate;
+            }
+        }
+        return null;
     }
 
     /**
@@ -411,7 +501,7 @@ public class PhysicalTableStorageAdapter implements StorageAdapter {
                                                      int limit,
                                                      List<FilterCondition> filters) {
         TableRef tableRef = getTableRef(definition);
-        String vectorIdent = sanitizeIdentifier(vectorColumn);
+        String vectorIdent = quoteIdentifier(vectorColumn);
         List<Object> params = new ArrayList<>();
 
         // Cosine distance (<=>) to the query vector; bound first so its '?' precedes any filter '?'.
@@ -452,11 +542,11 @@ public class PhysicalTableStorageAdapter implements StorageAdapter {
         for (int i = 0; i < specs.size(); i++) {
             AggregationSpec spec = specs.get(i);
             if (i > 0) selectList.append(", ");
-            String aliasIdent = sanitizeIdentifier(spec.alias());
+            String aliasIdent = quoteIdentifier(spec.alias());
             if ("COUNT".equals(spec.function())) {
                 selectList.append("COUNT(*) AS ").append(aliasIdent);
             } else {
-                String columnName = sanitizeIdentifier(resolveColumnName(definition, spec.field()));
+                String columnName = quoteIdentifier(resolveColumnName(definition, spec.field()));
                 selectList.append(spec.function()).append("(").append(columnName).append(") AS ").append(aliasIdent);
             }
         }
@@ -590,18 +680,18 @@ public class PhysicalTableStorageAdapter implements StorageAdapter {
                 if (SYSTEM_COLUMNS.contains(columnName)) {
                     continue; // Already handled as a system field above
                 }
-                columns.add(sanitizeIdentifier(columnName));
+                columns.add(quoteIdentifier(columnName));
                 placeholders.add(castPlaceholder(field.type()));
                 values.add(convertValueForStorage(data.get(field.name()), field.type()));
 
                 // Handle companion columns
                 if (field.type() == FieldType.CURRENCY && data.containsKey(field.name() + "_currency_code")) {
-                    columns.add(sanitizeIdentifier(columnName + "_currency_code"));
+                    columns.add(quoteIdentifier(columnName + "_currency_code"));
                     placeholders.add("?");
                     values.add(data.get(field.name() + "_currency_code"));
                 }
                 if (field.type() == FieldType.GEOLOCATION && data.get(field.name()) instanceof Map<?,?> geo) {
-                    columns.add(sanitizeIdentifier(columnName + "_longitude"));
+                    columns.add(quoteIdentifier(columnName + "_longitude"));
                     placeholders.add("?");
                     values.add(((Number) geo.get("longitude")).doubleValue());
                 }
@@ -709,7 +799,7 @@ public class PhysicalTableStorageAdapter implements StorageAdapter {
                 if (SYSTEM_COLUMNS.contains(columnName)) {
                     continue; // Already handled as a system field above
                 }
-                setClauses.add(sanitizeIdentifier(columnName) + " = " + castPlaceholder(field.type()));
+                setClauses.add(quoteIdentifier(columnName) + " = " + castPlaceholder(field.type()));
                 values.add(convertValueForStorage(data.get(field.name()), field.type()));
             }
         }
@@ -789,7 +879,7 @@ public class PhysicalTableStorageAdapter implements StorageAdapter {
 
         StringBuilder sql = new StringBuilder("SELECT COUNT(*) FROM ");
         sql.append(tableRef.toSql());
-        sql.append(" WHERE ").append(sanitizeIdentifier(columnName)).append(" = ?");
+        sql.append(" WHERE ").append(quoteIdentifier(columnName)).append(" = ?");
 
         List<Object> params = new ArrayList<>();
         params.add(value);
@@ -826,7 +916,7 @@ public class PhysicalTableStorageAdapter implements StorageAdapter {
             return 0;
         }
         TableRef tableRef = getTableRef(definition);
-        String col = sanitizeIdentifier(resolveColumnName(definition, fieldName));
+        String col = quoteIdentifier(resolveColumnName(definition, fieldName));
 
         StringBuilder sql = new StringBuilder("UPDATE ");
         sql.append(tableRef.toSql());
@@ -911,7 +1001,7 @@ public class PhysicalTableStorageAdapter implements StorageAdapter {
     static String buildHnswIndexStatement(String idxName, String qualifiedName, String column) {
         return "CREATE INDEX IF NOT EXISTS " + idxName
                 + " ON " + qualifiedName
-                + " USING hnsw (" + sanitizeIdentifier(column) + " vector_cosine_ops)";
+                + " USING hnsw (" + quoteIdentifier(column) + " vector_cosine_ops)";
     }
 
     /**
@@ -967,6 +1057,29 @@ public class PhysicalTableStorageAdapter implements StorageAdapter {
             throw new IllegalArgumentException("Invalid identifier: " + identifier);
         }
         return identifier;
+    }
+
+    /**
+     * Sanitizes a column identifier and wraps it in double quotes for use as a column
+     * <em>reference</em> in DDL or DML.
+     *
+     * <p>Without the quotes, a field whose name collides with a PostgreSQL reserved word
+     * ({@code user}, {@code order}, {@code group}, {@code default}, …) produces
+     * {@code syntax error at or near "user"} — which aborts {@code CREATE TABLE} for the
+     * whole collection, so it never gets a table and never reconciles. Column names always
+     * arrive lower-cased (via {@link #toSnakeCase} or an explicit {@code columnName}
+     * mapping), so quoting is semantically identical to the previous bare rendering for
+     * every non-reserved name — it only stops the parser from claiming the reserved ones.
+     *
+     * <p>Use {@link #sanitizeIdentifier} instead for generated constraint/index
+     * <em>names</em>: those are matched against {@code pg_constraint.conname} as string
+     * literals and must stay unquoted.
+     *
+     * @param identifier the column name to sanitize and quote
+     * @return the double-quoted identifier, e.g. {@code "user"}
+     */
+    static String quoteIdentifier(String identifier) {
+        return "\"" + sanitizeIdentifier(identifier) + "\"";
     }
 
     /**
@@ -1120,8 +1233,10 @@ public class PhysicalTableStorageAdapter implements StorageAdapter {
 
         for (String field : fields) {
             String columnName = resolveColumnName(definition, field);
+            // Dedupe against the bare system-column names added above, but emit the
+            // quoted form so reserved-word columns (user, order, …) parse.
             if (!selectFields.contains(columnName)) {
-                selectFields.add(sanitizeIdentifier(columnName));
+                selectFields.add(quoteIdentifier(columnName));
             }
         }
 
@@ -1153,7 +1268,7 @@ public class PhysicalTableStorageAdapter implements StorageAdapter {
      */
     private String buildFilterCondition(FilterCondition filter, CollectionDefinition definition,
                                          List<Object> params) {
-        String fieldName = sanitizeIdentifier(resolveColumnName(definition, filter.fieldName()));
+        String fieldName = quoteIdentifier(resolveColumnName(definition, filter.fieldName()));
         FilterOperator operator = filter.operator();
         Object value = filter.value();
 
@@ -1288,7 +1403,7 @@ public class PhysicalTableStorageAdapter implements StorageAdapter {
      */
     private String buildOrderByClause(List<SortField> sorting, CollectionDefinition definition) {
         return sorting.stream()
-            .map(sort -> sanitizeIdentifier(resolveColumnName(definition, sort.fieldName()))
+            .map(sort -> quoteIdentifier(resolveColumnName(definition, sort.fieldName()))
                     + " " + sort.direction().name())
             .collect(Collectors.joining(", "));
     }

--- a/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/storage/SchemaMigrationEngine.java
+++ b/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/storage/SchemaMigrationEngine.java
@@ -355,7 +355,7 @@ public class SchemaMigrationEngine {
             }
             String sql = "ALTER TABLE " + tableRef.toSql()
                 + " ADD CONSTRAINT " + uniqueConstraintName(tableRef.tableName(), columnName)
-                + " UNIQUE (" + columnName + ")";
+                + " UNIQUE (" + quoteIdentifier(columnName) + ")";
             try {
                 jdbcTemplate.execute(sql);
             } catch (DataAccessException e) {
@@ -827,6 +827,18 @@ public class SchemaMigrationEngine {
         }
         return identifier;
     }
+
+    /**
+     * Sanitizes and double-quotes a column name for use as a column <em>reference</em> in DDL.
+     * Mirrors {@link PhysicalTableStorageAdapter#quoteIdentifier} — without it, an
+     * {@code ALTER TABLE … ADD COLUMN user …} is a syntax error, so a collection that
+     * initialized fine would fail to reconcile the moment such a field is added.
+     * Constraint/index <em>names</em> and values compared against catalog strings keep using
+     * {@link #sanitizeIdentifier}.
+     */
+    private String quoteIdentifier(String identifier) {
+        return PhysicalTableStorageAdapter.quoteIdentifier(identifier);
+    }
     
     /**
      * Maps a field's type to its PostgreSQL column type. The {@code field} argument
@@ -919,7 +931,7 @@ public class SchemaMigrationEngine {
         StringBuilder sql = new StringBuilder("ALTER TABLE ");
         sql.append(tableIdentifier);
         sql.append(" ADD COLUMN IF NOT EXISTS ");
-        sql.append(sanitizeIdentifier(columnName));
+        sql.append(quoteIdentifier(columnName));
         sql.append(" ");
         sql.append(mapFieldTypeToSql(field.type(), field));
 
@@ -933,12 +945,12 @@ public class SchemaMigrationEngine {
         // Companion columns
         if (field.type() == FieldType.CURRENCY) {
             sql.append("; ALTER TABLE ").append(tableIdentifier);
-            sql.append(" ADD COLUMN IF NOT EXISTS ").append(sanitizeIdentifier(columnName + "_currency_code"));
+            sql.append(" ADD COLUMN IF NOT EXISTS ").append(quoteIdentifier(columnName + "_currency_code"));
             sql.append(" VARCHAR(3)");
         }
         if (field.type() == FieldType.GEOLOCATION) {
             sql.append("; ALTER TABLE ").append(tableIdentifier);
-            sql.append(" ADD COLUMN IF NOT EXISTS ").append(sanitizeIdentifier(columnName + "_longitude"));
+            sql.append(" ADD COLUMN IF NOT EXISTS ").append(quoteIdentifier(columnName + "_longitude"));
             sql.append(" DOUBLE PRECISION");
         }
 
@@ -957,7 +969,7 @@ public class SchemaMigrationEngine {
         String sql = String.format(
             "COMMENT ON COLUMN %s.%s IS 'DEPRECATED: This column is no longer in use as of %s'",
             tableIdentifier,
-            sanitizeIdentifier(columnName),
+            quoteIdentifier(columnName),
             Instant.now().toString()
         );
 
@@ -982,16 +994,16 @@ public class SchemaMigrationEngine {
         StringBuilder sql = new StringBuilder("ALTER TABLE ");
         sql.append(tableIdentifier);
         sql.append(" DROP COLUMN IF EXISTS ");
-        sql.append(sanitizeIdentifier(columnName));
+        sql.append(quoteIdentifier(columnName));
 
         // Companion columns mirror createAddColumnMigration so no orphan column survives a drop.
         if (field.type() == FieldType.CURRENCY) {
             sql.append("; ALTER TABLE ").append(tableIdentifier);
-            sql.append(" DROP COLUMN IF EXISTS ").append(sanitizeIdentifier(columnName + "_currency_code"));
+            sql.append(" DROP COLUMN IF EXISTS ").append(quoteIdentifier(columnName + "_currency_code"));
         }
         if (field.type() == FieldType.GEOLOCATION) {
             sql.append("; ALTER TABLE ").append(tableIdentifier);
-            sql.append(" DROP COLUMN IF EXISTS ").append(sanitizeIdentifier(columnName + "_longitude"));
+            sql.append(" DROP COLUMN IF EXISTS ").append(quoteIdentifier(columnName + "_longitude"));
         }
 
         return new MigrationAction(definition.name(), MigrationType.DROP_COLUMN, sql.toString());
@@ -1010,9 +1022,9 @@ public class SchemaMigrationEngine {
         String sql = String.format(
             "ALTER TABLE %s ALTER COLUMN %s TYPE %s USING %s::%s",
             tableIdentifier,
-            sanitizeIdentifier(columnName),
+            quoteIdentifier(columnName),
             newSqlType,
-            sanitizeIdentifier(columnName),
+            quoteIdentifier(columnName),
             newSqlType
         );
 

--- a/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/integration/AutomaticTableCreationTest.java
+++ b/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/integration/AutomaticTableCreationTest.java
@@ -8,8 +8,6 @@ import io.kelta.runtime.storage.SchemaMigrationEngine;
 import io.kelta.runtime.storage.StorageAdapter;
 import org.junit.jupiter.api.*;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
-import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
 
 import javax.sql.DataSource;
 import java.time.Instant;
@@ -47,9 +45,12 @@ class AutomaticTableCreationTest {
     @BeforeEach
     void setUp() {
         // Set up embedded H2 database
-        dataSource = new EmbeddedDatabaseBuilder()
-            .setType(EmbeddedDatabaseType.H2)
-            .build();
+        // DATABASE_TO_LOWER makes H2 fold unquoted identifiers to lower case the way
+        // PostgreSQL does. Without it, DDL that quotes a lower-case column name (needed so
+        // reserved words like `user` parse) would not match the upper-cased column H2
+        // creates for the same name unquoted — a divergence from production, not a real bug.
+        dataSource = new org.springframework.jdbc.datasource.DriverManagerDataSource(
+            "jdbc:h2:mem:autotable;DATABASE_TO_LOWER=TRUE;MODE=PostgreSQL;DB_CLOSE_DELAY=-1");
         jdbcTemplate = new JdbcTemplate(dataSource);
         
         // Initialize components
@@ -116,15 +117,17 @@ class AutomaticTableCreationTest {
             storageAdapter.initializeCollection(projects);
             
             // Verify system columns exist by querying metadata
+            // Identifiers land lower-cased in the catalog (DATABASE_TO_LOWER, matching
+            // PostgreSQL); compare case-insensitively so the assertion holds on either.
             List<Map<String, Object>> columns = jdbcTemplate.queryForList(
-                "SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS " +
-                "WHERE TABLE_NAME = 'TBL_PROJECTS_SYSTEM' " +
+                "SELECT COLUMN_NAME AS col FROM INFORMATION_SCHEMA.COLUMNS " +
+                "WHERE UPPER(TABLE_NAME) = 'TBL_PROJECTS_SYSTEM' " +
                 "ORDER BY COLUMN_NAME");
-            
+
             List<String> columnNames = columns.stream()
-                .map(col -> (String) col.get("COLUMN_NAME"))
+                .map(col -> ((String) col.values().iterator().next()).toUpperCase())
                 .toList();
-            
+
             assertTrue(columnNames.contains("ID"), "Should have ID column");
             assertTrue(columnNames.contains("CREATED_AT"), "Should have CREATED_AT column");
             assertTrue(columnNames.contains("UPDATED_AT"), "Should have UPDATED_AT column");
@@ -210,7 +213,7 @@ class AutomaticTableCreationTest {
             // Verify project_id column exists in tasks table
             List<Map<String, Object>> columns = jdbcTemplate.queryForList(
                 "SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS " +
-                "WHERE TABLE_NAME = 'TBL_TASKS_FK' AND COLUMN_NAME = 'PROJECT_ID'");
+                "WHERE UPPER(TABLE_NAME) = 'TBL_TASKS_FK' AND UPPER(COLUMN_NAME) = 'PROJECT_ID'");
             
             assertEquals(1, columns.size(), "project_id column should exist");
         }

--- a/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/integration/KeltaRuntimeIntegrationTest.java
+++ b/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/integration/KeltaRuntimeIntegrationTest.java
@@ -11,8 +11,6 @@ import io.kelta.runtime.validation.DefaultValidationEngine;
 import io.kelta.runtime.validation.ValidationEngine;
 import org.junit.jupiter.api.*;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
-import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
 
 import javax.sql.DataSource;
 import java.util.HashMap;
@@ -41,9 +39,12 @@ class KeltaRuntimeIntegrationTest {
     @BeforeEach
     void setUp() {
         // Set up embedded database
-        dataSource = new EmbeddedDatabaseBuilder()
-            .setType(EmbeddedDatabaseType.H2)
-            .build();
+        // DATABASE_TO_LOWER makes H2 fold unquoted identifiers to lower case the way
+        // PostgreSQL does. Without it, DDL that quotes a lower-case column name (needed so
+        // reserved words like `user` parse) would not match the upper-cased column H2
+        // creates for the same name unquoted — a divergence from production, not a real bug.
+        dataSource = new org.springframework.jdbc.datasource.DriverManagerDataSource(
+            "jdbc:h2:mem:runtimeint;DATABASE_TO_LOWER=TRUE;MODE=PostgreSQL;DB_CLOSE_DELAY=-1");
         jdbcTemplate = new JdbcTemplate(dataSource);
         
         // Initialize components

--- a/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/storage/CompositeUniqueConstraintServiceTest.java
+++ b/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/storage/CompositeUniqueConstraintServiceTest.java
@@ -12,8 +12,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
-import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
 
 import javax.sql.DataSource;
 import java.time.Instant;
@@ -42,9 +40,12 @@ class CompositeUniqueConstraintServiceTest {
 
     @BeforeEach
     void setUp() {
-        DataSource dataSource = new EmbeddedDatabaseBuilder()
-                .setType(EmbeddedDatabaseType.H2)
-                .build();
+        // DATABASE_TO_LOWER makes H2 fold unquoted identifiers to lower case the way
+        // PostgreSQL does. Without it, DDL that quotes a lower-case column name (needed so
+        // reserved words like `user` parse) would not match the upper-cased column H2
+        // creates for the same name unquoted — a divergence from production, not a real bug.
+        DataSource dataSource = new org.springframework.jdbc.datasource.DriverManagerDataSource(
+            "jdbc:h2:mem:composite;DATABASE_TO_LOWER=TRUE;MODE=PostgreSQL;DB_CLOSE_DELAY=-1");
         jdbcTemplate = new JdbcTemplate(dataSource);
         SchemaMigrationEngine migrationEngine = new SchemaMigrationEngine(jdbcTemplate);
         adapter = new PhysicalTableStorageAdapter(jdbcTemplate, migrationEngine,

--- a/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/storage/PhysicalTableStorageAdapterSemanticSearchTest.java
+++ b/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/storage/PhysicalTableStorageAdapterSemanticSearchTest.java
@@ -65,8 +65,8 @@ class PhysicalTableStorageAdapterSemanticSearchTest {
         verify(jdbcTemplate).queryForList(sql.capture(), params.capture());
 
         assertThat(sql.getValue())
-                .contains("embedding <=> CAST(? AS vector)) AS _distance")
-                .contains("WHERE embedding IS NOT NULL")
+                .contains("\"embedding\" <=> CAST(? AS vector)) AS _distance")
+                .contains("WHERE \"embedding\" IS NOT NULL")
                 .contains("ORDER BY _distance ASC LIMIT ?");
         // Vector literal is bound before the limit (and before any filter params).
         assertThat(params.getValue()).containsExactly("[0.1,0.2]", 5);
@@ -80,7 +80,7 @@ class PhysicalTableStorageAdapterSemanticSearchTest {
                 "hnsw_docs_embedding", "public.docs", "embedding");
         assertThat(ddl).isEqualTo(
                 "CREATE INDEX IF NOT EXISTS hnsw_docs_embedding ON public.docs"
-                        + " USING hnsw (embedding vector_cosine_ops)");
+                        + " USING hnsw (\"embedding\" vector_cosine_ops)");
     }
 
     @Test

--- a/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/storage/PhysicalTableStorageAdapterSystemCollectionTest.java
+++ b/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/storage/PhysicalTableStorageAdapterSystemCollectionTest.java
@@ -55,6 +55,11 @@ class PhysicalTableStorageAdapterSystemCollectionTest {
         jdbcTemplate = mock(JdbcTemplate.class);
         migrationEngine = mock(SchemaMigrationEngine.class);
         adapter = new PhysicalTableStorageAdapter(jdbcTemplate, migrationEngine, new tools.jackson.databind.ObjectMapper());
+        // Before writing a FK the adapter locates the target table (it may live in the tenant
+        // schema or, for a system collection, in public). Default to "found" so FK tests
+        // exercise the ADD CONSTRAINT path rather than the skip path.
+        when(jdbcTemplate.queryForObject(anyString(), eq(Boolean.class), any(Object[].class)))
+                .thenReturn(true);
     }
 
     // ==================== Helper Methods ====================
@@ -242,6 +247,111 @@ class PhysicalTableStorageAdapterSystemCollectionTest {
             inOrder.verify(jdbcTemplate).execute(argThat((String sql) ->
                     sql.contains("FOREIGN KEY") && sql.contains("parent_ref")));
         }
+
+        @Test
+        @DisplayName("Should quote column names so reserved words like `user` are legal fields")
+        void initializeCollection_quotesReservedWordColumns() {
+            // `user` is a PostgreSQL reserved word. Emitted bare, the whole CREATE TABLE dies
+            // with `syntax error at or near "user"` — so the collection never gets a table and
+            // never reconciles, however many times the worker restarts.
+            CollectionDefinition withReservedWord = new CollectionDefinitionBuilder()
+                    .name("watchlists")
+                    .displayName("Watchlists")
+                    .addField(FieldDefinition.requiredString("user"))
+                    .addField(FieldDefinition.requiredString("notes"))
+                    .build();
+
+            adapter.initializeCollection(withReservedWord);
+
+            verify(jdbcTemplate).execute(argThat((String sql) ->
+                    sql.contains("CREATE TABLE IF NOT EXISTS")
+                            && sql.contains("\"user\" TEXT")
+                            && !sql.contains(", user TEXT")));
+        }
+
+        @Test
+        @DisplayName("Should fall back to the public schema when the FK target is a system collection")
+        void initializeCollection_resolvesForeignKeyTarget_inPublicSchema() {
+            // A tenant collection may point a LOOKUP at a system collection, whose table is
+            // Flyway-managed and lives in public — not alongside the source. Assuming
+            // co-location produced `relation "<tenant>.users" does not exist` and aborted
+            // initialization for the entire collection.
+            reset(jdbcTemplate);
+            // The tenant-schema existence pre-check, then the two FK target probes:
+            // absent from the tenant schema, present in public.
+            when(jdbcTemplate.queryForObject(anyString(), eq(Integer.class), any(Object[].class)))
+                    .thenReturn(1);
+            when(jdbcTemplate.queryForObject(anyString(), eq(Boolean.class), any(Object[].class)))
+                    .thenReturn(false)
+                    .thenReturn(true);
+
+            io.kelta.runtime.context.TenantContext.runWithTenant("tenant-1", "acme", () ->
+                    adapter.initializeCollection(buildCollectionWithLookupTo("users")));
+
+            verify(jdbcTemplate).execute(argThat((String sql) ->
+                    sql.contains("FOREIGN KEY") && sql.contains("REFERENCES users")));
+        }
+
+        @Test
+        @DisplayName("Should skip — not fail — a FK whose target table exists nowhere")
+        void initializeCollection_skipsForeignKey_whenTargetMissing() {
+            reset(jdbcTemplate);
+            when(jdbcTemplate.queryForObject(anyString(), eq(Boolean.class), any(Object[].class)))
+                    .thenReturn(false);
+
+            assertDoesNotThrow(() ->
+                    adapter.initializeCollection(buildCollectionWithLookupTo("ghosts")));
+
+            // The table itself is still created; only the dangling constraint is skipped.
+            verify(jdbcTemplate).execute(argThat((String sql) ->
+                    sql.contains("CREATE TABLE IF NOT EXISTS")));
+            verify(jdbcTemplate, never()).execute(argThat((String sql) ->
+                    sql.contains("FOREIGN KEY")));
+        }
+
+        @Test
+        @DisplayName("Should add FKs NOT VALID, then validate, so legacy orphans can't block the deploy")
+        void initializeCollection_addsForeignKeyNotValid_thenValidates() {
+            // One orphaned row otherwise fails ADD CONSTRAINT on every single boot, forever,
+            // leaving the column with no referential integrity at all. NOT VALID enforces the
+            // FK for every subsequent write immediately; VALIDATE then promotes it when the
+            // existing rows turn out to be clean.
+            adapter.initializeCollection(buildCollectionWithLookupTo("users"));
+
+            InOrder inOrder = inOrder(jdbcTemplate);
+            inOrder.verify(jdbcTemplate).execute(argThat((String sql) ->
+                    sql.contains("ADD CONSTRAINT") && sql.contains("NOT VALID")));
+            inOrder.verify(jdbcTemplate).execute(argThat((String sql) ->
+                    sql.contains("VALIDATE CONSTRAINT")));
+        }
+
+        @Test
+        @DisplayName("Should keep the FK enforced when validation fails on existing rows")
+        void initializeCollection_toleratesValidateFailure_onOrphanedRows() {
+            doThrow(new org.springframework.dao.DataIntegrityViolationException(
+                    "insert or update on table violates foreign key constraint"))
+                    .when(jdbcTemplate).execute(argThat((String sql) ->
+                            sql != null && sql.contains("VALIDATE CONSTRAINT")));
+
+            assertDoesNotThrow(() ->
+                    adapter.initializeCollection(buildCollectionWithLookupTo("users")));
+
+            verify(jdbcTemplate).execute(argThat((String sql) ->
+                    sql.contains("ADD CONSTRAINT") && sql.contains("NOT VALID")));
+        }
+    }
+
+    /** A non-system collection with a single LOOKUP field pointing at {@code target}. */
+    private CollectionDefinition buildCollectionWithLookupTo(String target) {
+        return new CollectionDefinitionBuilder()
+                .name("watchlists")
+                .displayName("Watchlists")
+                .addField(new FieldDefinitionBuilder()
+                        .name("owner")
+                        .type(FieldType.LOOKUP)
+                        .referenceConfig(ReferenceConfig.lookup(target, "Owner"))
+                        .build())
+                .build();
     }
 
     // ==================== Column Name Mapping Tests (via create) ====================

--- a/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/storage/PhysicalTableStorageAdapterTest.java
+++ b/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/storage/PhysicalTableStorageAdapterTest.java
@@ -18,8 +18,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
-import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
 
 import javax.sql.DataSource;
 import java.time.Instant;
@@ -45,9 +43,12 @@ class PhysicalTableStorageAdapterTest {
     @BeforeEach
     void setUp() {
         // Create embedded H2 database
-        DataSource dataSource = new EmbeddedDatabaseBuilder()
-            .setType(EmbeddedDatabaseType.H2)
-            .build();
+        // DATABASE_TO_LOWER makes H2 fold unquoted identifiers to lower case the way
+        // PostgreSQL does. Without it, DDL that quotes a lower-case column name (needed so
+        // reserved words like `user` parse) would not match the upper-cased column H2
+        // creates for the same name unquoted — a divergence from production, not a real bug.
+        DataSource dataSource = new org.springframework.jdbc.datasource.DriverManagerDataSource(
+            "jdbc:h2:mem:adapter;DATABASE_TO_LOWER=TRUE;MODE=PostgreSQL;DB_CLOSE_DELAY=-1");
         
         jdbcTemplate = new JdbcTemplate(dataSource);
         

--- a/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/storage/SchemaMigrationEngineTest.java
+++ b/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/storage/SchemaMigrationEngineTest.java
@@ -14,8 +14,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.dao.DataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
-import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
 
 import javax.sql.DataSource;
 import java.time.Instant;
@@ -41,9 +39,12 @@ class SchemaMigrationEngineTest {
     @BeforeEach
     void setUp() {
         // Create embedded H2 database
-        DataSource dataSource = new EmbeddedDatabaseBuilder()
-            .setType(EmbeddedDatabaseType.H2)
-            .build();
+        // DATABASE_TO_LOWER makes H2 fold unquoted identifiers to lower case the way
+        // PostgreSQL does. Without it, DDL that quotes a lower-case column name (needed so
+        // reserved words like `user` parse) would not match the upper-cased column H2
+        // creates for the same name unquoted — a divergence from production, not a real bug.
+        DataSource dataSource = new org.springframework.jdbc.datasource.DriverManagerDataSource(
+            "jdbc:h2:mem:migengine;DATABASE_TO_LOWER=TRUE;MODE=PostgreSQL;DB_CLOSE_DELAY=-1");
         
         jdbcTemplate = new JdbcTemplate(dataSource);
         

--- a/kelta-worker/CLAUDE.md
+++ b/kelta-worker/CLAUDE.md
@@ -69,6 +69,18 @@ Use the next sequential `V<n>__description.sql` — check the highest existing v
 ls kelta-worker/src/main/resources/db/migration | sort -V | tail -3
 ```
 
+### Deploy-time schema (migrate profile)
+Flyway **and** collection DDL run in the `migrate` profile only — the ArgoCD `PreSync` Job. Pods
+run neither. `runner/SchemaBootstrapRunner` (`@Profile("migrate")`, `@Order(10)`) applies every
+active collection's `CREATE TABLE`/reconcile once and throws on failure, which fails the Job and
+stops the rollout. Two rules follow:
+- **Don't put work in an `ApplicationRunner` ordered at/after `MigrateShutdownRunner`**
+  (`@Order(Integer.MAX_VALUE)`) — its `System.exit(0)` means anything after it never runs, and
+  `ApplicationReadyEvent` listeners never fire in the Job at all.
+- **Keep `applySchema=true` on runtime paths.** `CollectionLifecycleManager.initializeCollection`
+  defaults to applying DDL; only `WorkerBootstrapService` passes `false`. A collection created
+  after deploy has no Job to lean on and needs its table from the NATS `collection.changed` path.
+
 ### Error Handling
 - `ScimException` → SCIM endpoints (400, 404, 409 with scimType)
 - `EmailDeliveryException` → Email send failures

--- a/kelta-worker/src/main/java/io/kelta/worker/runner/SchemaBootstrapRunner.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/runner/SchemaBootstrapRunner.java
@@ -1,0 +1,96 @@
+package io.kelta.worker.runner;
+
+import io.kelta.worker.service.CollectionLifecycleManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.annotation.Order;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Applies every active collection's physical schema, once, from the migrate Job.
+ *
+ * <p>Runs only under the {@code migrate} profile — the ArgoCD PreSync hook Job that also runs
+ * Flyway. Two things follow from that placement:
+ *
+ * <ul>
+ *   <li><b>No race.</b> Previously the worker pods did this on {@code ApplicationReadyEvent},
+ *       so every replica issued {@code CREATE TABLE} / {@code reconcileSchema} for every
+ *       collection concurrently against the same database. The storage adapter can recover
+ *       from the resulting {@code pg_type} unique violations, but only after the fact. Here a
+ *       single process owns the DDL and the pods that follow just read the finished schema.</li>
+ *   <li><b>No half-deployed schema.</b> A failure throws, which fails the Job
+ *       ({@code backoffLimit: 0}), which fails the PreSync hook, which stops the sync before
+ *       the worker Deployment is touched. The previous behaviour logged the error and started
+ *       serving traffic against a table that was never created.</li>
+ * </ul>
+ *
+ * <p>Ordered after {@code SystemCollectionSeeder} (@Order(5)) so seeded system collections are
+ * present, and well before {@link MigrateShutdownRunner} (@Order(Integer.MAX_VALUE)), whose
+ * {@code System.exit(0)} would otherwise cut this short.
+ *
+ * <p>Collections created at runtime — after the deploy — are unaffected: they get their table
+ * from the NATS {@code collection-changed} path, which still applies DDL on the pod.
+ *
+ * @since 1.0.0
+ */
+@Component
+@Profile("migrate")
+@Order(10)
+public class SchemaBootstrapRunner implements ApplicationRunner {
+
+    private static final Logger log = LoggerFactory.getLogger(SchemaBootstrapRunner.class);
+
+    private static final String SELECT_ACTIVE_COLLECTIONS =
+            "SELECT id, name FROM collection WHERE active = true";
+
+    private final JdbcTemplate jdbcTemplate;
+    private final CollectionLifecycleManager lifecycleManager;
+
+    public SchemaBootstrapRunner(JdbcTemplate jdbcTemplate,
+                                 CollectionLifecycleManager lifecycleManager) {
+        this.jdbcTemplate = jdbcTemplate;
+        this.lifecycleManager = lifecycleManager;
+    }
+
+    @Override
+    public void run(ApplicationArguments args) {
+        List<Map<String, Object>> collections = jdbcTemplate.queryForList(SELECT_ACTIVE_COLLECTIONS);
+        log.info("Schema bootstrap: applying schema for {} active collections", collections.size());
+
+        // Collect every failure before giving up, so one deploy surfaces the full list of
+        // broken collections instead of leaking them one Job run at a time.
+        List<String> failures = new ArrayList<>();
+
+        for (Map<String, Object> collection : collections) {
+            String collectionId = (String) collection.get("id");
+            String collectionName = (String) collection.get("name");
+            if (collectionId == null) {
+                continue;
+            }
+            try {
+                lifecycleManager.initializeCollectionOrThrow(collectionId, true);
+            } catch (Exception e) {
+                log.error("Schema bootstrap failed for collection '{}' (id={})",
+                        collectionName, collectionId, e);
+                failures.add(collectionName + " (id=" + collectionId + "): " + e.getMessage());
+            }
+        }
+
+        if (!failures.isEmpty()) {
+            throw new IllegalStateException(
+                    "Schema bootstrap failed for " + failures.size() + " of " + collections.size()
+                            + " collections; aborting the migration Job so the worker rollout does "
+                            + "not proceed against an incomplete schema. Failures: " + failures);
+        }
+
+        log.info("Schema bootstrap complete: {} collections applied", collections.size());
+    }
+}

--- a/kelta-worker/src/main/java/io/kelta/worker/service/CollectionLifecycleManager.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/service/CollectionLifecycleManager.java
@@ -156,7 +156,48 @@ public class CollectionLifecycleManager {
      * @param collectionId the collection ID to initialize
      */
     public void initializeCollection(String collectionId) {
-        log.info("Initializing collection: {}", collectionId);
+        initializeCollection(collectionId, true);
+    }
+
+    /**
+     * Initializes a collection on this worker, optionally skipping the storage (DDL) half.
+     *
+     * <p>{@code applySchema=false} registers the definition and its validation rules in this
+     * pod's in-memory state without touching the database schema. Startup bootstrap uses it so
+     * that N worker replicas don't each run {@code CREATE TABLE}/{@code reconcileSchema} for
+     * every collection against the same database — concurrent DDL that the storage adapter can
+     * only paper over after the fact (see its {@code DuplicateKeyException} race handling). The
+     * schema is applied once, ahead of the rollout, by the migrate Job.
+     *
+     * <p>Runtime paths (NATS config events, read-after-write refresh) keep {@code true}: a
+     * collection created after deploy has no Job to lean on and needs its table immediately.
+     *
+     * @param collectionId the collection ID to initialize
+     * @param applySchema whether to create/reconcile the physical table
+     */
+    public void initializeCollection(String collectionId, boolean applySchema) {
+        try {
+            initializeCollectionOrThrow(collectionId, applySchema);
+        } catch (Exception e) {
+            log.error("Failed to initialize collection {}: {}", collectionId, e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Same as {@link #initializeCollection(String, boolean)} but propagates failures instead of
+     * logging them.
+     *
+     * <p>Used by the migrate Job's schema bootstrap, where a failed {@code CREATE TABLE} must
+     * abort the Job so the ArgoCD PreSync hook fails and the worker rollout never starts. On
+     * the request-serving pods the swallowing variant is still right — one broken collection
+     * must not stop the pod from serving the other few hundred.
+     *
+     * @param collectionId the collection ID to initialize
+     * @param applySchema whether to create/reconcile the physical table
+     * @throws RuntimeException if the definition cannot be loaded or the schema cannot be applied
+     */
+    public void initializeCollectionOrThrow(String collectionId, boolean applySchema) {
+        log.info("Initializing collection: {} (applySchema={})", collectionId, applySchema);
 
         if (metricsConfig != null) {
             metricsConfig.getInitializingCount().incrementAndGet();
@@ -194,14 +235,16 @@ public class CollectionLifecycleManager {
             // Register in local registry (makes it available to DynamicCollectionRouter)
             collectionRegistry.register(definition);
 
-            // Set tenant context so the storage adapter uses the correct schema
-            setTenantContextFromRow(collectionRow);
-            try {
-                // Initialize storage (creates database table if needed)
-                // System collections have Flyway-managed tables, so initializeCollection is a no-op for them
-                storageAdapter.initializeCollection(definition);
-            } finally {
-                TenantContext.clear();
+            if (applySchema) {
+                // Set tenant context so the storage adapter uses the correct schema
+                setTenantContextFromRow(collectionRow);
+                try {
+                    // Initialize storage (creates database table if needed)
+                    // System collections have Flyway-managed tables, so initializeCollection is a no-op for them
+                    storageAdapter.initializeCollection(definition);
+                } finally {
+                    TenantContext.clear();
+                }
             }
 
             // Load and register validation rules from DB
@@ -212,8 +255,6 @@ public class CollectionLifecycleManager {
 
             log.info("Successfully initialized collection '{}' (id={})", collectionName, collectionId);
 
-        } catch (Exception e) {
-            log.error("Failed to initialize collection {}: {}", collectionId, e.getMessage(), e);
         } finally {
             if (metricsConfig != null) {
                 metricsConfig.getInitializingCount().decrementAndGet();

--- a/kelta-worker/src/main/java/io/kelta/worker/service/WorkerBootstrapService.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/service/WorkerBootstrapService.java
@@ -3,6 +3,7 @@ package io.kelta.worker.service;
 import io.kelta.worker.config.WorkerProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -15,13 +16,21 @@ import java.util.Map;
  * Bootstraps the worker by loading all active collections from the database on startup.
  *
  * <p>On {@link ApplicationReadyEvent}, queries the database directly for all active
- * collections and initializes each one via {@link CollectionLifecycleManager}.
+ * collections and registers each one via {@link CollectionLifecycleManager}.
  * This ensures every worker can serve every collection, allowing the K8s Service
  * to load-balance requests across all worker pods.
  *
+ * <p><b>Registration only — no DDL.</b> Applying each collection's schema here meant every
+ * replica ran {@code CREATE TABLE}/{@code reconcileSchema} for every collection at the same
+ * time against the same database: the same work N times over, racing itself. Schema is now
+ * applied once by {@link io.kelta.worker.runner.SchemaBootstrapRunner} in the migrate Job,
+ * which ArgoCD runs as a PreSync hook — so by the time these pods start, the tables are
+ * already correct. Set {@code kelta.storage.schema-bootstrap.enabled=true} to restore the old
+ * behaviour (single-pod deployments, or local runs with no migrate Job).
+ *
  * <p>There is no control plane dependency. The worker reads collection definitions
  * directly from the shared database. Runtime schema changes are handled by the
- * existing NATS {@code collection-changed} listener.
+ * existing NATS {@code collection-changed} listener, which still applies DDL.
  *
  * @since 1.0.0
  */
@@ -36,13 +45,17 @@ public class WorkerBootstrapService {
     private final WorkerProperties workerProperties;
     private final JdbcTemplate jdbcTemplate;
     private final CollectionLifecycleManager lifecycleManager;
+    private final boolean applySchema;
 
     public WorkerBootstrapService(WorkerProperties workerProperties,
                                    JdbcTemplate jdbcTemplate,
-                                   CollectionLifecycleManager lifecycleManager) {
+                                   CollectionLifecycleManager lifecycleManager,
+                                   @Value("${kelta.storage.schema-bootstrap.enabled:false}")
+                                   boolean applySchema) {
         this.workerProperties = workerProperties;
         this.jdbcTemplate = jdbcTemplate;
         this.lifecycleManager = lifecycleManager;
+        this.applySchema = applySchema;
     }
 
     /**
@@ -50,7 +63,8 @@ public class WorkerBootstrapService {
      */
     @EventListener(ApplicationReadyEvent.class)
     public void onApplicationReady() {
-        log.info("Worker '{}' starting bootstrap from database", workerProperties.getId());
+        log.info("Worker '{}' starting bootstrap from database (applySchema={})",
+                workerProperties.getId(), applySchema);
 
         try {
             initializeAllCollections();
@@ -77,7 +91,7 @@ public class WorkerBootstrapService {
 
             if (collectionId != null) {
                 try {
-                    lifecycleManager.initializeCollection(collectionId);
+                    lifecycleManager.initializeCollection(collectionId, applySchema);
                 } catch (Exception e) {
                     log.warn("Failed to initialize collection '{}' (id={}): {}",
                             collectionName, collectionId, e.getMessage());

--- a/kelta-worker/src/main/resources/application.yml
+++ b/kelta-worker/src/main/resources/application.yml
@@ -160,6 +160,12 @@ kelta:
       exclude-paths: /actuator,/health
   storage:
     mode: PHYSICAL_TABLES
+    schema-bootstrap:
+      # Whether worker pods apply collection DDL (CREATE TABLE / reconcile) at startup.
+      # Off by default: the migrate Job (PreSync hook, `migrate` profile) owns that work and
+      # runs it once, before any pod rolls out — N replicas doing it concurrently is the same
+      # work N times over, racing itself. Turn on only where no migrate Job runs.
+      enabled: ${KELTA_SCHEMA_BOOTSTRAP_ENABLED:false}
     s3:
       enabled: ${KELTA_S3_ENABLED:false}
       endpoint: ${KELTA_S3_ENDPOINT:http://localhost:3900}

--- a/kelta-worker/src/test/java/io/kelta/worker/runner/SchemaBootstrapRunnerTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/runner/SchemaBootstrapRunnerTest.java
@@ -1,0 +1,117 @@
+package io.kelta.worker.runner;
+
+import io.kelta.worker.service.CollectionLifecycleManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SchemaBootstrapRunner")
+class SchemaBootstrapRunnerTest {
+
+    @Mock
+    private JdbcTemplate jdbcTemplate;
+
+    @Mock
+    private CollectionLifecycleManager lifecycleManager;
+
+    @InjectMocks
+    private SchemaBootstrapRunner runner;
+
+    @Test
+    @DisplayName("applies schema for every active collection")
+    void appliesSchemaForEachCollection() {
+        when(jdbcTemplate.queryForList(anyString())).thenReturn(List.of(
+                Map.of("id", "col-1", "name", "accounts"),
+                Map.of("id", "col-2", "name", "contacts")
+        ));
+
+        assertDoesNotThrow(() -> runner.run(null));
+
+        verify(lifecycleManager).initializeCollectionOrThrow("col-1", true);
+        verify(lifecycleManager).initializeCollectionOrThrow("col-2", true);
+    }
+
+    @Test
+    @DisplayName("throws so the migrate Job fails and the worker rollout never starts")
+    void throwsOnFailureToFailTheJob() {
+        // backoffLimit: 0 on the Job + PreSync hook means this exception is what stops ArgoCD
+        // from rolling out workers against a schema that was never fully applied.
+        when(jdbcTemplate.queryForList(anyString())).thenReturn(List.of(
+                Map.of("id", "col-1", "name", "watchlists")
+        ));
+        doThrow(new RuntimeException("syntax error at or near \"user\""))
+                .when(lifecycleManager).initializeCollectionOrThrow("col-1", true);
+
+        IllegalStateException thrown =
+                assertThrows(IllegalStateException.class, () -> runner.run(null));
+        assertTrue(thrown.getMessage().contains("watchlists"),
+                "the failure must name the offending collection: " + thrown.getMessage());
+    }
+
+    @Test
+    @DisplayName("reports every broken collection in one run, not one per deploy")
+    void collectsAllFailuresBeforeThrowing() {
+        when(jdbcTemplate.queryForList(anyString())).thenReturn(List.of(
+                Map.of("id", "col-1", "name", "watchlists"),
+                Map.of("id", "col-2", "name", "alerts"),
+                Map.of("id", "col-3", "name", "healthy")
+        ));
+        doThrow(new RuntimeException("boom"))
+                .when(lifecycleManager).initializeCollectionOrThrow("col-1", true);
+        doThrow(new RuntimeException("boom"))
+                .when(lifecycleManager).initializeCollectionOrThrow("col-2", true);
+
+        IllegalStateException thrown =
+                assertThrows(IllegalStateException.class, () -> runner.run(null));
+
+        assertTrue(thrown.getMessage().contains("watchlists"), thrown.getMessage());
+        assertTrue(thrown.getMessage().contains("alerts"), thrown.getMessage());
+        // The healthy collection is still attempted rather than skipped after the first failure.
+        verify(lifecycleManager).initializeCollectionOrThrow("col-3", true);
+    }
+
+    @Test
+    @DisplayName("succeeds when there are no collections")
+    void succeedsWithNoCollections() {
+        when(jdbcTemplate.queryForList(anyString())).thenReturn(List.of());
+
+        assertDoesNotThrow(() -> runner.run(null));
+    }
+
+    @Test
+    @DisplayName("runs in the migrate profile, ordered before the runner that exits the JVM")
+    void isOrderedBeforeMigrateShutdown() {
+        // MigrateShutdownRunner calls System.exit(0) once the runners finish. If this one
+        // ever sorts after it, schema bootstrap silently never executes and the Job still
+        // reports success — the exact failure mode this class exists to prevent.
+        org.springframework.context.annotation.Profile profile =
+                SchemaBootstrapRunner.class.getAnnotation(
+                        org.springframework.context.annotation.Profile.class);
+        assertTrue(profile != null && List.of(profile.value()).contains("migrate"),
+                "SchemaBootstrapRunner must be confined to the migrate profile");
+
+        int bootstrapOrder = SchemaBootstrapRunner.class
+                .getAnnotation(org.springframework.core.annotation.Order.class).value();
+        int shutdownOrder = MigrateShutdownRunner.class
+                .getAnnotation(org.springframework.core.annotation.Order.class).value();
+        assertTrue(bootstrapOrder < shutdownOrder,
+                "schema bootstrap (" + bootstrapOrder + ") must run before the JVM exit ("
+                        + shutdownOrder + ")");
+    }
+}

--- a/kelta-worker/src/test/java/io/kelta/worker/service/WorkerBootstrapServiceTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/service/WorkerBootstrapServiceTest.java
@@ -12,6 +12,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import java.util.List;
 import java.util.Map;
 
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
@@ -33,7 +34,9 @@ class WorkerBootstrapServiceTest {
     @BeforeEach
     void setUp() {
         when(workerProperties.getId()).thenReturn("worker-1");
-        service = new WorkerBootstrapService(workerProperties, jdbcTemplate, lifecycleManager);
+        // Production default: pods register collections but do not apply DDL — the migrate
+        // Job owns that, once, before the rollout.
+        service = new WorkerBootstrapService(workerProperties, jdbcTemplate, lifecycleManager, false);
     }
 
     @Test
@@ -46,8 +49,8 @@ class WorkerBootstrapServiceTest {
 
         service.onApplicationReady();
 
-        verify(lifecycleManager).initializeCollection("col-1");
-        verify(lifecycleManager).initializeCollection("col-2");
+        verify(lifecycleManager).initializeCollection("col-1", false);
+        verify(lifecycleManager).initializeCollection("col-2", false);
     }
 
     @Test
@@ -57,7 +60,7 @@ class WorkerBootstrapServiceTest {
 
         service.onApplicationReady();
 
-        verify(lifecycleManager, never()).initializeCollection(anyString());
+        verify(lifecycleManager, never()).initializeCollection(anyString(), anyBoolean());
     }
 
     @Test
@@ -67,12 +70,12 @@ class WorkerBootstrapServiceTest {
                 Map.of("id", "col-1", "name", "accounts"),
                 Map.of("id", "col-2", "name", "contacts")
         ));
-        doThrow(new RuntimeException("init failed")).when(lifecycleManager).initializeCollection("col-1");
+        doThrow(new RuntimeException("init failed")).when(lifecycleManager).initializeCollection("col-1", false);
 
         service.onApplicationReady();
 
-        verify(lifecycleManager).initializeCollection("col-1");
-        verify(lifecycleManager).initializeCollection("col-2");
+        verify(lifecycleManager).initializeCollection("col-1", false);
+        verify(lifecycleManager).initializeCollection("col-2", false);
     }
 
     @Test
@@ -85,7 +88,22 @@ class WorkerBootstrapServiceTest {
 
         service.onApplicationReady();
 
-        verify(lifecycleManager, never()).initializeCollection(anyString());
+        verify(lifecycleManager, never()).initializeCollection(anyString(), anyBoolean());
+    }
+
+    @Test
+    @DisplayName("applies schema at startup only when schema-bootstrap is explicitly enabled")
+    void appliesSchemaWhenEnabled() {
+        // Escape hatch for deployments with no migrate Job (single pod, local runs).
+        WorkerBootstrapService schemaApplying =
+                new WorkerBootstrapService(workerProperties, jdbcTemplate, lifecycleManager, true);
+        when(jdbcTemplate.queryForList(anyString())).thenReturn(List.of(
+                Map.of("id", "col-1", "name", "accounts")
+        ));
+
+        schemaApplying.onApplicationReady();
+
+        verify(lifecycleManager).initializeCollection("col-1", true);
     }
 
     @Test
@@ -96,6 +114,6 @@ class WorkerBootstrapServiceTest {
 
         service.onApplicationReady();
 
-        verify(lifecycleManager, never()).initializeCollection(anyString());
+        verify(lifecycleManager, never()).initializeCollection(anyString(), anyBoolean());
     }
 }


### PR DESCRIPTION
Found in Loki: seven couchpicks collections have thrown `StorageException: Failed to initialize table` on **every worker boot** for months. Since the throw happens before `reconcileSchema`, those collections also stopped picking up later field additions — their physical tables have drifted from their metadata (e.g. `alerts` has a `name` column where the metadata says `user`).

## The three causes

**(a) Column identifiers were emitted unquoted.** A field named `user` — or `order`, `group`, `default`, … — produced `ERROR: syntax error at or near "user"` and killed the entire `CREATE TABLE`. Hits `alerts`, `watchlists`, `click-events`, `search-queries`.

Added `PhysicalTableStorageAdapter.quoteIdentifier` for column *references*, in DDL **and** DML (mirrored in `SchemaMigrationEngine` and `CompositeUniqueConstraintService`). Constraint/index *names* keep bare `sanitizeIdentifier` — they're matched against `pg_constraint.conname` as string literals. Column names are already lower-cased by `toSnakeCase`, so quoting is a no-op for every non-reserved name.

**(b) FK targets assumed the source's schema.** A tenant collection with a LOOKUP to a *system* collection resolved to `"<tenant>"."users"` → `relation does not exist`. Hits `editorial-lists.curator`, `title-matches.reviewer`. The target now gets located via `to_regclass` (source schema, then `public`), and one found in neither is skipped with an actionable warning instead of failing the whole collection.

**(c) One orphaned row blocked the FK forever.** `ADD CONSTRAINT` validated existing rows, so a single dangling reference failed the statement on every boot — leaving the column with *no* referential integrity at all. `couchpicks.availabilities` has exactly 1 such row out of 52,958. FKs are now added `NOT VALID` (enforced for every new write immediately), then validated separately; a validation failure only warns, naming the table and the exact `VALIDATE CONSTRAINT` fix-up.

## Collection DDL moves to deploy time

`WorkerBootstrapService` ran this DDL on `ApplicationReadyEvent`, so all 3 replicas issued `CREATE TABLE`/`reconcileSchema` for every collection concurrently against the same database — the same work N times over, racing itself (the adapter can only paper over the resulting `pg_type` unique violations after the fact).

`SchemaBootstrapRunner` (`@Profile("migrate")`, `@Order(10)`) now applies it once in the migrate Job — already an ArgoCD `PreSync` hook with `backoffLimit: 0` — and **throws** on failure, so the hook fails and the worker rollout never starts against a half-applied schema. The previous code logged the error and started serving traffic against a table that was never created.

Pods now only *register* collections at startup. `kelta.storage.schema-bootstrap.enabled=true` restores the old behaviour for deployments with no migrate Job. Collections created **at runtime** are unaffected — they still get their table on the pod via the NATS `collection.changed` path.

Note `MigrateShutdownRunner`'s `System.exit(0)` at `@Order(Integer.MAX_VALUE)`: the new runner sorts before it, and a test asserts that ordering, since getting it wrong would silently skip schema bootstrap while the Job still reported success.

## Test harness

runtime-core storage tests now build H2 with `DATABASE_TO_LOWER=TRUE`, as `ExternalJdbcStorageAdapterTest` already did. H2 folds unquoted identifiers to **upper** case where PostgreSQL folds to **lower** — without the flag the suite disagrees with production about quoted DDL, and would have passed reserved-word DDL that fails in prod.

## Verification

`/verify` fully green: runtime modules built · gateway 591 tests · worker 2432 tests · kelta-web lint/typecheck/format/1135 tests. New coverage: reserved-word column DDL, FK resolution to public schema, FK skip on missing target, `NOT VALID` + validate ordering, tolerating validation failure, and the runner's fail-the-Job behaviour.

Not included (separate findings from the same log sweep, happy to file): gateway logs `Unknown PAT` on every *successful* PAT request (~10.4k/day, a `Mono<Void>` `switchIfEmpty` trap) and kelta-auth pushes metrics to `localhost:4318` (~1.4k exceptions/day, missing env var in argo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)