### PR TITLE
fix(flow): resolve tenant-scoped action handlers in Task steps

### DIFF
--- a/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/flow/executor/TaskStateExecutor.java
+++ b/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/flow/executor/TaskStateExecutor.java
@@ -49,8 +49,14 @@ public class TaskStateExecutor implements StateExecutor {
         // 1. Apply InputPath
         Map<String, Object> input = dataResolver.applyInputPath(context.stateData(), task.inputPath());
 
-        // 2. Resolve handler
-        Optional<ActionHandler> handler = handlerRegistry.getHandler(task.resource());
+        // 2. Resolve handler.
+        // Tenant-scoped first, then global. Runtime-loaded modules register their
+        // handlers with ActionHandlerRegistry#registerTenantHandler, so resolving
+        // against the global map alone made every module-contributed step fail
+        // ResourceNotFound no matter how cleanly the module installed — the whole
+        // runtime-module feature was unreachable from a flow.
+        Optional<ActionHandler> handler =
+            handlerRegistry.getHandler(context.tenantId(), task.resource());
         if (handler.isEmpty()) {
             return handleError(task, context, "ResourceNotFound",
                 "No handler found for resource: " + task.resource());

--- a/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/flow/FlowEngineTest.java
+++ b/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/flow/FlowEngineTest.java
@@ -990,6 +990,119 @@ class FlowEngineTest {
         }
     }
 
+    @Nested
+    @DisplayName("Tenant-scoped handlers")
+    class TenantScopedHandlers {
+
+        /**
+         * A step whose Resource comes from a runtime-loaded module, i.e. one
+         * registered with {@code registerTenantHandler} rather than
+         * {@code register}. Resolving against the global map alone made every
+         * module-contributed step fail ResourceNotFound, which left the whole
+         * runtime-module feature unreachable from a flow — installed, ACTIVE,
+         * and silently unusable.
+         */
+        private static final String MODULE_STEP_FLOW = """
+            {
+                "StartAt": "Ingest",
+                "States": {
+                    "Ingest": {
+                        "Type": "Task",
+                        "Resource": "MODULE_STEP",
+                        "ResultPath": "$.moduleResult",
+                        "Next": "Done"
+                    },
+                    "Done": { "Type": "Succeed" }
+                }
+            }
+            """;
+
+        private ActionHandler handlerReturning(String key, Map<String, Object> output) {
+            return new ActionHandler() {
+                @Override
+                public String getActionTypeKey() { return key; }
+
+                @Override
+                public ActionResult execute(ActionContext context) {
+                    return ActionResult.success(output);
+                }
+            };
+        }
+
+        @Test
+        @DisplayName("a Task resolves a handler registered only for its tenant")
+        void tenantHandlerResolves() {
+            handlerRegistry.registerTenantHandler(
+                "t1", handlerReturning("MODULE_STEP", Map.of("ranInModule", true)));
+
+            Map<String, Object> result =
+                engine.executeSynchronous("t1", "f1", MODULE_STEP_FLOW, Map.of(), "u1");
+
+            assertNotNull(result.get("moduleResult"), "tenant-scoped handler was not resolved");
+            @SuppressWarnings("unchecked")
+            Map<String, Object> moduleResult = (Map<String, Object>) result.get("moduleResult");
+            assertEquals(true, moduleResult.get("ranInModule"));
+        }
+
+        @Test
+        @DisplayName("a tenant handler is invisible to another tenant")
+        void tenantHandlerDoesNotLeakAcrossTenants() {
+            // Modules are installed per tenant, so one tenant's step must not
+            // become executable for everyone else.
+            handlerRegistry.registerTenantHandler(
+                "t1", handlerReturning("MODULE_STEP", Map.of("ranInModule", true)));
+
+            FlowExecutionData failed = runToCompletion("t2", MODULE_STEP_FLOW);
+
+            assertEquals(FlowExecutionData.STATUS_FAILED, failed.status());
+            assertTrue(String.valueOf(failed.errorMessage()).contains("MODULE_STEP"),
+                "expected ResourceNotFound naming the unresolved resource, got: "
+                    + failed.errorMessage());
+        }
+
+        @Test
+        @DisplayName("a tenant handler overrides a global one with the same key")
+        void tenantHandlerTakesPriorityOverGlobal() {
+            // The registry documents tenant handlers as taking priority; assert
+            // it, since the override is the whole point of a per-tenant module.
+            handlerRegistry.register(handlerReturning("OVERRIDABLE", Map.of("from", "global")));
+            handlerRegistry.registerTenantHandler(
+                "t1", handlerReturning("OVERRIDABLE", Map.of("from", "tenant")));
+
+            String json = MODULE_STEP_FLOW.replace("MODULE_STEP", "OVERRIDABLE");
+
+            @SuppressWarnings("unchecked")
+            Map<String, Object> tenant = (Map<String, Object>)
+                engine.executeSynchronous("t1", "f1", json, Map.of(), "u1").get("moduleResult");
+            @SuppressWarnings("unchecked")
+            Map<String, Object> other = (Map<String, Object>)
+                engine.executeSynchronous("t2", "f1", json, Map.of(), "u1").get("moduleResult");
+
+            assertEquals("tenant", tenant.get("from"));
+            assertEquals("global", other.get("from"), "t2 should still see the global handler");
+        }
+
+        private FlowExecutionData runToCompletion(String tenantId, String definitionJson) {
+            String executionId = engine.startExecution(
+                tenantId, "f1", definitionJson, Map.of(), "u1", null, false);
+            long deadline = System.currentTimeMillis() + 5000;
+            while (System.currentTimeMillis() < deadline) {
+                Optional<FlowExecutionData> current = flowStore.loadExecution(executionId);
+                if (current.isPresent()
+                        && !FlowExecutionData.STATUS_RUNNING.equals(current.get().status())) {
+                    return current.get();
+                }
+                try {
+                    Thread.sleep(20);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    break;
+                }
+            }
+            return flowStore.loadExecution(executionId).orElseThrow();
+        }
+    }
+
     static class InMemoryFlowStore implements FlowStore {
         private final Map<String, FlowExecutionData> executions = new ConcurrentHashMap<>();
         private final Map<String, List<FlowStepLogData>> stepLogs = new ConcurrentHashMap<>();

--- a/kelta-platform/runtime/runtime-module-core/src/main/java/io/kelta/runtime/module/core/handlers/DecisionActionHandler.java
+++ b/kelta-platform/runtime/runtime-module-core/src/main/java/io/kelta/runtime/module/core/handlers/DecisionActionHandler.java
@@ -96,7 +96,12 @@ public class DecisionActionHandler implements ActionHandler {
                     continue;
                 }
 
-                Optional<ActionHandler> handlerOpt = handlerRegistry.getHandler(actionType);
+                // Tenant-scoped first, then global — same reason as
+                // TaskStateExecutor: a nested action supplied by a runtime-loaded
+                // module lives only in the tenant map, so a global-only lookup
+                // silently SKIPPED it.
+                Optional<ActionHandler> handlerOpt =
+                    handlerRegistry.getHandler(context.tenantId(), actionType);
                 if (handlerOpt.isEmpty()) {
                     log.warn("No handler for nested action type '{}' in decision", actionType);
                     actionResults.add(Map.of("actionType", actionType, "status", "SKIPPED",


### PR DESCRIPTION
## The bug

Runtime-loaded modules register their handlers with `ActionHandlerRegistry#registerTenantHandler`, which writes to the **per-tenant** map:

```java
// RuntimeModuleManager.java:363
actionHandlerRegistry.registerTenantHandler(tenantId, handler);
```

`TaskStateExecutor` resolved with the **single-argument** `getHandler`, which reads only the **global** map:

```java
// TaskStateExecutor.java:53 (before)
Optional<ActionHandler> handler = handlerRegistry.getHandler(task.resource());
```

The two-argument overload that checks tenant-then-global has existed all along at `ActionHandlerRegistry.java:85` — it was simply **never called from production code**. I grepped every call site across `kelta-platform`, `kelta-worker`, `kelta-mcp` and `kelta-ai`; the only hit outside tests was the declaration itself.

## Why it matters

Every module-contributed flow step failed `ResourceNotFound` regardless of how cleanly the module installed. A module could be uploaded, signature-verified, loaded, and reported `ACTIVE` — and its steps were still unreachable. **The entire runtime-module feature was dead on the flow path, and nothing surfaced it.**

`DecisionActionHandler` had the identical bug for nested actions, where it presented as a silent `SKIPPED` entry in the results array rather than a failure.

## The fix

Both sites now use the tenant-aware overload. `FlowExecutionContext` already carries `tenantId` (it was in use ten lines below, building the `ActionContext`), and `ActionContext` already carries it in `DecisionActionHandler`.

The alternative — having `RuntimeModuleManager` call `register()` instead — also "works", but makes every module global across all tenants. That is the wrong direction: modules are installed per tenant and `tenant_module` is RLS-scoped.

Nothing about the registry needed changing. `register`/`registerTenantHandler` are public and `ConcurrentHashMap`-backed, and `TaskState.resource()` is a free-form string rather than an enum, so the step vocabulary was always open for extension. Only the lookup was wrong.

## Tests

Adds `FlowEngineTest$TenantScopedHandlers` — as far as I can tell the **first coverage of this path at all**. No existing test resolved a tenant-registered handler through the engine, which is how a one-line mismatch survived in a feature with a controller, a classloader, a signature verifier, a UI page and four unit-test classes.

| Test | Without the fix |
|---|---|
| a Task resolves a handler registered only for its tenant | **fails** — `tenant-scoped handler was not resolved` |
| a tenant handler overrides a global one with the same key | **fails** — `expected: <tenant> but was: <global>` |
| a tenant handler is invisible to another tenant | passes either way — see below |

The third passes with or without the change by design. It is not a test of this bug; it guards against a future "fix" that registers module handlers globally and quietly makes one tenant's step executable for everyone.

Verified by reverting the fix and re-running, rather than assuming the tests were load-bearing.

- `runtime-core`: **1,486 tests, 0 failures, 0 errors**
- `runtime-module-core`: **70 tests, 0 failures, 0 errors**

Built and run on JDK 25 (GraalVM 25.0.2).

## Not addressed here

Adjacent findings from tracing this, each worth its own issue:

- **`GET /api/flows/resources` returns `[]`** while its Javadoc promises "all available flow task resources (built-in + runtime modules)". Even with this fix, module steps remain undiscoverable via the API.
- **The flow designer's step list is hardcoded** in `FlowDesignerPage/types.ts` `RESOURCE_GROUPS`, and the `ActionHandlerDescriptor` SPI — which the module manifest's `configSchema`/`inputSchema`/`outputSchema` feed — is not consumed by the builder. Module steps must be authored in raw JSON.
- **A failed module load silently degrades to stubs** that return `ActionResult.success(..., "mode", "stub")`, so a broken module is indistinguishable from a working one to its caller.
- **`TRANSFORM_DATA`** appears in `RESOURCE_GROUPS` and in the AI flow-generation prompt but **has no handler** — generated flows using it fail at runtime.
- **`ActionHandler`'s Javadoc still instructs registering the action type in the `workflow_action_type` table**, which was dropped in `V72__drop_legacy_workflow_tables.sql`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)