### PR TITLE
chore(ci): stop the cli-downloads smoke rolling back an unchanged tag

### DIFF
--- a/.claude/docs/ci-cd.md
+++ b/.claude/docs/ci-cd.md
@@ -41,8 +41,19 @@ Trigger: `push` → `main` (path-filtered), plus `workflow_dispatch`.
 3. **`deploy`** — checks out `homelab-argo`, runs kustomize to bump image tags (verifies
    each image exists on Harbor first), commits to `homelab-argo`. ArgoCD then syncs.
 4. **`smoke-test`** — waits for k8s rollouts; `curl .../actuator/health/liveness` on gateway
-   + worker.
+   + worker; then (only when cli-downloads was rebuilt) downloads and executes the CLI binary.
+   **The CLI check keys on two different values and they can disagree:** `CLI_VERSION` is baked
+   in as `1.0.<run_number>`, but ArgoCD only rolls when the image *tag* `main-<short-sha>`
+   changes. A rebuild at an already-deployed commit (`workflow_dispatch` with
+   `force_build_all=true`, a re-run) pushes an identical tag, so nothing rolls, the pod keeps
+   serving the earlier run's version, and the version poll times out on a perfectly good
+   deploy. The step now compares the running tag to the pushed tag first and asserts against
+   the *served* version when they match. Don't reintroduce a bare `1.0.<run_number>` assertion.
 5. **`rollback-on-smoke-failure`** — `git revert HEAD` in `homelab-argo` if smoke fails.
+   **It reverts the whole image bump, not just the failing service** — a false failure in one
+   smoke step rolls back every service in that commit. Run 31510066633 reverted a gateway +
+   worker bump whose own health steps had already passed, because the cli-downloads version
+   check timed out on an unchanged tag.
 6. **`e2e-test`** — Playwright against production (`app.kelta.io`, `api.kelta.io`) using
    E2E token + Authentik secrets. Timeout 25 min. Files failing-E2E bug tasks to `emf-queue`.
    Also builds `@kelta/cli` (`kelta-web`: formula+sdk, then cli) so the CLI smoke spec

--- a/.claude/docs/ci-cd.md
+++ b/.claude/docs/ci-cd.md
@@ -116,3 +116,12 @@ until it reports `1.0.<run_number>` (≤5 min)** before asserting, and runs **on
 `cli_downloads == 'true'`** (the image is only rebuilt then; the old `|| workflows == 'true'`
 ran the strict `EXPECT == run_number` check on runs where the image was not rebuilt, so it
 could never match).
+
+**Two keys, and they can disagree.** The served version is `1.0.<run_number>` (baked in at
+build time) but the rollout is triggered by the image tag `main-<short-sha>`. A rebuild at an
+already-deployed commit — `workflow_dispatch` with `force_build_all=true`, or a re-run —
+pushes an identical tag, so ArgoCD applies nothing, the pod keeps serving the version from the
+run that first built that tag, and `EXPECT` can never arrive. The step compares the running tag
+to the pushed tag before polling and asserts against the **served** version when they match
+(run 31510066633 is the case that proved it). Do not reintroduce a bare
+`1.0.<run_number>` assertion.

--- a/.github/workflows/build-and-publish-containers.yml
+++ b/.github/workflows/build-and-publish-containers.yml
@@ -505,6 +505,37 @@ jobs:
           BASE="http://${DEPLOY}.${NS}.svc.cluster.local"
           EXPECT="1.0.${{ github.run_number }}"
 
+          # The served version and the thing that triggers a rollout are keyed on different
+          # values: CLI_VERSION is baked in as 1.0.<run_number>, but ArgoCD only rolls when
+          # the image *tag* (main-<sha>) changes. A rebuild at a commit whose tag is already
+          # running therefore pushes an identical tag — ArgoCD has nothing to apply, the pod
+          # keeps serving the version from the run that first built it, and EXPECT can never
+          # arrive. That is not a bad deploy, but the poll below would time out and hand the
+          # auto-rollback a healthy release to revert. It did exactly that to run 31510066633,
+          # reverting a gateway+worker bump whose own health checks had already passed.
+          PUSHED_TAG="main-$(echo "${GITHUB_SHA}" | cut -c1-7)"
+          RUNNING_TAG=$(kubectl -n ${NS} get deploy ${DEPLOY} \
+            -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null | sed 's/.*://')
+          if [ "${RUNNING_TAG}" = "${PUSHED_TAG}" ]; then
+            echo "::notice::${DEPLOY} is already running ${PUSHED_TAG} — this run rebuilt an" \
+                 "unchanged commit, so ArgoCD will not roll and the served version stays at the" \
+                 "run that first built this tag. Verifying what is served instead of ${EXPECT}."
+            SERVED=$(curl -fsS "${BASE}/cli/manifest.json" 2>/dev/null \
+              | sed -n 's/.*"version": *"\([^"]*\)".*/\1/p' | head -1)
+            if [ -z "${SERVED}" ]; then
+              echo "::error::${DEPLOY} is running ${PUSHED_TAG} but served no manifest version."
+              exit 1
+            fi
+            curl -fsS "${BASE}/health" | grep -q '"status":"UP"'
+            curl -fsS "${BASE}/cli/releases/${SERVED}/kelta-linux-x64" -o /tmp/kelta-smoke
+            chmod +x /tmp/kelta-smoke
+            /tmp/kelta-smoke version --output json | grep -q "\"version\": \"${SERVED}\"" || {
+              echo "::error::Downloaded binary does not report the served version ${SERVED}"; exit 1;
+            }
+            echo "CLI downloads smoke OK: ${SERVED} served and executable (tag unchanged)."
+            exit 0
+          fi
+
           # ArgoCD applies the image bump we just pushed asynchronously, so `rollout status`
           # returns immediately against the still-old ReplicaSet and a one-shot version check
           # races the sync. Poll the served manifest until it reports EXPECT (i.e. ArgoCD has


### PR DESCRIPTION
## What happened

Run [31510066633](https://github.com/cklinker/emf/actions/runs/31510066633) (`workflow_dispatch`,
`force_build_all=true`) built and pushed every service, bumped all the ArgoCD tags, and passed
its own health checks:

```
3. Wait for rollout:              success
4. Verify gateway health:         success
5. Verify worker health:          success
6. Verify CLI downloads service:  FAILURE
```

`rollback-on-smoke-failure` then reverted **the entire image bump**, stranding two merged
gateway fixes (#1350, #1351) that had just been verified healthy in that same run.

## Why step 6 could not pass

The served version and the thing that triggers a rollout key on different values:

| | keyed on |
|---|---|
| `CLI_VERSION` baked into the image | `1.0.${{ github.run_number }}` |
| whether ArgoCD rolls at all | image tag `main-<short-sha>` |

A rebuild at an already-deployed commit pushes an **identical tag**. ArgoCD has nothing to
apply, so the pod keeps serving the version from the run that first built that tag, and the
poll waits out its full 5 minutes for a version that will never arrive:

```
waiting for ArgoCD to serve 1.0.1252 (currently '1.0.1251')…   ×30
##[error]Manifest version 1.0.1251 != expected 1.0.1252 after 5m
```

`1251` was correct — cli-downloads was already running `main-ad72c6c` from the preceding push
build. Nothing was broken; the assertion was just unsatisfiable.

This is the same false-rollback class #1311 fixed for workflows-only changes. Its
`cli_downloads == 'true'` guard doesn't cover a rebuild at an unchanged SHA, where the image
*is* rebuilt but the tag it lands on is already deployed.

## Fix

Compare the running tag to the pushed tag before polling. When they match, the version
assertion is meaningless, so verify what is actually served instead — manifest reachable,
`/health` UP, and the downloaded binary self-reporting the served version. Still a real
end-to-end check of serve → download → execute, just anchored to the served version rather
than one this run can never produce.

The normal path (a genuine tag change) is untouched, including the existing 5-minute
ArgoCD-sync poll.

## Blast radius worth noting separately

`rollback-on-smoke-failure` reverts the whole commit, so **any** false failure in one smoke
step rolls back every service in that bump. Documented in `ci-cd.md` rather than changed here —
narrowing the rollback to the failing service is a bigger design call.

## Verification

- Every `run:` block in the workflow bash-syntax-checked (`bash -n` with GitHub expressions stripped); YAML parses.
- Both branches reasoned against the real run above: unchanged-tag hits the new path, a normal
  push still takes the poll.
- Recovery for the stranded deploy was applied separately in `homelab-argo` (`3e37dc1`); all
  services are now live on `main-ad72c6c` and both gateway fixes verified against production.

## Docs

`ci-cd.md` — the smoke step's two-keys hazard, and that auto-rollback is not scoped to the
failing service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)