### PR TITLE
fix(router): stop caching scheduled-jobs, which is written out-of-band

### DIFF
--- a/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/router/DynamicCollectionRouter.java
+++ b/kelta-platform/runtime/runtime-core/src/main/java/io/kelta/runtime/router/DynamicCollectionRouter.java
@@ -1787,15 +1787,44 @@ public class DynamicCollectionRouter {
     }
 
     /**
+     * System collections that are writable through this router but whose rows are also mutated
+     * out-of-band, so {@code readOnly} does not exclude them and caching them serves fiction.
+     *
+     * <p>{@code scheduled-jobs} is the case in hand. Every meaningful write to it happens via
+     * {@code ScheduledJobRepository}'s direct JDBC — the scheduler stamps {@code last_run_at},
+     * {@code last_status} and a recomputed {@code next_run_at} after <em>every</em> execution, and
+     * {@code FlowScheduleSyncHook} rewrites {@code active}/{@code next_run_at} whenever a flow's
+     * schedule changes. None of that goes through this router, so nothing evicts the entry.
+     *
+     * <p>Eviction on write would not fix it either: the cache is per-pod, so a pod that never
+     * served the write keeps its own stale copy regardless. Not caching is the only correct
+     * answer short of broadcasting invalidation over NATS, and this data is low-traffic
+     * operational state where caching buys nothing.
+     *
+     * <p>The cost of getting this wrong is not a slightly stale list. It is that every tool for
+     * answering "is this schedule healthy?" reports fiction — the endpoint kept serving
+     * {@code active=false, next_run_at=null} for a job that was active with a correct next run,
+     * which reads exactly like a broken scheduler and sent one investigation down a bug that did
+     * not exist.
+     */
+    private static final Set<String> NEVER_CACHED_SYSTEM_COLLECTIONS = Set.of("scheduled-jobs");
+
+    /**
      * Whether this collection's responses may be served from / stored in the
      * {@link SystemCollectionCache}. Read-only system collections (record-versions,
      * field-history, email-logs, login-history, audit logs, ...) are excluded:
      * they are written by backend services via direct JDBC, never through this
      * router, so no write path ever evicts their entries — caching them serves
      * stale, per-pod results until the TTL expires.
+     *
+     * <p>{@link #NEVER_CACHED_SYSTEM_COLLECTIONS} extends that exclusion to collections which are
+     * writable here but still mutated out-of-band.
      */
     private boolean cacheable(CollectionDefinition definition) {
-        return definition.systemCollection() && !definition.readOnly() && systemCollectionCache != null;
+        return definition.systemCollection()
+                && !definition.readOnly()
+                && !NEVER_CACHED_SYSTEM_COLLECTIONS.contains(definition.name())
+                && systemCollectionCache != null;
     }
 
     /**

--- a/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/router/DynamicCollectionRouterCacheTest.java
+++ b/kelta-platform/runtime/runtime-core/src/test/java/io/kelta/runtime/router/DynamicCollectionRouterCacheTest.java
@@ -178,6 +178,48 @@ class DynamicCollectionRouterCacheTest {
         }
 
         @Test
+        @DisplayName("Should NOT cache scheduled-jobs — it is mutated out-of-band by the scheduler")
+        void list_doesNotCache_forScheduledJobs() throws Exception {
+            // scheduled-jobs is writable through this router, so readOnly does not exclude it, but
+            // every meaningful write happens in ScheduledJobRepository via direct JDBC: the
+            // scheduler stamps last_run_at/last_status/next_run_at after every execution, and
+            // FlowScheduleSyncHook rewrites active/next_run_at when a flow's schedule changes.
+            // Nothing evicts the entry, and the cache is per-pod so eviction-on-write would not
+            // help either. Caching it made the endpoint report active=false/next_run_at=null for a
+            // job that was active with a correct next run — indistinguishable from a dead scheduler.
+            CollectionDefinition def = buildSystemCollection("scheduled-jobs");
+            when(registry.get("scheduled-jobs")).thenReturn(def);
+
+            QueryResult result = QueryResult.empty(Pagination.defaults());
+            when(queryEngine.executeQuery(eq(def), any(QueryRequest.class))).thenReturn(result);
+
+            mockMvc.perform(get("/api/scheduled-jobs")
+                            .header("X-Tenant-ID", "tenant-1"))
+                    .andExpect(status().isOk());
+
+            verify(cache, never()).getListResponse(any(), any(), any());
+            verify(cache, never()).putListResponse(any(), any(), any(), any());
+        }
+
+        @Test
+        @DisplayName("Should still cache other writable system collections")
+        void list_stillCaches_forOtherWritableSystemCollections() throws Exception {
+            // Guards the exclusion from being widened by accident.
+            CollectionDefinition def = buildSystemCollection("ui-menus");
+            when(registry.get("ui-menus")).thenReturn(def);
+            when(cache.getListResponse(any(), any(), any())).thenReturn(Optional.empty());
+
+            QueryResult result = QueryResult.empty(Pagination.defaults());
+            when(queryEngine.executeQuery(eq(def), any(QueryRequest.class))).thenReturn(result);
+
+            mockMvc.perform(get("/api/ui-menus")
+                            .header("X-Tenant-ID", "tenant-1"))
+                    .andExpect(status().isOk());
+
+            verify(cache).putListResponse(any(), any(), any(), any());
+        }
+
+        @Test
         @DisplayName("Should NOT cache response when include parameter is present")
         void list_doesNotCache_whenIncludePresent() throws Exception {
             CollectionDefinition def = buildSystemCollection("collections");


### PR DESCRIPTION
`GET /api/scheduled-jobs` served a stale response **indefinitely**. Observed against the database:

```
API:  ridb-ingest-sweep  active=False  next=None               updated=03:39:50
DB:   ridb-ingest-sweep  active=t      next=2026-08-14 13:00Z  updated=03:41:28
```

## Cause

`cacheable()` already excludes read-only system collections, and its javadoc says exactly why: *"they are written by backend services via direct JDBC, never through this router, so no write path ever evicts their entries — caching them serves stale, per-pod results."*

`scheduled-jobs` has precisely that property but **isn't marked read-only**, so it was cached:

- the scheduler stamps `last_run_at`, `last_status` and a recomputed `next_run_at` after **every** execution
- `FlowScheduleSyncHook` rewrites `active`/`next_run_at` whenever a flow's schedule changes

Neither goes through this router.

## Why not evict on write

The cache is **per-pod**. A pod that never served the write keeps its own stale copy regardless. Not caching is the only correct answer short of broadcasting invalidation over NATS — and this is low-traffic operational state where caching buys nothing.

## Why this one was expensive

The cost isn't a slightly stale list. **Every tool for answering "is this schedule healthy?" reports fiction** — including `FlowScheduleStatusController`, which exists specifically to answer that question and reads the same way.

A job that was active with a correct next run read as `active=false, next_run_at=null`: indistinguishable from a dead scheduler. It sent one investigation several hours into a bug that did not exist, across three diagnostic rollouts, before a direct database query settled it in one command.

## Tests

Both directions — `scheduled-jobs` is never cached, and another writable system collection still is, so the exclusion can't widen by accident. Confirmed by **negative control**: removing the exclusion fails `list_doesNotCache_forScheduledJobs`.

runtime-core **1488** tests, worker **2479** tests, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)