### PR TITLE
fix(scheduler): notice when a scheduled_job update matches no row

### DIFF
--- a/kelta-worker/src/main/java/io/kelta/worker/listener/FlowScheduleSyncHook.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/listener/FlowScheduleSyncHook.java
@@ -164,17 +164,27 @@ public class FlowScheduleSyncHook implements BeforeSaveHook {
         Instant nextRunAt = active ? ScheduledJobRepository.calculateNextRunAt(normalized, timezone) : null;
 
         Optional<Map<String, Object>> existing = scheduledJobRepository.findByFlowId(flowId, tenantId);
-        if (existing.isEmpty()) {
-            String createdBy = resolveCreatedBy(record, flowId);
-            if (createdBy == null) {
-                log.warn("Cannot create scheduled_job for flow {} — could not resolve createdBy", flowId);
+        if (existing.isPresent()) {
+            String jobId = asString(existing.get().get("id"));
+            if (scheduledJobRepository.updateForFlow(
+                    jobId, flowName, normalized, timezone, active, nextRunAt)) {
                 return;
             }
-            scheduledJobRepository.insertForFlow(flowId, tenantId, flowName, normalized, timezone, active, nextRunAt, createdBy);
-        } else {
-            String jobId = asString(existing.get().get("id"));
-            scheduledJobRepository.updateForFlow(jobId, flowName, normalized, timezone, active, nextRunAt);
+            // The row was read a moment ago and is gone now — deleted concurrently, or never
+            // visible to this connection for write. Fall through and recreate it rather than
+            // leave the flow marked active with no job behind it, which never fires and shows
+            // no symptom anywhere the flow itself is displayed.
+            log.warn("scheduled_job {} for flow {} vanished between read and update — recreating",
+                    jobId, flowId);
         }
+
+        String createdBy = resolveCreatedBy(record, flowId);
+        if (createdBy == null) {
+            log.warn("Cannot create scheduled_job for flow {} — could not resolve createdBy", flowId);
+            return;
+        }
+        scheduledJobRepository.insertForFlow(
+            flowId, tenantId, flowName, normalized, timezone, active, nextRunAt, createdBy);
     }
 
     private String resolveCreatedBy(Map<String, Object> record, String flowId) {

--- a/kelta-worker/src/main/java/io/kelta/worker/repository/ScheduledJobRepository.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/repository/ScheduledJobRepository.java
@@ -256,9 +256,11 @@ public class ScheduledJobRepository {
 
     /**
      * Inserts a new scheduled_job row for a FLOW.
+     *
+     * @return the new job id
      */
-    public void insertForFlow(String flowId, String tenantId, String name, String cronExpression,
-                               String timezone, boolean active, Instant nextRunAt, String createdBy) {
+    public String insertForFlow(String flowId, String tenantId, String name, String cronExpression,
+                                 String timezone, boolean active, Instant nextRunAt, String createdBy) {
         String id = UUID.randomUUID().toString();
         jdbcTemplate.update(
                 "INSERT INTO scheduled_job (id, tenant_id, name, job_type, job_reference_id, " +
@@ -274,14 +276,23 @@ public class ScheduledJobRepository {
                 createdBy
         );
         log.debug("Inserted scheduled_job {} for flow {}", id, flowId);
+        return id;
     }
 
     /**
      * Updates an existing scheduled_job for a FLOW (cron, timezone, active, next_run_at, name).
+     *
+     * <p>Warns when the statement matches no row. Without that check this method logged
+     * "Updated scheduled_job ..." whether it wrote one row or none, so a schedule that silently
+     * stopped syncing was indistinguishable from one that synced fine — and the consequence is
+     * invisible in the usual places: the flow still reads {@code active}, and a job left at
+     * {@code active=false} or a null {@code next_run_at} simply never fires.
+     *
+     * @return whether a row was actually updated
      */
-    public void updateForFlow(String jobId, String name, String cronExpression,
-                               String timezone, boolean active, Instant nextRunAt) {
-        jdbcTemplate.update(
+    public boolean updateForFlow(String jobId, String name, String cronExpression,
+                                  String timezone, boolean active, Instant nextRunAt) {
+        int updated = jdbcTemplate.update(
                 "UPDATE scheduled_job SET name = ?, cron_expression = ?, timezone = ?, " +
                         "active = ?, next_run_at = ?, updated_at = ? WHERE id = ?",
                 name,
@@ -292,7 +303,14 @@ public class ScheduledJobRepository {
                 Timestamp.from(Instant.now()),
                 jobId
         );
+        if (updated == 0) {
+            log.warn("scheduled_job {} matched no row on update (cron={}, active={}) — "
+                    + "the flow's schedule is now out of sync and it will not fire as configured",
+                    jobId, cronExpression, active);
+            return false;
+        }
         log.debug("Updated scheduled_job {} (cron={}, active={})", jobId, cronExpression, active);
+        return true;
     }
 
     /**

--- a/kelta-worker/src/test/java/io/kelta/worker/listener/FlowScheduleSyncHookTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/listener/FlowScheduleSyncHookTest.java
@@ -219,4 +219,69 @@ class FlowScheduleSyncHookTest {
                 eq("0 0 */4 * * *"), eq("UTC"), eq(true),
                 notNull(), eq("user-1"));
     }
+
+    @Test
+    @DisplayName("afterUpdate keeps the job in sync when the row is there")
+    void afterUpdateSyncsExistingJob() {
+        when(repository.findByFlowId(anyString(), anyString()))
+                .thenReturn(Optional.of(Map.of("id", "job-1")));
+        when(repository.updateForFlow(anyString(), anyString(), anyString(),
+                anyString(), anyBoolean(), any())).thenReturn(true);
+
+        hook.afterUpdate("flow-1", activeScheduledFlow(true), previousScheduledFlow(), "tenant-1");
+
+        verify(repository).updateForFlow(
+                eq("job-1"), eq("Nightly sweep"), eq("0 0 13 * * *"), eq("UTC"), eq(true), notNull());
+        verify(repository, never()).insertForFlow(
+                anyString(), anyString(), anyString(), anyString(), anyString(),
+                anyBoolean(), any(), anyString());
+    }
+
+    @Test
+    @DisplayName("a vanished job row is recreated, not silently left missing")
+    void afterUpdateRecreatesAVanishedJob() {
+        // updateForFlow matching no row means the schedule is gone while the flow still reads
+        // active — it would never fire, and nothing about the flow would show it. Recreate.
+        when(repository.findByFlowId(anyString(), anyString()))
+                .thenReturn(Optional.of(Map.of("id", "job-1")));
+        when(repository.updateForFlow(anyString(), anyString(), anyString(),
+                anyString(), anyBoolean(), any())).thenReturn(false);
+
+        hook.afterUpdate("flow-1", activeScheduledFlow(true), previousScheduledFlow(), "tenant-1");
+
+        verify(repository).insertForFlow(
+                eq("flow-1"), eq("tenant-1"), eq("Nightly sweep"), eq("0 0 13 * * *"),
+                eq("UTC"), eq(true), notNull(), eq("user-1"));
+    }
+
+    @Test
+    @DisplayName("deactivating clears next_run_at so the executor stops picking it up")
+    void afterUpdateDeactivationNullsNextRun() {
+        when(repository.findByFlowId(anyString(), anyString()))
+                .thenReturn(Optional.of(Map.of("id", "job-1")));
+        when(repository.updateForFlow(anyString(), anyString(), anyString(),
+                anyString(), anyBoolean(), any())).thenReturn(true);
+
+        hook.afterUpdate("flow-1", activeScheduledFlow(false), previousScheduledFlow(), "tenant-1");
+
+        verify(repository).updateForFlow(
+                eq("job-1"), eq("Nightly sweep"), eq("0 0 13 * * *"), eq("UTC"), eq(false), isNull());
+    }
+
+    private static Map<String, Object> activeScheduledFlow(boolean active) {
+        Map<String, Object> record = new HashMap<>();
+        record.put("id", "flow-1");
+        record.put("name", "Nightly sweep");
+        record.put("flowType", "SCHEDULED");
+        record.put("active", active);
+        record.put("createdBy", "user-1");
+        record.put("triggerConfig", Map.of("cron", "0 0 13 * * *", "timezone", "UTC"));
+        return record;
+    }
+
+    private static Map<String, Object> previousScheduledFlow() {
+        Map<String, Object> record = activeScheduledFlow(true);
+        record.put("active", false);
+        return record;
+    }
 }

--- a/kelta-worker/src/test/java/io/kelta/worker/repository/ScheduledJobRepositoryTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/repository/ScheduledJobRepositoryTest.java
@@ -6,6 +6,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import java.util.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
@@ -85,5 +86,27 @@ class ScheduledJobRepositoryTest {
 
         assertThat(result).isPresent();
         assertThat(result.get().get("definition")).isNull();
+    }
+
+    @Test
+    void updateForFlowReportsWhenNoRowMatched() {
+        // Without this the method logged "Updated scheduled_job ..." whether it wrote one row or
+        // none, so a schedule that silently stopped syncing looked identical to a healthy one.
+        when(jdbcTemplate.update(contains("UPDATE scheduled_job"),
+                any(), any(), any(), any(), any(), any(), any())).thenReturn(0);
+
+        boolean updated = repository.updateForFlow(
+                "job-1", "nightly", "0 0 13 * * *", "UTC", true, java.time.Instant.now());
+
+        assertFalse(updated, "a zero-row update must not report success");
+    }
+
+    @Test
+    void updateForFlowReportsSuccessWhenARowMatched() {
+        when(jdbcTemplate.update(contains("UPDATE scheduled_job"),
+                any(), any(), any(), any(), any(), any(), any())).thenReturn(1);
+
+        assertTrue(repository.updateForFlow(
+                "job-1", "nightly", "0 0 13 * * *", "UTC", true, java.time.Instant.now()));
     }
 }


### PR DESCRIPTION
`updateForFlow` ignored `jdbcTemplate.update`'s affected-row count and logged

```
Updated scheduled_job {} (cron=…, active=…)
```

**unconditionally** — the same line whether it wrote one row or none. A schedule that stopped syncing was indistinguishable from a healthy one.

## Why this one matters more than its size

That gap is what made a recent investigation expensive. Chasing an apparent flow-activation bug, this log line was read as proof the write had landed. It *happened* to be true — the write had landed and a stale cached read was lying — but **the line was never evidence either way**, and hours went into a bug that did not exist.

## Change

`updateForFlow` now returns whether a row was updated and warns when none matched, naming the consequence: *the flow's schedule is out of sync and it will not fire as configured*.

The hook acts on it. A row that was read a moment ago and is gone at write time is **recreated** rather than left missing — the alternative is a flow that reads `active` with no job behind it: never fires, nothing about the flow shows it. `insertForFlow` returns its new id so the recreate path is traceable.

## Tests

- update path both directions — activation writes a `next_run_at`, deactivation nulls it so the executor stops picking it up
- zero-row result reported as failure
- vanished row is recreated

Confirmed by **negative control**: restoring the old ignore-the-count behaviour fails `afterUpdateRecreatesAVanishedJob`.

Worker suite **2479 tests**, all passing.

## Not fixed here — and it's the larger problem

`GET /api/scheduled-jobs` serves a **stale cached read**. `scheduled-jobs` is a system collection with a response cache, and this repository writes via direct SQL, so nothing invalidates it:

```
API:  ridb-ingest-sweep  active=False  next=None               updated=03:39:50
DB:   ridb-ingest-sweep  active=t      next=2026-08-14 13:00Z  updated=03:41:28
```

Flows still fire — the executor reads the table — but **every tool for checking whether a schedule is healthy reports fiction**, including `FlowScheduleStatusController`, which exists precisely to answer that question. That belongs in its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)