### PR TITLE
fix(gateway): stop double-encoding the query on every bracketed request

### DIFF
--- a/.claude/docs/architecture.md
+++ b/.claude/docs/architecture.md
@@ -62,11 +62,41 @@ Order values below are the live `getOrder()` returns from source (lower runs fir
 | 50 | HeaderTransformationFilter | Inject `X-Tenant-*` headers for worker |
 | 100 | SecurityHeadersFilter | Response security headers |
 | 200 | SecurityAuditFilter | Record final response status |
+| 9000 | QueryBracketEncodingFilter | Percent-encode literal `[`/`]` in the query so Spring Cloud Gateway forwards the rest of it verbatim (see below) |
 
 Cross-cutting (off main path): `ObservabilityContextFilter (-90)`, `HttpBodyCaptureFilter
 (-80)`, `SystemCollectionResponseCacheFilter (-10)`, `RequestLoggingFilter (MAX)`. `?include=`
 resolution is done by `IncludeResolver` (`jsonapi` package), not a numbered filter; read-side
 FLS is enforced in the worker (`CerbosFieldSecurityAdvice`), not the gateway.
+
+### Query encoding across the gateway hop
+
+Spring Cloud Gateway's `RouteToRequestUrlFilter` (order 10000) asks
+`ServerWebExchangeUtils.containsEncodedParts(uri)` whether the incoming URI is already
+encoded, and **re-encodes the whole query when the answer is no**. That check runs
+`UriComponentsBuilder.fromUri(uri).build(true)`, which rejects a raw `[` or `]` — RFC 3986
+reserves those gen-delims for IPv6 literals in the authority.
+
+JSON:API puts brackets in nearly every query Kelta serves (`page[size]`, `fields[type]`,
+`filter[field][op]`), so any request that *also* carried a correctly percent-encoded value
+reached the worker double-encoded — `%2C` arrived as `%252C`, and the worker's parameter
+binding decoded it back to the literal text `%2C`:
+
+```
+GET /api/things?sort=a%2Cb              → worker sees "a,b"     ✅
+GET /api/things?sort=a%2Cb&page[size]=1 → worker sees "a%2Cb"   ❌ 400 "Sort field does not exist"
+```
+
+This corrupted **any** encoded value, not just the comma-separated `sort`/`fields` lists that
+surfaced it: a filter value containing a space, `&`, `+`, `#`, or `/` arrived mangled and
+silently failed to match.
+
+`QueryBracketEncodingFilter` (order 9000) rewrites literal `[`/`]` to `%5B`/`%5D` before
+`RouteToRequestUrlFilter` runs, which makes the URI strictly encoded so the query passes
+through verbatim. The worker's servlet container decodes `%5B` back to `[` before parameter
+binding, so `page[size]` binds exactly as it always did. **Any new gateway filter that
+rewrites the request URI must preserve raw encoding** (`UriComponentsBuilder…build(true)`) —
+building with `build()` re-encodes and reintroduces this bug.
 
 ### Gateway startup & readiness
 

--- a/kelta-gateway/CLAUDE.md
+++ b/kelta-gateway/CLAUDE.md
@@ -79,6 +79,7 @@ All handled by `error/GlobalErrorHandler`.
 | Pattern | File |
 |---------|------|
 | Reactive filter | `filter/TenantResolutionFilter.java` |
+| Request-URI rewrite (must preserve raw encoding) | `filter/QueryBracketEncodingFilter.java` |
 | Principal extraction | `auth/GatewayPrincipal.java` |
 | Cerbos integration | `authz/cerbos/CerbosAuthorizationService.java` |
 | Route data model | `route/RouteDefinition.java` |

--- a/kelta-gateway/src/main/java/io/kelta/gateway/filter/QueryBracketEncodingFilter.java
+++ b/kelta-gateway/src/main/java/io/kelta/gateway/filter/QueryBracketEncodingFilter.java
@@ -1,0 +1,89 @@
+package io.kelta.gateway.filter;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.filter.GlobalFilter;
+import org.springframework.cloud.gateway.filter.RouteToRequestUrlFilter;
+import org.springframework.cloud.gateway.support.ServerWebExchangeUtils;
+import org.springframework.core.Ordered;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.util.UriComponentsBuilder;
+import reactor.core.publisher.Mono;
+
+import java.net.URI;
+
+/**
+ * Percent-encodes literal {@code [} / {@code ]} in the query string so Spring Cloud
+ * Gateway forwards the rest of the query untouched.
+ *
+ * <p>Spring Cloud Gateway's {@link RouteToRequestUrlFilter} (order
+ * {@link RouteToRequestUrlFilter#ROUTE_TO_URL_FILTER_ORDER 10000}) rebuilds the backend URI
+ * and asks {@link ServerWebExchangeUtils#containsEncodedParts(URI)} whether the incoming URI
+ * is already encoded. That check runs {@code UriComponentsBuilder.fromUri(uri).build(true)},
+ * which rejects a raw {@code [} or {@code ]} — RFC 3986 reserves those gen-delims for IPv6
+ * literals in the authority. So a query carrying an unencoded bracket is classified as
+ * <em>not</em> encoded and the whole query gets re-encoded on the way out, turning every
+ * legitimate {@code %XX} escape into {@code %25XX}.
+ *
+ * <p>JSON:API puts brackets in nearly every query Kelta serves ({@code page[size]},
+ * {@code fields[type]}, {@code filter[field][op]}), so any request that also carries a
+ * correctly-encoded value silently reached the worker double-encoded:
+ *
+ * <pre>
+ * GET /api/things?sort=a%2Cb                 → worker sees "a,b"    ✓
+ * GET /api/things?sort=a%2Cb&amp;page[size]=1    → worker sees "a%2Cb"  ✗
+ * </pre>
+ *
+ * <p>That corrupts any encoded value, not just comma-separated {@code sort}/{@code fields}
+ * lists — a filter value containing a space, {@code &amp;}, {@code +}, {@code #} or {@code /}
+ * arrives with its escapes mangled and silently fails to match.
+ *
+ * <p>Rewriting the brackets to {@code %5B} / {@code %5D} makes the URI strictly encoded, so
+ * Spring Cloud Gateway passes the query through verbatim. The worker's servlet container
+ * decodes {@code %5B} back to {@code [} before parameter binding, so {@code page[size]} still
+ * binds exactly as before.
+ *
+ * <p>Runs at order 9000 — after the tenant/auth/authz chain (which reads decoded query
+ * params and is unaffected either way) and before {@code RouteToRequestUrlFilter}.
+ */
+@Component
+public class QueryBracketEncodingFilter implements GlobalFilter, Ordered {
+
+    private static final Logger log = LoggerFactory.getLogger(QueryBracketEncodingFilter.class);
+
+    static final int ORDER = 9000;
+
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+        URI uri = exchange.getRequest().getURI();
+        String rawQuery = uri.getRawQuery();
+        if (rawQuery == null || (rawQuery.indexOf('[') < 0 && rawQuery.indexOf(']') < 0)) {
+            return chain.filter(exchange);
+        }
+
+        String encodedQuery = rawQuery.replace("[", "%5B").replace("]", "%5D");
+        URI newUri;
+        try {
+            newUri = UriComponentsBuilder.fromUri(uri)
+                    .replaceQuery(encodedQuery)
+                    .build(true)
+                    .toUri();
+        } catch (IllegalArgumentException e) {
+            // Some other part of the URI is not strictly encoded. Leave the request alone
+            // rather than fail it — Spring Cloud Gateway's own re-encoding still applies.
+            log.debug("Could not normalize bracket encoding for query '{}', forwarding as-is", rawQuery, e);
+            return chain.filter(exchange);
+        }
+
+        ServerHttpRequest normalized = exchange.getRequest().mutate().uri(newUri).build();
+        return chain.filter(exchange.mutate().request(normalized).build());
+    }
+
+    @Override
+    public int getOrder() {
+        return ORDER;
+    }
+}

--- a/kelta-gateway/src/test/java/io/kelta/gateway/filter/QueryBracketEncodingFilterTest.java
+++ b/kelta-gateway/src/test/java/io/kelta/gateway/filter/QueryBracketEncodingFilterTest.java
@@ -1,0 +1,127 @@
+package io.kelta.gateway.filter;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.filter.RouteToRequestUrlFilter;
+import org.springframework.cloud.gateway.support.ServerWebExchangeUtils;
+import org.springframework.http.HttpMethod;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+import java.net.URI;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for QueryBracketEncodingFilter.
+ *
+ * Tests verify that:
+ * - Literal brackets in the query are percent-encoded so Spring Cloud Gateway treats the
+ *   URI as already-encoded and stops re-encoding the rest of the query
+ * - Existing percent escapes survive the rewrite (the actual bug: %2C arrived as %252C)
+ * - Queries without brackets, and requests with no query at all, pass through untouched
+ * - The rewritten URI satisfies ServerWebExchangeUtils.containsEncodedParts, which is the
+ *   exact predicate RouteToRequestUrlFilter uses to decide whether to re-encode
+ * - The filter runs before RouteToRequestUrlFilter
+ *
+ * <p>Requests are built through {@code MockServerHttpRequest.method(GET, URI)} rather than
+ * the {@code get(String)} overload — the latter encodes the template, which would turn the
+ * {@code %2C} under test into {@code %252C} before the filter ever sees it.
+ */
+@DisplayName("QueryBracketEncodingFilter Tests")
+class QueryBracketEncodingFilterTest {
+
+    private QueryBracketEncodingFilter filter;
+    private GatewayFilterChain chain;
+    private ServerWebExchange captured;
+
+    @BeforeEach
+    void setUp() {
+        filter = new QueryBracketEncodingFilter();
+        chain = mock(GatewayFilterChain.class);
+        captured = null;
+        when(chain.filter(any(ServerWebExchange.class))).thenAnswer(invocation -> {
+            captured = invocation.getArgument(0);
+            return Mono.empty();
+        });
+    }
+
+    private MockServerWebExchange exchangeFor(String rawUri) {
+        return MockServerWebExchange.from(
+                MockServerHttpRequest.method(HttpMethod.GET, URI.create(rawUri)).build());
+    }
+
+    @Test
+    @DisplayName("Should percent-encode literal brackets in the query")
+    void shouldEncodeLiteralBrackets() {
+        filter.filter(exchangeFor("http://api.kelta.io/api/things?page[size]=1"), chain).block();
+
+        assertThat(captured.getRequest().getURI().getRawQuery()).isEqualTo("page%5Bsize%5D=1");
+    }
+
+    @Test
+    @DisplayName("Should preserve existing percent escapes alongside brackets")
+    void shouldPreserveExistingEscapes() {
+        filter.filter(exchangeFor("http://api.kelta.io/api/things?sort=a%2Cb&page[size]=1"), chain).block();
+
+        // The escape must stay single-encoded — %252C is the bug this filter exists to prevent.
+        assertThat(captured.getRequest().getURI().getRawQuery()).isEqualTo("sort=a%2Cb&page%5Bsize%5D=1");
+    }
+
+    @Test
+    @DisplayName("Should produce a URI that Spring Cloud Gateway treats as already encoded")
+    void shouldProduceEncodedUriSoGatewayDoesNotReEncode() {
+        String raw = "http://api.kelta.io/api/things?sort=a%2Cb&page[size]=1";
+        // Establishes the premise: the raw bracket is why the query got re-encoded.
+        assertThat(ServerWebExchangeUtils.containsEncodedParts(URI.create(raw))).isFalse();
+
+        filter.filter(exchangeFor(raw), chain).block();
+
+        assertThat(ServerWebExchangeUtils.containsEncodedParts(captured.getRequest().getURI())).isTrue();
+    }
+
+    @Test
+    @DisplayName("Should decode back to the original parameter names and values")
+    void shouldStillBindTheSameParameterNames() {
+        filter.filter(
+                exchangeFor("http://api.kelta.io/api/things?fields[things]=a%2Cb&filter[name][eq]=x%20y"),
+                chain).block();
+
+        // getQueryParams() decodes, mirroring what the worker's parameter binding sees.
+        assertThat(captured.getRequest().getQueryParams().getFirst("fields[things]")).isEqualTo("a,b");
+        assertThat(captured.getRequest().getQueryParams().getFirst("filter[name][eq]")).isEqualTo("x y");
+    }
+
+    @Test
+    @DisplayName("Should pass through a bracket-free query untouched")
+    void shouldPassThroughQueryWithoutBrackets() {
+        MockServerWebExchange exchange = exchangeFor("http://api.kelta.io/api/things?sort=a%2Cb");
+
+        filter.filter(exchange, chain).block();
+
+        assertThat(captured).isSameAs(exchange);
+    }
+
+    @Test
+    @DisplayName("Should pass through a request with no query at all")
+    void shouldPassThroughRequestWithoutQuery() {
+        MockServerWebExchange exchange = exchangeFor("http://api.kelta.io/api/things");
+
+        filter.filter(exchange, chain).block();
+
+        assertThat(captured).isSameAs(exchange);
+    }
+
+    @Test
+    @DisplayName("Should run before RouteToRequestUrlFilter")
+    void shouldRunBeforeRouteToRequestUrlFilter() {
+        assertThat(filter.getOrder()).isLessThan(RouteToRequestUrlFilter.ROUTE_TO_URL_FILTER_ORDER);
+    }
+}


### PR DESCRIPTION
## Problem

Found while investigating a single `400` in the worker logs:

```
Invalid query parameter for field 'source%2ClastPollAt%2CupdatedAt%2CtargetsPolled':
Requested field does not exist in collection 'poller-health'
```

The percent-escapes were never decoded. Reproduced live against `api.kelta.io`:

```
GET /api/poller-health?sort=source%2ClastPollAt              → 200 ✅
GET /api/poller-health?sort=source%2ClastPollAt&page[size]=1 → 400 ❌
GET /api/poller-health?sort=source%2ClastPollAt&page%5Bsize%5D=1 → 200 ✅
```

A raw `[` or `]` **anywhere in the query** is the trigger.

## Root cause

Spring Cloud Gateway's `RouteToRequestUrlFilter` (order 10000) asks
`ServerWebExchangeUtils.containsEncodedParts(uri)` whether the incoming URI is already
encoded, and re-encodes the whole query when the answer is no. That check runs
`UriComponentsBuilder.fromUri(uri).build(true)`, which rejects a raw `[`/`]` — RFC 3986
reserves those gen-delims for IPv6 literals in the authority.

JSON:API puts brackets in nearly every query this platform serves (`page[size]`,
`fields[type]`, `filter[field][op]`), so any request that *also* carried a correctly
percent-encoded value reached the worker double-encoded: `%2C` arrived as `%252C`, and the
worker's parameter binding decoded it back to the literal text `%2C`.

Confirmed by the discriminator — sending `%252C` produced `field 'source%252ClastPollAt'`
in the worker log, exactly one extra encoding layer.

## Blast radius

Wider than the comma-separated `sort`/`fields` lists that surfaced it. **Any** encoded
value was corrupted: a filter value containing a space, `&`, `+`, `#`, `/`, an email, or an
ISO timestamp with `+` arrived mangled and silently failed to match. Correctly-behaved
clients — anything doing `encodeURIComponent(value)` — were the ones affected.

## Fix

`QueryBracketEncodingFilter` (order 9000) rewrites literal `[`/`]` to `%5B`/`%5D` before
`RouteToRequestUrlFilter` runs, making the URI strictly encoded so the query forwards
verbatim. The worker's servlet container decodes `%5B` back to `[` before parameter
binding, so `page[size]` binds exactly as before — verified live by the third probe above.

Falls through untouched when the query has no brackets, has no query at all, or when some
other part of the URI is not strictly encoded.

## Tests

7 unit tests, including one that asserts `containsEncodedParts` is `false` before the
rewrite and `true` after — pinning the exact predicate the bug hinges on. Full
`kelta-gateway` suite green.

## Docs

`architecture.md` — filter-chain table + a new "Query encoding across the gateway hop"
section; `kelta-gateway/CLAUDE.md` reference-impl row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)