### PR TITLE
fix(runtime): resolve FK targets to the system collection's real table

### DIFF
--- a/.claude/docs/concerns.md
+++ b/.claude/docs/concerns.md
@@ -555,12 +555,19 @@ time of the fix. Fix: `AND conrelid = to_regclass('<qualified source table>')`. 
 created automatically on the next migrate-Job run. The validate-failure warning also now only
 blames orphaned rows when the cause is genuinely a `DataIntegrityViolationException`.
 
-**Open (not a regression) — the `users` system collection has no physical table.** Six couchpicks
-reference fields (`alerts.user`, `watchlists.user`, `click-events.user`, `search-queries.user`,
-`editorial-lists.curator`, `title-matches.reviewer`) point at the `users` system collection, whose
-table exists in no schema — the platform's user table is `platform_user`. Their FKs are now
-skipped with a warning rather than failing the collection, but they will never be created until
-the collection's `storageConfig.tableName` maps to the real table or the references are repointed.
+**FIXED (fix/fk-target-system-collection-table) — FK targets used the collection name as the table
+name.** `ReferenceConfig` names the target *collection*; the adapter passed that straight through
+as a table name. For tenant collections the two are always identical
+(`CollectionLifecycleManager` builds `StorageConfig.physicalTable(collectionName)`), but a
+**system** collection maps onto its Flyway table — `users` → `platform_user`, `page-layouts` →
+`page_layout`, and ~40 more. So *any* LOOKUP at a system collection resolved to a table that has
+never existed. Symptom: six couchpicks fields (`alerts.user`, `watchlists.user`,
+`click-events.user`, `search-queries.user`, `editorial-lists.curator`, `title-matches.reviewer`)
+logged `target table 'users' does not exist` on every migrate-Job run. Fix:
+`SYSTEM_COLLECTION_TABLES`, built once from `SystemCollectionDefinitions.byName()`, resolves the
+real table. **Candidate order matters and is tested** — tenant schema under the raw name is tried
+*first*, so a tenant collection legitimately named `users` still wins in its own schema instead of
+being redirected to `platform_user`.
 
 **Test-harness note:** the runtime-core storage tests now build H2 with `DATABASE_TO_LOWER=TRUE`
 (as `ExternalJdbcStorageAdapterTest` already did). H2 folds unquoted identifiers to *upper* case

--- a/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/storage/PhysicalTableStorageAdapter.java
+++ b/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/storage/PhysicalTableStorageAdapter.java
@@ -76,6 +76,19 @@ public class PhysicalTableStorageAdapter implements StorageAdapter {
         "record_type_id", "created_geo", "updated_geo"
     );
 
+    /**
+     * Physical table name for each system collection, keyed by collection name.
+     *
+     * <p>Only system collections need this: a tenant collection's storage config always names the
+     * table after the collection, whereas a system collection maps onto its Flyway-managed table
+     * ({@code users} → {@code platform_user}). Used to resolve foreign keys whose target is a
+     * system collection — see {@link #resolveTargetTable}.
+     */
+    private static final Map<String, String> SYSTEM_COLLECTION_TABLES =
+            io.kelta.runtime.model.system.SystemCollectionDefinitions.byName().entrySet().stream()
+                    .collect(Collectors.toUnmodifiableMap(
+                            Map.Entry::getKey, e -> getBaseTableName(e.getValue())));
+
     private final JdbcTemplate jdbcTemplate;
     private final SchemaMigrationEngine migrationEngine;
     private final tools.jackson.databind.ObjectMapper objectMapper;
@@ -388,14 +401,37 @@ public class PhysicalTableStorageAdapter implements StorageAdapter {
     }
 
     /**
-     * Locates the table a foreign key should reference: the source's own schema first, then
-     * {@code public} (where system collections live). Returns {@code null} when neither holds it.
+     * Locates the table a foreign key should reference.
+     *
+     * <p>A {@code ReferenceConfig} names the target <em>collection</em>, not its table. For tenant
+     * collections those are always the same string, but a **system** collection stores in a
+     * Flyway-managed table whose name usually differs — {@code users} lives in
+     * {@code platform_user}, {@code page-layouts} in {@code page_layout}, and so on for 40-odd
+     * others. Taking the collection name as the table name meant any LOOKUP pointing at a system
+     * collection resolved to a table that has never existed.
+     *
+     * <p>Candidates are tried in order:
+     * <ol>
+     *   <li>the source's own schema under the raw target name — a tenant collection that happens
+     *       to share a name with a system one must still win in its own schema;</li>
+     *   <li>{@code public} under the system collection's real table name, when the target is a
+     *       known system collection;</li>
+     *   <li>{@code public} under the raw name, covering system collections whose name already
+     *       matches their table and sources that live in public themselves.</li>
+     * </ol>
+     *
+     * @return the first candidate that exists, or {@code null} when none do
      */
     private TableRef resolveTargetTable(PendingForeignKey fk) {
-        List<TableRef> candidates = fk.sourceRef().isPublicSchema()
-                ? List.of(TableRef.publicSchema(fk.targetTableName()))
-                : List.of(TableRef.tenantSchema(fk.sourceRef().schema(), fk.targetTableName()),
-                          TableRef.publicSchema(fk.targetTableName()));
+        List<TableRef> candidates = new ArrayList<>();
+        if (!fk.sourceRef().isPublicSchema()) {
+            candidates.add(TableRef.tenantSchema(fk.sourceRef().schema(), fk.targetTableName()));
+        }
+        String systemTable = SYSTEM_COLLECTION_TABLES.get(fk.targetTableName());
+        if (systemTable != null && !systemTable.equals(fk.targetTableName())) {
+            candidates.add(TableRef.publicSchema(systemTable));
+        }
+        candidates.add(TableRef.publicSchema(fk.targetTableName()));
 
         for (TableRef candidate : candidates) {
             Boolean exists = jdbcTemplate.queryForObject(

--- a/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/storage/PhysicalTableStorageAdapterSystemCollectionTest.java
+++ b/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/storage/PhysicalTableStorageAdapterSystemCollectionTest.java
@@ -270,7 +270,7 @@ class PhysicalTableStorageAdapterSystemCollectionTest {
         }
 
         @Test
-        @DisplayName("Should fall back to the public schema when the FK target is a system collection")
+        @DisplayName("Should fall back to the public schema when the target is not in the tenant's")
         void initializeCollection_resolvesForeignKeyTarget_inPublicSchema() {
             // A tenant collection may point a LOOKUP at a system collection, whose table is
             // Flyway-managed and lives in public — not alongside the source. Assuming
@@ -285,11 +285,54 @@ class PhysicalTableStorageAdapterSystemCollectionTest {
                     .thenReturn(false)
                     .thenReturn(true);
 
+            // A non-system target, so the raw name is the table name in both schemas.
+            io.kelta.runtime.context.TenantContext.runWithTenant("tenant-1", "acme", () ->
+                    adapter.initializeCollection(buildCollectionWithLookupTo("archived_orders")));
+
+            verify(jdbcTemplate).execute(argThat((String sql) ->
+                    sql.contains("FOREIGN KEY") && sql.contains("REFERENCES archived_orders")));
+        }
+
+        @Test
+        @DisplayName("Should map a system-collection FK target to its real table (users → platform_user)")
+        void initializeCollection_resolvesSystemCollectionTarget_toItsPhysicalTable() {
+            // ReferenceConfig names the target COLLECTION, not its table. Tenant collections make
+            // those identical, but a system collection maps onto its Flyway-managed table, so
+            // `users` is stored in `platform_user` — a table named `users` exists nowhere. Taking
+            // the collection name as the table name left every LOOKUP at a system collection
+            // pointing at a table that never existed.
+            reset(jdbcTemplate);
+            when(jdbcTemplate.queryForObject(anyString(), eq(Integer.class), any(Object[].class)))
+                    .thenReturn(1);
+            when(jdbcTemplate.queryForObject(anyString(), eq(Boolean.class), any(Object[].class)))
+                    .thenReturn(false)   // no tenant-local `users` collection…
+                    .thenReturn(true);   // …so the system mapping in public wins
+
             io.kelta.runtime.context.TenantContext.runWithTenant("tenant-1", "acme", () ->
                     adapter.initializeCollection(buildCollectionWithLookupTo("users")));
 
             verify(jdbcTemplate).execute(argThat((String sql) ->
-                    sql.contains("FOREIGN KEY") && sql.contains("REFERENCES users")));
+                    sql.contains("FOREIGN KEY") && sql.contains("REFERENCES platform_user")));
+        }
+
+        @Test
+        @DisplayName("Should prefer a tenant's own table over the system mapping of the same name")
+        void initializeCollection_prefersTenantTable_overSystemMapping() {
+            // A tenant collection is allowed to be called `users`; its own table must win in its
+            // own schema rather than being redirected to the platform's user table.
+            reset(jdbcTemplate);
+            when(jdbcTemplate.queryForObject(anyString(), eq(Integer.class), any(Object[].class)))
+                    .thenReturn(1);
+            when(jdbcTemplate.queryForObject(anyString(), eq(Boolean.class), any(Object[].class)))
+                    .thenReturn(true);   // first candidate = tenant schema, raw name
+
+            io.kelta.runtime.context.TenantContext.runWithTenant("tenant-1", "acme", () ->
+                    adapter.initializeCollection(buildCollectionWithLookupTo("users")));
+
+            verify(jdbcTemplate).execute(argThat((String sql) ->
+                    sql.contains("FOREIGN KEY")
+                            && sql.contains("REFERENCES \"acme\".\"users\"")
+                            && !sql.contains("platform_user")));
         }
 
         @Test


### PR DESCRIPTION
The migrate Job has been logging this on every run since #1336 deployed:

```
Skipping foreign key 'fk_alerts_user' on collection 'alerts': target table 'users'
does not exist in schema 'couchpicks' or 'public'.
```

The metadata is fine — `SystemCollectionDefinitions.users()` is `systemBuilder("users", "Users", "platform_user")`. The resolution was wrong.

## Cause

`ReferenceConfig` names the target **collection**; the adapter used that string as a **table** name. For tenant collections they're always identical — `CollectionLifecycleManager` builds `StorageConfig.physicalTable(collectionName)`, so a tenant collection's table is always named after it. But a **system** collection maps onto its Flyway-managed table:

```
users        -> platform_user      page-layouts  -> page_layout
tenants      -> tenant             list-views    -> list_view
profiles     -> profile            validation-rules -> validation_rule        (~40 more)
```

So **any** LOOKUP at **any** system collection resolved to a table that has never existed. Before #1336 that failed the whole collection's initialization; after #1336 it's a skip-with-warning, which is how it became visible.

In production this is six couchpicks fields with no FK: `alerts.user`, `watchlists.user`, `click-events.user`, `search-queries.user`, `editorial-lists.curator`, `title-matches.reviewer`.

## Fix

`SYSTEM_COLLECTION_TABLES` — built once from `SystemCollectionDefinitions.byName()`, same module, no new dependency or bean wiring, and no ordering hazard from the registry not being populated yet at bootstrap.

**Candidate order is the subtle part**, and it's tested:

1. tenant schema, raw name — a tenant collection legitimately named `users` must win in its own schema, not get redirected to `platform_user`
2. `public`, system table name — the fix
3. `public`, raw name — system collections whose name already matches their table

## Tests

runtime-core 1480 · worker 2432. Three cases: `users` → `platform_user`; a tenant's own `users` table beating the system mapping; and the raw-name-in-public fallback.

One existing test changed: it asserted `users` resolves to a table called `users`. That expectation was the bug written down, so it's repointed at a non-system target where it still covers candidate 3.

Independent of #1338 (different method), so these two can merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)