### PR TITLE
fix(sdk): type flow jsonb fields as objects, unbreaking the kelta-ui typecheck

### DIFF
--- a/.claude/docs/conventions.md
+++ b/.claude/docs/conventions.md
@@ -260,6 +260,17 @@ MCP tools (`query_collection`, `list_picklists`, `list_approvals`) take flat `pa
 - Generics for type-safe resource ops: `ResourceClient<T>`
 - Explicit return types on public methods
 - Readonly properties for immutability
+- **`jsonb`-backed fields carry objects on the wire, not JSON strings.** Send the object
+  (`definition`, `triggerConfig`, …). Sending a JSON *string* lands in the column as
+  `{"type":"jsonb","value":"<escaped json>"}`, which every reader then has to unwrap — see
+  the defensive `"jsonb"`/`"value"` unwrap in `NatsTriggerFlowListener` /
+  `FlowEventListener`. In `@kelta/sdk` these are typed `JsonObjectField | string` (the
+  `string` arm covers rows written before that was understood; narrow on `typeof`).
+- **A cast at a call site is a bug report about the type.** `as unknown as X` around an SDK
+  request body means the request type disagrees with what the endpoint accepts — fix the
+  type, don't widen the cast. Three flow call sites carried such casts, all hiding the same
+  stale `triggerConfig?: string`; the casts also masked a `description: null` mismatch that
+  only surfaced once they were removed.
 
 ### Component reuse (kelta-ui/app and kelta-web)
 

--- a/kelta-ui/app/src/pages/FlowDesignerPage/FlowDesignerPage.tsx
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/FlowDesignerPage.tsx
@@ -5,7 +5,6 @@ import { ReactFlowProvider } from '@xyflow/react'
 import type { Node, Edge } from '@xyflow/react'
 
 import { useApi } from '../../context/ApiContext'
-import type { CreateFlowRequest } from '@kelta/sdk'
 import type { Flow } from './types'
 import { unwrapResource } from '../../utils/jsonapi'
 import { useToast, LoadingSpinner, ErrorMessage } from '../../components'
@@ -97,7 +96,7 @@ export function FlowDesignerPage() {
             ? JSON.parse(flow.triggerConfig)
             : flow.triggerConfig
           : null,
-      } as unknown as Partial<CreateFlowRequest>)
+      })
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['flow', flowId] })

--- a/kelta-ui/app/src/pages/FlowDesignerPage/components/TriggerEditSheet.tsx
+++ b/kelta-ui/app/src/pages/FlowDesignerPage/components/TriggerEditSheet.tsx
@@ -17,7 +17,6 @@ import {
   NatsTriggerForm,
 } from '@/components/flows'
 import { useApi } from '@/context/ApiContext'
-import type { CreateFlowRequest } from '@kelta/sdk'
 import { useToast } from '@/components'
 import type { Flow, TriggerConfig } from '../types'
 
@@ -90,7 +89,7 @@ export function TriggerEditSheet({ open, onOpenChange, flow }: TriggerEditSheetP
         definition,
         triggerConfig: config,
         runAsUserId: runAsUserId === RUN_AS_OWNER ? null : runAsUserId,
-      } as Partial<CreateFlowRequest>)
+      })
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['flow', flow.id] })

--- a/kelta-ui/app/src/pages/FlowsPage/CreateFlowWizard.tsx
+++ b/kelta-ui/app/src/pages/FlowsPage/CreateFlowWizard.tsx
@@ -11,7 +11,6 @@ import {
 import { Button } from '@/components/ui/button'
 import { useApi } from '@/context/ApiContext'
 import { useToast } from '@/components'
-import type { CreateFlowRequest } from '@kelta/sdk'
 import { getTenantSlug } from '@/context/TenantContext'
 import { cn } from '@/lib/utils'
 import type { FlowType, NatsTriggerConfig, TriggerConfig } from '@/pages/FlowDesignerPage/types'
@@ -70,11 +69,7 @@ export function CreateFlowWizard({ open, onOpenChange }: CreateFlowWizardProps) 
         definition: MINIMAL_DEFINITION,
         triggerConfig: Object.keys(triggerConfig).length > 0 ? triggerConfig : null,
       }
-      const resp = await keltaClient.admin.flows.create(
-        '',
-        '',
-        payload as unknown as CreateFlowRequest
-      )
+      const resp = await keltaClient.admin.flows.create('', '', payload)
       return resp
     },
     onSuccess: (data) => {

--- a/kelta-web/packages/sdk/src/admin/types.ts
+++ b/kelta-web/packages/sdk/src/admin/types.ts
@@ -1680,6 +1680,25 @@ export interface CreateApprovalStepRequest {
 
 // --- Flow Engine (Phase 4 Stream D) ---
 
+/**
+ * A field backed by a Postgres `jsonb` column, so its wire shape is a real JSON
+ * object — not a JSON string.
+ *
+ * Writing a *string* into one of these lands in the database as
+ * `{"type":"jsonb","value":"<escaped json>"}`, which every reader then has to
+ * defensively unwrap (see the `"jsonb"`/`"value"` unwrap in
+ * `kelta-worker/.../listener/NatsTriggerFlowListener.java`). Send the object.
+ *
+ * `string` stays in the read/write unions for rows written before that was
+ * understood; callers narrow on `typeof` before use.
+ *
+ * Deliberately `object` rather than `Record<string, unknown>`: callers pass
+ * their own domain interfaces here (a flow state machine, a trigger config),
+ * and TypeScript gives an implicit index signature to type aliases but not to
+ * interfaces, so `Record<string, unknown>` would reject them.
+ */
+export type JsonObjectField = object;
+
 export interface FlowDefinition {
   id: string;
   name: string;
@@ -1710,11 +1729,14 @@ export interface FlowExecution {
 
 export interface CreateFlowRequest {
   name: string;
-  description?: string;
+  /** `null` clears the stored description; `undefined` leaves it untouched. */
+  description?: string | null;
   flowType: string;
   active?: boolean;
-  triggerConfig?: string;
-  definition: string;
+  /** `jsonb` — send an object. See {@link JsonObjectField}. */
+  triggerConfig?: JsonObjectField | string | null;
+  /** `jsonb` — send an object. See {@link JsonObjectField}. */
+  definition: JsonObjectField | string;
   /**
    * Audit identity stamped on records this flow writes when the execution has
    * no initiating user (cron/NATS/webhook starts). Falls back to the flow

--- a/kelta-web/packages/sdk/src/index.ts
+++ b/kelta-web/packages/sdk/src/index.ts
@@ -118,6 +118,7 @@ export type {
   ApprovalProcess,
   ApprovalInstance,
   CreateApprovalProcessRequest,
+  JsonObjectField,
   FlowDefinition,
   FlowExecution,
   CreateFlowRequest,


### PR DESCRIPTION
## Problem

`npm run typecheck` in `kelta-ui/app` is **red on `main`** (verified against a clean
checkout at `5c901cbf`):

```
src/pages/FlowDesignerPage/components/TriggerEditSheet.tsx(85,53): error TS2352:
  Conversion of type '{ ... triggerConfig: Partial<TriggerConfig>; ... }' to type
  'Partial<CreateFlowRequest>' may be a mistake because neither type sufficiently overlaps.
    Type 'Partial<TriggerConfig>' is not comparable to type 'string | undefined'.
```

#1347 made that typecheck a CI gate, so this fails the frontend job on **every open PR**,
on an error none of them introduced.

## Which side is wrong

The SDK type. `flow.definition` and `flow.trigger_config` are `jsonb` columns
(`FlowRepository`: `UPDATE flow SET trigger_config = ?::jsonb`), and every caller already
sends objects:

- the UI, with an explicit `// JSON-type fields must be objects (not strings)` comment
- the CLI (`commands/flows.ts`), which runs both through `readDataArgument()` → `Record<string, unknown>` — and dodged the type entirely by posting through the raw axios instance

Sending a *string* is the actually-broken path: it lands as
`{"type":"jsonb","value":"<escaped json>"}`, which is why `NatsTriggerFlowListener` and
`FlowEventListener` both carry a defensive unwrap for exactly that shape.

Three call sites were casting past the stale type:

| File | Cast |
|---|---|
| `TriggerEditSheet.tsx` | `as Partial<CreateFlowRequest>` |
| `FlowDesignerPage.tsx` | `as unknown as Partial<CreateFlowRequest>` |
| `CreateFlowWizard.tsx` | `as unknown as CreateFlowRequest` |

Only the first was weak enough for TS to still complain — the two `as unknown as` casts
silenced it completely.

## Fix

- `CreateFlowRequest.definition` / `.triggerConfig` → `JsonObjectField | string`
  (the `string` arm covers rows written before this was understood; readers narrow on `typeof`)
- Drop all three casts, so these calls are now genuinely type-checked
- Removing them surfaced a **second** mismatch the casts had hidden: both wizards send
  `description: null` to clear the field, against a `description?: string`. Widened to
  `string | null` with a note on the semantics.

`JsonObjectField` is `object`, not `Record<string, unknown>`, because callers pass their own
domain interfaces (`Partial<TriggerConfig>`, the flow state machine) and TypeScript gives an
implicit index signature to type aliases but not to interfaces.

All changes are **widening** — no existing caller passing a string stops compiling.

## Verification

| Check | Result |
|---|---|
| `kelta-ui/app` typecheck | green (was the failure) |
| `kelta-web` typecheck | green |
| `kelta-web` lint / format:check | 0 errors, clean |
| `kelta-web` test:coverage | 1135 passed / 57 files |
| `kelta-ui/app` test:run | 2659 passed / 221 files |

## Docs

`conventions.md` → Type Safety: `jsonb` fields carry objects not JSON strings, and a cast
around an SDK request body is a bug report about the type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)