### PR TITLE
chore(worker): build the production image as JVM, not native

### DIFF
--- a/.github/workflows/build-and-publish-containers.yml
+++ b/.github/workflows/build-and-publish-containers.yml
@@ -225,8 +225,13 @@ jobs:
             dockerfile: kelta-gateway/Dockerfile
             image: kelta-gateway
             changed: ${{ needs.changes.outputs.gateway }}
+          # JVM, not native-image. Runtime module JAR loading needs a bytecode
+          # interpreter: SandboxedModuleClassLoader defines classes from a JAR at
+          # runtime, and a native image cannot do that, so every installed module
+          # fell back to inert stub handlers while /api/modules still said ACTIVE.
+          # See kelta-worker/Dockerfile.jvm.
           - service: worker
-            dockerfile: kelta-worker/Dockerfile
+            dockerfile: kelta-worker/Dockerfile.jvm
             image: kelta-worker
             changed: ${{ needs.changes.outputs.worker }}
           - service: worker-migrate

--- a/kelta-worker/Dockerfile.jvm
+++ b/kelta-worker/Dockerfile.jvm
@@ -1,5 +1,20 @@
-# JVM-mode build of Kelta Worker for CI/e2e — fast iteration, not for production.
-# Production builds use kelta-worker/Dockerfile (GraalVM native-image).
+# JVM build of Kelta Worker. THIS IS WHAT PRODUCTION RUNS.
+#
+# The native-image build (kelta-worker/Dockerfile) is kept for local `make up`
+# and for reference, but it cannot run this service's runtime-module feature:
+# SandboxedModuleClassLoader defines classes from an installed JAR at runtime and
+# a native image has no bytecode interpreter, so URLClassLoader.findClass throws
+# ClassNotFoundException, the loader falls back to inert stub handlers, and
+# /api/modules keeps reporting ACTIVE. Nothing surfaces the breakage.
+#
+# Trade-offs accepted: ~20-40s startup instead of ~50ms, and a larger heap.
+# Startup is covered by the deployment's startupProbe (up to ~310s).
+#
+# NOTE: no OpenTelemetry javaagent is installed here on purpose. Tracing goes
+# through Spring Boot's own OTLP exporter
+# (MANAGEMENT_OPENTELEMETRY_TRACING_EXPORT_OTLP_ENDPOINT); adding the agent as
+# well would double-instrument every request. Do not put -javaagent in JAVA_OPTS
+# for this image — the JVM refuses to start when the agent path does not exist.
 
 # =============================================================================
 # Stage 1: Build runtime-platform dependencies


### PR DESCRIPTION
Runtime module JAR loading **cannot work in a GraalVM native image**. `SandboxedModuleClassLoader` defines classes from an installed JAR at runtime; a native image has no bytecode interpreter, so `URLClassLoader.findClass` throws even though the class is present in the archive.

**The failure is silent, which is the worst part.** The loader catches it and falls back to inert stub handlers, and `/api/modules` keeps reporting `ACTIVE`.

Observed installing the RIDB module — signature verified, checksum matched, JAR downloaded and cached, class present in the archive:

```
ClassNotFoundException: com.spotopened.ridb.RidbModule
  at java.net.URLClassLoader.findClass
  at com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine
```

That last frame is the native-image runtime. So the platform's dynamic module feature has never been able to work in its own production deployment.

## Change

Switches the worker's published image to `kelta-worker/Dockerfile.jvm`. Image name, tag scheme and the homelab-argo auto-bump are unchanged, so nothing downstream needs to know.

Trade-offs accepted: ~20–40s startup instead of ~50ms, and a larger heap. Startup is already covered by the deployment's `startupProbe` (up to ~310s); liveness and readiness do not run until it succeeds.

`kelta-worker/Dockerfile` (native) is kept for local `make up` and reference — but note it is now **unbuilt by CI and will drift**.

## Merge order

**[homelab-argo#208](https://github.com/cklinker/homelab-argo/pull/208) must merge first.** Merging this builds the JVM image and auto-bumps the argo tag; if the ConfigMap still carries `-javaagent:/app/opentelemetry-javaagent.jar` at that moment, every pod CrashLoopBackOffs. That flag is inert under native (entrypoint is the binary) and fatal under the JVM (entrypoint is `java $JAVA_OPTS -jar`). Verified:

```
$ docker run --rm eclipse-temurin:25-jre-alpine \
    java -javaagent:/app/opentelemetry-javaagent.jar -version
Error opening zip file or JAR manifest missing : /app/opentelemetry-javaagent.jar
Error occurred during initialization of VM
```

No agent is added to the image on purpose — tracing already goes through Spring Boot's own OTLP exporter, and running both would double-instrument every request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)