### PR TITLE
fix(modules): return the id when listing signing keys

### DIFF
--- a/kelta-worker/src/main/java/io/kelta/worker/controller/ModuleSigningKeyController.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/controller/ModuleSigningKeyController.java
@@ -69,8 +69,6 @@ public class ModuleSigningKeyController {
                 .map(key -> keyToMap(key, keyStore.countModulesSignedBy(tenantId, key.fingerprint())))
                 .toList();
 
-        Map<String, Object> response =
-                new LinkedHashMap<>(JsonApiResponseBuilder.collection("module-signing-keys", records));
         // Surfaced because it changes what these keys mean: while a platform-wide key is
         // configured it is trusted for every tenant, so this tenant's key set is not the whole
         // trust boundary. Its fingerprint is included so a module recorded against it is
@@ -82,8 +80,8 @@ public class ModuleSigningKeyController {
         if (platformFingerprint != null) {
             meta.put("platformKeyFingerprint", platformFingerprint);
         }
-        response.put("meta", meta);
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(
+                JsonApiResponseBuilder.collection("module-signing-keys", records, meta));
     }
 
     /**
@@ -138,8 +136,7 @@ public class ModuleSigningKeyController {
 
         log.info("Added module signing key '{}' ({}, fingerprint {}) for tenant {}",
                 key.label(), key.algorithm(), key.shortFingerprint(), tenantId);
-        return ResponseEntity.ok(JsonApiResponseBuilder.single(
-                "module-signing-keys", key.id(), keyToMap(key, 0)));
+        return singleKey(key, 0, null);
     }
 
     /**
@@ -196,8 +193,7 @@ public class ModuleSigningKeyController {
         }
         keyStore.delete(tenantId, id);
         log.info("Deleted retired module signing key '{}' for tenant {}", key.label(), tenantId);
-        return ResponseEntity.ok(JsonApiResponseBuilder.single(
-                "module-signing-keys", id, keyToMap(key, 0)));
+        return singleKey(key, 0, null);
     }
 
     private ResponseEntity<Map<String, Object>> setActive(
@@ -219,18 +215,38 @@ public class ModuleSigningKeyController {
         }
 
         ModuleSigningKey updated = keyStore.findById(tenantId, id).orElse(existing);
-        Map<String, Object> attributes = keyToMap(updated, dependents);
-        if (!active && dependents > 0) {
-            attributes.put("warning", dependents + " installed module(s) were signed by this key "
-                    + "and will fall back to stub handlers on their next load until re-signed "
-                    + "with an active key");
+        String warning = (!active && dependents > 0)
+                ? dependents + " installed module(s) were signed by this key and will fall back "
+                    + "to stub handlers on their next load until re-signed with an active key"
+                : null;
+        return singleKey(updated, dependents, warning);
+    }
+
+    /**
+     * One key as a JSON:API single-resource response.
+     *
+     * <p>Drops {@code id} from the attribute map — {@code single()} puts the id in the resource
+     * envelope itself and does not strip it from attributes the way the collection path does, and
+     * JSON:API forbids an {@code id} member inside {@code attributes}.
+     */
+    private ResponseEntity<Map<String, Object>> singleKey(
+            ModuleSigningKey key, int dependentModules, String warning) {
+        Map<String, Object> attributes = keyToMap(key, dependentModules);
+        attributes.remove("id");
+        if (warning != null) {
+            attributes.put("warning", warning);
         }
         return ResponseEntity.ok(JsonApiResponseBuilder.single(
-                "module-signing-keys", id, attributes));
+                "module-signing-keys", key.id(), attributes));
     }
 
     private Map<String, Object> keyToMap(ModuleSigningKey key, int dependentModules) {
         Map<String, Object> map = new LinkedHashMap<>();
+        // JsonApiResponseBuilder.toResource() lifts "id" out of the record map into the resource
+        // envelope. Without it every listed key serialises as "id": null, and since retire,
+        // activate and delete are all addressed by id, the listing could not be acted on — which
+        // is the entire rotation workflow.
+        map.put("id", key.id());
         map.put("label", key.label());
         map.put("algorithm", key.algorithm());
         map.put("fingerprint", key.fingerprint());

--- a/kelta-worker/src/test/java/io/kelta/worker/controller/ModuleSigningKeyControllerTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/controller/ModuleSigningKeyControllerTest.java
@@ -1,0 +1,209 @@
+package io.kelta.worker.controller;
+
+import io.kelta.runtime.module.ModuleSigningKey;
+import io.kelta.runtime.module.ModuleSigningKeyStore;
+import io.kelta.worker.module.ModuleSignatureVerifier;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.security.KeyPairGenerator;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("ModuleSigningKeyController")
+class ModuleSigningKeyControllerTest {
+
+    private static final String TENANT = "tenant-a";
+
+    private FakeStore store;
+    private ModuleSigningKeyController controller;
+
+    @BeforeEach
+    void setUp() {
+        store = new FakeStore();
+        controller = new ModuleSigningKeyController(
+                store, new ModuleSignatureVerifier("", "Ed25519"));
+    }
+
+    private static String pem() throws Exception {
+        return "-----BEGIN PUBLIC KEY-----\n"
+                + Base64.getEncoder().encodeToString(
+                    KeyPairGenerator.getInstance("Ed25519").generateKeyPair().getPublic().getEncoded())
+                + "\n-----END PUBLIC KEY-----\n";
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<Map<String, Object>> data(Map<String, Object> body) {
+        return (List<Map<String, Object>>) body.get("data");
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> resource(Map<String, Object> body) {
+        return (Map<String, Object>) body.get("data");
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> attributes(Map<String, Object> resource) {
+        return (Map<String, Object>) resource.get("attributes");
+    }
+
+    @Test
+    @DisplayName("listed keys carry their id, so retire/activate/delete can address them")
+    void listingCarriesId() throws Exception {
+        // The bug this pins: keyToMap omitted "id", and JsonApiResponseBuilder.toResource() lifts
+        // "id" out of the record map — so every listed key serialised as "id": null and the whole
+        // rotation workflow was unreachable from the listing.
+        controller.addKey(TENANT, "admin", Map.of("label", "2026-h2", "publicKeyPem", pem()));
+
+        Map<String, Object> body = controller.listKeys(TENANT).getBody();
+        assertThat(data(body)).hasSize(1);
+        assertThat(data(body).get(0).get("id")).isNotNull();
+        assertThat(data(body).get(0).get("id")).isEqualTo(store.keys.get(0).id());
+    }
+
+    @Test
+    @DisplayName("id is not duplicated inside attributes — JSON:API forbids it there")
+    void idIsNotInAttributes() throws Exception {
+        controller.addKey(TENANT, "admin", Map.of("label", "2026-h2", "publicKeyPem", pem()));
+
+        Map<String, Object> listed = data(controller.listKeys(TENANT).getBody()).get(0);
+        assertThat(attributes(listed)).doesNotContainKey("id");
+
+        String id = store.keys.get(0).id();
+        Map<String, Object> single = resource(controller.retireKey(TENANT, "admin", id).getBody());
+        assertThat(single.get("id")).isEqualTo(id);
+        assertThat(attributes(single)).doesNotContainKey("id");
+    }
+
+    @Test
+    @DisplayName("listing reports the platform key and whether signing is required")
+    void listingReportsMeta() {
+        Map<String, Object> body = controller.listKeys(TENANT).getBody();
+        assertThat(body).containsKey("meta");
+        Map<?, ?> meta = (Map<?, ?>) body.get("meta");
+        assertThat(meta.get("signingRequired")).isEqualTo(false);
+        assertThat(meta.get("platformKeyConfigured")).isEqualTo(false);
+    }
+
+    @Test
+    @DisplayName("rejects a PEM that is not a usable key rather than storing it")
+    void rejectsBadPem() {
+        var response = controller.addKey(
+                TENANT, "admin", Map.of("label", "bad", "publicKeyPem", "not a pem"));
+
+        assertThat(response.getStatusCode().value()).isEqualTo(400);
+        assertThat(store.keys).isEmpty();
+    }
+
+    @Test
+    @DisplayName("retiring a key with dependents warns instead of failing silently")
+    void retireWarnsWhenModulesDependOnKey() throws Exception {
+        controller.addKey(TENANT, "admin", Map.of("label", "2026-h1", "publicKeyPem", pem()));
+        store.dependents = 3;
+
+        Map<String, Object> single = resource(
+                controller.retireKey(TENANT, "admin", store.keys.get(0).id()).getBody());
+
+        assertThat(attributes(single).get("warning").toString())
+                .contains("3 installed module(s)")
+                .contains("stub handlers");
+    }
+
+    @Test
+    @DisplayName("refuses to delete an active key — retire is the reversible step")
+    void refusesDeletingActiveKey() throws Exception {
+        controller.addKey(TENANT, "admin", Map.of("label", "2026-h2", "publicKeyPem", pem()));
+
+        var response = controller.deleteKey(TENANT, store.keys.get(0).id());
+
+        assertThat(response.getStatusCode().value()).isEqualTo(409);
+        assertThat(store.keys).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("refuses to delete a retired key that modules still depend on")
+    void refusesDeletingKeyWithDependents() throws Exception {
+        controller.addKey(TENANT, "admin", Map.of("label", "2026-h1", "publicKeyPem", pem()));
+        String id = store.keys.get(0).id();
+        controller.retireKey(TENANT, "admin", id);
+        store.dependents = 2;
+
+        var response = controller.deleteKey(TENANT, id);
+
+        assertThat(response.getStatusCode().value()).isEqualTo(409);
+        assertThat(store.keys).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("another tenant's key id is a 404, not someone else's key")
+    void keysAreTenantScoped() throws Exception {
+        controller.addKey(TENANT, "admin", Map.of("label", "2026-h2", "publicKeyPem", pem()));
+        String id = store.keys.get(0).id();
+
+        assertThat(controller.retireKey("tenant-b", "admin", id).getStatusCode().value())
+                .isEqualTo(404);
+        assertThat(controller.deleteKey("tenant-b", id).getStatusCode().value()).isEqualTo(404);
+    }
+
+    /** In-memory store; setActive flips the stored row so the response reflects the change. */
+    static final class FakeStore implements ModuleSigningKeyStore {
+        final List<ModuleSigningKey> keys = new ArrayList<>();
+        int dependents = 0;
+
+        @Override
+        public List<ModuleSigningKey> findActiveByTenant(String tenantId) {
+            return keys.stream().filter(k -> k.tenantId().equals(tenantId))
+                    .filter(ModuleSigningKey::active).toList();
+        }
+
+        @Override
+        public List<ModuleSigningKey> findByTenant(String tenantId) {
+            return keys.stream().filter(k -> k.tenantId().equals(tenantId)).toList();
+        }
+
+        @Override
+        public Optional<ModuleSigningKey> findById(String tenantId, String id) {
+            return keys.stream()
+                    .filter(k -> k.tenantId().equals(tenantId) && k.id().equals(id)).findFirst();
+        }
+
+        @Override
+        public String create(ModuleSigningKey key) {
+            keys.add(key);
+            return key.id();
+        }
+
+        @Override
+        public boolean setActive(String tenantId, String id, boolean active, String updatedBy) {
+            keys.replaceAll(k -> k.tenantId().equals(tenantId) && k.id().equals(id)
+                    ? new ModuleSigningKey(k.id(), k.tenantId(), k.label(), k.algorithm(),
+                        k.publicKeyPem(), k.fingerprint(), active,
+                        active ? null : Instant.now(), k.createdAt(), k.createdBy())
+                    : k);
+            return true;
+        }
+
+        @Override
+        public boolean delete(String tenantId, String id) {
+            return keys.removeIf(k -> k.tenantId().equals(tenantId) && k.id().equals(id));
+        }
+
+        @Override
+        public int countModulesSignedBy(String tenantId, String fingerprint) {
+            return dependents;
+        }
+
+        @SuppressWarnings("unused")
+        String newId() {
+            return UUID.randomUUID().toString();
+        }
+    }
+}


### PR DESCRIPTION
`GET /api/modules/signing-keys` serialised every key as `"id": null`, so the listing could not be acted on — and retire, activate and delete are all addressed by id, which is the **entire rotation workflow** the endpoint exists to support.

```json
{ "data": [ { "type": "module-signing-keys", "id": null, "attributes": { "label": "2026-h2", ... } } ] }
```

## Cause

`JsonApiResponseBuilder.toResource()` lifts `"id"` out of the record map into the resource envelope, and `keyToMap()` never put one there. The `POST` response looked correct because `single()` takes the id as its own argument — so the gap only showed on the collection path.

Found by registering the first real key against the `spotopened` tenant and **reading the response back**, rather than treating a 200 on the write as done.

## Also in this change

- Use the existing `collection(type, records, meta)` overload instead of copying the document map to bolt `meta` on afterwards.
- Strip `id` from attributes on the single-resource paths. `single()` does not remove it the way `toResource()` does, so including it in `keyToMap` would have put the id in *both* the envelope and the attributes — and JSON:API forbids an `id` member inside `attributes`.

## Tests

Adds `ModuleSigningKeyControllerTest`. The controller had **no tests**, which is why this shipped in #1356. Eight cases:

- the id contract in **both** response shapes (present in the envelope, absent from attributes)
- tenant scoping — another tenant's key id is a 404, not someone else's key
- the retire-with-dependents warning
- both delete refusals (active key; retired key with dependents)
- a bad PEM is rejected rather than stored

Confirmed by **negative control**: removing the `map.put("id", ...)` line fails `listingCarriesId`.

Worker suite **2468 tests**, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)