### PR TITLE
fix(gateway): stop logging every successful PAT request as an unknown token

### DIFF
--- a/kelta-gateway/src/main/java/io/kelta/gateway/auth/PatAuthenticationFilter.java
+++ b/kelta-gateway/src/main/java/io/kelta/gateway/auth/PatAuthenticationFilter.java
@@ -15,6 +15,7 @@ import org.springframework.data.redis.core.ReactiveStringRedisTemplate;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
 
@@ -96,20 +97,38 @@ public class PatAuthenticationFilter implements GlobalFilter, Ordered {
                         metrics.recordAuthFailure(tenantSlug, "revoked_pat");
                         return unauthorized(exchange, "Token has been revoked");
                     }
-                    // Try Redis first, fall back to worker
+                    // Try Redis first, fall back to worker.
+                    //
+                    // The "unknown token" branch keys off whether the *lookup* produced JSON,
+                    // never off whether the downstream Mono emitted. authenticateWithPat ends in
+                    // chain.filter(...), a Mono<Void> that always completes empty — so hanging a
+                    // switchIfEmpty off it fired on every successful request, logging "Unknown
+                    // PAT" ~10k times a day and recording an unknown_pat auth failure for each,
+                    // which made the metric useless for spotting real ones. (The bogus 401 that
+                    // followed was swallowed only because the response was already committed.)
                     return redisTemplate.opsForValue().get(PAT_KEY_PREFIX + tokenHash)
                             .switchIfEmpty(fetchFromWorker(tokenHash))
-                            .flatMap(patJson -> authenticateWithPat(patJson, exchange, chain, path, tenantSlug))
-                            .switchIfEmpty(Mono.defer(() -> {
+                            .flatMap(patJson ->
+                                    authenticateWithPat(patJson, exchange, chain, path, tenantSlug)
+                                            .thenReturn(Boolean.TRUE))
+                            .defaultIfEmpty(Boolean.FALSE)
+                            .flatMap(recognized -> {
+                                if (Boolean.TRUE.equals(recognized)) {
+                                    return Mono.empty();
+                                }
                                 log.warn("Unknown PAT used for path: {}", path);
                                 metrics.recordAuthFailure(tenantSlug, "unknown_pat");
                                 return unauthorized(exchange, "Invalid or expired token");
-                            }));
+                            });
                 });
     }
 
     /**
      * Fallback: call the worker's PAT validation endpoint.
+     *
+     * <p>A 404 is the worker's normal answer for a token it doesn't know, so it stays at debug.
+     * Anything else — worker down, timeout, 5xx — makes every cache-missing PAT look invalid to
+     * the caller, which is an incident rather than a bad token, so it is logged at warn.
      */
     private Mono<String> fetchFromWorker(String tokenHash) {
         return workerClient.get()
@@ -117,7 +136,13 @@ public class PatAuthenticationFilter implements GlobalFilter, Ordered {
                 .retrieve()
                 .bodyToMono(String.class)
                 .onErrorResume(e -> {
-                    log.debug("Worker PAT validation fallback failed: {}", e.getMessage());
+                    if (e instanceof WebClientResponseException.NotFound) {
+                        log.debug("Worker does not recognise this PAT hash");
+                    } else {
+                        log.warn("Worker PAT validation is failing — PATs missing from the Redis "
+                                + "cache will be rejected as invalid until it recovers: {}",
+                                e.toString());
+                    }
                     return Mono.empty();
                 });
     }

--- a/kelta-gateway/src/test/java/io/kelta/gateway/auth/PatAuthenticationFilterTest.java
+++ b/kelta-gateway/src/test/java/io/kelta/gateway/auth/PatAuthenticationFilterTest.java
@@ -21,7 +21,10 @@ import reactor.test.StepVerifier;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -89,6 +92,63 @@ class PatAuthenticationFilterTest {
         // Filter must complete cleanly — no exception bubbling out.
         StepVerifier.create(filter.filter(exchange, filterChain))
                 .verifyComplete();
+    }
+
+    @Nested
+    @DisplayName("Recognised vs unknown PAT")
+    class TokenRecognition {
+
+        private static final String TOKEN = "klt_valid_token";
+        private static final String HASH = PatAuthenticationFilter.sha256(TOKEN);
+        private static final String PAT_JSON = """
+                {"userId":"u-1","tenantId":"t-1","email":"a@b.c","scopes":"[\\"api\\"]"}""";
+
+        private MockServerWebExchange exchangeFor(String path) {
+            return MockServerWebExchange.from(MockServerHttpRequest
+                    .get(path)
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + TOKEN)
+                    .build());
+        }
+
+        @Test
+        @DisplayName("a cache hit authenticates and records no auth failure")
+        void cacheHitDoesNotReportUnknownPat() {
+            // Regression: authenticateWithPat ends in chain.filter(...), a Mono<Void> that
+            // always completes empty, so a switchIfEmpty hung off it fired on every SUCCESSFUL
+            // request — ~10k bogus "Unknown PAT" warnings a day, each recording an unknown_pat
+            // auth failure and poisoning the metric that security alerting keys on.
+            when(redisTemplate.opsForValue()).thenReturn(valueOps);
+            when(valueOps.get("pat:revoked:" + HASH)).thenReturn(Mono.empty());
+            when(valueOps.get("pat:" + HASH)).thenReturn(Mono.just(PAT_JSON));
+
+            MockServerWebExchange exchange = exchangeFor("/api/titles");
+
+            StepVerifier.create(filter.filter(exchange, filterChain)).verifyComplete();
+
+            verify(filterChain).filter(any(ServerWebExchange.class));
+            verify(metrics, never()).recordAuthFailure(any(), eq("unknown_pat"));
+            assertThat(exchange.getResponse().getStatusCode()).isNull();
+            assertThat(exchange.getAttributes()).containsKey("gateway.principal");
+        }
+
+        @Test
+        @DisplayName("a token in neither Redis nor the worker is rejected as unknown")
+        void unknownTokenIsRejected() {
+            when(redisTemplate.opsForValue()).thenReturn(valueOps);
+            when(valueOps.get("pat:revoked:" + HASH)).thenReturn(Mono.empty());
+            // Empty cache; the worker fallback also yields nothing (WebClient points at a
+            // dead local port, and fetchFromWorker maps any error to empty).
+            when(valueOps.get("pat:" + HASH)).thenReturn(Mono.empty());
+
+            MockServerWebExchange exchange = exchangeFor("/api/titles");
+
+            StepVerifier.create(filter.filter(exchange, filterChain)).verifyComplete();
+
+            verify(filterChain, never()).filter(any(ServerWebExchange.class));
+            verify(metrics).recordAuthFailure(any(), eq("unknown_pat"));
+            assertThat(exchange.getResponse().getStatusCode())
+                    .isEqualTo(org.springframework.http.HttpStatus.UNAUTHORIZED);
+        }
     }
 
     @Nested


### PR DESCRIPTION
Found in Loki: `Unknown PAT used for path: ...` fires ~10,400×/day, sustained for at least 3 days. The requests it warns about are **succeeding** — the gateway WARN at `19:48:34.160`/`.241` for `/api/titles` lines up exactly with the worker running `SELECT * FROM "couchpicks"."titles" WHERE id = ?` twice at `19:48:34`. The worker's `/api/me/tokens/validate` endpoint saw **zero** calls in 3h, confirming these are Redis cache hits that authenticated fine.

## Cause

```java
.flatMap(patJson -> authenticateWithPat(patJson, exchange, chain, path, tenantSlug))
.switchIfEmpty(Mono.defer(() -> { /* Unknown PAT */ }));
```

`authenticateWithPat` ends in `chain.filter(...)` — a `Mono<Void>`, which always completes empty. So the `switchIfEmpty` fired on every successful request.

Three consequences, in increasing order of how much they matter:
1. ~10.4k junk WARNs/day.
2. Every one also called `metrics.recordAuthFailure(tenantSlug, "unknown_pat")`, so that counter is pure noise — any security alert keyed on unknown-token spikes is dead.
3. `unauthorized(...)` then ran on an already-authenticated request. It was swallowed only because `ResponseHelpers.prepareJsonResponse` sees the response already committed and bails; a downstream that completed *without* committing would have gotten a spurious 401.

The unknown-token branch now keys off whether the **lookup** produced JSON, not off whether the downstream `Mono` emitted.

## Also

`fetchFromWorker` swallowed every failure at `debug`. A 404 is the worker's normal answer for a token it doesn't recognise and stays at debug, but anything else — worker down, timeout, 5xx — silently turns *every* cache-missing PAT into "invalid token" for the caller. That's an incident, not a bad token, so it now logs at `warn` naming the consequence.

## Tests

Two new cases in `PatAuthenticationFilterTest`. The first fails on the old code:
- cache hit → chain proceeds, principal set, **no** `unknown_pat` failure recorded, no status set
- token in neither Redis nor worker → chain never invoked, `unknown_pat` recorded, 401

Gateway suite green: 593 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)