### PR TITLE
fix(modules): let modules load the types QueryEngine requires

### DIFF
--- a/kelta-worker/src/main/java/io/kelta/worker/module/SandboxedModuleClassLoader.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/module/SandboxedModuleClassLoader.java
@@ -26,6 +26,8 @@ import java.util.Set;
  *   <li>{@code io.kelta.runtime.flow.} — ActionHandlerDescriptor</li>
  *   <li>{@code io.kelta.runtime.module.} — ModuleManifest, TenantModuleData</li>
  *   <li>{@code io.kelta.runtime.query.} — QueryEngine for data access</li>
+ *   <li>{@code io.kelta.runtime.model.} — CollectionDefinition, FieldDefinition and friends;
+ *       the parameter and return types of everything in {@code .query} and {@code .registry}</li>
  *   <li>{@code io.kelta.runtime.registry.} — CollectionRegistry</li>
  *   <li>{@code io.kelta.runtime.formula.} — FormulaEvaluator</li>
  *   <li>{@code io.kelta.runtime.storage.} — StorageAdapter</li>
@@ -50,6 +52,15 @@ public class SandboxedModuleClassLoader extends URLClassLoader implements Closea
         "io.kelta.runtime.flow.",
         "io.kelta.runtime.module.",
         "io.kelta.runtime.query.",
+        // Required to make .query and .registry usable at all: every
+        // QueryEngine method takes a CollectionDefinition, and
+        // CollectionRegistry#get returns one. Without this a module is handed
+        // QueryEngine and CollectionRegistry in its ModuleContext and cannot
+        // call a single method on either — the linker fails resolving the
+        // parameter type. Pure data-model types (CollectionDefinition,
+        // FieldDefinition, FieldType, builders, config records); this widens
+        // the API surface, not the trust boundary.
+        "io.kelta.runtime.model.",
         "io.kelta.runtime.registry.",
         "io.kelta.runtime.formula.",
         "io.kelta.runtime.storage.",

--- a/kelta-worker/src/test/java/io/kelta/worker/module/SandboxedModuleClassLoaderTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/module/SandboxedModuleClassLoaderTest.java
@@ -51,6 +51,24 @@ class SandboxedModuleClassLoaderTest {
     }
 
     @Test
+    void shouldAllowTheTypesQueryEngineActuallyNeeds() throws Exception {
+        // ModuleContext hands every module a QueryEngine and a
+        // CollectionRegistry. Both are useless unless CollectionDefinition
+        // resolves too: every QueryEngine method takes one as a parameter and
+        // CollectionRegistry#get returns one, so a module that could not load
+        // it could not read or write a single record.
+        URL jarUrl = createEmptyJar("empty.jar");
+        try (SandboxedModuleClassLoader cl = new SandboxedModuleClassLoader("test", jarUrl, getClass().getClassLoader())) {
+            assertNotNull(cl.loadClass("io.kelta.runtime.query.QueryEngine"));
+            assertNotNull(cl.loadClass("io.kelta.runtime.registry.CollectionRegistry"));
+            assertNotNull(cl.loadClass("io.kelta.runtime.model.CollectionDefinition"),
+                "CollectionDefinition is in every QueryEngine signature");
+            assertNotNull(cl.loadClass("io.kelta.runtime.model.FieldDefinition"));
+            assertNotNull(cl.loadClass("io.kelta.runtime.model.FieldType"));
+        }
+    }
+
+    @Test
     void shouldAllowSlf4jClasses() throws Exception {
         URL jarUrl = createEmptyJar("empty.jar");
         try (SandboxedModuleClassLoader cl = new SandboxedModuleClassLoader("test", jarUrl, getClass().getClassLoader())) {


### PR DESCRIPTION
## The bug

`ModuleContext` hands every runtime-loaded module a `QueryEngine` and a `CollectionRegistry`. Neither was callable.

**Every** `QueryEngine` method takes an `io.kelta.runtime.model.CollectionDefinition`:

```java
QueryResult executeQuery(CollectionDefinition definition, QueryRequest request);
Map<String, Object> aggregate(CollectionDefinition definition, ...);
Optional<Map<String, Object>> getById(CollectionDefinition definition, String id);
Map<String, Object> create(CollectionDefinition definition, Map<String, Object> data);
Optional<Map<String, Object>> update(CollectionDefinition definition, String id, Map<String, Object> data);
boolean delete(CollectionDefinition definition, String id);
```

and `CollectionRegistry#get` returns one. But `io.kelta.runtime.model.` was missing from `ALLOWED_PARENT_PREFIXES`, and `SandboxedModuleClassLoader` deliberately has **no parent fallback** — so resolving any of those signatures throws:

```
Module 'x' cannot access class 'io.kelta.runtime.model.CollectionDefinition':
not in module JAR and not in allowed platform API
```

`io.kelta.runtime.query.` was allowlisted, so `QueryEngine`, `QueryRequest` and `QueryResult` all loaded fine. Only the parameter type was unreachable — which is exactly why this wasn't obvious.

## Why it matters

A module could be signed, verified, loaded, and reported `ACTIVE` while being unable to read or write a single record. The two services the SPI advertises most prominently were decoration.

Note this is **independent of** #1354 and neither fixes the other. That one makes a module's step *reachable* from a flow; this one makes the step able to *do* anything once it runs. Both are needed before the runtime-module feature works end to end.

## Is this a sandbox weakening?

No. `io.kelta.runtime.model` is pure data-model types — `CollectionDefinition`, `FieldDefinition`, `FieldType`, the builders, and the config records (`ApiConfig`, `AuthzConfig`, `StorageConfig`, `ReferenceConfig`, `ValidationRules`).

The allowlist is a **dependency-visibility** mechanism, not a security boundary. Modules already receive `java.*` wholesale — sockets, filesystem, threads, `ProcessBuilder`. Anything reachable through `CollectionDefinition` was already reachable through `QueryEngine` itself; this just lets the caller name the type.

## Test

`shouldAllowTheTypesQueryEngineActuallyNeeds` asserts the whole set a module must touch to work with records — `QueryEngine`, `CollectionRegistry`, `CollectionDefinition`, `FieldDefinition`, `FieldType` — rather than only the one class that happened to be missing, so the next signature change surfaces here rather than at a tenant's runtime.

Verified it fails without the fix, with precisely the `ClassNotFoundException` quoted above, rather than assuming it was load-bearing.

- `SandboxedModuleClassLoaderTest`: 9 tests
- module suite (`SandboxedModuleClassLoader`, `RuntimeModuleManager`, `ModuleJarService`, `ModuleSignatureVerifier`): **40 tests, 0 failures, 0 errors**

JDK 25 (GraalVM 25.0.2).

## Related, not fixed here

`RuntimeModuleManager` silently degrades a failed module load to stub handlers that return `ActionResult.success(..., "mode", "stub")`. That is how both of these bugs stayed invisible: an unusable module is indistinguishable from a working one at the call site. Worth a separate issue — either surface the degraded state on `GET /api/modules` (it currently reports `ACTIVE`), or make stub mode opt-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)