### PR TITLE
fix(runtime): stop runtime-core forcing JDBC DEBUG on every consuming service

### DIFF
--- a/.claude/docs/concerns.md
+++ b/.claude/docs/concerns.md
@@ -507,6 +507,20 @@ keep the raw name via `TableRef` quoting. Watch-out for future DDL: never pass a
 name into `sanitizeIdentifier` directly — names go through `identifierPart`, references
 through `TableRef`.
 
+**FIXED (fix/runtime-core-forcing-jdbc-debug) — a library jar was setting production log levels.**
+`runtime-core/src/main/resources/application.properties` is packaged *inside the jar*, so Spring
+Boot loads it as application configuration for every service that depends on runtime-core —
+**kelta-worker, kelta-ai, kelta-mcp, kelta-auth** (kelta-gateway does not depend on it). It
+carried `logging.level.org.springframework.jdbc=DEBUG`, which put every prepared statement and
+connection fetch into production logs: **493k lines/day on kelta-worker, ~92% of the platform's
+entire log volume**, with full SQL text landing in Loki. It read as a worker problem for months
+precisely because the setting isn't in kelta-worker — worker's own `logback-spring.xml` says
+`<root level="INFO">` and its `application.yml` sets no `logging.*` at all. Gateway looked healthy
+for the same reason: no runtime-core dependency. Guarded by
+`RuntimeCoreDefaultPropertiesTest`. **Never put operational settings in that file** — it still
+ships datasource credentials, Hikari pool sizes, Redis host and actuator exposure, every one of
+which silently becomes a consuming service's value unless that service overrides it.
+
 **FIXED (fix/schema-bootstrap-in-migrate-job) — three ways `initializeCollection` could abort a
 collection permanently.** All three were found in Loki: seven couchpicks collections threw
 `StorageException: Failed to initialize table` on *every* worker boot for months. Because the

--- a/kelta-platform/runtime/runtime-core/src/main/resources/application.properties
+++ b/kelta-platform/runtime/runtime-core/src/main/resources/application.properties
@@ -1,4 +1,14 @@
 # Kelta Runtime Core - Default Configuration
+#
+# WARNING: this file is packaged INSIDE the runtime-core jar, so Spring Boot loads it as
+# application configuration for every service that depends on runtime-core -- currently
+# kelta-worker, kelta-ai, kelta-mcp and kelta-auth (kelta-gateway does not depend on it). Any
+# property here silently becomes that service's value unless the service sets it itself.
+#
+# Do NOT add operational settings here. A `logging.level.org.springframework.jdbc=DEBUG` left
+# in this file put every JDBC statement into production logs: 493k lines/day on kelta-worker,
+# ~92% of the platform's entire log volume, full SQL text included. It looked like a worker
+# problem for months precisely because the setting does not live in kelta-worker.
 
 # Query Engine Configuration
 kelta.query.default-page-size=20
@@ -26,6 +36,6 @@ spring.data.redis.port=6379
 management.endpoints.web.exposure.include=health,info,metrics
 management.endpoint.health.show-details=when_authorized
 
-# Logging Configuration
-logging.level.io.kelta.runtime=INFO
-logging.level.org.springframework.jdbc=DEBUG
+# Logging: deliberately none. A library must not choose log levels for its consumers --
+# each service sets its own in logback-spring.xml, overridable per deployment via
+# LOGGING_LEVEL_* env vars.

--- a/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/config/RuntimeCoreDefaultPropertiesTest.java
+++ b/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/config/RuntimeCoreDefaultPropertiesTest.java
@@ -1,0 +1,63 @@
+package io.kelta.runtime.config;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.InputStream;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Guards the defaults that runtime-core ships inside its jar.
+ *
+ * <p>{@code application.properties} packaged in a library is loaded by Spring Boot as
+ * application configuration for every service that depends on it — kelta-worker, kelta-ai,
+ * kelta-mcp and kelta-auth. Anything added here silently becomes those services' behaviour,
+ * and looks like their bug rather than this module's.
+ *
+ * <p>This is not hypothetical: a stray {@code logging.level.org.springframework.jdbc=DEBUG}
+ * lived here long enough to put every SQL statement into production logs — 493k lines a day
+ * on kelta-worker alone, roughly 92% of the platform's total log volume.
+ */
+@DisplayName("runtime-core packaged defaults")
+class RuntimeCoreDefaultPropertiesTest {
+
+    private Properties load() throws Exception {
+        Properties props = new Properties();
+        try (InputStream in = getClass().getClassLoader().getResourceAsStream("application.properties")) {
+            if (in == null) {
+                return props; // file removed entirely — also fine
+            }
+            props.load(in);
+        }
+        return props;
+    }
+
+    @Test
+    @DisplayName("does not set log levels for consuming services")
+    void shipsNoLoggingLevels() throws Exception {
+        Properties props = load();
+        for (String key : props.stringPropertyNames()) {
+            if (key.startsWith("logging.")) {
+                fail("runtime-core's application.properties must not set '" + key + "'. It is "
+                        + "packaged in the jar, so it silently overrides log levels for every "
+                        + "service that depends on runtime-core. Each service owns its own "
+                        + "levels via logback-spring.xml / LOGGING_LEVEL_* env vars.");
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("does not enable debug logging for any package")
+    void shipsNoDebugLevels() throws Exception {
+        Properties props = load();
+        for (String key : props.stringPropertyNames()) {
+            String value = props.getProperty(key);
+            assertTrue(value == null || !value.equalsIgnoreCase("DEBUG") && !value.equalsIgnoreCase("TRACE"),
+                    "runtime-core's application.properties sets " + key + "=" + value
+                            + ", which turns on verbose logging for every consuming service");
+        }
+    }
+}


### PR DESCRIPTION
`kelta-worker` emits **493,275 log lines/day** — ~**92%** of all emf log volume (538k total) — almost entirely `Executing prepared SQL statement [...]` and `Fetching JDBC Connection from DataSource`, with full SQL text stored in Loki.

## Not where you'd look for it

I initially assumed a GraalVM/logback quirk in the worker. Wrong. Worker's own config is innocent:
- `kelta-worker/.../logback-spring.xml` → `<root level="INFO">`
- `kelta-worker/.../application.yml` → no `logging.*` at all

The setting lives in **`runtime-core`**:

```properties
# runtime-core/src/main/resources/application.properties
logging.level.org.springframework.jdbc=DEBUG
```

That file is packaged *inside the library jar*, and Spring Boot loads a classpath `application.properties` as application configuration. So it applies to every service depending on runtime-core: **kelta-worker, kelta-ai, kelta-mcp, kelta-auth**.

Two independent facts confirm it:
- **kelta-gateway is clean** — identical `<root level="INFO">`, no `logging.*` — and it is the only service with **no** runtime-core dependency.
- The `emf-worker-migrate` **JVM** image logs DEBUG too, so this was never native-image related. Same jar, same classpath.

The DEBUG loggers observed in Loki are exactly `org.springframework.jdbc.core.JdbcTemplate` and `org.springframework.jdbc.datasource.DataSourceUtils` — both under `org.springframework.jdbc`, and nothing else. Root really was INFO the whole time.

## Fix

Removed the logging block. `RuntimeCoreDefaultPropertiesTest` fails the build if any `logging.*` key or `DEBUG`/`TRACE` value reappears there.

The file keeps a header explaining why: it still ships `spring.datasource.{url,username,password}`, Hikari pool sizes, `spring.data.redis.host` and `management.endpoints.web.exposure.include`, **each of which silently becomes a consuming service's value unless that service overrides it.** I left those alone — changing datasource/actuator defaults for four services is not this PR's business — but they're now flagged in `concerns.md`.

## Verification

runtime-core 1480 · worker 2432 · ai 141 · mcp 221 · auth 343 — all green.

Expect worker log volume to drop by roughly 20× after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)