### PR TITLE
fix(watch): check the quota before promoting, not after

### DIFF
--- a/kelta-worker/src/main/java/io/kelta/worker/controller/WatchController.java
+++ b/kelta-worker/src/main/java/io/kelta/worker/controller/WatchController.java
@@ -151,18 +151,13 @@ public class WatchController implements SelfScopedController {
         String tenantId = requireTenant();
         String subject = resolveSubject(request, tenantId,
                 body == null ? null : body.memberId());
-        WatchTarget target = resolveTarget(tenantId, body);
-        if (!target.active()) {
-            throw new ResponseStatusException(HttpStatus.CONFLICT,
-                    "Target is not currently watchable");
-        }
-
-        String criteria = validateCriteria(body.criteria());
-        List<String> channels = intersectChannels(tenantId, subject, body.channels());
-
-        // Pre-check the quota so the member gets an actionable message with an
-        // upgrade hint. The quota hook still enforces it on the way through — this
-        // is a nicer error, not the guard.
+        // Quota BEFORE resolving the target, because resolving may create one.
+        // The other order leaks: a member at their limit gets a 422 and still leaves a
+        // watch_target behind, so retrying in a loop mints unlimited rows — each one
+        // something the poller can be asked to poll — while never creating a watch.
+        //
+        // Still a pre-check for a nicer message, not the guard; the quota hook enforces
+        // it on the way through.
         int limit = entitlementService.intLimit(tenantId, subject, ENTITLEMENT_MAX_WATCHES,
                 Integer.MAX_VALUE);
         if (limit != Integer.MAX_VALUE) {
@@ -174,6 +169,15 @@ public class WatchController implements SelfScopedController {
                                 + "). Upgrade your plan to add more watches.");
             }
         }
+
+        WatchTarget target = resolveTarget(tenantId, body);
+        if (!target.active()) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT,
+                    "Target is not currently watchable");
+        }
+
+        String criteria = validateCriteria(body.criteria());
+        List<String> channels = intersectChannels(tenantId, subject, body.channels());
 
         Map<String, Object> data = new LinkedHashMap<>();
         // Direct queryEngine.create must set tenantId itself — the JSON:API layer

--- a/kelta-worker/src/test/java/io/kelta/worker/controller/WatchControllerTest.java
+++ b/kelta-worker/src/test/java/io/kelta/worker/controller/WatchControllerTest.java
@@ -334,4 +334,27 @@ class WatchControllerTest {
                 .isInstanceOf(ResponseStatusException.class)
                 .hasMessageContaining("targetId, or source and externalId, is required");
     }
+
+    @Test
+    @DisplayName("a member at their plan limit does not leave a promoted target behind")
+    void quotaRejectionPromotesNothing() {
+        // Found in production: the 422 fired AFTER the target was created, so retrying at
+        // the limit minted unlimited watch_target rows — each one something the poller can
+        // be asked to poll — while never creating a watch.
+        WatchController promoting = controllerWithPromotable("recreation.gov");
+        when(entitlements.intLimit(anyString(), anyString(),
+                eq(WatchController.ENTITLEMENT_MAX_WATCHES), anyInt())).thenReturn(1);
+        when(watchRepository.countByMemberAndStatus(TENANT, OWNER, Watch.STATUS_ACTIVE))
+                .thenReturn(1);
+        when(targetRepository.findBySourceAndExternalId(TENANT, "recreation.gov", "274314"))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> promoting.create(
+                promoteRequest("recreation.gov", "274314", "Silver Valley"),
+                requestFrom(OWNER, false)))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("plan limit");
+
+        verify(queryEngine, never()).create(any(), any());
+    }
 }


### PR DESCRIPTION
A member at their plan limit got a **422 and still left a `watch_target` behind**. Retrying in a loop mints unlimited rows — each one something the poller can be asked to poll — while never creating a watch.

## How it surfaced

By testing the promotion path in production immediately after deploying [#1364](https://github.com/cklinker/emf/pull/1364), rather than assuming the happy path generalised:

```
POST /api/watches {source, externalId, name}
  -> 422 "You have reached your plan limit (1/1)"

watch_target count: 22 -> 23
```

The first test I ran resolved an *existing* target, so it proved nothing about the create path. Only when I picked a facility with no target did the leak show.

## Fix

The quota pre-check ran **after** `resolveTarget()`, and `resolveTarget()` is where promotion creates the row. Order swapped, so nothing is created for a request that's going to be refused anyway.

It remains a pre-check for a nicer message rather than the guard — the quota hook enforces it on the way through. But it now guards a **side effect** too, which is a stronger reason to run it early than the error text was.

## Test

`quotaRejectionPromotesNothing`, confirmed by **negative control**: restoring the old order fails it.

Worker suite **2486 tests**, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)