### PR TITLE
fix(gateway): serve tenant UI translations to the pre-login bootstrap

### DIFF
--- a/.claude/docs/architecture.md
+++ b/.claude/docs/architecture.md
@@ -443,6 +443,16 @@ Cerbos enforcement is **collection/record-scoped, not blanket**. Concretely:
   The endpoint resolves its own tenant from the verified token and records events under
   `TenantContext.withTenant`. Campaign management itself is a normal `/api/admin/campaigns`
   endpoint gated in-controller on `MANAGE_CAMPAIGNS` (the DB-lookup pattern above).
+  Either list is guarded by `PublicSurfaceTest`, which reads the **shipped** `application.yml`
+  and asserts the allowlist equals a reviewed set — widening it must also edit that test.
+- **UI bootstrap endpoints**: `kelta-ui/app/src/utils/bootstrapCache.ts` fetches `ui-pages`,
+  `ui-menus`, `ui-translations`, `oidc-providers`, and `tenants` **with no token**, before a
+  session exists. Every one of those must be in `public-paths` (GET/HEAD only) or the gateway
+  401s it. The bootstrap is deliberately failure-tolerant — a non-ok response resolves to an
+  empty list rather than failing the whole app — so a missing prefix does **not** surface as a
+  visible error, only as a permanently empty section of the bootstrap plus a gateway
+  `Missing Authorization header` WARN. Adding a new pre-login fetch means adding its prefix
+  here in the same change.
 - **Sandbox/promotion/package routes** (2026-07-04): `/api/environments/**` and
   `/api/promotions/**` (static routes `environments`/`promotions`) are gated in-controller on
   **`MANAGE_SANDBOXES`**; `/api/packages/**` (static route `packages`) on

--- a/kelta-gateway/src/main/resources/application.yml
+++ b/kelta-gateway/src/main/resources/application.yml
@@ -127,7 +127,13 @@ kelta:
       permissions-cache-ttl-minutes: ${PERMISSIONS_CACHE_TTL:5}   # Redis cache TTL for resolved permissions
       # Paths accessible without authentication (GET/HEAD only).
       # Matched as prefixes against the slug-stripped path.
-      public-paths: /api/ui-pages,/api/ui-menus,/api/oidc-providers,/api/tenants
+      # These are exactly the endpoints the UI bootstrap fetches before a session exists
+      # (kelta-ui/app/src/utils/bootstrapCache.ts) — tenant-scoped presentation metadata:
+      # page/menu structure, the tenant's UI translation overlay, the IdP list to render a
+      # login button, and the tenant record itself. Writes stay authenticated: this list is
+      # GET/HEAD only. Adding a path here also bypasses TenantIpAllowlistFilter, so keep it
+      # to metadata that is safe to serve to an anonymous visitor of that tenant.
+      public-paths: /api/ui-pages,/api/ui-menus,/api/ui-translations,/api/oidc-providers,/api/tenants
       # Paths accessible without authentication for ALL HTTP methods.
       # Used for endpoints receiving data from unauthenticated sources (e.g., browser OTEL SDK,
       # campaign open-pixel / click-redirect / unsubscribe links authenticated by HMAC token,

--- a/kelta-gateway/src/test/java/io/kelta/gateway/auth/PublicSurfaceTest.java
+++ b/kelta-gateway/src/test/java/io/kelta/gateway/auth/PublicSurfaceTest.java
@@ -47,9 +47,18 @@ class PublicSurfaceTest {
             "/api/telehealth/webhooks",     // LiveKit webhook (signed JWT + body digest)
             "/api/billing/webhooks");       // payment-processor webhook (HMAC)
 
-    /** GET/HEAD-only bootstrap data the UI needs before anyone has signed in. */
+    /**
+     * GET/HEAD-only bootstrap data the UI needs before anyone has signed in — exactly the
+     * requests {@code kelta-ui/app/src/utils/bootstrapCache.ts} issues with no token.
+     * All of it is tenant-scoped presentation metadata, none of it is tenant-private
+     * business data; writes stay authenticated because this list is GET/HEAD only.
+     */
     private static final List<String> EXPECTED_PUBLIC_GET = List.of(
-            "/api/ui-pages", "/api/ui-menus", "/api/oidc-providers", "/api/tenants");
+            "/api/ui-pages",                // page structure
+            "/api/ui-menus",                // nav structure
+            "/api/ui-translations",         // tenant UI label overlay (i18n), rendered pre-login
+            "/api/oidc-providers",          // which login buttons to render
+            "/api/tenants");                // the tenant record behind the slug
 
     private static Properties shippedConfig() {
         YamlPropertiesFactoryBean yaml = new YamlPropertiesFactoryBean();

--- a/kelta-ui/app/src/utils/bootstrapCache.test.ts
+++ b/kelta-ui/app/src/utils/bootstrapCache.test.ts
@@ -1,8 +1,9 @@
 /**
- * Unit tests for the bootstrap menu-item tree assembly (submenus via parentId).
+ * Unit tests for the bootstrap menu-item tree assembly (submenus via parentId)
+ * and for the failure-tolerant tenant-translation fetch.
  */
-import { describe, it, expect } from 'vitest'
-import { buildItemTree } from './bootstrapCache'
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { buildItemTree, clearBootstrapCache, fetchBootstrapConfig } from './bootstrapCache'
 
 const item = (id: string, parentId?: string | null) => ({
   id,
@@ -38,5 +39,45 @@ describe('buildItemTree', () => {
   it('ignores a self-referencing parentId', () => {
     const tree = buildItemTree([item('a', 'a')])
     expect(tree.map((i) => i.id)).toEqual(['a'])
+  })
+})
+
+describe('fetchBootstrapConfig — tenant translations', () => {
+  afterEach(() => {
+    clearBootstrapCache()
+    vi.restoreAllMocks()
+  })
+
+  const ok = (data: unknown[]) =>
+    Promise.resolve({ ok: true, status: 200, json: async () => ({ data }) } as Response)
+
+  /** Every bootstrap call succeeds except ui-translations, which answers with `status`. */
+  const stubFetch = (status: number) =>
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((url: string) =>
+        url.includes('/api/ui-translations')
+          ? Promise.resolve({ ok: false, status, json: async () => ({}) } as Response)
+          : ok([])
+      )
+    )
+
+  it('warns and falls back to built-in strings when translations are rejected', async () => {
+    // 401 is what a missing gateway public-paths prefix produces. The overlay must
+    // degrade rather than fail, but it must not degrade silently.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    stubFetch(401)
+
+    const config = (await fetchBootstrapConfig()) as { translations: Record<string, unknown> }
+
+    expect(config.translations).toEqual({})
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('HTTP 401'))
+  })
+
+  it('does not fail the whole bootstrap when translations are unavailable', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    stubFetch(500)
+
+    await expect(fetchBootstrapConfig()).resolves.toBeDefined()
   })
 })

--- a/kelta-ui/app/src/utils/bootstrapCache.ts
+++ b/kelta-ui/app/src/utils/bootstrapCache.ts
@@ -230,10 +230,18 @@ export function fetchBootstrapConfig(): Promise<unknown> {
     ),
     // Tenant translation overlay (app-intelligence slice 4) — failure-tolerant:
     // a non-ok response OR a thrown fetch resolves empty so the overlay can never
-    // take the whole bootstrap down.
+    // take the whole bootstrap down. It warns on a non-ok response because silence
+    // is how this went unnoticed: the endpoint was missing from the gateway's
+    // public-paths allowlist, so every pre-login fetch 401'd and the overlay was
+    // permanently empty with nothing in the console to say so.
     fetch(`${base}/api/ui-translations?page[size]=2000`)
       .then(async (r) => {
-        if (!r.ok) return { data: [] }
+        if (!r.ok) {
+          console.warn(
+            `Tenant translations unavailable (HTTP ${r.status}); falling back to built-in strings`
+          )
+          return { data: [] }
+        }
         return r.json()
       })
       .catch(() => ({ data: [] })),


### PR DESCRIPTION
> ⚠️ Touches the gateway's unauthenticated allowlist — **no auto-merge**, wants a real review.

## Problem

`Missing Authorization header for path: /api/ui-translations` was the single largest source
of gateway WARNs in production (22 in 10h, the bulk of all gateway warnings).

`kelta-ui/app/src/utils/bootstrapCache.ts` fetches five endpoints **with no token**, before a
session exists: `ui-pages`, `ui-menus`, `oidc-providers`, `tenants`, and `ui-translations`.
Only the first four are in `kelta.gateway.security.public-paths`.

So every `ui-translations` bootstrap fetch has 401'd and the tenant translation overlay
(app-intelligence slice 4) has **never loaded** — the UI has been silently falling back to
built-in strings since the feature shipped.

## Why nobody noticed

The bootstrap treats a non-ok translations response as an empty list on purpose, so the
overlay can never take the whole app down:

```ts
fetch(`${base}/api/ui-translations?page[size]=2000`)
  .then(async (r) => { if (!r.ok) return { data: [] }; return r.json() })
  .catch(() => ({ data: [] }))
```

Good failure-tolerance, zero observability. The gateway WARN was the only trace.

## Fix

1. Add `/api/ui-translations` to `public-paths`. That list is **GET/HEAD only**
   (`PublicPathMatcher`), so authoring stays authenticated — only reads open up.
2. Record it in `PublicSurfaceTest`, the guard that reads the *shipped* `application.yml`
   and asserts the allowlist equals a reviewed set. Its method-scoping test now also proves
   `POST/PUT/PATCH/DELETE /api/ui-translations` stay closed.
3. `console.warn` on a non-ok translations response, so the next instance of this is visible
   instead of silent.

## Security review notes

- Same trust class as the four prefixes already there: tenant-scoped **presentation**
  metadata (UI label text), not tenant-private business data, served to an anonymous visitor
  of that tenant — which is the point, the strings render on the login screen.
- Reads only. `PublicSurfaceTest.publicPathsAreReadOnly` covers every method.
- Prefix matching means `GET /api/ui-translations/{id}` is also public — consistent with
  `ui-pages`/`ui-menus` today.
- Like any public path this bypasses `TenantIpAllowlistFilter`. Called out in the
  `application.yml` comment added here.

## Tests

`PublicSurfaceTest` + `PublicPathMatcherTest` green (23). Two new `bootstrapCache` tests
cover the warn-and-degrade path.

## Docs

`architecture.md` → "Authorizing a new endpoint" gains a UI-bootstrap-endpoints entry
explaining the pre-login fetch set and why a missing prefix fails silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)