### PR TITLE
chore(ci): run kelta-ui lint, format check and unit tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,6 +221,31 @@ jobs:
         working-directory: kelta-ui/app
         run: npm run typecheck
 
+      - name: Lint kelta-ui
+        working-directory: kelta-ui/app
+        run: npm run lint
+
+      - name: Format check kelta-ui
+        working-directory: kelta-ui/app
+        run: npm run format:check
+
+      # kelta-ui/app's 2657 unit tests (221 files) had never run in CI — the job's
+      # `defaults.run.working-directory: kelta-web` meant every step above only ever
+      # covered the SDK workspace. Like the typecheck, this must stay after the
+      # kelta-web package build: components imported from a stale @kelta/components
+      # dist render as `undefined` and 27 test files fail on "Element type is invalid".
+      #
+      # Gates the job (a failure here is a red CI run). Local wall time is ~1 min, but
+      # this job shares the runner with the Java matrix and the e2e image builds, and
+      # the frontend suite has starved under that kind of contention before
+      # (concerns.md → "Frontend suite starves under concurrent image builds"), so the
+      # step timeout is deliberately generous. kelta-ui/app already sets a 30s
+      # testTimeout/hookTimeout in vitest.config.ts, which covers the per-test half.
+      - name: Test kelta-ui
+        working-directory: kelta-ui/app
+        run: npm run test:run
+        timeout-minutes: 15
+
       - name: Upload coverage report
         continue-on-error: true
         if: always()


### PR DESCRIPTION
## Summary

The `test-frontend` job sets `defaults.run.working-directory: kelta-web`, so its Lint / Type check / Format check / `test:coverage` steps only ever covered the SDK workspace. **kelta-ui/app's lint and its 2657 unit tests (221 files) have never run in CI** — the same blind spot that let 22 TypeScript errors accumulate on main before #1347 added the typecheck step.

This closes the rest of the gap:

- `Lint kelta-ui` — `npm run lint`
- `Format check kelta-ui` — `npm run format:check`
- `Test kelta-ui` — `npm run test:run`

All three set `working-directory: kelta-ui/app` explicitly and sit after the existing `Type check kelta-ui` step, so they inherit its `npm ci`.

## Step ordering is load-bearing

kelta-ui/app resolves `@kelta/*` through the **built** `dist/` of the kelta-web packages, so the new steps must stay after `Build kelta-web packages (kelta-ui type resolution)`. This is not just a typecheck concern — running the suite against a stale `dist` fails **27 test files** with:

```
Element type is invalid: expected a string ... but got: undefined.
Check the render method of `ChatPanelLive`.
```

because the components resolve to `undefined`. After building the packages, 221/221 files pass. Verified both ways locally.

## CI runtime

Gates the job — a failure is a red CI run.

| Step | Local wall time |
|------|-----------------|
| `lint` | 27s (0 errors, 13 `react-hooks`/`jsx-a11y` warnings; no `--max-warnings`, so warnings don't gate) |
| `format:check` | 7s |
| `test:run` | 59s wall / 287s CPU — 2657 passed, 34 skipped |

`Test kelta-ui` gets `timeout-minutes: 15` rather than the ~1 min it actually needs. Per `concerns.md` → "Frontend suite starves under concurrent image builds (2026-08-06)", this job shares a runner with the Java matrix and the e2e image builds, and under that contention the kelta-web suite once reported `environment 594s` cumulative. The per-test half of that risk is already covered — kelta-ui/app sets `testTimeout`/`hookTimeout` to 30s in `vitest.config.ts` (more headroom than kelta-web's 20s) — so the timeout here only guards against a genuinely wedged job.

Scope note: only `ci.yml` (the PR gate) changes. `build-and-publish-containers.yml` has its own, separate `test-frontend` job and is untouched — `build-and-push` is gated on `test-frontend.result != 'failure'` there, so widening that job's surface would put a frontend flake directly in the path of every image build.

## Docs

`ci-cd.md`'s `test-frontend` row rewritten to describe both workspaces, the mandatory build order and its two failure modes, and the timeout rationale. The row was already stale — it predates #1347's typecheck step.

## Test plan

```bash
cd kelta-ui/app && npm run lint && npm run format:check && npm run test:run
```

Green (after the kelta-web packages are built). YAML parsed and step order asserted.

## Merge order

⚠️ Stacked on #1347 (`fix/kelta-ui-typecheck-gate`) because it depends on the `Build kelta-web packages` + `Install kelta-ui dependencies` steps that PR introduces. Base is that branch so the diff stays clean; GitHub retargets it to `main` when #1347 squash-merges. **Auto-merge deliberately not enabled** — merging this before #1347 lands would push it into a base branch that is about to disappear. Re-check the diff after the retarget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)