### PR TITLE
fix(runtime): scope the FK existence check to its table, not the database

### DIFF
--- a/.claude/docs/concerns.md
+++ b/.claude/docs/concerns.md
@@ -528,6 +528,26 @@ additions either — the physical table silently drifts from its metadata.
   integrity at all. Fix: add `NOT VALID` (enforced for all new writes immediately), then a
   separate `VALIDATE CONSTRAINT` that only warns, naming the table and the exact fix-up command.
 
+**FIXED (fix/fk-existence-check-scoped-to-table) — FK existence check was global, so only the
+first tenant with a given collection+field pair ever got its foreign key.** The idempotence guard
+was `IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = '<fk>')` — unqualified, so it
+searched every schema. `conname` is unique per *table*, not per database, and generated FK names
+derive from collection + field names, which repeat across tenants: every tenant with an `orders`
+collection and a `customer` field generates `fk_orders_customer`. The first tenant to initialize
+claimed the name; every tenant after it matched that row and silently skipped its own
+`ADD CONSTRAINT`. Surfaced by the `VALIDATE CONSTRAINT` step added above, which then failed with
+`constraint … does not exist` — a **25-constraint** gap across 5 tenants in the homelab at the
+time of the fix. Fix: `AND conrelid = to_regclass('<qualified source table>')`. Missing FKs are
+created automatically on the next migrate-Job run. The validate-failure warning also now only
+blames orphaned rows when the cause is genuinely a `DataIntegrityViolationException`.
+
+**Open (not a regression) — the `users` system collection has no physical table.** Six couchpicks
+reference fields (`alerts.user`, `watchlists.user`, `click-events.user`, `search-queries.user`,
+`editorial-lists.curator`, `title-matches.reviewer`) point at the `users` system collection, whose
+table exists in no schema — the platform's user table is `platform_user`. Their FKs are now
+skipped with a warning rather than failing the collection, but they will never be created until
+the collection's `storageConfig.tableName` maps to the real table or the references are repointed.
+
 **Test-harness note:** the runtime-core storage tests now build H2 with `DATABASE_TO_LOWER=TRUE`
 (as `ExternalJdbcStorageAdapterTest` already did). H2 folds unquoted identifiers to *upper* case
 while PostgreSQL folds to *lower*; without the flag, quoted-lowercase DDL wouldn't match the

--- a/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/storage/PhysicalTableStorageAdapter.java
+++ b/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/storage/PhysicalTableStorageAdapter.java
@@ -16,6 +16,7 @@ import io.kelta.runtime.validation.TypeCoercionService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.dao.DataAccessException;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
@@ -347,9 +348,17 @@ public class PhysicalTableStorageAdapter implements StorageAdapter {
             return;
         }
 
+        // The existence check MUST be scoped to this table. `conname` is unique per table, not
+        // per database, and generated FK names are derived from collection + field names — which
+        // repeat across tenants (every tenant with an `orders` collection and a `customer` field
+        // generates fk_orders_customer). An unqualified `WHERE conname = ...` matched some other
+        // tenant's constraint and skipped creating this one, so only the first tenant to
+        // initialize ever got its foreign key; every tenant after it silently ran with no
+        // referential integrity on that column.
         jdbcTemplate.execute(
                 "DO $$ BEGIN "
-                + "IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = '" + fk.fkName() + "') THEN "
+                + "IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = '" + fk.fkName() + "'"
+                + " AND conrelid = to_regclass('" + fk.sourceTable() + "')) THEN "
                 + "ALTER TABLE " + fk.sourceTable()
                 + " ADD CONSTRAINT " + fk.fkName()
                 + " FOREIGN KEY (" + fk.sourceColumn() + ")"
@@ -361,11 +370,20 @@ public class PhysicalTableStorageAdapter implements StorageAdapter {
             jdbcTemplate.execute("ALTER TABLE " + fk.sourceTable()
                     + " VALIDATE CONSTRAINT " + fk.fkName());
         } catch (DataAccessException e) {
-            log.warn("Foreign key '{}' on '{}' is enforced for new writes but could not be validated "
-                    + "against existing rows — the table holds orphaned references to '{}'. Clean them "
-                    + "up (or null them out), then run: ALTER TABLE {} VALIDATE CONSTRAINT {}. Cause: {}",
-                    fk.fkName(), fk.sourceTable(), fk.targetTableName(),
-                    fk.sourceTable(), fk.fkName(), e.getMostSpecificCause().getMessage());
+            // Only an integrity violation means orphaned rows; anything else (a missing
+            // constraint, a lock timeout) would be misdiagnosed by that advice.
+            String cause = e.getMostSpecificCause().getMessage();
+            if (e instanceof DataIntegrityViolationException) {
+                log.warn("Foreign key '{}' on '{}' is enforced for new writes but could not be "
+                        + "validated against existing rows — the table holds orphaned references "
+                        + "to '{}'. Clean them up (or null them out), then run: "
+                        + "ALTER TABLE {} VALIDATE CONSTRAINT {}. Cause: {}",
+                        fk.fkName(), fk.sourceTable(), fk.targetTableName(),
+                        fk.sourceTable(), fk.fkName(), cause);
+            } else {
+                log.warn("Could not validate foreign key '{}' on '{}': {}",
+                        fk.fkName(), fk.sourceTable(), cause);
+            }
         }
     }
 

--- a/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/storage/PhysicalTableStorageAdapterSystemCollectionTest.java
+++ b/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/storage/PhysicalTableStorageAdapterSystemCollectionTest.java
@@ -326,6 +326,21 @@ class PhysicalTableStorageAdapterSystemCollectionTest {
         }
 
         @Test
+        @DisplayName("Should scope the FK existence check to this table, not the whole database")
+        void initializeCollection_scopesForeignKeyExistenceCheck_toTable() {
+            // conname is unique per table, not per database, and generated FK names derive from
+            // collection + field names — which repeat across tenants. An unqualified
+            // `WHERE conname = ...` matched another tenant's constraint and skipped creating
+            // this one, so only the first tenant to initialize ever got its foreign key.
+            adapter.initializeCollection(buildCollectionWithLookupTo("users"));
+
+            verify(jdbcTemplate).execute(argThat((String sql) ->
+                    sql.contains("ADD CONSTRAINT")
+                            && sql.contains("conname = 'fk_watchlists_owner'")
+                            && sql.contains("conrelid = to_regclass(")));
+        }
+
+        @Test
         @DisplayName("Should keep the FK enforced when validation fails on existing rows")
         void initializeCollection_toleratesValidateFailure_onOrphanedRows() {
             doThrow(new org.springframework.dao.DataIntegrityViolationException(


### PR DESCRIPTION
Found while verifying #1336 in production. The migrate Job logged:

```
Foreign key 'fk_orders_customer' on '"test3"."orders"' is enforced for new writes but could not
be validated ... Cause: ERROR: constraint "fk_orders_customer" of relation "orders" does not exist
```

The constraint didn't exist because it was never created. `fk_orders_customer` lives in `threadline-clothing`:

```
       schema        | table  |      conname       | convalidated
---------------------+--------+--------------------+--------------
 threadline-clothing | orders | fk_orders_customer | t
```

## Cause

```sql
IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'fk_orders_customer') THEN ...
```

Unqualified, so it searches **every schema**. `conname` is unique per *table*, not per database, and generated FK names derive from collection + field names — which repeat across tenants. Every tenant with an `orders` collection and a `customer` field generates the same `fk_orders_customer`. The first tenant to initialize claimed the name; every tenant after it matched that row and silently skipped its own `ADD CONSTRAINT`.

Net effect: **for any collection+field name pair shared by two tenants, only one tenant has referential integrity on that column.** A survey of the homelab found **25 such constraints missing across 5 tenants** (`test3`, `telehealth`, `summit-comfort`, `threadline-clothing`, `couchpicks`) — `fk_orders_customer`, `fk_payments_order_id`, `fk_products_category`, `fk_inventory_product` and 21 more.

This predates #1336; the `VALIDATE CONSTRAINT` step added there is simply what made it visible, since a skipped constraint can't be validated.

## Fix

`AND conrelid = to_regclass('<qualified source table>')`. The missing constraints are created automatically on the next migrate-Job run — as `NOT VALID` first, so a tenant carrying orphaned rows gets the constraint enforced going forward rather than a failed deploy.

Also corrected the validate-failure warning: it told every caller to go clean up orphaned rows, which is only right for a `DataIntegrityViolationException`. A missing constraint or a lock timeout now logs the plain cause.

## Verification

runtime-core 1479 tests · worker 2432 tests. New test asserts the guard carries both `conname` and `conrelid = to_regclass(...)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)