### PR TITLE
fix(s3): stop sending checksum trailers Garage cannot parse

### DIFF
--- a/kelta-worker/src/main/java/io/kelta/worker/service/S3StorageService.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/service/S3StorageService.java
@@ -7,7 +7,10 @@ import org.springframework.stereotype.Service;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.core.checksums.RequestChecksumCalculation;
+import software.amazon.awssdk.core.checksums.ResponseChecksumValidation;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Configuration;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3Configuration;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
@@ -308,6 +311,32 @@ public class S3StorageService {
                 .credentialsProvider(StaticCredentialsProvider.create(
                         AwsBasicCredentials.create(config.getAccessKey(), config.getSecretKey())))
                 .forcePathStyle(true)
+                // Required for S3-COMPATIBLE stores; this deployment runs Garage, not AWS.
+                //
+                // SDK 2.30 changed the default to WHEN_SUPPORTED, which adds a flexible-checksum
+                // trailer and sends the literal header
+                //   x-amz-content-sha256: STREAMING-UNSIGNED-PAYLOAD-TRAILER
+                // instead of a hex digest. Garage parses that as a hash and rejects the request:
+                //   "Invalid content sha256 hash: Invalid character 'S' at position 0"
+                // — the 'S' being the start of STREAMING.
+                //
+                // WHEN_REQUIRED still sends a checksum wherever the S3 API mandates one, so
+                // integrity is not being traded away; it only stops the SDK adding trailers the
+                // server cannot parse.
+                //
+                // This affects every server-side upload — module JARs, data exports and
+                // telehealth archives. It went unnoticed because ordinary attachments upload
+                // via presigned URLs straight from the browser, which never sends the trailer.
+                .requestChecksumCalculation(RequestChecksumCalculation.WHEN_REQUIRED)
+                .responseChecksumValidation(ResponseChecksumValidation.WHEN_REQUIRED)
+                // Both settings are needed, and this is the one that actually removes the
+                // STREAMING-UNSIGNED-PAYLOAD-TRAILER header: WHEN_REQUIRED alone stops the
+                // flexible-checksum trailer but leaves aws-chunked framing on, so the sentinel
+                // value is still sent and Garage still rejects it. Verified by
+                // S3StorageServiceChecksumTest against a real client on a loopback socket.
+                .serviceConfiguration(S3Configuration.builder()
+                        .chunkedEncodingEnabled(false)
+                        .build())
                 .build();
     }
 

--- a/kelta-worker/src/test/java/io/kelta/worker/service/S3StorageServiceChecksumTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/service/S3StorageServiceChecksumTest.java
@@ -1,0 +1,116 @@
+package io.kelta.worker.service;
+
+import com.sun.net.httpserver.HttpServer;
+import io.kelta.worker.config.S3ConfigProperties;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.InputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Pins the S3 request shape against an S3-COMPATIBLE store. This deployment runs Garage, not AWS.
+ *
+ * <p>AWS SDK 2.30 changed {@code requestChecksumCalculation} to default {@code WHEN_SUPPORTED},
+ * which sends the literal header {@code x-amz-content-sha256: STREAMING-UNSIGNED-PAYLOAD-TRAILER}
+ * plus a trailing checksum instead of a hex digest in the header. Garage parses that value as a
+ * hash and rejects the upload with
+ * {@code "Invalid content sha256 hash: Invalid character 'S' at position 0"} — the {@code S} being
+ * the start of {@code STREAMING}.
+ *
+ * <p>Asserted against a real {@code S3Client} talking to a loopback HTTP server, so this exercises
+ * the SDK's actual wire behaviour rather than a mock's idea of it. A plain assertion on the builder
+ * would not have caught the regression, because the default lives in the SDK and changed under us.
+ */
+@DisplayName("S3StorageService request checksums")
+class S3StorageServiceChecksumTest {
+
+    private HttpServer server;
+    private final Map<String, String> lastHeaders = new ConcurrentHashMap<>();
+
+    @BeforeEach
+    void startServer() throws Exception {
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/", exchange -> {
+            exchange.getRequestHeaders().forEach((name, values) -> {
+                if (!values.isEmpty()) {
+                    lastHeaders.put(name.toLowerCase(), values.get(0));
+                }
+            });
+            try (InputStream body = exchange.getRequestBody()) {
+                body.readAllBytes();
+            }
+            exchange.getResponseHeaders().add("ETag", "\"d41d8cd98f00b204e9800998ecf8427e\"");
+            exchange.sendResponseHeaders(200, -1);
+            exchange.close();
+        });
+        server.start();
+    }
+
+    @AfterEach
+    void stopServer() {
+        if (server != null) {
+            server.stop(0);
+        }
+    }
+
+    private S3StorageService service() {
+        S3ConfigProperties config = new S3ConfigProperties();
+        config.setEnabled(true);
+        config.setEndpoint("http://127.0.0.1:" + server.getAddress().getPort());
+        config.setPublicEndpoint("http://127.0.0.1:" + server.getAddress().getPort());
+        config.setRegion("garage");
+        config.setBucket("test-bucket");
+        config.setAccessKey("test-access-key");
+        config.setSecretKey("test-secret-key");
+        return new S3StorageService(config);
+    }
+
+    @Test
+    @DisplayName("sends a hex digest, never the STREAMING trailer sentinel Garage rejects")
+    void uploadSendsHexContentSha256() {
+        service().uploadObject("modules/test.jar", "jar bytes".getBytes(StandardCharsets.UTF_8),
+                "application/java-archive");
+
+        String contentSha256 = lastHeaders.get("x-amz-content-sha256");
+        assertThat(contentSha256)
+                .as("Garage parses this header as a hash; the SDK default sends "
+                        + "STREAMING-UNSIGNED-PAYLOAD-TRAILER, which fails with "
+                        + "\"Invalid character 'S' at position 0\"")
+                .isNotNull()
+                .doesNotStartWith("STREAMING")
+                .matches("[0-9a-f]{64}");
+    }
+
+    @Test
+    @DisplayName("does not add a flexible-checksum trailer the store cannot parse")
+    void uploadDoesNotSendChecksumTrailer() {
+        service().uploadObject("modules/test.jar", "jar bytes".getBytes(StandardCharsets.UTF_8),
+                "application/java-archive");
+
+        // WHEN_SUPPORTED advertises the trailing checksum via these headers and switches the body
+        // to aws-chunked framing. WHEN_REQUIRED leaves both off for a plain PutObject.
+        assertThat(lastHeaders).doesNotContainKey("x-amz-trailer");
+        // Absent entirely is the expected outcome, so this must tolerate null rather than
+        // assert on it — chunked framing is what would set it.
+        assertThat(lastHeaders.getOrDefault("content-encoding", "")).doesNotContain("aws-chunked");
+    }
+
+    @Test
+    @DisplayName("the body is the object itself, not aws-chunked framing around it")
+    void uploadSendsRawBodyLength() {
+        byte[] data = "jar bytes".getBytes(StandardCharsets.UTF_8);
+        service().uploadObject("modules/test.jar", data, "application/java-archive");
+
+        // Chunked framing inflates content-length past the object size; a store that stored it
+        // verbatim would hand back a corrupt JAR whose checksum no longer matches.
+        assertThat(lastHeaders.get("content-length")).isEqualTo(String.valueOf(data.length));
+    }
+}


### PR DESCRIPTION
Every **server-side** S3 upload has been failing:

```
Invalid content sha256 hash: Invalid character 'S' at position 0
(Service: S3, Status Code: 400)
```

That `S` is the start of `STREAMING`. AWS SDK 2.30 changed `requestChecksumCalculation` to default `WHEN_SUPPORTED`, which switches `PutObject` to aws-chunked framing and sends the literal header

```
x-amz-content-sha256: STREAMING-UNSIGNED-PAYLOAD-TRAILER
```

instead of a hex digest. Garage parses that value as a hash and rejects it. **This deployment runs Garage, not AWS.**

Found by installing a signed module JAR — the signature verified, then the upload 400'd underneath it.

## Both settings are required, and the second is the one that matters

`WHEN_REQUIRED` alone stops the flexible-checksum trailer but **leaves chunked encoding on**, so the sentinel header is still sent and Garage still rejects it. The first attempt at this fix looked correct and changed nothing — caught only because the test drives a real `S3Client` over a loopback socket instead of asserting on the builder. `chunkedEncodingEnabled(false)` is what actually removes it.

`WHEN_REQUIRED` still sends a checksum wherever the S3 API mandates one, so no integrity guarantee is given up — it only stops the SDK adding framing the server cannot read.

## Scope is wider than modules

`uploadObject()` backs **module JARs, data exports and telehealth archives** — all three were broken. It went unnoticed because ordinary attachments upload via presigned URLs straight from the browser, which never sends the trailer, so the common path looked healthy.

## Test

`S3StorageServiceChecksumTest` asserts on the **actual wire request**, not the builder:

- `x-amz-content-sha256` is a 64-char hex digest and does not start with `STREAMING`
- no `x-amz-trailer`, no `aws-chunked` content-encoding
- `content-length` equals the object size rather than the inflated framed size

A builder-level assertion would not have caught this, because the default lives in the SDK and changed underneath us — a future SDK bump can do it again.

Worker suite **2463 tests**, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)